### PR TITLE
Openalgo Sandbox Initialization Update

### DIFF
--- a/app.py
+++ b/app.py
@@ -54,6 +54,7 @@ from database.chartink_db import init_db as ensure_chartink_tables_exists
 from database.traffic_db import init_logs_db as ensure_traffic_logs_exists
 from database.latency_db import init_latency_db as ensure_latency_tables_exists
 from database.strategy_db import init_db as ensure_strategy_tables_exists
+from database.sandbox_db import init_db as ensure_sandbox_tables_exists
 
 from utils.plugin_loader import load_broker_auth_functions
 
@@ -308,6 +309,7 @@ def setup_environment(app):
         ensure_traffic_logs_exists()
         ensure_latency_tables_exists()
         ensure_strategy_tables_exists()
+        ensure_sandbox_tables_exists()
 
     # Conditionally setup ngrok in development environment
     if os.getenv('NGROK_ALLOW') == 'TRUE':


### PR DESCRIPTION
Openalgo Sandbox Initialization Update
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Initialize sandbox database on startup so the sandbox runs without missing-table errors. Adds ensure_sandbox_tables_exists() to setup_environment alongside other DB initializers.

<!-- End of auto-generated description by cubic. -->

