### PR TITLE
Update default ticker from ZOMATO to ETERNAL due to ticker change

### DIFF
--- a/static/js/tradingview.js
+++ b/static/js/tradingview.js
@@ -10,7 +10,7 @@ document.addEventListener('DOMContentLoaded', function() {
 
     // Set default values and generate JSON
     if (symbolInput && exchangeSelect && productSelect) {
-        symbolInput.value = 'ZOMATO';
+        symbolInput.value = 'ETERNAL';
         exchangeSelect.value = 'NSE';
         productSelect.value = 'MIS';
         


### PR DESCRIPTION
This commit updates the default ticker from 'ZOMATO' to 'ETERNAL' due to a recent change in the data set. Previously, accessing the /tradingview page resulted in an "Error generating JSON" message caused by the outdated ticker. By updating to 'ETERNAL', this change resolves the error and ensures correct JSON generation and application functionality.