### PR TITLE
kotak master contract sqlite database issue fixed

### DIFF
--- a/broker/kotak/api/auth_api.py
+++ b/broker/kotak/api/auth_api.py
@@ -49,9 +49,14 @@ def authenticate_broker(mobile_number, totp, mpin):
         logger.debug(f"Parsed UCC: {ucc}, Access Token length: {len(access_token)}")
 
         # Ensure mobile number has +91 prefix
-        mobile_number = mobile_number.strip().replace('+91', '')
-        if not mobile_number.startswith('+91'):
-            mobile_number = f'+91{mobile_number}'
+        # Handle all cases: +919876543210, 919876543210, 9876543210
+        mobile_number = mobile_number.strip()
+        # Remove any existing +91 or 91 prefix
+        mobile_number = mobile_number.replace('+91', '').replace(' ', '')
+        if mobile_number.startswith('91') and len(mobile_number) == 12:
+            mobile_number = mobile_number[2:]  # Remove leading 91
+        # Add +91 prefix
+        mobile_number = f'+91{mobile_number}'
 
         # Get the shared httpx client with connection pooling
         client = get_httpx_client()

--- a/database/master_contract_status_db.py
+++ b/database/master_contract_status_db.py
@@ -22,7 +22,7 @@ if DB_PATH and 'sqlite' in DB_PATH:
         DB_PATH,
         echo=False,
         poolclass=NullPool,
-        connect_args={'check_same_thread': False}
+        connect_args={'check_same_thread': False, 'timeout': 30}
     )
 else:
     # For other databases like PostgreSQL, use connection pooling


### PR DESCRIPTION
kotak master contract sqlite database issue fixed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed SQLite lock issues in the Kotak master contract flow and made mobile number normalization in broker auth more reliable.

- **Bug Fixes**
  - Increased SQLite connection timeout to 30s in master_contract_status_db to reduce “database is locked” errors.
  - Normalized mobile numbers in Kotak auth to always use +91 format; handles +91..., 91..., and 10-digit inputs and trims spaces.

<!-- End of auto-generated description by cubic. -->

