### PR TITLE
Adding Paytm Integration to OpenAlgo

### DIFF
--- a/blueprints/brlogin.py
+++ b/blueprints/brlogin.py
@@ -167,6 +167,11 @@ def broker_callback(broker,para=None):
             auth_token, error_message = auth_function(otp,token,sid,userid,access_token,hsServerId)
             forward_url = 'kotak.html'
 
+    elif broker == 'paytm':
+         request_token = request.args.get('requestToken')
+         print(f'The request token is {request_token}')
+         auth_token, error_message = auth_function(request_token)
+
     else:
         code = request.args.get('code') or request.args.get('request_token')
         print(f'The code is {code}')

--- a/broker/paytm/api/auth_api.py
+++ b/broker/paytm/api/auth_api.py
@@ -1,0 +1,47 @@
+import os
+import requests
+
+def authenticate_broker(request_token):
+    """
+    Authenticate with Paytm Money broker API.
+    
+    The authentication flow works as follows:
+    1. Navigate to Paytm Money API endpoint: https://login.paytmmoney.com/merchant-login?apiKey={api_key}&state={state_key}
+    2. After successful login, a request_token is returned as URL parameter to the registered redirect URL
+    3. Use the request_token to generate an access_token
+    
+    Args:
+        code: The request token received from the redirect URL after successful login
+    
+    Returns:
+        tuple: (access_token, error_message)
+            - access_token: The token to use for subsequent API calls
+            - error_message: Error details if authentication fails, None on success
+    """
+    try:
+        BROKER_API_KEY = os.getenv('BROKER_API_KEY')
+        BROKER_API_SECRET = os.getenv('BROKER_API_SECRET')
+        
+        url = 'https://developer.paytmmoney.com/accounts/v2/gettoken'
+        data = {
+            'api_key': BROKER_API_KEY,
+            'api_secret_key': BROKER_API_SECRET,
+            'request_token': request_token
+        }
+        headers = {'Content-Type': 'application/json'}
+        response = requests.post(url, json=data, headers=headers)
+
+        if response.status_code == 200:
+            response_data = response.json()
+            if 'access_token' in response_data:
+                return response_data['access_token'], None
+            else:
+                return None, "Authentication succeeded but no access token was returned. Please check the response."
+        else:
+            # Parsing the error message from the API response
+            error_detail = response.json()  # Assuming the error is in JSON format
+            error_messages = error_detail.get('errors', [])
+            detailed_error_message = "; ".join([error['message'] for error in error_messages])
+            return None, f"API error: {error_messages}" if detailed_error_message else "Authentication failed. Please try again."
+    except Exception as e:
+        return None, f"An exception occurred: {str(e)}"

--- a/broker/paytm/api/data.py
+++ b/broker/paytm/api/data.py
@@ -1,0 +1,269 @@
+import http.client
+import json
+import os
+import urllib.parse
+from database.token_db import get_br_symbol, get_token
+from broker.paytm.database.master_contract_db import SymToken, db_session
+import logging
+import pandas as pd
+from datetime import datetime, timedelta
+
+# Configure logging
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
+def get_api_response(endpoint, auth, method="GET", payload=''):
+    AUTH_TOKEN = auth
+    conn = http.client.HTTPSConnection("developer.paytmmoney.com")
+    headers = {
+        'x-jwt-token': AUTH_TOKEN,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    try:
+        # Log the complete request details for Postman
+        logger.info("=== API Request Details ===")
+        logger.info(f"URL: https://developer.paytmmoney.com{endpoint}")
+        logger.info(f"Method: {method}")
+        logger.info(f"Headers: {json.dumps(headers, indent=2)}")
+        if payload:
+            logger.info(f"Payload: {payload}")
+
+        conn.request(method, endpoint, payload, headers)
+        res = conn.getresponse()
+        data = res.read()
+        response = json.loads(data.decode("utf-8"))
+
+        # Log the complete response
+        logger.info("=== API Response Details ===")
+        logger.info(f"Status Code: {res.status}")
+        logger.info(f"Response Headers: {dict(res.getheaders())}")
+        logger.info(f"Response Body: {json.dumps(response, indent=2)}")
+
+        return response
+    except Exception as e:
+        logger.error(f"API request failed: {str(e)}")
+        raise
+
+class BrokerData:
+    def __init__(self, auth_token):
+        """Initialize Paytm data handler with authentication token"""
+        self.auth_token = auth_token
+        
+        # PAYTM does not support historical data API
+        # Map common timeframe format to Paytm intervals
+        self.timeframe_map = {
+            # Minutes
+            '1m': 'minute',
+            '3m': '3minute',
+            '5m': '5minute',
+            '10m': '10minute',
+            '15m': '15minute',
+            '30m': '30minute',
+            '60m': '60minute',
+            # Daily
+            'D': 'day'
+        }
+        
+        # Market timing configuration for different exchanges
+        self.market_timings = {
+            'NSE': {
+                'start': '09:15:00',
+                'end': '15:30:00'
+            },
+            'BSE': {
+                'start': '09:15:00',
+                'end': '15:30:00'
+            },
+            'NFO': {
+                'start': '09:15:00',
+                'end': '15:30:00'
+            },
+            'CDS': {
+                'start': '09:00:00',
+                'end': '17:00:00'
+            },
+            'BCD': {
+                'start': '09:00:00',
+                'end': '17:00:00'
+            }
+        }
+        
+        # Default market timings if exchange not found
+        self.default_market_timings = {
+            'start': '09:15:00',
+            'end': '15:29:59'
+        }
+
+    def get_market_timings(self, exchange: str) -> dict:
+        """Get market start and end times for given exchange"""
+        return self.market_timings.get(exchange, self.default_market_timings)
+
+    def get_quotes(self, symbol: str, exchange: str) -> dict:
+        """
+        Get real-time quotes for given symbol
+        Args:
+            symbol: Trading symbol
+            exchange: Exchange (e.g., NSE, BSE)
+        Returns:
+            dict: Quote data with required fields
+        """
+        try:
+            # Convert symbol to broker format
+            token = get_token(symbol, exchange)
+            logger.info(f"Fetching quotes for {exchange}:{token}")
+
+            br_symbol = get_br_symbol(symbol, exchange)
+            # Determine opt_type based on symbol format
+            parts = br_symbol.split('-')
+            if len(parts) > 2:
+                if parts[-1] in ['CE', 'PE']:
+                    opt_type = 'OPTION'
+                elif 'FUT' in parts[-1]:
+                    opt_type = 'FUTURE'
+                else:
+                    opt_type = 'EQUITY'
+            else:
+                opt_type = 'EQUITY'
+            
+            # URL encode the symbol to handle special characters
+            # Paytm expects the symbol to be in the format "exchange:symbol" E,g: NSE:335:EQUITY
+            # 	INDEX, EQUITY, ETF, FUTURE, OPTION
+            encoded_symbol = urllib.parse.quote(f"{exchange}:{token}:{opt_type}")
+            
+            response = get_api_response(f"/data/v1/price/live?mode=QUOTE&pref={encoded_symbol}", self.auth_token)
+            
+            if not response or not response.get('data', []):
+                raise Exception(f"Error from Paytm API: {response.get('message', 'Unknown error')}")
+            
+            
+            # Return quote data
+            quote = response.get('data', [])[0] if response.get('data') else {}
+            if not quote:
+                raise Exception("No quote data found")
+
+            return {
+                'ask': 0,  # Not available in new format
+                'bid': 0,  # Not available in new format
+                'high': quote.get('ohlc', {}).get('high', 0),
+                'low': quote.get('ohlc', {}).get('low', 0),
+                'ltp': quote.get('last_price', 0),
+                'open': quote.get('ohlc', {}).get('open', 0),
+                'prev_close': quote.get('ohlc', {}).get('close', 0),
+                'volume': quote.get('volume_traded', 0)
+            }
+            
+        except Exception as e:
+            logger.error(f"Error fetching quotes: {str(e)}")
+            raise Exception(f"Error fetching quotes: {str(e)}")
+
+
+    def get_market_depth(self, symbol: str, exchange: str) -> dict:
+        """
+        Get market depth for given symbol
+        Args:
+            symbol: Trading symbol
+            exchange: Exchange (e.g., NSE, BSE)
+        Returns:
+            dict: Market depth data
+        """
+        try:
+            # Convert symbol to broker format
+            token = get_token(symbol, exchange)
+            logger.info(f"Fetching quotes for {exchange}:{token}")
+
+            br_symbol = get_br_symbol(symbol, exchange)
+            # Determine opt_type based on symbol format
+            parts = br_symbol.split('-')
+            if len(parts) > 2:
+                if parts[-1] in ['CE', 'PE']:
+                    opt_type = 'OPTION'
+                elif 'FUT' in parts[-1]:
+                    opt_type = 'FUTURE'
+                else:
+                    opt_type = 'EQUITY'
+            else:
+                opt_type = 'EQUITY'
+            
+            # URL encode the symbol to handle special characters
+            # Paytm expects the symbol to be in the format "exchange:symbol" E,g: NSE:335:EQUITY
+            # 	INDEX, EQUITY, ETF, FUTURE, OPTION
+            encoded_symbol = urllib.parse.quote(f"{exchange}:{token}:{opt_type}")
+            
+            response = get_api_response(f"/data/v1/price/live?mode=FULL&pref={encoded_symbol}", self.auth_token)
+            
+            if not response or not response.get('data', []):
+                raise Exception(f"Error from Paytm API: {response.get('message', 'Unknown error')}")
+            
+            
+            # Return quote data
+            quote = response.get('data', [])[0] if response.get('data') else {}
+            if not quote:
+                raise Exception("No quote data found")
+            
+            depth = quote.get('depth', {})
+            
+            # Format asks and bids data
+            asks = []
+            bids = []
+            
+            # Process sell orders (asks)
+            sell_orders = depth.get('sell', [])
+            for i in range(5):
+                if i < len(sell_orders):
+                    asks.append({
+                        'price': sell_orders[i].get('price', 0),
+                        'quantity': sell_orders[i].get('quantity', 0)
+                    })
+                else:
+                    asks.append({'price': 0, 'quantity': 0})
+                    
+            # Process buy orders (bids)
+            buy_orders = depth.get('buy', [])
+            for i in range(5):
+                if i < len(buy_orders):
+                    bids.append({
+                        'price': buy_orders[i].get('price', 0),
+                        'quantity': buy_orders[i].get('quantity', 0)
+                    })
+                else:
+                    bids.append({'price': 0, 'quantity': 0})
+            
+            # Return market depth data
+            return {
+                'asks': asks,
+                'bids': bids,
+                'high': quote.get('ohlc', {}).get('high', 0),
+                'low': quote.get('ohlc', {}).get('low', 0),
+                'ltp': quote.get('last_price', 0),
+                'ltq': quote.get('last_quantity', 0),
+                'oi': quote.get('oi', 0),
+                'open': quote.get('ohlc', {}).get('open', 0),
+                'prev_close': quote.get('ohlc', {}).get('close', 0),
+                'totalbuyqty': sum(order.get('quantity', 0) for order in buy_orders),
+                'totalsellqty': sum(order.get('quantity', 0) for order in sell_orders),
+                'volume': quote.get('volume', 0)
+            }
+            
+        except Exception as e:
+            logger.error(f"Error fetching market depth: {str(e)}")
+            raise Exception(f"Error fetching market depth: {str(e)}")
+
+    def get_depth(self, symbol: str, exchange: str) -> dict:
+        """Alias for get_market_depth to maintain compatibility with common API"""
+        return self.get_market_depth(symbol, exchange)
+
+    def get_history(self, symbol: str, exchange: str, timeframe: str, from_date: str, to_date: str) -> pd.DataFrame:
+        """
+        Get historical data for given symbol and timeframe
+        Args:
+            symbol: Trading symbol
+            exchange: Exchange (e.g., NSE, BSE)
+            timeframe: Timeframe (e.g., 1m, 5m, 15m, 60m, D)
+            from_date: Start date in format YYYY-MM-DD
+            to_date: End date in format YYYY-MM-DD
+        Returns:
+            pd.DataFrame: Historical data with OHLCV
+        """
+        raise NotImplementedError("Paytm does not support historical data API")

--- a/broker/paytm/api/funds.py
+++ b/broker/paytm/api/funds.py
@@ -1,0 +1,67 @@
+# api/funds.py
+
+import os
+import http.client
+import json
+from broker.paytm.api.order_api import get_positions
+
+def get_margin_data(auth_token):
+    print(auth_token)
+    """Fetch margin data from Paytm API using the provided auth token."""
+    #api_key = os.getenv('BROKER_API_KEY')
+    conn = http.client.HTTPSConnection("developer.paytmmoney.com")
+    headers = {
+        'x-jwt-token': auth_token,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    request_path = "/accounts/v1/funds/summary?config=true"
+    print(f"Making request to: https://{conn.host}{request_path}")
+    conn.request("GET", request_path, '', headers)
+ 
+
+    res = conn.getresponse()
+    data = res.read()
+    margin_data = json.loads(data.decode("utf-8"))
+
+    print(f"Funds Details: {margin_data}")
+
+
+    if margin_data.get('status') == 'error':
+        # Log the error or return an empty dictionary to indicate failure
+        print(f"Error fetching margin data: {margin_data.get('errors')}")
+        return {}
+
+    try:
+
+        position_book = get_positions(auth_token)
+
+        print(f'Positionbook : {position_book}')
+
+        #position_book = map_position_data(position_book)
+
+        def sum_realised_unrealised(position_book):
+            total_realised = 0
+            total_unrealised = 0
+            if isinstance(position_book.get('data', []), list):
+                for position in position_book['data']:
+                    total_realised += float(position.get('realised_profit', 0))
+                    # Since all positions are closed, unrealized profit is 0
+                    total_unrealised += float(position.get('unrealised_profit', 0))
+            return total_realised, total_unrealised
+
+        total_realised, total_unrealised = sum_realised_unrealised(position_book)
+        
+        # Construct and return the processed margin data
+        processed_margin_data = {
+            "availablecash": "{:.2f}".format(margin_data.get('data', {}).get('funds_summary', {}).get('available_cash', 0)),
+            "collateral": "{:.2f}".format(margin_data.get('data', {}).get('funds_summary', {}).get('collaterals', 0)),
+            "m2munrealized": "{:.2f}".format(total_unrealised),
+            "m2mrealized": "{:.2f}".format(total_realised),
+            "utiliseddebits": "{:.2f}".format(margin_data.get('data', {}).get('funds_summary', {}).get('utilised_amount', 0)),
+        }
+        return processed_margin_data
+    except KeyError:
+        # Return an empty dictionary in case of unexpected data structure
+        return {}

--- a/broker/paytm/api/order_api.py
+++ b/broker/paytm/api/order_api.py
@@ -4,12 +4,11 @@ import os
 import urllib.parse
 from database.auth_db import get_auth_token
 from database.token_db import get_br_symbol, get_oa_symbol
-from broker.paytm.mapping.transform_data import transform_data , map_product_type, reverse_map_product_type, transform_modify_order_data
-
+from broker.paytm.mapping.transform_data import transform_data, map_product_type, reverse_map_product_type, transform_modify_order_data
 
 
 def get_api_response(endpoint, auth, method="GET", payload=''):
-    
+
     AUTH_TOKEN = auth
     conn = http.client.HTTPSConnection("developer.paytmmoney.com")
     headers = {
@@ -23,28 +22,33 @@ def get_api_response(endpoint, auth, method="GET", payload=''):
     data = res.read()
     return json.loads(data.decode("utf-8"))
 
-def get_order_book(auth):
-    return get_api_response("/orders/v1/user/orders",auth)
 
-#PAYTM does not provide all tradebook details. every tradebook call needs orderID
+def get_order_book(auth):
+    return get_api_response("/orders/v1/user/orders", auth)
+
+# PAYTM does not provide all tradebook details. every tradebook call needs orderID
+
+
 def get_trade_book(auth):
-    return get_api_response("/orders/v1/user/orders",auth)
+    return get_api_response("/orders/v1/user/orders", auth)
+
 
 def get_positions(auth):
-    return get_api_response("/orders/v1/position",auth)
+    return get_api_response("/orders/v1/position", auth)
+
 
 def get_holdings(auth):
-    return get_api_response("/holdings/v1/get-user-holdings-data",auth)
+    return get_api_response("/holdings/v1/get-user-holdings-data", auth)
 
-def get_open_position(tradingsymbol, exchange, product,auth):
 
-    #Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
-    tradingsymbol = get_br_symbol(tradingsymbol,exchange)
-    
+def get_open_position(tradingsymbol, exchange, product, auth):
+
+    # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
+    tradingsymbol = get_br_symbol(tradingsymbol, exchange)
 
     positions_data = get_positions(auth)
     net_qty = '0'
-    #print(positions_data['data']['net'])
+    # print(positions_data['data']['net'])
 
     if positions_data and positions_data.get('status') and positions_data.get('data'):
         for position in positions_data['data']['net']:
@@ -55,8 +59,9 @@ def get_open_position(tradingsymbol, exchange, product,auth):
 
     return net_qty
 
-def place_order_api(data,auth):
-    
+
+def place_order_api(data, auth):
+
     AUTH_TOKEN = auth
     conn = http.client.HTTPSConnection("developer.paytmmoney.com")
     headers = {
@@ -64,18 +69,17 @@ def place_order_api(data,auth):
         'Content-Type': 'application/json',
         'Accept': 'application/json',
     }
-    
-    payload = transform_data(data)  
+
+    payload = transform_data(data)
 
     payload = json.dumps(payload)
 
-    #payload =  urllib.parse.urlencode(payload)
+    # payload =  urllib.parse.urlencode(payload)
     print(payload)
 
     conn.request("POST", "/orders/v1/place/regular", payload, headers)
     res = conn.getresponse()
     response_data = json.loads(res.read().decode("utf-8"))
-
 
     print(response_data)
 
@@ -86,13 +90,13 @@ def place_order_api(data,auth):
     return res, response_data, orderid
 
 
-def close_all_positions(current_api_key,auth):
+def close_all_positions(current_api_key, auth):
 
     AUTH_TOKEN = auth
     # Fetch the current open positions
     positions_response = get_positions(AUTH_TOKEN)
 
-    #print(positions_response)
+    # print(positions_response)
     # Check if the positions data is null or empty
     if positions_response['data'] is None or not positions_response['data']:
         return {"message": "No Open Positions Found"}, 200
@@ -108,8 +112,9 @@ def close_all_positions(current_api_key,auth):
             action = 'SELL' if int(position['quantity']) > 0 else 'BUY'
             quantity = abs(int(position['quantity']))
 
-            #Get OA Symbol before sending to Place Order
-            symbol = get_oa_symbol(position['tradingsymbol'],position['exchange'])
+            # Get OA Symbol before sending to Place Order
+            symbol = get_oa_symbol(
+                position['tradingsymbol'], position['exchange'])
             # Prepare the order payload
             place_order_payload = {
                 "apikey": current_api_key,
@@ -118,65 +123,76 @@ def close_all_positions(current_api_key,auth):
                 "action": action,
                 "exchange": position['exchange'],
                 "pricetype": "MARKET",
-                "product": reverse_map_product_type(position['exchange'],position['product']),
+                "product": reverse_map_product_type(position['exchange'], position['product']),
                 "quantity": str(quantity)
             }
 
             print(place_order_payload)
 
             # Place the order to close the position
-            _, api_response, _ =   place_order_api(place_order_payload,AUTH_TOKEN)
+            _, api_response, _ = place_order_api(
+                place_order_payload, AUTH_TOKEN)
 
             print(api_response)
-            
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
     return {'status': 'success', "message": "All Open Positions SquaredOff"}, 200
 
 
-def cancel_order(orderid,auth):
-    # Assuming you have a function to get the authentication token
+def cancel_order(orderid, auth):
+
     AUTH_TOKEN = auth
-    
-    # Set up the request headers
+    conn = http.client.HTTPSConnection("developer.paytmmoney.com")
     headers = {
-        'X-Kite-Version': '3',
-        'Authorization': f'token {AUTH_TOKEN}',
+        'x-jwt-token': AUTH_TOKEN,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
     }
-    
-    # Prepare the payload
-    payload = ''
-    
-    # Establish the connection and send the request
-    conn = http.client.HTTPSConnection("api.kite.trade")  # Adjust the URL as necessary
-    conn.request("DELETE", f"/orders/regular/{orderid}", payload, headers)
-    res = conn.getresponse()
-    data = json.loads(res.read().decode("utf-8"))
-    print(data)
-    
-    # Check if the request was successful
-    if data.get("status"):
-        # Return a success response
-        return {"status": "success", "orderid": data['data']['order_id']}, 200
-    else:
-        # Return an error response
-        return {"status": "error", "message": data.get("message", "Failed to cancel order")}, res.status
+    orders_list = get_order_book(AUTH_TOKEN)
+    for order in orders_list['data']:
+        if order['order_no'] == orderid:
+            if order['status'] == 'Pending':
+                print("Cancelling order:", orderid)
+                payload = json.dumps({"order_no": orderid, "source": "N",
+                                      "txn_type": order['txn_type'],
+                                      "exchange": order['exchange'],
+                                      "segment": order['segment'],
+                                      "product": order['product'],
+                                      "security_id": order['security_id'],
+                                      "quantity": order['quantity'],
+                                      "validity": order['validity'],
+                                      "order_type": order['order_type'],
+                                      "price": order['price'],
+                                      "off_mkt_flag": order['off_mkt_flag'],
+                                      "mkt_type": order['mkt_type'],
+                                      "serial_no": order['serial_no'],
+                                      "group_id": order['group_id'],
+                                      })
+                conn.request("POST", "/orders/v1/cancel/regular",
+                             payload, headers)
+                res = conn.getresponse()
+                response_data = json.loads(res.read().decode("utf-8"))
+                if response_data.get("status"):
+                    # Return a success response
+                    return {"status": "success", "orderid": response_data['data'][0]['order_no']}, 200
+                else:
+                    # Return an error response
+                    return {"status": "error", "message": response_data.get("message", "Failed to cancel order")}, res.status
 
 
-def modify_order(data,auth):
-
-    
+def modify_order(data, auth):
 
     AUTH_TOKEN = auth
-    
-    newdata = transform_modify_order_data(data)  # You need to implement this function
-    
-  
+
+    # You need to implement this function
+    newdata = transform_modify_order_data(data)
+
     # Set up the request headers
     headers = {
         'X-Kite-Version': '3',
         'Authorization': f'token {AUTH_TOKEN}',
-        'Content-Type': 'application/x-www-form-urlencoded' 
+        'Content-Type': 'application/x-www-form-urlencoded'
     }
     payload = {
         'order_type': newdata['order_type'],
@@ -185,11 +201,11 @@ def modify_order(data,auth):
         'trigger_price': newdata['trigger_price'],
         'disclosed_quantity': newdata['disclosed_quantity'],
         'validity': newdata['validity']
-      }
+    }
 
     print(payload)
 
-    payload =  urllib.parse.urlencode(payload)
+    payload = urllib.parse.urlencode(payload)
 
     conn = http.client.HTTPSConnection("api.kite.trade")
     conn.request("PUT", f"/orders/regular/{data['orderid']}", payload, headers)
@@ -201,32 +217,31 @@ def modify_order(data,auth):
         return {"status": "success", "orderid": data["data"]["order_id"]}, 200
     else:
         return {"status": "error", "message": data.get("message", "Failed to modify order")}, res.status
-    
 
-def cancel_all_orders_api(data,auth):
+
+def cancel_all_orders_api(data, auth):
 
     AUTH_TOKEN = auth
     # Get the order book
     order_book_response = get_order_book(AUTH_TOKEN)
-    #print(order_book_response)
+    # print(order_book_response)
     if order_book_response['status'] != 'success':
         return [], []  # Return empty lists indicating failure to retrieve the order book
 
     # Filter orders that are in 'open' or 'trigger_pending' state
     orders_to_cancel = [order for order in order_book_response.get('data', [])
-                        if order['status'] in ['OPEN', 'TRIGGER PENDING']]
+                        if order['status'] in ['Pending']]
     print(orders_to_cancel)
     canceled_orders = []
     failed_cancellations = []
 
     # Cancel the filtered orders
     for order in orders_to_cancel:
-        orderid = order['order_id']
-        cancel_response, status_code = cancel_order(orderid,AUTH_TOKEN)
+        orderid = order['order_no']
+        cancel_response, status_code = cancel_order(orderid, AUTH_TOKEN)
         if status_code == 200:
             canceled_orders.append(orderid)
         else:
             failed_cancellations.append(orderid)
-    
-    return canceled_orders, failed_cancellations
 
+    return canceled_orders, failed_cancellations

--- a/broker/paytm/api/order_api.py
+++ b/broker/paytm/api/order_api.py
@@ -79,7 +79,7 @@ def place_order_api(data,auth):
     print(response_data)
 
     if response_data['status'] == 'success':
-        orderid = response_data['data']['order_id']
+        orderid = response_data['data'][0]['order_no']
     else:
         orderid = None
     return res, response_data, orderid

--- a/broker/paytm/api/order_api.py
+++ b/broker/paytm/api/order_api.py
@@ -1,0 +1,317 @@
+import http.client
+import json
+import os
+import urllib.parse
+from database.auth_db import get_auth_token
+from database.token_db import get_br_symbol, get_oa_symbol
+from broker.paytm.mapping.transform_data import transform_data , map_product_type, reverse_map_product_type, transform_modify_order_data
+
+
+
+def get_api_response(endpoint, auth, method="GET", payload=''):
+    
+    AUTH_TOKEN = auth
+    conn = http.client.HTTPSConnection("developer.paytmmoney.com")
+    headers = {
+        'x-jwt-token': AUTH_TOKEN,
+        'Content-Type': 'application/json',
+        'Accept': 'application/json',
+    }
+
+    conn.request(method, endpoint, payload, headers)
+    res = conn.getresponse()
+    data = res.read()
+    return json.loads(data.decode("utf-8"))
+
+def get_order_book(auth):
+    return get_api_response("/orders/v1/user/orders",auth)
+
+def get_trade_book(auth):
+    return get_api_response("/orders/v1/trade-details",auth)
+
+def get_positions(auth):
+    return get_api_response("/orders/v1/position",auth)
+
+def get_holdings(auth):
+    return get_api_response("/holdings/v1/get-user-holdings-data",auth)
+
+def get_open_position(tradingsymbol, exchange, product,auth):
+
+    #Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
+    tradingsymbol = get_br_symbol(tradingsymbol,exchange)
+    
+
+    positions_data = get_positions(auth)
+    net_qty = '0'
+    #print(positions_data['data']['net'])
+
+    if positions_data and positions_data.get('status') and positions_data.get('data'):
+        for position in positions_data['data']['net']:
+            if position.get('tradingsymbol') == tradingsymbol and position.get('exchange') == exchange and position.get('product') == product:
+                net_qty = position.get('quantity', '0')
+                print(f'Net Quantity {net_qty}')
+                break  # Assuming you need the first match
+
+    return net_qty
+
+def place_order_api(data,auth):
+    
+    AUTH_TOKEN = auth
+    
+    BROKER_API_KEY = os.getenv('BROKER_API_KEY')
+    data['apikey'] = BROKER_API_KEY
+    #token = get_token(data['symbol'], data['exchange'])
+    newdata = transform_data(data)  
+    headers = {
+        'X-Kite-Version': '3',
+        'Authorization': f'token {AUTH_TOKEN}',
+        'Content-Type': 'application/x-www-form-urlencoded' 
+    }
+
+    payload = {
+        'tradingsymbol': newdata['tradingsymbol'],
+        'exchange': newdata['exchange'],
+        'transaction_type': newdata['transaction_type'],
+        'order_type': newdata['order_type'],
+        'quantity': newdata['quantity'],
+        'product': newdata['product'],
+        'price': newdata['price'],
+        'trigger_price': newdata['trigger_price'],
+        'disclosed_quantity': newdata['disclosed_quantity'],
+        'validity': newdata['validity'],
+        'tag' : newdata['tag']
+    }
+
+    print(payload)
+
+    payload =  urllib.parse.urlencode(payload)
+
+    conn = http.client.HTTPSConnection("api.kite.trade")
+    conn.request("POST", "/orders/regular", payload, headers)
+    res = conn.getresponse()
+    response_data = json.loads(res.read().decode("utf-8"))
+
+
+    print(response_data)
+
+    if response_data['status'] == 'success':
+        orderid = response_data['data']['order_id']
+    else:
+        orderid = None
+    return res, response_data, orderid
+
+def place_smartorder_api(data,auth):
+
+    AUTH_TOKEN = auth
+
+    #If no API call is made in this function then res will return None
+    res = None
+
+    # Extract necessary info from data
+    symbol = data.get("symbol")
+    exchange = data.get("exchange")
+    product = data.get("product")
+    position_size = int(data.get("position_size", "0"))
+
+    
+
+    # Get current open position for the symbol
+    current_position = int(get_open_position(symbol, exchange, map_product_type(product),AUTH_TOKEN))
+
+
+    print(f"position_size : {position_size}") 
+    print(f"Open Position : {current_position}") 
+    
+    # Determine action based on position_size and current_position
+    action = None
+    quantity = 0
+
+
+    
+
+   
+   
+
+    if position_size == 0 and current_position>0 :
+        action = "SELL"
+        quantity = abs(current_position)
+    elif position_size == 0 and current_position<0 :
+        action = "BUY"
+        quantity = abs(current_position)
+    elif current_position == 0:
+        action = "BUY" if position_size > 0 else "SELL"
+        quantity = abs(position_size)
+    else:
+        if position_size > current_position:
+            action = "BUY"
+            quantity = position_size - current_position
+            #print(f"smart buy quantity : {quantity}")
+        elif position_size < current_position:
+            action = "SELL"
+            quantity = current_position - position_size
+            #print(f"smart sell quantity : {quantity}")
+
+
+
+
+    if action:
+        # Prepare data for placing the order
+        order_data = data.copy()
+        order_data["action"] = action
+        order_data["quantity"] = str(quantity)
+
+        #print(order_data)
+        # Place the order
+        res, response, orderid = place_order_api(order_data,AUTH_TOKEN)
+        #print(res)
+        #print(response)
+        
+        return res , response, orderid
+    
+
+
+
+def close_all_positions(current_api_key,auth):
+
+    AUTH_TOKEN = auth
+    # Fetch the current open positions
+    positions_response = get_positions(AUTH_TOKEN)
+
+    #print(positions_response)
+    # Check if the positions data is null or empty
+    if positions_response['data'] is None or not positions_response['data']:
+        return {"message": "No Open Positions Found"}, 200
+
+    if positions_response['status']:
+        # Loop through each position to close
+        for position in positions_response['data']['net']:
+            # Skip if net quantity is zero
+            if int(position['quantity']) == 0:
+                continue
+
+            # Determine action based on net quantity
+            action = 'SELL' if int(position['quantity']) > 0 else 'BUY'
+            quantity = abs(int(position['quantity']))
+
+            #Get OA Symbol before sending to Place Order
+            symbol = get_oa_symbol(position['tradingsymbol'],position['exchange'])
+            # Prepare the order payload
+            place_order_payload = {
+                "apikey": current_api_key,
+                "strategy": "Squareoff",
+                "symbol": symbol,
+                "action": action,
+                "exchange": position['exchange'],
+                "pricetype": "MARKET",
+                "product": reverse_map_product_type(position['exchange'],position['product']),
+                "quantity": str(quantity)
+            }
+
+            print(place_order_payload)
+
+            # Place the order to close the position
+            _, api_response, _ =   place_order_api(place_order_payload,AUTH_TOKEN)
+
+            print(api_response)
+            
+            # Note: Ensure place_order_api handles any errors and logs accordingly
+
+    return {'status': 'success', "message": "All Open Positions SquaredOff"}, 200
+
+
+def cancel_order(orderid,auth):
+    # Assuming you have a function to get the authentication token
+    AUTH_TOKEN = auth
+    
+    # Set up the request headers
+    headers = {
+        'X-Kite-Version': '3',
+        'Authorization': f'token {AUTH_TOKEN}',
+    }
+    
+    # Prepare the payload
+    payload = ''
+    
+    # Establish the connection and send the request
+    conn = http.client.HTTPSConnection("api.kite.trade")  # Adjust the URL as necessary
+    conn.request("DELETE", f"/orders/regular/{orderid}", payload, headers)
+    res = conn.getresponse()
+    data = json.loads(res.read().decode("utf-8"))
+    print(data)
+    
+    # Check if the request was successful
+    if data.get("status"):
+        # Return a success response
+        return {"status": "success", "orderid": data['data']['order_id']}, 200
+    else:
+        # Return an error response
+        return {"status": "error", "message": data.get("message", "Failed to cancel order")}, res.status
+
+
+def modify_order(data,auth):
+
+    
+
+    AUTH_TOKEN = auth
+    
+    newdata = transform_modify_order_data(data)  # You need to implement this function
+    
+  
+    # Set up the request headers
+    headers = {
+        'X-Kite-Version': '3',
+        'Authorization': f'token {AUTH_TOKEN}',
+        'Content-Type': 'application/x-www-form-urlencoded' 
+    }
+    payload = {
+        'order_type': newdata['order_type'],
+        'quantity': newdata['quantity'],
+        'price': newdata['price'],
+        'trigger_price': newdata['trigger_price'],
+        'disclosed_quantity': newdata['disclosed_quantity'],
+        'validity': newdata['validity']
+      }
+
+    print(payload)
+
+    payload =  urllib.parse.urlencode(payload)
+
+    conn = http.client.HTTPSConnection("api.kite.trade")
+    conn.request("PUT", f"/orders/regular/{data['orderid']}", payload, headers)
+    res = conn.getresponse()
+    data = json.loads(res.read().decode("utf-8"))
+    print(data)
+
+    if data.get("status") == "success" or data.get("message") == "SUCCESS":
+        return {"status": "success", "orderid": data["data"]["order_id"]}, 200
+    else:
+        return {"status": "error", "message": data.get("message", "Failed to modify order")}, res.status
+    
+
+def cancel_all_orders_api(data,auth):
+
+    AUTH_TOKEN = auth
+    # Get the order book
+    order_book_response = get_order_book(AUTH_TOKEN)
+    #print(order_book_response)
+    if order_book_response['status'] != 'success':
+        return [], []  # Return empty lists indicating failure to retrieve the order book
+
+    # Filter orders that are in 'open' or 'trigger_pending' state
+    orders_to_cancel = [order for order in order_book_response.get('data', [])
+                        if order['status'] in ['OPEN', 'TRIGGER PENDING']]
+    print(orders_to_cancel)
+    canceled_orders = []
+    failed_cancellations = []
+
+    # Cancel the filtered orders
+    for order in orders_to_cancel:
+        orderid = order['order_id']
+        cancel_response, status_code = cancel_order(orderid,AUTH_TOKEN)
+        if status_code == 200:
+            canceled_orders.append(orderid)
+        else:
+            failed_cancellations.append(orderid)
+    
+    return canceled_orders, failed_cancellations
+

--- a/broker/paytm/api/order_api.py
+++ b/broker/paytm/api/order_api.py
@@ -26,8 +26,9 @@ def get_api_response(endpoint, auth, method="GET", payload=''):
 def get_order_book(auth):
     return get_api_response("/orders/v1/user/orders",auth)
 
+#PAYTM does not provide all tradebook details. every tradebook call needs orderID
 def get_trade_book(auth):
-    return get_api_response("/orders/v1/trade-details",auth)
+    return get_api_response("/orders/v1/user/orders",auth)
 
 def get_positions(auth):
     return get_api_response("/orders/v1/position",auth)

--- a/broker/paytm/database/master_contract_db.py
+++ b/broker/paytm/database/master_contract_db.py
@@ -138,7 +138,7 @@ def reformat_symbol(row):
     # For futures
     elif instrument_type in ['FUTSTK', 'FUTIDX']:
         # Remove any spaces and standardize format
-        base_symbol = symbol.split(' ')[0].strip()
+        base_symbol = row['name'].split(' ')[0].strip()
         return f"{base_symbol}{expiry}FUT"
     
     # For options

--- a/broker/paytm/database/master_contract_db.py
+++ b/broker/paytm/database/master_contract_db.py
@@ -1,0 +1,278 @@
+#database/master_contract_db.py
+
+import os
+import pandas as pd
+import numpy as np
+import requests
+import pandas as pd
+
+from sqlalchemy import create_engine, Column, Integer, String, Float , Sequence, Index
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.ext.declarative import declarative_base
+from extensions import socketio  # Import SocketIO
+
+
+
+DATABASE_URL = os.getenv('DATABASE_URL')  # Replace with your database path
+
+engine = create_engine(DATABASE_URL)
+db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+class SymToken(Base):
+    __tablename__ = 'symtoken'
+    id = Column(Integer, Sequence('symtoken_id_seq'), primary_key=True)
+    symbol = Column(String, nullable=False, index=True)  # Single column index
+    brsymbol = Column(String, nullable=False, index=True)  # Single column index
+    name = Column(String)
+    exchange = Column(String, index=True)  # Include this column in a composite index
+    brexchange = Column(String, index=True)  
+    token = Column(String, index=True)  # Indexed for performance
+    expiry = Column(String)
+    strike = Column(Float)
+    lotsize = Column(Integer)
+    instrumenttype = Column(String)
+    tick_size = Column(Float)
+
+    # Define a composite index on symbol and exchange columns
+    __table_args__ = (Index('idx_symbol_exchange', 'symbol', 'exchange'),)
+
+def init_db():
+    print("Initializing Master Contract DB")
+    Base.metadata.create_all(bind=engine)
+
+def delete_symtoken_table():
+    print("Deleting Symtoken Table")
+    SymToken.query.delete()
+    db_session.commit()
+
+def copy_from_dataframe(df):
+    print("Performing Bulk Insert")
+    # Convert DataFrame to a list of dictionaries
+    data_dict = df.to_dict(orient='records')
+
+    # Retrieve existing tokens to filter them out from the insert
+    existing_tokens = {result.token for result in db_session.query(SymToken.token).all()}
+
+    # Filter out data_dict entries with tokens that already exist
+    filtered_data_dict = [row for row in data_dict if row['token'] not in existing_tokens]
+
+    # Insert in bulk the filtered records
+    try:
+        if filtered_data_dict:  # Proceed only if there's anything to insert
+            # Pre-validate records before insertion
+            invalid_records = []
+            valid_records = []
+            
+            for record in filtered_data_dict:
+                # Check if symbol exists and is not empty/null
+                symbol = record.get('symbol')
+                if not symbol or pd.isna(symbol) or str(symbol).strip() == '':
+                    invalid_records.append(record)
+                    print(f"Schema validation failed for record: {record}")
+                    print(f"Symbol is missing, empty, or null")
+                else:
+                    valid_records.append(record)
+            
+            if valid_records:
+                db_session.bulk_insert_mappings(SymToken, valid_records)
+                db_session.commit()
+                print(f"Bulk insert completed successfully with {len(valid_records)} new records.")
+                
+            if invalid_records:
+                print(f"Warning: {len(invalid_records)} records failed schema validation and were skipped.")
+        else:
+            print("No new records to insert.")
+    except Exception as e:
+        print(f"Error during bulk insert: {e}")
+        if hasattr(e, '__cause__'):
+            print(f"Caused by: {e.__cause__}")
+        db_session.rollback()
+
+
+
+
+def download_csv_paytm_data(output_path):
+
+    print("Downloading Master Contract CSV Files")
+    # Create output directory if it doesn't exist
+    if not os.path.exists(output_path):
+        os.makedirs(output_path)
+        print(f"Created directory: {output_path}")
+
+    # URLs of the CSV files to be downloaded
+    csv_urls = {
+        "master": "https://developer.paytmmoney.com/data/v1/scrips/security_master.csv"
+    }
+    
+    # Create a list to hold the paths of the downloaded files
+    downloaded_files = []
+
+    # Iterate through the URLs and download the CSV files
+    for key, url in csv_urls.items():
+        # Send GET request
+        response = requests.get(url,timeout=10)
+        # Check if the request was successful
+        if response.status_code == 200:
+            # Construct the full output path for the file
+            file_path = os.path.join(output_path, f"{key}.csv")
+            # Write the content to the file
+            with open(file_path, 'wb') as file:
+                file.write(response.content)
+            downloaded_files.append(file_path)
+        else:
+            print(f"Failed to download {key} from {url}. Status code: {response.status_code}")
+    
+
+def reformat_symbol(row):
+    # Use trading symbol as base instead of name
+    symbol = row['symbol']
+    instrument_type = row['instrument_type']
+    expiry = row['expiry_date'].replace('-', '')
+    
+    # For equity and index instruments, use the symbol as is
+    if instrument_type in ['ES', 'I']:
+        return symbol
+    
+    # For futures
+    elif instrument_type in ['FUTSTK', 'FUTIDX']:
+        # Remove any spaces and standardize format
+        base_symbol = symbol.split(' ')[0].strip()
+        return f"{base_symbol}{expiry}FUT"
+    
+    # For options
+    elif instrument_type in ['OPTIDX', 'OPTSTK']:
+        parts = row['name'].split(' ')
+        base_symbol = parts[0].strip()
+        
+        # Get strike price from the row directly instead of parsing from symbol
+        strike = str(int(float(row['strike_price'])))
+        
+        # Determine option type (CE/PE)
+        option_type = 'CE' if 'CALL' in row['name'].upper() else 'PE' if 'PUT' in row['name'].upper() else parts[-1]
+        
+        return f"{base_symbol}{expiry}{strike}{option_type}"
+    
+    # For any other instrument type, return symbol as is
+    else:
+        return symbol
+
+# Define the function to apply conditions
+def assign_values(row):
+    # Handle equity segment
+    if row['exchange'] == 'NSE' and row['series'] == 'EQ':
+        return 'NSE', 'NSE_EQ', 'EQ'
+    elif row['exchange'] == 'BSE' and row['series'] == 'EQ':
+        return 'BSE', 'BSE_EQ', 'EQ'
+    
+    # Handle indices
+    elif row['exchange'] == 'NSE' and row['instrument_type'] == 'I':
+        return 'NSE_INDEX', 'IDX_I', 'INDEX'
+    elif row['exchange'] == 'BSE' and row['instrument_type'] == 'I':
+        return 'BSE_INDEX', 'IDX_I', 'INDEX'
+    
+    # Handle futures
+    elif row['exchange'] == 'NSE' and row['instrument_type'] in ['FUTIDX', 'FUTSTK']:
+        return 'NFO', 'NSE_FNO', 'FUT'
+    elif row['exchange'] == 'BSE' and row['instrument_type'] in ['FUTIDX', 'FUTSTK']:
+        return 'BFO', 'BSE_FNO', 'FUT'
+    
+    # Handle options
+    elif row['exchange'] == 'NSE' and row['instrument_type'] in ['OPTIDX', 'OPTSTK']:
+        return 'NFO', 'NSE_FNO', 'OPT'
+    elif row['exchange'] == 'BSE' and row['instrument_type'] in ['OPTIDX', 'OPTSTK']:
+        return 'BFO', 'BSE_FNO', 'OPT'
+    
+    # Handle unknown cases
+    else:
+        return 'Unknown', 'Unknown', 'Unknown'
+
+def process_paytm_csv(path):
+    """Processes the Paytm CSV file to fit the existing database schema and performs exchange name mapping."""
+    print("Processing Paytm Scrip Master CSV Data")
+    file_path = os.path.join(path, "master.csv")
+
+    df = pd.read_csv(file_path, low_memory=False)
+    df.columns = df.columns.str.strip()
+
+    # Attempt to convert all date entries to datetime objects, errors are coerced to NaT
+    df['expiry_date'] = pd.to_datetime(df['expiry_date'], errors='coerce')
+
+    # Format all non-NaT datetime objects to the desired format "DD-MMM-YY"
+    df['expiry_date'] = df['expiry_date'].dt.strftime('%d-%b-%y')
+
+    # Handle NaT values by replacing them with '-1'
+    df['expiry_date'] = df['expiry_date'].fillna('-1')
+
+    # Assigning headers to the DataFrame
+    df['token'] = df['security_id']
+    df['name'] = df['name']
+    df['expiry'] = df['expiry_date'].str.upper()
+    df['strike'] = df['strike_price']
+    df['lotsize'] = df['lot_size']
+    df['tick_size'] = df['tick_size']
+    df['brsymbol'] = df['symbol']
+
+    # Apply the function to get exchange mappings
+    df[['exchange', 'brexchange', 'instrumenttype']] = df.apply(assign_values, axis=1, result_type='expand')
+
+    # Generate symbol field and ensure it's not null
+    df['symbol'] = df.apply(reformat_symbol, axis=1)
+    df['symbol'] = df['symbol'].fillna(df['brsymbol'])  # Use brsymbol as fallback if reformat_symbol returns None
+
+    # Remove rows where symbol is still null
+    df = df.dropna(subset=['symbol'])
+
+    # List of columns to remove
+    columns_to_remove = [
+        "security_id", "series", "lot_size",
+        "segment", "upper_limit", "lower_limit", 
+        "expiry_date", "strike_price", "freeze_quantity"
+    ]
+
+    # Removing the specified columns
+    token_df = df.drop(columns=columns_to_remove)
+
+    return token_df
+
+
+    
+
+def delete_paytm_temp_data(output_path):
+    # Check each file in the directory
+    for filename in os.listdir(output_path):
+        # Construct the full file path
+        file_path = os.path.join(output_path, filename)
+        # If the file is a CSV, delete it
+        if filename.endswith(".csv") and os.path.isfile(file_path):
+            os.remove(file_path)
+            print(f"Deleted {file_path}")
+    
+
+def master_contract_download():
+    print("Downloading Master Contract")
+    
+
+    output_path = 'tmp'
+    try:
+        download_csv_paytm_data(output_path)
+        delete_symtoken_table()
+        token_df = process_paytm_csv(output_path)
+        copy_from_dataframe(token_df)
+        delete_paytm_temp_data(output_path)
+        #token_df['token'] = pd.to_numeric(token_df['token'], errors='coerce').fillna(-1).astype(int)
+        
+        #token_df = token_df.drop_duplicates(subset='symbol', keep='first')
+        
+        return socketio.emit('master_contract_download', {'status': 'success', 'message': 'Successfully Downloaded'})
+
+    
+    except Exception as e:
+        print(str(e))
+        return socketio.emit('master_contract_download', {'status': 'error', 'message': str(e)})
+
+
+
+def search_symbols(symbol, exchange):
+    return SymToken.query.filter(SymToken.symbol.like(f'%{symbol}%'), SymToken.exchange == exchange).all()

--- a/broker/paytm/database/master_contract_db.py
+++ b/broker/paytm/database/master_contract_db.py
@@ -138,7 +138,8 @@ def reformat_symbol(row):
     # For futures
     elif instrument_type in ['FUTSTK', 'FUTIDX']:
         # Remove any spaces and standardize format
-        base_symbol = row['name'].split(' ')[0].strip()
+        parts = row['name'].split(' ')
+        base_symbol = parts[0].strip()
         return f"{base_symbol}{expiry}FUT"
     
     # For options
@@ -160,29 +161,30 @@ def reformat_symbol(row):
 
 # Define the function to apply conditions
 def assign_values(row):
+    #Paytm Exchange Mappings are simply NSE and BSE. No other complications
     # Handle equity segment
-    if row['exchange'] == 'NSE' and row['series'] == 'EQ':
-        return 'NSE', 'NSE_EQ', 'EQ'
-    elif row['exchange'] == 'BSE' and row['series'] == 'EQ':
-        return 'BSE', 'BSE_EQ', 'EQ'
+    if row['exchange'] == 'NSE' and (row['instrument_type'] == 'ETF' or row['instrument_type'] == 'ES'):
+        return 'NSE', 'NSE', 'EQ'
+    elif row['exchange'] == 'BSE' and (row['instrument_type'] == 'ETF' or row['instrument_type'] == 'ES'):
+        return 'BSE', 'BSE', 'EQ'
     
     # Handle indices
     elif row['exchange'] == 'NSE' and row['instrument_type'] == 'I':
-        return 'NSE_INDEX', 'IDX_I', 'INDEX'
+        return 'NSE_INDEX', 'NSE', 'INDEX'
     elif row['exchange'] == 'BSE' and row['instrument_type'] == 'I':
-        return 'BSE_INDEX', 'IDX_I', 'INDEX'
+        return 'BSE_INDEX', 'BSE', 'INDEX'
     
     # Handle futures
     elif row['exchange'] == 'NSE' and row['instrument_type'] in ['FUTIDX', 'FUTSTK']:
-        return 'NFO', 'NSE_FNO', 'FUT'
+        return 'NFO', 'NSE', 'FUT'
     elif row['exchange'] == 'BSE' and row['instrument_type'] in ['FUTIDX', 'FUTSTK']:
-        return 'BFO', 'BSE_FNO', 'FUT'
+        return 'BFO', 'BSE', 'FUT'
     
     # Handle options
     elif row['exchange'] == 'NSE' and row['instrument_type'] in ['OPTIDX', 'OPTSTK']:
-        return 'NFO', 'NSE_FNO', 'OPT'
+        return 'NFO', 'NSE', 'OPT'
     elif row['exchange'] == 'BSE' and row['instrument_type'] in ['OPTIDX', 'OPTSTK']:
-        return 'BFO', 'BSE_FNO', 'OPT'
+        return 'BFO', 'BSE', 'OPT'
     
     # Handle unknown cases
     else:

--- a/broker/paytm/mapping/order_data.py
+++ b/broker/paytm/mapping/order_data.py
@@ -1,0 +1,272 @@
+import json
+from database.token_db import get_symbol , get_oa_symbol
+
+def map_order_data(order_data):
+    """
+    Processes and modifies a list of order dictionaries based on specific conditions.
+    
+    Parameters:
+    - order_data: A list of dictionaries, where each dictionary represents an order.
+    
+    Returns:
+    - The modified order_data with updated 'tradingsymbol' and 'product' fields.
+    """
+        # Check if 'data' is None
+    if order_data['data'] is None:
+        # Handle the case where there is no data
+        # For example, you might want to display a message to the user
+        # or pass an empty list or dictionary to the template.
+        print("No data available.")
+        order_data = {}  # or set it to an empty list if it's supposed to be a list
+    else:
+        order_data = order_data['data']
+        
+    #print(order_data)
+
+    if order_data:
+        for order in order_data:
+            # Extract the instrument_token and exchange for the current order
+            exchange = order['exchange']
+            symbol = order['tradingsymbol']
+       
+            
+            # Check if a symbol was found; if so, update the trading_symbol in the current order
+            if symbol:
+                order['tradingsymbol'] = get_oa_symbol(symbol=symbol,exchange=exchange)
+            else:
+                print(f"{symbol} and exchange {exchange} not found. Keeping original trading symbol.")
+                
+    return order_data
+
+
+def calculate_order_statistics(order_data):
+    """
+    Calculates statistics from order data, including totals for buy orders, sell orders,
+    completed orders, open orders, and rejected orders.
+
+    Parameters:
+    - order_data: A list of dictionaries, where each dictionary represents an order.
+
+    Returns:
+    - A dictionary containing counts of different types of orders.
+    """
+    # Initialize counters
+    total_buy_orders = total_sell_orders = 0
+    total_completed_orders = total_open_orders = total_rejected_orders = 0
+
+    if order_data:
+        for order in order_data:
+            # Count buy and sell orders
+            if order['transaction_type'] == 'BUY':
+                total_buy_orders += 1
+            elif order['transaction_type'] == 'SELL':
+                total_sell_orders += 1
+            
+            # Count orders based on their status
+            if order['status'] == 'COMPLETE':
+                total_completed_orders += 1
+            elif order['status'] == 'OPEN':
+                total_open_orders += 1
+            elif order['status'] == 'REJECTED':
+                total_rejected_orders += 1
+
+    # Compile and return the statistics
+    return {
+        'total_buy_orders': total_buy_orders,
+        'total_sell_orders': total_sell_orders,
+        'total_completed_orders': total_completed_orders,
+        'total_open_orders': total_open_orders,
+        'total_rejected_orders': total_rejected_orders
+    }
+
+
+def transform_order_data(orders):
+    # Directly handling a dictionary assuming it's the structure we expect
+    if isinstance(orders, dict):
+        # Convert the single dictionary into a list of one dictionary
+        orders = [orders]
+
+    transformed_orders = []
+    
+    for order in orders:
+        # Make sure each item is indeed a dictionary
+        if not isinstance(order, dict):
+            print(f"Warning: Expected a dict, but found a {type(order)}. Skipping this item.")
+            continue
+
+        if(order.get("status", "")=="COMPLETE"):
+            order_status = "complete"
+        if(order.get("status", "")=="REJECTED"):
+            order_status = "rejected"
+        if(order.get("status", "")=="TRIGGER PENDING"):
+            order_status = "trigger pending"
+        if(order.get("status", "")=="OPEN"):
+            order_status = "open"
+        if(order.get("status", "")=="CANCELLED"):
+            order_status = "cancelled"
+
+        transformed_order = {
+            "symbol": order.get("tradingsymbol", ""),
+            "exchange": order.get("exchange", ""),
+            "action": order.get("transaction_type", ""),
+            "quantity": order.get("quantity", 0),
+            "price": order.get("price", 0.0),
+            "trigger_price": order.get("trigger_price", 0.0),
+            "pricetype": order.get("order_type", ""),
+            "product": order.get("product", ""),
+            "orderid": order.get("order_id", ""),
+            "order_status": order_status,
+            "timestamp": order.get("order_timestamp", "")
+        }
+
+        transformed_orders.append(transformed_order)
+
+    return transformed_orders
+
+def map_trade_data(trade_data):
+    return map_order_data(trade_data)
+
+def transform_tradebook_data(tradebook_data):
+    transformed_data = []
+    for trade in tradebook_data:
+     
+        transformed_trade = {
+            "symbol": trade.get('tradingsymbol'),
+            "exchange": trade.get('exchange', ''),
+            "product": trade.get('product', ''),
+            "action": trade.get('transaction_type', ''),
+            "quantity": trade.get('quantity', 0),
+            "average_price": trade.get('average_price', 0.0),
+            "trade_value": trade.get('quantity', 0) * trade.get('average_price', 0.0),
+            "orderid": trade.get('order_id', ''),
+            "timestamp": trade.get('order_timestamp', '')
+        }
+        transformed_data.append(transformed_trade)
+    return transformed_data
+
+def map_position_data(position_data):
+    """
+    Processes and modifies a list of OpenPosition dictionaries based on specific conditions.
+    
+    Parameters:
+    - position_data: A list of dictionaries, where each dictionary represents an Open Position.
+    
+    Returns:
+    - The modified order_data with updated 'tradingsymbol'
+    """
+        # Check if 'data' is None
+    if position_data['data'] is None:
+        # Handle the case where there is no data
+        # For example, you might want to display a message to the user
+        # or pass an empty list or dictionary to the template.
+        print("No data available.")
+        position_data = {}  # or set it to an empty list if it's supposed to be a list
+    else:
+        position_data = position_data['data']
+        
+    #print(order_data)
+
+    if position_data:
+        for position in position_data:
+            # Extract the instrument_token and exchange for the current order
+            print(position)
+            exchange = position['exchange']
+            symbol = position['security_id']
+            
+            if exchange == "NSE" and ("OPT" in position['instrument'] or "FUT" in position['instrument']):
+                exchange = "NFO"
+
+            if exchange == "BSE" and ("OPT" in position['instrument'] or "FUT" in position['instrument']):
+                exchange = "BFO"
+            
+            # Check if a symbol was found; if so, update the trading_symbol in the current order
+            if symbol:
+                position['security_id'] = get_symbol(token=symbol,exchange=exchange)
+            else:
+                print(f"{symbol} and exchange {exchange} not found. Keeping original trading symbol.")
+                
+    return position_data
+    
+
+def transform_positions_data(positions_data):
+    transformed_data = [] 
+
+    for position in positions_data:
+        # Ensure average_price is treated as a float, then format to a string with 2 decimal places
+        average_price_formatted = "{:.2f}".format(float(position.get('average_price', 0.0)))
+
+        transformed_position = {
+            "symbol": position.get('tradingsymbol', ''),
+            "exchange": position.get('exchange', ''),
+            "product": position.get('product', ''),
+            "quantity": position.get('quantity', '0'),
+            "average_price": average_price_formatted,
+        }
+        transformed_data.append(transformed_position)
+    return transformed_data
+
+def transform_holdings_data(holdings_data):
+    transformed_data = []
+    for holdings in holdings_data:
+        transformed_position = {
+            "symbol": holdings.get('tradingsymbol', ''),
+            "exchange": holdings.get('exchange', ''),
+            "quantity": holdings.get('quantity', 0),
+            "product": holdings.get('product', ''),
+            "pnl": round(holdings.get('pnl', 0.0), 2),  # Rounded to two decimals
+            "pnlpercent": round((holdings.get('last_price', 0) - holdings.get('average_price', 0.0)) / holdings.get('average_price', 0.0) * 100, 2)  # Rounded to two decimals
+        
+        }
+        transformed_data.append(transformed_position)
+    return transformed_data
+
+    
+def map_portfolio_data(portfolio_data):
+    """
+    Processes and modifies a list of Portfolio dictionaries based on specific conditions.
+    
+    Parameters:
+    - portfolio_data: A list of dictionaries, where each dictionary represents an portfolio information.
+    
+    Returns:
+    - The modified portfolio_data with  'product' fields.
+    """
+        # Check if 'data' is None
+    if portfolio_data['data'] is None:
+        # Handle the case where there is no data
+        # For example, you might want to display a message to the user
+        # or pass an empty list or dictionary to the template.
+        print("No data available.")
+        portfolio_data = {}  # or set it to an empty list if it's supposed to be a list
+    else:
+        portfolio_data = portfolio_data['data']
+        
+
+
+    if portfolio_data:
+        for portfolio in portfolio_data:
+            if portfolio['product'] == 'CNC':
+                portfolio['product'] = 'CNC'
+
+            else:
+                print(f"Zerodha Portfolio - Product Value for Delivery Not Found or Changed.")
+                
+    return portfolio_data
+
+
+def calculate_portfolio_statistics(holdings_data):
+    totalholdingvalue = sum(item['last_price'] * item['quantity'] for item in holdings_data)
+    totalinvvalue = sum(item['average_price'] * item['quantity'] for item in holdings_data)
+    totalprofitandloss = sum(item['pnl'] for item in holdings_data)
+    
+    # To avoid division by zero in the case when total_investment_value is 0
+    totalpnlpercentage = (totalprofitandloss / totalinvvalue * 100) if totalinvvalue else 0
+
+    return {
+        'totalholdingvalue': totalholdingvalue,
+        'totalinvvalue': totalinvvalue,
+        'totalprofitandloss': totalprofitandloss,
+        'totalpnlpercentage': totalpnlpercentage
+    }
+
+

--- a/broker/paytm/mapping/transform_data.py
+++ b/broker/paytm/mapping/transform_data.py
@@ -1,0 +1,82 @@
+#Mapping OpenAlgo API Request https://openalgo.in/docs
+#Mapping Paytm Broking Parameters https://developer.paytmmoney.com/docs/api/login
+
+from database.token_db import get_br_symbol
+
+def transform_data(data):
+    """
+    Transforms the new API request structure to the current expected structure.
+    """
+    symbol = get_br_symbol(data['symbol'],data['exchange'])
+
+    # Basic mapping
+    transformed = {
+        "tradingsymbol" : symbol,
+        "exchange" : data['exchange'],
+        "transaction_type": data['action'].upper(),
+        "order_type": data["pricetype"],
+        "quantity": data["quantity"],
+        "product": data["product"],
+        "price": data.get("price", "0"),
+        "trigger_price": data.get("trigger_price", "0"),
+        "disclosed_quantity": data.get("disclosed_quantity", "0"),  
+        "validity":"DAY",
+        "tag": "openalgo",
+    }
+
+
+    # Extended mapping for fields that might need conditional logic or additional processing
+    transformed["disclosed_quantity"] = data.get("disclosed_quantity", "0")
+    transformed["trigger_price"] = data.get("trigger_price", "0")
+    
+    return transformed
+
+
+def transform_modify_order_data(data):
+    return {
+        "order_type": map_order_type(data["pricetype"]),
+        "quantity": data["quantity"],
+        "price": data["price"],
+        "trigger_price": data.get("trigger_price", "0"),
+        "disclosed_quantity": data.get("disclosed_quantity", "0"),
+        "validity": "DAY"      
+    }
+
+
+
+def map_order_type(pricetype):
+    """
+    Maps the new pricetype to the existing order type.
+    """
+    order_type_mapping = {
+        "MARKET": "MARKET",
+        "LIMIT": "LIMIT",
+        "SL": "SL",
+        "SL-M": "SL-M"
+    }
+    return order_type_mapping.get(pricetype, "MARKET")  # Default to MARKET if not found
+
+def map_product_type(product):
+    """
+    Maps the new product type to the existing product type.
+    """
+    product_type_mapping = {
+        "CNC": "CNC",
+        "NRML": "NRML",
+        "MIS": "MIS",
+    }
+    return product_type_mapping.get(product, "MIS")  # Default to INTRADAY if not found
+
+def reverse_map_product_type(exchange,product):
+    """
+    Reverse maps the broker product type to the OpenAlgo product type, considering the exchange.
+    """
+    # Exchange to OpenAlgo product type mapping for 'D'
+    exchange_mapping = {
+        "CNC": "CNC",
+        "NRML": "NRML",
+        "MIS": "MIS",
+    }
+   
+    return exchange_mapping.get(product)
+    

--- a/broker/paytm/mapping/transform_data.py
+++ b/broker/paytm/mapping/transform_data.py
@@ -5,21 +5,21 @@ from database.token_db import get_br_symbol
 
 def transform_data(data):
     """
-    Transforms the new API request structure to the current expected structure.
+    Transforms the OpenAlgo API request structure to Paytm v2 API structure.
     """
     symbol = get_br_symbol(data['symbol'],data['exchange'])
 
     # Basic mapping
     transformed = {
-        "tradingsymbol" : symbol,
+        "security_id" : symbol,
         "exchange" : data['exchange'],
-        "transaction_type": data['action'].upper(),
+        "txn_type": data['action'].upper(),
         "order_type": data["pricetype"],
         "quantity": data["quantity"],
         "product": data["product"],
         "price": data.get("price", "0"),
         "trigger_price": data.get("trigger_price", "0"),
-        "disclosed_quantity": data.get("disclosed_quantity", "0"),  
+        #"disclosed_quantity": data.get("disclosed_quantity", "0"),  
         "validity":"DAY",
         "tag": "openalgo",
     }
@@ -49,10 +49,10 @@ def map_order_type(pricetype):
     Maps the new pricetype to the existing order type.
     """
     order_type_mapping = {
-        "MARKET": "MARKET",
-        "LIMIT": "LIMIT",
-        "SL": "SL",
-        "SL-M": "SL-M"
+        "MKT": "MARKET",
+        "LMT": "LIMIT",
+        "SL": "STOP_LOSS",
+        "SLM": "STOP_LOSS_MARKET"
     }
     return order_type_mapping.get(pricetype, "MARKET")  # Default to MARKET if not found
 
@@ -61,9 +61,9 @@ def map_product_type(product):
     Maps the new product type to the existing product type.
     """
     product_type_mapping = {
-        "CNC": "CNC",
-        "NRML": "NRML",
-        "MIS": "MIS",
+        "C": "CNC",
+        "M": "MARGIN",
+        "I": "MIS",
     }
     return product_type_mapping.get(product, "MIS")  # Default to INTRADAY if not found
 
@@ -73,9 +73,9 @@ def reverse_map_product_type(exchange,product):
     """
     # Exchange to OpenAlgo product type mapping for 'D'
     exchange_mapping = {
-        "CNC": "CNC",
-        "NRML": "NRML",
-        "MIS": "MIS",
+        "CNC": "C",
+        "MARGIN": "M",
+        "MIS": "I"
     }
    
     return exchange_mapping.get(product)

--- a/broker/paytm/mapping/transform_data.py
+++ b/broker/paytm/mapping/transform_data.py
@@ -1,53 +1,54 @@
-#Mapping OpenAlgo API Request https://openalgo.in/docs
-#Mapping Paytm Broking Parameters https://developer.paytmmoney.com/docs/api/login
+# Mapping OpenAlgo API Request https://openalgo.in/docs
+# Mapping Paytm Broking Parameters https://developer.paytmmoney.com/docs/api/login
 
 from database.token_db import get_token
+
 
 def transform_data(data):
     """
     Transforms the OpenAlgo API request structure to Paytm v2 API structure.
     """
-    symbol = get_token(data['symbol'],data['exchange'])
+    symbol = get_token(data['symbol'], data['exchange'])
     txn_type = "B" if data['action'].upper() == "BUY" else "S"
-    # Source from which the order is placed 
-    #Website - W, mWeb - M, Android - N, iOS - I, Exe - R, OperatorWorkStation - O
+    # Source from which the order is placed
+    # Website - W, mWeb - M, Android - N, iOS - I, Exe - R, OperatorWorkStation - O
     source = "M"
     # This describes, to which segment the transaction belongs. (E→ Equity Cash / D→ Equity Derivative)
     segment = "E" if data['exchange'] in ['NSE', 'BSE'] else "D"
 
     # Basic mapping
     transformed = {
-        "security_id" : symbol,
-        "exchange" : data['exchange'],
+        "security_id": symbol,
+        "exchange": data['exchange'],
         "txn_type": txn_type,
         "order_type": reverse_map_order_type(data["pricetype"]),
         "quantity": data["quantity"],
         "product": reverse_map_product_type(data["product"]),
         "price": data.get("price", "0"),
-        #"trigger_price": data.get("trigger_price", "0"),
-        #"disclosed_quantity": data.get("disclosed_quantity", "0"),  
-        "validity":"DAY",
+        # "trigger_price": data.get("trigger_price", "0"),
+        # "disclosed_quantity": data.get("disclosed_quantity", "0"),
+        "validity": "DAY",
         "segment": segment,
         "source": source,
     }
 
-
     # Extended mapping for fields that might need conditional logic or additional processing
-    #transformed["trigger_price"] = data.get("trigger_price", "0")
-    
+    # transformed["trigger_price"] = data.get("trigger_price", "0")
+
     return transformed
+
+# As long as an order is pending in the system, certain attributes of it can be modified. 
+# Price, quantity, validity, product are some of the variables that can be modified by the user.
+# You have to pass "order_no", "serial_no" "group_id" as compulsory to modify the order.
 
 
 def transform_modify_order_data(data):
     return {
-        "order_type": map_order_type(data["pricetype"]),
+        "product": map_product_type(data["product"]),
         "quantity": data["quantity"],
         "price": data["price"],
-        "trigger_price": data.get("trigger_price", "0"),
-        "disclosed_quantity": data.get("disclosed_quantity", "0"),
-        "validity": "DAY"      
+        "validity": "DAY"
     }
-
 
 
 def map_order_type(pricetype):
@@ -60,7 +61,9 @@ def map_order_type(pricetype):
         "SL": "STOP_LOSS",
         "SLM": "STOP_LOSS_MARKET"
     }
-    return order_type_mapping.get(pricetype, "MARKET")  # Default to MARKET if not found
+    # Default to MARKET if not found
+    return order_type_mapping.get(pricetype, "MARKET")
+
 
 def map_product_type(product):
     """
@@ -71,7 +74,9 @@ def map_product_type(product):
         "M": "MARGIN",
         "I": "MIS",
     }
-    return product_type_mapping.get(product, "MIS")  # Default to INTRADAY if not found
+    # Default to INTRADAY if not found
+    return product_type_mapping.get(product, "MIS")
+
 
 def reverse_map_product_type(product):
     """
@@ -83,8 +88,9 @@ def reverse_map_product_type(product):
         "MARGIN": "M",
         "MIS": "I"
     }
-   
+
     return exchange_mapping.get(product)
+
 
 def reverse_map_order_type(order_type):
     """
@@ -96,5 +102,5 @@ def reverse_map_order_type(order_type):
         "STOP_LOSS": "SL",
         "STOP_LOSS_MARKET": "SLM"
     }
-    return reverse_order_type_mapping.get(order_type, "MKT")  # Default to MKT if not found
-    
+    # Default to MKT if not found
+    return reverse_order_type_mapping.get(order_type, "MKT")

--- a/broker/paytm/plugin.json
+++ b/broker/paytm/plugin.json
@@ -1,0 +1,8 @@
+{
+    "Plugin Name": "paytm",
+    "Plugin URI": "https://openalgo.in",
+    "Description": "Paytm OpenAlgo Plugin",
+    "Version": "1.0",
+    "Author": "Naidu A",
+    "Author URI": "https://openalgo.in"
+}

--- a/static/css/main.css
+++ b/static/css/main.css
@@ -5208,6 +5208,10 @@ code[class*="language-"] {
   --tw-text-opacity: 1;
   color: var(--fallback-er,oklch(var(--er)/var(--tw-text-opacity, 1)));
 }
+.text-green-600 {
+  --tw-text-opacity: 1;
+  color: rgb(22 163 74 / var(--tw-text-opacity, 1));
+}
 .text-info {
   --tw-text-opacity: 1;
   color: var(--fallback-in,oklch(var(--in)/var(--tw-text-opacity, 1)));
@@ -5227,6 +5231,10 @@ code[class*="language-"] {
 .text-primary-content {
   --tw-text-opacity: 1;
   color: var(--fallback-pc,oklch(var(--pc)/var(--tw-text-opacity, 1)));
+}
+.text-red-600 {
+  --tw-text-opacity: 1;
+  color: rgb(220 38 38 / var(--tw-text-opacity, 1));
 }
 .text-secondary {
   --tw-text-opacity: 1;
@@ -5310,9 +5318,6 @@ code[class*="language-"] {
 }
 .ease-in-out {
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
-}
-.ease-out {
-  transition-timing-function: cubic-bezier(0, 0, 0.2, 1);
 }
 @media (max-width: 640px) {
         .container {

--- a/templates/broker.html
+++ b/templates/broker.html
@@ -66,6 +66,9 @@
                 case 'zerodha':
                     loginUrl = 'https://kite.trade/connect/login?api_key={{broker_api_key}}';
                     break;
+                case 'paytm':
+                    loginUrl = 'https://login.paytmmoney.com/merchant-login?apiKey={{broker_api_key}}&state={default}';
+                    break;
                 default:
                     alert('Please select a broker');
                     return;
@@ -105,6 +108,7 @@
                                 <option value="fyers" {{ 'disabled' if broker_name != 'fyers' }}>Fyers {{ '(Disabled)' if broker_name != 'fyers' }}</option>
                                 <option value="icici" {{ 'disabled' if broker_name != 'icici' }}>ICICI Direct {{ '(Disabled)' if broker_name != 'icici' }}</option>
                                 <option value="kotak" {{ 'disabled' if broker_name != 'kotak' }}>Kotak Securities {{ '(Disabled)' if broker_name != 'kotak' }}</option>
+                                <option value="paytm" {{ 'disabled' if broker_name != 'paytm' }}>Paytm Money {{ '(Disabled)' if broker_name != 'paytm' }}</option>
                                 <option value="shoonya" {{ 'disabled' if broker_name != 'shoonya' }}>Shoonya {{ '(Disabled)' if broker_name != 'shoonya' }}</option>
                                 <option value="upstox" {{ 'disabled' if broker_name != 'upstox' }}>Upstox {{ '(Disabled)' if broker_name != 'upstox' }}</option>
                                 <option value="zebu" {{ 'disabled' if broker_name != 'zebu' }}>Zebu {{ '(Disabled)' if broker_name != 'zebu' }}</option>


### PR DESCRIPTION
# Paytm Money Broker Integration

## Overview
This PR implements a new broker integration for Paytm Money, adding support for trading through Paytm Money's API v2. The integration includes core trading functionalities and real-time market data features.

## Key Features
- Authentication system using Paytm Money's OAuth flow
- Real-time market data streaming (quotes and market depth)
- Order management (place, modify, cancel orders)
- Position and holdings tracking
- Portfolio and funds management
- Master contracts management with SQLAlchemy

## Technical Implementation
- Database schema for storing master contracts using SQLAlchemy ORM
- Symbol mapping and standardization across different instrument types
- Real-time WebSocket integration using SocketIO
- Comprehensive error handling and validation
- Support for multiple exchanges (NSE, BSE, NFO, BFO)

## Supported Order Types
- Regular orders (Market, Limit)
- Stop Loss orders (SL, SL-M)
- Support for different product types (CNC, MIS, MARGIN)

## Testing
- [x] Authentication flow
- [ ] Order placement and management
- [x] Market data retrieval
- [x] Symbol search and validation
- [x] Position and holdings tracking

## Documentation
- API endpoints and parameters are documented inline https://developer.paytmmoney.com/docs/api/login
- Market timing configurations included
- Symbol formatting rules implemented

## Limitations
- Historical data API not supported by Paytm Money
- Some advanced order types may not be available

## Next Steps
- Add unit tests
- Implement WebSocket for real-time market data
- Test New order placement via openalgo 
- Enhance logging and monitoring