### PR TITLE
Upstox Quotes API Fixed

### DIFF
--- a/broker/upstox/api/data.py
+++ b/broker/upstox/api/data.py
@@ -71,16 +71,35 @@ class BrokerData:
         }
 
     def _get_instrument_key(self, symbol: str, exchange: str) -> str:
-        """Get the correct instrument key for a symbol"""
+        """Get the correct instrument key for a symbol with smart fallback for indices"""
         try:
             # Get token from database - this already includes the exchange prefix
             token = get_token(symbol, exchange)
+
+            # If token not found and exchange looks like it might be an index exchange
+            # Try the _INDEX variant (e.g., NSE -> NSE_INDEX)
+            if not token and exchange in ['NSE', 'BSE', 'MCX']:
+                index_exchange = f"{exchange}_INDEX"
+                logger.debug(f"Token not found for {symbol} on {exchange}, trying {index_exchange}")
+                token = get_token(symbol, index_exchange)
+                if token:
+                    logger.info(f"Found token using index exchange: {index_exchange}")
+
+            # If still not found and exchange is an index exchange, try without _INDEX
+            # (e.g., NSE_INDEX -> NSE)
+            if not token and exchange.endswith('_INDEX'):
+                base_exchange = exchange.replace('_INDEX', '')
+                logger.debug(f"Token not found for {symbol} on {exchange}, trying {base_exchange}")
+                token = get_token(symbol, base_exchange)
+                if token:
+                    logger.info(f"Found token using base exchange: {base_exchange}")
+
             if not token:
                 raise ValueError(f"No token found for {symbol} on {exchange}")
-            
+
             logger.debug(f"Using instrument key: {token}")
             return token
-            
+
         except Exception as e:
             logger.exception(f"Error getting instrument key for {symbol} on {exchange}")
             raise
@@ -97,12 +116,26 @@ class BrokerData:
         Get real-time quotes for given symbol
         Args:
             symbol: Trading symbol
-            exchange: Exchange (e.g., NSE, BSE)
+            exchange: Exchange (e.g., NSE, BSE, NSE_INDEX)
         Returns:
             dict: Quote data with standard fields
         """
         try:
-            # Get the correct instrument key
+            logger.debug(f"get_quotes called with symbol='{symbol}', exchange='{exchange}'")
+
+            # Auto-detect and fix reversed parameters (defensive programming)
+            # Exchange names are typically short codes like NSE, BSE, NFO, etc.
+            # Symbols are typically longer or alphanumeric
+            known_exchanges = ['NSE', 'BSE', 'NFO', 'BFO', 'CDS', 'MCX', 'NSE_INDEX', 'BSE_INDEX', 'MCX_INDEX',
+                             'NSE_EQ', 'NSE_FO', 'BSE_EQ', 'BSE_FO', 'MCX_FO', 'NSE_CD']
+            if symbol in known_exchanges and exchange not in known_exchanges:
+                # Parameters are likely reversed
+                logger.warning(f"Detected reversed parameters: symbol='{symbol}', exchange='{exchange}'. Auto-correcting...")
+                symbol, exchange = exchange, symbol
+                logger.info(f"Corrected to: symbol='{symbol}', exchange='{exchange}'")
+
+            # Get the correct instrument key using the original exchange (important for indices)
+            # This must happen BEFORE exchange normalization (like Angel does)
             instrument_key = self._get_instrument_key(symbol, exchange)
             
             # URL encode the instrument key


### PR DESCRIPTION
Upstox Quotes API Fixed
    
<!-- This is an auto-generated description by cubic. -->
---

## Summary by cubic
Fixed Upstox Quotes API to reliably fetch quotes for indices and handle swapped symbol/exchange inputs. Adds smart exchange fallbacks to resolve missing tokens and reduces errors from parameter mix-ups.

- **Bug Fixes**
  - Added index-aware token fallback (NSE <-> NSE_INDEX, etc.).
  - Auto-corrects reversed symbol/exchange parameters in get_quotes.
  - Improved logging for token resolution and parameter correction.

<!-- End of auto-generated description by cubic. -->

