### PR TITLE
fix(flux): update timeframe for flux scan to work properly

### DIFF
--- a/broker/zerodha/api/data.py
+++ b/broker/zerodha/api/data.py
@@ -143,6 +143,9 @@ class BrokerData:
             '15m': '15minute',
             '30m': '30minute',
             '60m': '60minute',
+            # For flux scan to work for 1h interval
+            '1h': '60minute',
+            
             # Daily
             'D': 'day'
         }


### PR DESCRIPTION

    
<!-- This is an auto-generated description by cubic. -->

## Summary by cubic
Fixes flux scan for 1-hour intervals by mapping the '1h' timeframe to '60minute' in the Zerodha data API.
Prevents errors when users select '1h' and ensures scans run as expected.

<!-- End of auto-generated description by cubic. -->

