### PR TITLE
Angel Order_api and adapter fixed as per openalgo format

### DIFF
--- a/broker/angel/api/order_api.py
+++ b/broker/angel/api/order_api.py
@@ -43,13 +43,13 @@ def get_api_response(endpoint, auth, method="GET", payload=''):
     
     # Handle empty response
     if not response.text:
-        return {'status': 'error', 'message': 'Empty response from API'}
+        return {}
     
     try:
         return json.loads(response.text)
     except json.JSONDecodeError:
         logger.error(f"Failed to parse JSON response from {endpoint}: {response.text}")
-        return {'status': 'error', 'message': f'Invalid JSON response from API: {response.text}'}
+        return {}
 
 def get_order_book(auth):
     return get_api_response("/rest/secure/angelbroking/order/v1/getOrderBook",auth)


### PR DESCRIPTION
Angel Order_api and adapter fixed as per openalgo format

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligned Angel order API responses and streaming adapter to the OpenAlgo format. Empty/invalid API responses now return {}, market data field names are corrected, and MCX best-five depth is supported.

- **Refactors**
  - Order API returns {} on empty or invalid JSON responses to match OpenAlgo.
  - Market data uses open_price, high_price, low_price, and close_price for OHLC.

- **New Features**
  - Parse MCX best_five_buy_market_data and best_five_sell_market_data for depth.
  - Normalize price by dividing by 100 and include price, quantity, and orders.

<sup>Written for commit 1fe235e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

