### PR TITLE
Zerodha Daily timestamp Format issue and Upstox Current Day Data missing - Fixed

### DIFF
--- a/broker/upstox/api/data.py
+++ b/broker/upstox/api/data.py
@@ -397,28 +397,55 @@ class BrokerData:
                     logger.debug(f"Historical endpoint failed: {e}")
                     logger.exception("Historical endpoint exception details:")
             
-            # Handle special case for today's daily data if no historical data
-            if not all_candles and unit == 'days' and interval == 'D':
+            # Handle special case for today's daily data - use intraday API for current day
+            logger.info(f"Checking daily logic: unit={unit}, interval_value={interval_value}, original_interval={interval}")
+            if unit == 'days' and interval == 'D':
                 today = datetime.now().date()
+                logger.info(f"Daily timeframe check: today={today}, start_date={start_date.date()}, end_date={end_date.date()}")
                 if start_date.date() <= today <= end_date.date():
-                    logger.debug("Trying to get today's daily data from quotes...")
-                    try:
-                        quotes = self.get_quotes(symbol, exchange)
-                        if quotes and quotes.get('ltp', 0) > 0:
-                            today_ts = int((datetime.now().replace(hour=0, minute=0, second=0, microsecond=0) + timedelta(hours=5, minutes=30)).timestamp())
-                            today_candle = [
-                                today_ts * 1000,  # Upstox uses milliseconds
-                                quotes.get('open', quotes.get('ltp', 0)),
-                                quotes.get('high', quotes.get('ltp', 0)),
-                                quotes.get('low', quotes.get('ltp', 0)),
-                                quotes.get('ltp', 0),
-                                quotes.get('volume', 0),
-                                quotes.get('oi', 0)
-                            ]
-                            all_candles = [today_candle]
-                            logger.debug("Created today's candle from quotes")
-                    except Exception as e:
-                        logger.debug(f"Could not get today's data from quotes: {e}")
+                    logger.info("Today is within date range, checking if today's data exists")
+                    # Check if today's data is already in historical data
+                    today_found = False
+                    if all_candles:
+                        for candle in all_candles:
+                            try:
+                                candle_date = pd.to_datetime(candle[0], unit='ms' if isinstance(candle[0], (int, float)) else None).date()
+                                logger.debug(f"Checking candle date: {candle_date}")
+                                if candle_date == today:
+                                    today_found = True
+                                    logger.debug("Today's data found in historical candles")
+                                    break
+                            except Exception as e:
+                                logger.debug(f"Error parsing candle date: {e}")
+                                continue
+                    
+                    # If today's data not found, get it from quotes API
+                    if not today_found:
+                        logger.info("Today's data not found, fetching from quotes API")
+                        try:
+                            quotes = self.get_quotes(symbol, exchange)
+                            logger.info(f"Quotes API response: {quotes}")
+                            
+                            if quotes and quotes.get('ltp', 0) > 0:
+                                # Create today's daily candle with midnight timestamp
+                                today_ts = int((datetime.combine(today, datetime.min.time()) + timedelta(hours=5, minutes=30)).timestamp())
+                                today_candle = [
+                                    today_ts * 1000,  # Upstox uses milliseconds
+                                    quotes.get('open', quotes.get('ltp', 0)),
+                                    quotes.get('high', quotes.get('ltp', 0)),
+                                    quotes.get('low', quotes.get('ltp', 0)),
+                                    quotes.get('ltp', 0),
+                                    quotes.get('volume', 0),
+                                    quotes.get('oi', 0)
+                                ]
+                                all_candles.append(today_candle)
+                                logger.info("Added today's daily candle from quotes API")
+                            else:
+                                logger.info("No valid quotes data available for today")
+                                
+                        except Exception as e:
+                            logger.info(f"Could not get today's data from quotes API: {e}")
+                            logger.exception("Quotes API exception details:")
             
             # Return empty DataFrame if no data
             if not all_candles:
@@ -440,8 +467,15 @@ class BrokerData:
             # Convert timestamp from ISO 8601 string to Unix timestamp (seconds since epoch)
             # Upstox returns timestamps like '2024-12-09T15:29:00+05:30'
             try:
-                # Convert to datetime first
-                df['timestamp'] = pd.to_datetime(df['timestamp'])
+                # Convert to datetime first - handle mixed formats (strings and floats)
+                def safe_to_datetime(ts):
+                    if isinstance(ts, str):
+                        return pd.to_datetime(ts)
+                    else:
+                        # Numeric timestamp in milliseconds, convert to datetime
+                        return pd.to_datetime(ts, unit='ms')
+                
+                df['timestamp'] = df['timestamp'].apply(safe_to_datetime)
                 
                 # For daily timeframe, normalize to date only (remove time component)
                 # This matches Angel's behavior for daily data
@@ -450,9 +484,9 @@ class BrokerData:
                     df['timestamp'] = df['timestamp'].dt.date
                     df['timestamp'] = pd.to_datetime(df['timestamp'])
                 
-                # Convert to Unix timestamp (seconds since epoch)
-                df['timestamp'] = df['timestamp'].astype(int) // 10**9
-                logger.info(f"Successfully converted {len(df)} ISO 8601 timestamps to Unix timestamps")
+                # Convert to Unix timestamp (seconds since epoch) - following Angel's pattern
+                df['timestamp'] = df['timestamp'].astype('int64') // 10**9
+                logger.info(f"Successfully converted {len(df)} timestamps to Unix timestamps")
             except Exception as e:
                 logger.error(f"Failed to convert timestamps: {e}")
                 # Fallback: try to handle mixed formats
@@ -466,10 +500,18 @@ class BrokerData:
                                 dt = dt.date()
                                 dt = pd.to_datetime(dt)
                             return int(dt.timestamp())
+                        elif isinstance(ts, pd.Timestamp):
+                            # pandas Timestamp object
+                            if interval == 'D':
+                                dt = ts.date()
+                                dt = pd.to_datetime(dt)
+                                return int(dt.timestamp())
+                            return int(ts.timestamp())
                         else:
                             # Numeric format (milliseconds)
                             return int(float(ts) / 1000)
-                    except:
+                    except Exception as e:
+                        logger.warning(f"Failed to convert timestamp {ts} ({type(ts)}): {e}")
                         return None
                 
                 df['timestamp'] = df['timestamp'].apply(convert_timestamp)
@@ -499,12 +541,6 @@ class BrokerData:
     def _filter_candles_by_date(self, candles: list, start_date: datetime, end_date: datetime) -> list:
         """
         Filter candles to only include those within the specified date range
-        Args:
-            candles: List of candle data
-            start_date: Start date
-            end_date: End date
-        Returns:
-            list: Filtered candles
         """
         if not candles:
             return []
@@ -515,7 +551,27 @@ class BrokerData:
         
         for candle in candles:
             candle_ts = candle[0]  # Timestamp is first element
+            
+            # Handle different timestamp formats
+            if isinstance(candle_ts, str):
+                # Convert ISO 8601 string to timestamp (milliseconds)
+                try:
+                    dt = pd.to_datetime(candle_ts)
+                    candle_ts = dt.timestamp() * 1000
+                except Exception as e:
+                    logger.warning(f"Failed to parse timestamp {candle_ts}: {e}")
+                    continue
+            elif isinstance(candle_ts, (int, float)):
+                # Already numeric, ensure it's in milliseconds
+                if candle_ts < 1e12:  # If less than year 2001 in milliseconds, assume seconds
+                    candle_ts = candle_ts * 1000
+            else:
+                logger.warning(f"Unknown timestamp format: {type(candle_ts)} - {candle_ts}")
+                continue
+                
             if start_ts <= candle_ts < end_ts:
+                # Update the candle with the converted timestamp
+                candle[0] = candle_ts
                 filtered.append(candle)
         
         return filtered

--- a/broker/zerodha/api/data.py
+++ b/broker/zerodha/api/data.py
@@ -340,6 +340,11 @@ class BrokerData:
             
             # Convert timestamp to epoch properly using ISO format
             final_df['timestamp'] = pd.to_datetime(final_df['timestamp'], format='ISO8601')
+            
+            # For daily timeframe, convert UTC to IST by adding 5 hours and 30 minutes
+            if timeframe == 'D':
+                final_df['timestamp'] = final_df['timestamp'] + pd.Timedelta(hours=5, minutes=30)
+            
             final_df['timestamp'] = final_df['timestamp'].astype('int64') // 10**9  # Convert nanoseconds to seconds
             
             # Sort by timestamp and remove duplicates


### PR DESCRIPTION
Zerodha Daily timestamp Format issue and Upstox Current Day Data missing - Fixed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes missing current-day daily data for Upstox and corrects Zerodha daily timestamps to IST. Also hardens timestamp parsing and filtering for mixed formats.

- **Bug Fixes**
  - Upstox: If a daily range includes today but no candle exists, build today’s candle from Quotes (O/H/L/C/volume/oi) using midnight IST; normalize mixed timestamp formats and daily dates; fix date filtering by ensuring millisecond precision.
  - Zerodha: For daily data, convert ISO timestamps from UTC to IST (+5:30) before epoch conversion to produce correct daily timestamps.

<!-- End of auto-generated description by cubic. -->

