### PR TITLE
Fixed issue with displaying Issues in analyzer tab due to single quotes…

### DIFF
--- a/static/js/socket-events.js
+++ b/static/js/socket-events.js
@@ -207,14 +207,13 @@ async function refreshAnalyzer() {
             document.querySelectorAll('.view-details').forEach(button => {
                 button.addEventListener('click', function() {
                     try {
-                        const requestData = JSON.parse(this.getAttribute('data-request'));
-                        const responseData = JSON.parse(this.getAttribute('data-response'));
-                        
+                        const requestData = JSON.parse(decodeURIComponent(this.getAttribute('data-request')));
+                        const responseData = JSON.parse(decodeURIComponent(this.getAttribute('data-response')));
                         // Remove apikey from request data if present
                         if (requestData.apikey) {
                             delete requestData.apikey;
                         }
-                        
+
                         document.getElementById('request-data').textContent = JSON.stringify(requestData, null, 2);
                         document.getElementById('response-data').textContent = JSON.stringify(responseData, null, 2);
                         document.getElementById('requestModal').showModal();
@@ -444,9 +443,10 @@ document.addEventListener('DOMContentLoaded', function() {
         document.querySelectorAll('.view-details').forEach(button => {
             button.addEventListener('click', function() {
                 try {
-                    const requestData = JSON.parse(this.getAttribute('data-request'));
-                    const responseData = JSON.parse(this.getAttribute('data-response'));
-                    
+                    const requestData = JSON.parse(decodeURIComponent(this.getAttribute('data-request')));
+                    const responseData = JSON.parse(decodeURIComponent(this.getAttribute('data-response')));
+                    console.log(responseData);
+
                     // Remove apikey from request data if present
                     if (requestData.apikey) {
                         delete requestData.apikey;


### PR DESCRIPTION
I noticed when testing with backdated option symbols, where the symbols have expired that there is a message like "Invalid symbol 'NIFTY07JUL2527000PE' for exchange 'NFO'"

But when setting it to the 'data-response' field in the button, the single quote interferes when we just use JSON.stringify. Change encodes the content and then sets it. Tested locally and it works.