### PR TITLE
Remove obsolete 'version' attribute from Docker Compose file

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,5 +1,3 @@
-version: '3.8'
-
 services:
   web:
     build: .


### PR DESCRIPTION
This commit removes the obsolete 'version' attribute from the docker-compose.yaml file. Previously, a warning was issued indicating that the version attribute is now ignored. Removing this attribute resolves the warning message and reduces potential confusion, ensuring that the Docker Compose configuration aligns with current standards.