### PR TITLE
Handle cases where average price of holding is zero

### DIFF
--- a/broker/zerodha/mapping/order_data.py
+++ b/broker/zerodha/mapping/order_data.py
@@ -207,14 +207,23 @@ def transform_positions_data(positions_data):
 
 def transform_holdings_data(holdings_data):
     transformed_data = []
-    for holdings in holdings_data:
+    for holdings in holdings_data:  
+        # Handle zero average price case
+        average_price = holdings.get('average_price', 0.0)
+        if average_price == 0:
+            logger.debug(f"Encountering zero average price for symbol: {holdings.get('tradingsymbol', 'Unknown')}")
+            pnlpercent = 0.0
+        else:
+            pnlpercent = round((holdings.get('last_price', 0) - average_price) / average_price * 100, 2)
+        
         transformed_position = {
             "symbol": holdings.get('tradingsymbol', ''),
             "exchange": holdings.get('exchange', ''),
             "quantity": holdings.get('quantity', 0),
             "product": holdings.get('product', ''),
+            "average_price": average_price,
             "pnl": round(holdings.get('pnl', 0.0), 2),  # Rounded to two decimals
-            "pnlpercent": round((holdings.get('last_price', 0) - holdings.get('average_price', 0.0)) / holdings.get('average_price', 0.0) * 100, 2)  # Rounded to two decimals
+            "pnlpercent": pnlpercent  # Rounded to two decimals
         
         }
         transformed_data.append(transformed_position)


### PR DESCRIPTION
In Zerodha, there are many instances where holdings return avg price of zero. For e.g. when there are corporate bonds, G-Secs etc. In such cases, it takes upto T+2 days for them to reflect. 

Earlier logic was resulting in dividebyzero due to this. Logic handles this situation bit more gracefully.

This maybe happening in other brokers as well. Haven't checked.