### PR TITLE
Update flattrade supported intervals

### DIFF
--- a/broker/flattrade/api/data.py
+++ b/broker/flattrade/api/data.py
@@ -58,11 +58,14 @@ class BrokerData:
         self.timeframe_map = {
             # Minutes
             '1m': '1',    # 1 minute
+            '3m': '3',    # 3 minutes
             '5m': '5',    # 5 minutes
+            '10m': '10',  # 10 minutes
             '15m': '15',  # 15 minutes
             '30m': '30',  # 30 minutes
             # Hours
             '1h': '60',   # 1 hour (60 minutes)
+            '2h': '120',  # 2 hours (120 minutes)
             # Daily
             'D': 'D'      # Daily data
         }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Added support for 3m, 10m, and 2h intervals to the flattrade timeframe mapping.

<!-- End of auto-generated description by cubic. -->

