### PR TITLE
fix: additonal check in map_trade_data and updated angel_adapter 

### DIFF
--- a/broker/angel/mapping/order_data.py
+++ b/broker/angel/mapping/order_data.py
@@ -145,8 +145,8 @@ def map_trade_data(trade_data):
     Returns:
     - The modified order_data with updated 'tradingsymbol' and 'product' fields.
     """
-        # Check if 'data' is None
-    if trade_data['data'] is None:
+        # Check if 'data' is None or doesn't have 'data' key
+    if not trade_data or 'data' not in trade_data or trade_data['data'] is None:
         # Handle the case where there is no data
         # For example, you might want to display a message to the user
         # or pass an empty list or dictionary to the template.


### PR DESCRIPTION
Added checks if trade_data is empty or doesn't have 'data' key. Added missing fields in mode 3 and fixed invalid .get() for OHLC in angel_adapter
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Aligns AngelOne streaming adapter with the latest broker schema and prevents crashes on empty trade data. Adds key fields in mode 3 and fixes incorrect OHLC/LTT mappings.

- **Bug Fixes**
  - Guard against empty trade_data or missing 'data' key.
  - Correct OHLC/close keys and LTT mapping (modes 1–2 use exchange_timestamp; mode 3 uses last_traded_timestamp).
  - Remove outdated MCX depth parsing branches; rely on best_5_buy_data/sell_data.

- **New Features**
  - Surface mode 3 fields: last_quantity, average_price, total_buy_quantity, total_sell_quantity, 52W high, 52W low.
  - Ensure new price fields are normalized by dividing by 100.

<!-- End of auto-generated description by cubic. -->

