### PR TITLE
Zerodha orderbook does now show price for MIS order, only avg_prices.…

### DIFF
--- a/broker/zerodha/api/order_api.py
+++ b/broker/zerodha/api/order_api.py
@@ -105,7 +105,7 @@ def get_order_book(auth):
                         price_num = 0.0
 
                     if status == "COMPLETE" and price_num == 0 and avg_price is not None:
-                        order["price"] = avg_price
+                        order["price"] = float(avg_price)
                 except Exception:
                     # Skip any malformed order entries
                     continue


### PR DESCRIPTION
… Fix is to fill in the price since order_status calls use order_book output

Currently you see 0 for price in OA Orderbook view since we do not get prices for certain types of orders even after completion (for e.g. MIS)
This causes issues in many places, for e.g. in Backtrader, we get notified about an Market order completion, BUT, the orderstatus calls (which uses orderbook internally) returns 0 price and we cannot use it for running additional logic. like setting manual stoploss leg..

New logic. If an order is marked COMPLETE, then return average_price if price is missing. See before / after pictues...

<img width="859" height="155" alt="image" src="https://github.com/user-attachments/assets/d11b61de-04d9-4e0f-9263-fc5312255e99" />

<img width="850" height="212" alt="image" src="https://github.com/user-attachments/assets/e8ba538b-8c0f-43a0-8917-145caff48109" />

    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Zerodha Orderbook showing price=0 for completed MIS/intraday orders. We now backfill price from average_price for COMPLETE orders so order_status and the UI reflect the executed price.

- **Bug Fixes**
  - In get_order_book, set price = average_price when status is COMPLETE and price is 0.
  - Safely handle numeric/string prices; skip malformed entries and log errors.
  - Corrects prices in OA Orderbook and downstream consumers (e.g., Backtrader), enabling post-fill logic like stop-loss legs.
  - Only affects orders missing price; others unchanged.

<!-- End of auto-generated description by cubic. -->

