### PR TITLE
Fix wss thread timeout & more 

### DIFF
--- a/broker/flattrade/mapping/order_data.py
+++ b/broker/flattrade/mapping/order_data.py
@@ -14,17 +14,13 @@ def map_order_data(order_data):
     Returns:
     - The modified order_data with updated 'tradingsymbol' and 'product' fields.
     """
-        # Check if 'data' is None
+    # Check if 'data' is None
     if order_data is None or (isinstance(order_data, dict) and (order_data['stat'] == "Not_Ok")):
         # Handle the case where there is no data
-        # For example, you might want to display a message to the user
-        # or pass an empty list or dictionary to the template.
         logger.warning("No data available.")
         order_data = {}  # or set it to an empty list if it's supposed to be a list
     else:
         order_data = order_data
-        
-
 
     if order_data:
         for order in order_data:
@@ -55,9 +51,16 @@ def map_order_data(order_data):
                     order['prctyp']="SL-M"
                 elif(order['prctyp']=="SL-LMT"):
                     order['prctyp']="SL"
-                    
-                # 🔥 ADD: Price logic INSIDE the symbol_found block
-                if order['prctyp'] in ["MARKET", "SL-M"] and float(order.get('prc', 0)) == 0.0:
+                
+                # 🔥 NEW: Use avgprc if instname and avgprc are present (highest priority)
+                if order.get('instname') and order.get('avgprc'):
+                    avgprc = order.get('avgprc', 0)
+                    if avgprc and float(avgprc) > 0:
+                        order['prc'] = avgprc
+                        logger.debug(f"Updated price from avgprc for order with instname: {order.get('norenordno', '')} - Price: {avgprc}")
+                
+                # 🔥 EXISTING: Price logic for MARKET and SL-M orders (fallback)
+                elif order['prctyp'] in ["MARKET", "SL-M"] and float(order.get('prc', 0)) == 0.0:
                     rprc = order.get('rprc', 0)
                     if rprc and float(rprc) > 0:
                         order['prc'] = rprc
@@ -66,7 +69,7 @@ def map_order_data(order_data):
             else:
                 logger.warning(f"Symbol not found for token {symboltoken} and exchange {exchange}. Keeping original trading symbol.")
                 
-        return order_data
+    return order_data
 
 
 def calculate_order_statistics(order_data):


### PR DESCRIPTION
Still I'm unable to fix when the server is terminated I still get the stale data at the client after `Disconnected from ws://127.0.0.1:8765` message.

```
Poll 14:
{'ltp': {'NSE': {'TCS': {'timestamp': 1753803450765, 'ltp': 3056.0}}, 'MCX': {'CRUDEOIL14AUG255700CE': {'timestamp': 1753803456870, 'ltp': 298.8}}}}
LTP MCX:CRUDEOIL14AUG255700CE: 298.8 | Time: 1753803457923
LTP Update:
{'type': 'market_data', 'symbol': 'CRUDEOIL14AUG255700CE', 'exchange': 'MCX', 'mode': 1, 'data': {'ltp': 298.8, 'timestamp': 1753803457923}}
LTP MCX:CRUDEOIL14AUG255700CE: 298.8 | Time: 1753803457925
LTP Update:
{'type': 'market_data', 'symbol': 'CRUDEOIL14AUG255700CE', 'exchange': 'MCX', 'mode': 1, 'data': {'ltp': 298.8, 'timestamp': 1753803457925}}

Poll 15:
{'ltp': {'NSE': {'TCS': {'timestamp': 1753803450765, 'ltp': 3056.0}}, 'MCX': {'CRUDEOIL14AUG255700CE': {'timestamp': 1753803457925, 'ltp': 298.8}}}}
WebSocket error: [WinError 10054] An existing connection was forcibly closed by the remote host
Disconnected from ws://127.0.0.1:8765

Poll 16:
{'ltp': {'NSE': {'TCS': {'timestamp': 1753803450765, 'ltp': 3056.0}}, 'MCX': {'CRUDEOIL14AUG255700CE': {'timestamp': 1753803457925, 'ltp': 298.8}}}}

Poll 17:
{'ltp': {'NSE': {'TCS': {'timestamp': 1753803450765, 'ltp': 3056.0}}, 'MCX': {'CRUDEOIL14AUG255700CE': {'timestamp': 1753803457925, 'ltp': 298.8}}}}
```