### PR TITLE
Fix Zerodha Adapter Logger

### DIFF
--- a/broker/zerodha/streaming/zerodha_adapter.py
+++ b/broker/zerodha/streaming/zerodha_adapter.py
@@ -29,7 +29,7 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def __init__(self):
         """Initialize the Zerodha WebSocket adapter"""
         super().__init__()
-        self.logger = logging.getLogger("zerodha_websocket")
+        self.logger = get_logger("zerodha_websocket")
         self.ws_client = None
         self.user_id = None
         self.broker_name = "zerodha"


### PR DESCRIPTION
Fixes this error:
```
[2025-06-25 11:17:09,616] ERROR in server: Failed to create broker adapter for zerodha: name 'logging' is not defined
[2025-06-25 11:17:09,618] ERROR in server: Traceback (most recent call last):
  File "/Users/developer/Coding/python_projects/openalgo/websocket_proxy/server.py", line 370, in authenticate_client
    adapter = create_broker_adapter(broker_name)
  File "/Users/developer/Coding/python_projects/openalgo/websocket_proxy/broker_factory.py", line 41, in create_broker_adapter
    return BROKER_ADAPTERS[broker_name]()
           ~~~~~~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/Users/developer/Coding/python_projects/openalgo/broker/zerodha/streaming/zerodha_adapter.py", line 32, in __init__
    self.logger = logging.getLogger("zerodha_websocket")
                  ^^^^^^^
NameError: name 'logging' is not defined. Did you forget to import 'logging'?
```

The error was caused because `logging` module was being called without being imported, but was fixed by using the existing `get_logger` function