### PR TITLE
Run ngrok on specified port

### DIFF
--- a/app.py
+++ b/app.py
@@ -174,7 +174,7 @@ def create_app():
 
 def setup_environment(app):
     with app.app_context():
-        #load broker plugins
+        # load broker plugins
         app.broker_auth_functions = load_broker_auth_functions()
         # Ensure all the tables exist
         ensure_auth_tables_exists()
@@ -191,7 +191,10 @@ def setup_environment(app):
     # Conditionally setup ngrok in development environment
     if os.getenv('NGROK_ALLOW') == 'TRUE':
         from pyngrok import ngrok
-        public_url = ngrok.connect(name='flask').public_url  # Assuming Flask runs on the default port 5000
+        public_url = ngrok.connect(
+            addr=f"{os.getenv("FLASK_HOST_IP", '127.0.0.1')}:{os.getenv("FLASK_PORT", 5000)}",
+            name="flask",
+        ).public_url
         logger.info(f"ngrok URL: {public_url}")
 
 app = create_app()


### PR DESCRIPTION
Currently, ngrok runs on port 80 by default. This change points ngrok to the port where the flask process is running. For example, I run OpenAlgo Flask process on 5001 port, but when I have ngrok tunnelling turned on, the ngrok process points to port 80.