### PR TITLE
Fixing ZeroMQ port issue, when running openAlgo multiple instances

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -49,6 +49,10 @@ WEBSOCKET_HOST='localhost'
 WEBSOCKET_PORT='8765'
 WEBSOCKET_URL='ws://localhost:8765'
 
+# ZeroMQ Configuration
+ZMQ_HOST='localhost'
+ZMQ_PORT='5555'
+
 # OpenAlgo Rate Limit Settings
 LOGIN_RATE_LIMIT_MIN = "5 per minute" 
 LOGIN_RATE_LIMIT_HOUR = "25 per hour"

--- a/websocket_proxy/base_adapter.py
+++ b/websocket_proxy/base_adapter.py
@@ -4,6 +4,7 @@ import zmq
 import logging
 import random
 import socket
+import os
 from abc import ABC, abstractmethod
 
 def is_port_available(port):
@@ -85,6 +86,8 @@ class BaseBrokerWebSocketAdapter(ABC):
         self.logger = logging.getLogger("broker_adapter")
         self.zmq_port = self._bind_to_available_port()
         self.logger.info(f"ZeroMQ socket bound to port {self.zmq_port}")
+        # Updating used ZMQ_PORT in environment variable.
+        os.environ["ZMQ_PORT"] = str(self.zmq_port)
         
         # Subscription tracking
         self.subscriptions = {}

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -65,7 +65,10 @@ class WebSocketProxy:
         # ZeroMQ context for subscribing to broker adapters
         self.context = zmq.asyncio.Context()
         self.socket = self.context.socket(zmq.SUB)
-        self.socket.connect("tcp://localhost:5555")  # Connect to broker adapter publisher
+        # Connecting to ZMQ
+        ZMQ_HOST = os.getenv('ZMQ_HOST', 'localhost')
+        ZMQ_PORT = os.getenv('ZMQ_PORT')
+        self.socket.connect(f"tcp://{ZMQ_HOST}:{ZMQ_PORT}")  # Connect to broker adapter publisher
         
         # Set up ZeroMQ subscriber to receive all messages
         self.socket.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics


### PR DESCRIPTION
Tried fixing the zmq issue, by following changes:
1. Defined ZeroMQ config in .sample.env file.
2.  In websocket_proxy/server.py accessing ZMQ_HOST, ZMQ_PORT env variables to connect to zmq instance
3. In websocket_proxy/base_adapter.py after getting the available port for ZeroMQ, updating ZMQ_PORT env variable