### PR TITLE
Shoonya PNL Tracker Fixed

### DIFF
--- a/broker/kotak/api/data.py
+++ b/broker/kotak/api/data.py
@@ -86,7 +86,8 @@ class KotakWebSocket:
                             'low': float(msg.get('lo', 0)),
                             'ltp': float(msg.get('ltp', 0)),
                             'prev_close': float(msg.get('c', 0)),
-                            'volume': float(msg.get('v', 0))
+                            'volume': float(msg.get('v', 0)),
+                            'oi': int(msg.get('oi', 0))
                         }
                         self.ws.close()
         except Exception as e:
@@ -139,14 +140,14 @@ class BrokerData:
             return ws.last_quote or {
                 'bid': 0, 'ask': 0, 'open': 0,
                 'high': 0, 'low': 0, 'ltp': 0,
-                'prev_close': 0, 'volume': 0
+                'prev_close': 0, 'volume': 0, 'oi': 0
             }
         except Exception as e:
             logger.error(f"Error in get_quotes: {e}")
             return {
                 'bid': 0, 'ask': 0, 'open': 0,
                 'high': 0, 'low': 0, 'ltp': 0,
-                'prev_close': 0, 'volume': 0
+                'prev_close': 0, 'volume': 0, 'oi': 0
             }
 
     def get_depth(self, symbol: str, exchange: str) -> dict:
@@ -170,15 +171,7 @@ class BrokerData:
                 'bids': [{'price': 0, 'quantity': 0} for _ in range(5)],
                 'asks': [{'price': 0, 'quantity': 0} for _ in range(5)],
                 'totalbuyqty': 0,
-                'totalsellqty': 0,
-                'ltp': 0,
-                'ltq': 0,
-                'volume': 0,
-                'open': 0,
-                'high': 0,
-                'low': 0,
-                'prev_close': 0,
-                'oi': 0
+                'totalsellqty': 0
             }
 
             return ws.last_depth or default_depth
@@ -189,15 +182,7 @@ class BrokerData:
                 'bids': [{'price': 0, 'quantity': 0} for _ in range(5)],
                 'asks': [{'price': 0, 'quantity': 0} for _ in range(5)],
                 'totalbuyqty': 0,
-                'totalsellqty': 0,
-                'ltp': 0,
-                'ltq': 0,
-                'volume': 0,
-                'open': 0,
-                'high': 0,
-                'low': 0,
-                'prev_close': 0,
-                'oi': 0
+                'totalsellqty': 0
             }
 
     def get_history(self, symbol: str, exchange: str, interval: str, start_date: str, end_date: str) -> pd.DataFrame:

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -182,13 +182,14 @@ def map_trade_data(trade_data):
             # Check if a symbol was found; if so, update the trading_symbol in the current order
             if symbol_from_db:
                 order['trdSym'] = symbol_from_db
-                if order['trnsTp'] == 'B':
-                    order['trnsTp'] = 'BUY'
-                elif order['trnsTp'] == 'S':
-                    order['trnsTp'] = 'SELL'
-                    
             else:
                 logger.info(f"Unable to find the symbol {symbol} and exchange {exchange}. Keeping original trading symbol.")
+
+            # Map transaction type regardless of symbol lookup result
+            if order['trnsTp'] == 'B':
+                order['trnsTp'] = 'BUY'
+            elif order['trnsTp'] == 'S':
+                order['trnsTp'] = 'SELL'
     logger.info(f"{trade_data}")           
     return trade_data
 
@@ -232,7 +233,7 @@ def transform_positions_data(positions_data):
             transformed_position["average_price"] = round(float(position['buyAmt'])/float(position['flBuyQty']),2)
         elif transformed_position['quantity'] < 0:
             transformed_position["average_price"] = round(float(position['sellAmt'])/float(position['flSellQty']),2)
-            
+
         transformed_data.append(transformed_position)
     return transformed_data
 

--- a/broker/shoonya/mapping/order_data.py
+++ b/broker/shoonya/mapping/order_data.py
@@ -197,6 +197,12 @@ def map_trade_data(trade_data):
 def transform_tradebook_data(tradebook_data):
     transformed_data = []
     for trade in tradebook_data:
+        # Parse the timestamp from Shoonya format "HH:MM:SS DD-MM-YYYY" to just "HH:MM:SS"
+        timestamp = trade.get('norentm', '')
+        if timestamp and ' ' in timestamp:
+            # Extract just the time part (HH:MM:SS) from "HH:MM:SS DD-MM-YYYY"
+            timestamp = timestamp.split(' ')[0]
+
         transformed_trade = {
             "symbol": trade.get('tsym', ''),
             "exchange": trade.get('exch', ''),
@@ -206,7 +212,7 @@ def transform_tradebook_data(tradebook_data):
             "average_price": trade.get('avgprc', 0.0),
             "trade_value": float(trade.get('avgprc', 0)) * int(trade.get('qty', 0)),
             "orderid": trade.get('norenordno', ''),
-            "timestamp": trade.get('norentm', '')
+            "timestamp": timestamp  # Now just "HH:MM:SS"
         }
         transformed_data.append(transformed_trade)
     return transformed_data
@@ -258,12 +264,32 @@ def map_position_data(position_data):
 def transform_positions_data(positions_data):
     transformed_data = []
     for position in positions_data:
+        # Get position values
+        netqty = float(position.get('netqty', 0))
+        netavgprc = float(position.get('netavgprc', 0.0))
+        lp = float(position.get('lp', 0.0))  # Last Price from Shoonya
+
+        # Calculate PnL only if there's an open position
+        if netqty != 0 and lp > 0:
+            if netqty > 0:
+                # Long position
+                pnl = (lp - netavgprc) * netqty
+            else:
+                # Short position
+                pnl = (netavgprc - lp) * abs(netqty)
+        else:
+            # No position or no LTP available
+            pnl = 0.0
+            lp = 0.0 if netqty == 0 else lp  # Set LTP to 0 if position is closed
+
         transformed_position = {
             "symbol": position.get('tsym', ''),
             "exchange": position.get('exch', ''),
             "product": position.get('prd', ''),
-            "quantity": position.get('netqty', 0),
-            "average_price": position.get('netavgprc', 0.0),
+            "quantity": netqty,
+            "average_price": netavgprc,
+            "ltp": lp,
+            "pnl": pnl
         }
         transformed_data.append(transformed_position)
     return transformed_data


### PR DESCRIPTION
Shoonya PNL Tracker Fixed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixes Shoonya PnL tracking by correctly computing PnL for long and short positions and normalizing trade timestamps. Adds ltp and pnl to positions for accurate display.

- **Bug Fixes**
  - Compute PnL using netavgprc, netqty, and lp; return 0 when position is closed or LTP is missing.
  - Expose ltp and pnl in transform_positions_data output.
  - Normalize norentm from "HH:MM:SS DD-MM-YYYY" to "HH:MM:SS" in tradebook data.

<!-- End of auto-generated description by cubic. -->

