### PR TITLE
Flattrade Websocket- Multiple client subscription fixed

### DIFF
--- a/broker/flattrade/streaming/flattrade_adapter.py
+++ b/broker/flattrade/streaming/flattrade_adapter.py
@@ -15,8 +15,18 @@ from database.token_db import get_token
 import sys
 import os
 
-# Add parent directory to path to allow imports
+# Add parent directory to path to allow imports FIRST
 sys.path.append(os.path.join(os.path.dirname(__file__), '../../../'))
+
+# CRITICAL: Import config to load .env file which sets ZMQ_PORT
+# This must happen before any WebSocket server initialization
+import utils.config  # This loads .env file at module level
+
+# Ensure ZMQ_PORT is set (fallback if not in .env)
+if not os.getenv('ZMQ_PORT'):
+    os.environ['ZMQ_PORT'] = '5555'
+    temp_logger = logging.getLogger("flattrade_init")
+    temp_logger.info("ZMQ_PORT not found in environment, setting to 5555")
 
 from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
 from websocket_proxy.mapping import SymbolMapper
@@ -230,10 +240,20 @@ class DepthNormalizer:
 
 class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """Flattrade WebSocket adapter with improved structure and error handling"""
-    
+
     def __init__(self):
         super().__init__()
         self.logger = logging.getLogger("flattrade_websocket")
+
+        # Log the actual ZMQ port being used
+        actual_zmq_port = os.getenv('ZMQ_PORT', '5555')
+        self.logger.info(f"Flattrade adapter initialized - Expected ZMQ port: {actual_zmq_port}, Actual bound port: {self.zmq_port}")
+
+        # Warn if there's a mismatch
+        if str(self.zmq_port) != str(actual_zmq_port):
+            self.logger.warning(f"ZMQ port mismatch! Server expects {actual_zmq_port} but adapter bound to {self.zmq_port}")
+            self.logger.warning("Data may not reach clients properly!")
+
         self._setup_adapter()
         self._setup_market_cache()
         self._setup_connection_management()
@@ -336,46 +356,102 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def subscribe(self, symbol: str, exchange: str, mode: int = Config.MODE_QUOTE, depth_level: int = 5) -> Dict[str, Any]:
         """Subscribe to market data with improved error handling"""
         try:
+            self.logger.info(f"[SUBSCRIBE] Request for {symbol}.{exchange} mode={mode}")
+
             # Validate inputs
             if not self._validate_subscription_params(symbol, exchange, mode):
                 return self._create_error_response("INVALID_PARAMS", "Invalid subscription parameters")
-            
+
             # Get token information
             token_info = self._get_token_info(symbol, exchange)
             if not token_info:
                 return self._create_error_response("SYMBOL_NOT_FOUND", f"Symbol {symbol} not found")
-            
+
             # Create subscription
             subscription = self._create_subscription(symbol, exchange, mode, depth_level, token_info)
-            correlation_id = f"{symbol}_{exchange}_{mode}"
-            
-            # Store subscription and update mappings
+
+            # Generate a unique correlation_id for each subscription
+            # This allows multiple clients to subscribe to the same symbol
+            import uuid
+            unique_id = str(uuid.uuid4())[:8]
+            correlation_id = f"{symbol}_{exchange}_{mode}_{unique_id}"
+
+            # Check if we need to subscribe to WebSocket
+            base_correlation_id = f"{symbol}_{exchange}_{mode}"
+            already_ws_subscribed = any(
+                cid.startswith(base_correlation_id)
+                for cid in self.subscriptions.keys()
+            )
+
+            if already_ws_subscribed:
+                self.logger.info(f"[SUBSCRIBE] WebSocket already subscribed for {base_correlation_id}, adding client subscription {correlation_id}")
+            else:
+                self.logger.info(f"[SUBSCRIBE] New WebSocket subscription needed for {correlation_id}")
+
+            # Always store the subscription (each client gets their own entry)
             self._store_subscription(correlation_id, subscription)
-            
-            # Subscribe via WebSocket
+
+            # Subscribe via WebSocket (reference counting will handle duplicates)
             if self.connected:
                 self._websocket_subscribe(subscription)
-            
-            return self._create_success_response(f'Subscribed to {symbol}.{exchange}', 
+                if not already_ws_subscribed:
+                    self.logger.info(f"[SUBSCRIBE] WebSocket subscription sent for {subscription['scrip']}")
+            else:
+                self.logger.warning(f"[SUBSCRIBE] Not connected, cannot subscribe to {subscription['scrip']}")
+
+            # Log current ZMQ port and subscription state
+            self.logger.info(f"[SUBSCRIBE] Publishing to ZMQ port: {self.zmq_port}")
+            self.logger.info(f"[SUBSCRIBE] Total active subscriptions: {len(self.subscriptions)}")
+
+            return self._create_success_response(f'Subscribed to {symbol}.{exchange}',
                                                symbol=symbol, exchange=exchange, mode=mode)
-        
+
         except Exception as e:
             self.logger.error(f"Subscription error for {symbol}.{exchange}: {e}")
             return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
 
     def unsubscribe(self, symbol: str, exchange: str, mode: int = Config.MODE_QUOTE) -> Dict[str, Any]:
         """Unsubscribe from market data"""
-        correlation_id = f"{symbol}_{exchange}_{mode}"
-        
+        base_correlation_id = f"{symbol}_{exchange}_{mode}"
+
         with self.lock:
-            if correlation_id not in self.subscriptions:
-                return self._create_error_response("NOT_SUBSCRIBED", 
+            # Find the first matching subscription for this client
+            matching_subscriptions = [
+                (cid, sub) for cid, sub in self.subscriptions.items()
+                if cid.startswith(base_correlation_id)
+            ]
+
+            if not matching_subscriptions:
+                return self._create_error_response("NOT_SUBSCRIBED",
                                                   f"Not subscribed to {symbol}.{exchange}")
-            
-            subscription = self.subscriptions[correlation_id]
-            self._websocket_unsubscribe(subscription)
-            self._remove_subscription(correlation_id, subscription)
-        
+
+            # Remove the first matching subscription
+            correlation_id, subscription = matching_subscriptions[0]
+
+            # Check if this is the last subscription for this symbol/exchange/mode
+            is_last = len(matching_subscriptions) == 1
+
+            # Remove the subscription
+            del self.subscriptions[correlation_id]
+
+            # Clean up token mapping if no other subscriptions use it
+            token = subscription['token']
+            if not any(sub['token'] == token for sub in self.subscriptions.values()):
+                self.token_to_symbol.pop(token, None)
+
+            # Only unsubscribe from WebSocket if this was the last subscription
+            if is_last:
+                scrip = subscription['scrip']
+                if scrip in self.ws_subscription_refs:
+                    if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
+                        self.ws_subscription_refs[scrip]['touchline_count'] -= 1
+                        if self.ws_subscription_refs[scrip]['touchline_count'] <= 0:
+                            self._websocket_unsubscribe(subscription)
+                    elif mode == Config.MODE_DEPTH:
+                        self.ws_subscription_refs[scrip]['depth_count'] -= 1
+                        if self.ws_subscription_refs[scrip]['depth_count'] <= 0:
+                            self._websocket_unsubscribe(subscription)
+
         return self._create_success_response(
             f"Unsubscribed from {symbol}.{exchange}",
             symbol=symbol, exchange=exchange, mode=mode
@@ -420,21 +496,29 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Handle WebSocket subscription with reference counting"""
         scrip = subscription['scrip']
         mode = subscription['mode']
-        
+
         # Initialize reference count for this scrip if not exists
         if scrip not in self.ws_subscription_refs:
             self.ws_subscription_refs[scrip] = {'touchline_count': 0, 'depth_count': 0}
-        
+
         if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
             if self.ws_subscription_refs[scrip]['touchline_count'] == 0:
                 self.logger.info(f"First touchline subscription for {scrip}")
                 self.ws_client.subscribe_touchline(scrip)
-            self.ws_subscription_refs[scrip]['touchline_count'] += 1
+                self.ws_subscription_refs[scrip]['touchline_count'] = 1
+            else:
+                # Already subscribed, just increment the count
+                self.ws_subscription_refs[scrip]['touchline_count'] += 1
+                self.logger.info(f"Additional touchline subscription for {scrip}, count: {self.ws_subscription_refs[scrip]['touchline_count']}")
         elif mode == Config.MODE_DEPTH:
             if self.ws_subscription_refs[scrip]['depth_count'] == 0:
                 self.logger.info(f"First depth subscription for {scrip}")
                 self.ws_client.subscribe_depth(scrip)
-            self.ws_subscription_refs[scrip]['depth_count'] += 1
+                self.ws_subscription_refs[scrip]['depth_count'] = 1
+            else:
+                # Already subscribed, just increment the count
+                self.ws_subscription_refs[scrip]['depth_count'] += 1
+                self.logger.info(f"Additional depth subscription for {scrip}, count: {self.ws_subscription_refs[scrip]['depth_count']}")
 
     def _websocket_unsubscribe(self, subscription: Dict) -> None:
         """Handle WebSocket unsubscription with reference counting"""
@@ -461,16 +545,33 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Remove subscription and clean up mappings"""
         token = subscription['token']
         scrip = subscription['scrip']
-        
+        mode = subscription['mode']
+
         # Remove subscription
         del self.subscriptions[correlation_id]
-        
-        # Clean up reference count if both counts are 0
-        if scrip in self.ws_subscription_refs:
-            if (self.ws_subscription_refs[scrip]['touchline_count'] <= 0 and 
+
+        # Check if there are any other subscriptions for the same scrip and mode
+        has_other_subscriptions = any(
+            sub['scrip'] == scrip and sub['mode'] == mode
+            for sub in self.subscriptions.values()
+        )
+
+        # Only decrement reference count if no other subscriptions exist
+        if not has_other_subscriptions and scrip in self.ws_subscription_refs:
+            if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
+                self.ws_subscription_refs[scrip]['touchline_count'] -= 1
+                if self.ws_subscription_refs[scrip]['touchline_count'] <= 0:
+                    self.ws_subscription_refs[scrip]['touchline_count'] = 0
+            elif mode == Config.MODE_DEPTH:
+                self.ws_subscription_refs[scrip]['depth_count'] -= 1
+                if self.ws_subscription_refs[scrip]['depth_count'] <= 0:
+                    self.ws_subscription_refs[scrip]['depth_count'] = 0
+
+            # Clean up reference count if both counts are 0
+            if (self.ws_subscription_refs[scrip]['touchline_count'] <= 0 and
                 self.ws_subscription_refs[scrip]['depth_count'] <= 0):
                 del self.ws_subscription_refs[scrip]
-        
+
         # Remove token mapping if no other subscriptions use it
         if not any(sub['token'] == token for sub in self.subscriptions.values()):
             self.token_to_symbol.pop(token, None)
@@ -548,36 +649,38 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         with self.lock:
             # Reset reference counts
             self.ws_subscription_refs = {}
-            
+
             # Collect unique scrips for each subscription type
             touchline_scrips = set()
             depth_scrips = set()
-            
+
             for subscription in self.subscriptions.values():
                 scrip = subscription['scrip']
                 mode = subscription['mode']
-                
+
                 # Initialize reference count
                 if scrip not in self.ws_subscription_refs:
                     self.ws_subscription_refs[scrip] = {'touchline_count': 0, 'depth_count': 0}
-                
+
                 if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
-                    touchline_scrips.add(scrip)
+                    if scrip not in touchline_scrips:
+                        touchline_scrips.add(scrip)
                     self.ws_subscription_refs[scrip]['touchline_count'] += 1
                 elif mode == Config.MODE_DEPTH:
-                    depth_scrips.add(scrip)
+                    if scrip not in depth_scrips:
+                        depth_scrips.add(scrip)
                     self.ws_subscription_refs[scrip]['depth_count'] += 1
-            
+
             # Resubscribe in batches
             if touchline_scrips:
                 scrip_list = '#'.join(touchline_scrips)
                 self.ws_client.subscribe_touchline(scrip_list)
-                self.logger.info(f"Resubscribed to {len(touchline_scrips)} touchline scrips")
-            
+                self.logger.info(f"Resubscribed to {len(touchline_scrips)} touchline scrips with total {sum(self.ws_subscription_refs[s]['touchline_count'] for s in touchline_scrips)} subscriptions")
+
             if depth_scrips:
                 scrip_list = '#'.join(depth_scrips)
                 self.ws_client.subscribe_depth(scrip_list)
-                self.logger.info(f"Resubscribed to {len(depth_scrips)} depth scrips")
+                self.logger.info(f"Resubscribed to {len(depth_scrips)} depth scrips with total {sum(self.ws_subscription_refs[s]['depth_count'] for s in depth_scrips)} subscriptions")
 
     def _on_message(self, ws, message):
         """Handle incoming market data messages"""
@@ -655,7 +758,7 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Process message for a specific subscription"""
         mode = subscription['mode']
         msg_type = data.get('t')
-        
+
         # Normalize data
         normalized_data = self._normalize_market_data(data, msg_type, mode)
         normalized_data.update({
@@ -663,13 +766,35 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
             'exchange': exchange,
             'timestamp': int(time.time() * 1000)
         })
-        
+
         # Create topic and publish
         mode_str = {Config.MODE_LTP: 'LTP', Config.MODE_QUOTE: 'QUOTE', Config.MODE_DEPTH: 'DEPTH'}[mode]
         topic = f"{exchange}_{symbol}_{mode_str}"
-        
-        self.logger.debug(f"[{mode_str}] Publishing data for {symbol}")
-        self.publish_market_data(topic, normalized_data)
+
+        # Get client count for this subscription
+        client_count = subscription.get('client_count', 1)
+
+        self.logger.debug(f"[PUBLISH] Publishing {mode_str} data for {symbol} on topic: {topic}, ZMQ port: {self.zmq_port}, client_count: {client_count}")
+
+        # Debug: Check if data is actually being sent
+        try:
+            # Track published topics
+            if not hasattr(self, '_published_topics'):
+                self._published_topics = set()
+
+            if topic not in self._published_topics:
+                self.logger.info(f"[PUBLISH] First publish for topic: {topic}")
+                self._published_topics.add(topic)
+
+            # Publish once - the ZMQ PUB/SUB pattern will deliver to all subscribers
+            # The issue is not here but in how subscriptions are found
+            self.publish_market_data(topic, normalized_data)
+
+            # Log client count for debugging
+            if client_count > 1:
+                self.logger.debug(f"[PUBLISH] Published to topic {topic} for {client_count} clients")
+        except Exception as e:
+            self.logger.error(f"[PUBLISH] Failed to publish data: {e}")
 
     def _normalize_market_data(self, data: Dict[str, Any], msg_type: str, mode: int) -> Dict[str, Any]:
         """Normalize market data based on mode with improved structure"""

--- a/broker/groww/streaming/groww_protobuf.py
+++ b/broker/groww/streaming/groww_protobuf.py
@@ -324,12 +324,29 @@ class MiniProtobufParser:
 def parse_groww_market_data(data: bytes) -> Dict[str, Any]:
     """
     Convenience function to parse Groww market data
-    
+
     Args:
         data: Binary protobuf data
-        
+
     Returns:
         Parsed market data
     """
+    logger.info(f"Parsing protobuf data: {len(data)} bytes")
+    logger.debug(f"First 50 bytes (hex): {data[:50].hex() if len(data) > 50 else data.hex()}")
+
     parser = MiniProtobufParser()
-    return parser.parse_market_data(data)
+    result = parser.parse_market_data(data)
+
+    # Log what was parsed
+    if result:
+        logger.info(f"Successfully parsed protobuf data: {result.keys()}")
+        if 'ltp_data' in result:
+            logger.info(f"LTP data found: {result['ltp_data']}")
+        if 'index_data' in result:
+            logger.info(f"Index data found: {result['index_data']}")
+        if 'depth_data' in result:
+            logger.info(f"Depth data found: {result['depth_data']}")
+    else:
+        logger.warning("No data parsed from protobuf")
+
+    return result

--- a/broker/groww/streaming/nats_websocket.py
+++ b/broker/groww/streaming/nats_websocket.py
@@ -51,8 +51,8 @@ class GrowwNATSWebSocket:
         self.subscription_map = {}  # Map subscription keys to topics
         self.nats_sids = {}  # Map our keys to NATS subscription IDs
         
-        # NATS protocol handler
-        self.nats_protocol = groww_nats.NATSProtocol()
+        # NATS protocol handler (will be recreated on each connection)
+        self.nats_protocol = None
         
         # State
         self.running = False
@@ -117,11 +117,14 @@ class GrowwNATSWebSocket:
         if self.connected:
             logger.warning("Already connected")
             return
-        
+
         try:
+            # Create fresh NATS protocol handler for this connection
+            self.nats_protocol = groww_nats.NATSProtocol()
+
             # Generate socket token first
             self._generate_socket_token()
-            
+
             # Start WebSocket connection
             self.running = True
             self.ws_thread = threading.Thread(target=self._run_websocket, daemon=True)
@@ -270,7 +273,10 @@ class GrowwNATSWebSocket:
                     try:
                         ping_count += 1
                         logger.info(f"\U0001f3d3 Sending PING #{ping_count} to check connection...")
-                        self.ws.send(self.nats_protocol.create_ping())
+                        if self.nats_protocol:
+                            self.ws.send(self.nats_protocol.create_ping())
+                        else:
+                            logger.error("Cannot send PING - NATS protocol handler not initialized")
                     except Exception as e:
                         logger.error(f"Failed to send PING: {e}")
         
@@ -281,11 +287,16 @@ class GrowwNATSWebSocket:
         try:
             # Convert to string to find message boundaries
             text = data.decode('utf-8', errors='ignore')
-            
+
             # Log the message type for debugging
             if len(text) > 0:
                 logger.debug(f"Binary message text preview: {text[:100]}")
-            
+
+            # Ensure NATS protocol handler exists
+            if not self.nats_protocol:
+                logger.error("NATS protocol handler not initialized")
+                return
+
             # Check for different message types
             if text.startswith('INFO'):
                 # Parse as text for INFO messages
@@ -330,7 +341,10 @@ class GrowwNATSWebSocket:
             elif text.startswith('PING') or text.startswith('PONG') or text.startswith('+OK'):
                 # Parse as text for control messages
                 logger.info(f"Control message received: {text.strip()}")
-                messages = self.nats_protocol.parse_message(text)
+                if self.nats_protocol:
+                    messages = self.nats_protocol.parse_message(text)
+                else:
+                    messages = []
                 for msg in messages:
                     self._process_nats_message(msg)
             else:
@@ -353,9 +367,13 @@ class GrowwNATSWebSocket:
                 self._process_binary_nats_message(message)
             else:
                 logger.info(f"📥 Received TEXT message: {len(message)} chars")
-                
+
                 # Parse text message
-                messages = self.nats_protocol.parse_message(message)
+                if self.nats_protocol:
+                    messages = self.nats_protocol.parse_message(message)
+                else:
+                    logger.error("NATS protocol handler not initialized")
+                    messages = []
                 logger.info(f"Parsed {len(messages)} NATS messages")
                 for msg in messages:
                     logger.info(f"Processing NATS message type: {msg.get('type')}")
@@ -399,8 +417,11 @@ class GrowwNATSWebSocket:
                 
         elif msg_type == 'PING':
             # Respond with PONG
-            self.ws.send(self.nats_protocol.create_pong())
-            logger.info("🏓 Received PING from server, sent PONG")
+            if self.nats_protocol:
+                self.ws.send(self.nats_protocol.create_pong())
+                logger.info("🏓 Received PING from server, sent PONG")
+            else:
+                logger.error("Cannot send PONG - NATS protocol handler not initialized")
             
         elif msg_type == 'PONG':
             logger.info("✅ Received PONG from server - Connection alive")
@@ -474,8 +495,14 @@ class GrowwNATSWebSocket:
                         
                         # Add subscription info to market data
                         market_data['symbol'] = sub_info['symbol']
-                        market_data['exchange'] = sub_info['exchange']
+                        # For index mode, exchange might be NSE_INDEX/BSE_INDEX, normalize to NSE/BSE for matching
+                        if sub_info['mode'] == 'index' and '_INDEX' in sub_info['exchange']:
+                            market_data['exchange'] = sub_info['exchange'].replace('_INDEX', '')
+                        else:
+                            market_data['exchange'] = sub_info['exchange']
                         market_data['mode'] = sub_info['mode']
+                        # Also preserve the original exchange for the adapter
+                        market_data['original_exchange'] = sub_info['exchange']
                         
                         logger.info(f"🚀 Sending market data to callback: {market_data}")
                         
@@ -501,6 +528,10 @@ class GrowwNATSWebSocket:
         """Send NATS SUB command for subscription"""
         try:
             # Format topic for Groww
+            if not self.nats_protocol:
+                logger.error("NATS protocol handler not initialized")
+                return
+
             topic = self.nats_protocol.format_topic_for_groww(
                 exchange=sub_info.get('exchange', ''),
                 segment=sub_info.get('segment', ''),
@@ -523,7 +554,7 @@ class GrowwNATSWebSocket:
     def subscribe_ltp(self, exchange: str, segment: str, token: str, symbol: str = None):
         """
         Subscribe to LTP (Last Traded Price) updates
-        
+
         Args:
             exchange: Exchange (NSE, BSE, etc.)
             segment: Segment (CASH, FNO, etc.)
@@ -531,14 +562,26 @@ class GrowwNATSWebSocket:
             symbol: Trading symbol (optional, defaults to token)
         """
         sub_key = f"ltp_{exchange}_{segment}_{token}"
-        
+
         # Determine mode based on whether it's an index
         # Check if exchange contains INDEX or if symbol is an index name
-        if 'INDEX' in exchange.upper() or symbol in ['NIFTY', 'SENSEX', 'BANKNIFTY', 'FINNIFTY', 'MIDCPNIFTY']:
+        # Expanded list of index symbols
+        index_symbols = [
+            'NIFTY', 'BANKNIFTY', 'FINNIFTY', 'MIDCPNIFTY', 'SENSEX',
+            'BANKEX', 'NIFTYNXT50', 'NIFTYIT', 'NIFTYPHARMA', 'NIFTYAUTO',
+            'NIFTYBANK', 'NIFTYFIN', 'NIFTYFMCG', 'NIFTYMETAL', 'NIFTYREALTY'
+        ]
+
+        # Check if it's an index based on exchange or symbol
+        is_index = ('INDEX' in exchange.upper() or
+                   (symbol and any(idx in symbol.upper() for idx in index_symbols)))
+
+        if is_index:
             mode = 'index'
+            logger.info(f"Detected index subscription for {symbol} on {exchange}")
         else:
             mode = 'ltp'
-        
+
         # Store subscription info
         self.subscriptions[sub_key] = {
             'symbol': symbol if symbol else f"{token}",  # Use actual symbol if provided
@@ -547,11 +590,11 @@ class GrowwNATSWebSocket:
             'exchange_token': token,
             'mode': mode
         }
-        
+
         # Send NATS subscription if connected
         if self.connected:
             self._send_nats_subscription(sub_key, self.subscriptions[sub_key])
-        
+
         return sub_key
         
     def subscribe_depth(self, exchange: str, segment: str, token: str, symbol: str = None):
@@ -612,20 +655,27 @@ class GrowwNATSWebSocket:
     def disconnect(self):
         """Disconnect from WebSocket"""
         self.running = False
-        
+
         if self.ws:
             try:
                 self.ws.close()
             except Exception as e:
                 logger.error(f"Error closing WebSocket: {e}")
-        
+
         if self.ws_thread:
             self.ws_thread.join(timeout=5)
-        
+
+        # Clear all state for clean reconnection
         self.connected = False
         self.authenticated = False
-        
-        logger.info("Disconnected from Groww WebSocket")
+        self.subscriptions.clear()
+        self.nats_sids.clear()
+        self.subscription_map.clear()
+        self.server_nonce = None
+        self.socket_token = None
+        self.subscription_id = None
+
+        logger.info("Disconnected from Groww WebSocket and cleared state")
         
     def is_connected(self) -> bool:
         """Check if WebSocket is connected"""


### PR DESCRIPTION
Flattrade Websocket- Multiple client subscription fixed and Groww Websockets - instrumenttype lookup for index symbols Fixed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes multi-client subscriptions in Flattrade WebSocket and corrects Groww index handling (instrument type and topics), improving delivery reliability and reconnect stability.

- **Bug Fixes**
  - Flattrade: unique client correlation IDs with reference-counted touchline/depth subs; unsubscribe only when the last client leaves.
  - Flattrade: safe resubscribe after reconnect without duplicates; cleans token/reference maps correctly.
  - Flattrade: load .env early, default ZMQ_PORT to 5555, and log port/mismatch to avoid silent data drops.
  - Groww: instrumenttype lookup added; proper NSE_INDEX/BSE_INDEX token rules and index topics (/ld/indices/...); accurate matching in on_data.
  - Groww: avoid misclassifying F&O as index; correct exchange labeling in callbacks; stabilize NATS protocol lifecycle with null-guards.

- **Refactors**
  - Clear adapter/NATS state on disconnect for clean reconnects.
  - Pass instrumenttype through subscribe_ltp/depth.
  - Add targeted logs for protobuf parsing, topic generation, publish path, and client counts.
  - Guard pings/parsing/subscription maps; recreate NATSProtocol per connection.

<!-- End of auto-generated description by cubic. -->

