### PR TITLE
Fyers 'seconds' timeframe - historical data Updated

### DIFF
--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -38,7 +38,16 @@ class HistorySchema(Schema):
     apikey = fields.Str(required=True)
     symbol = fields.Str(required=True)
     exchange = fields.Str(required=True)  # Exchange (e.g., NSE, BSE)
-    interval = fields.Str(required=True, validate=validate.OneOf(["1m", "5m", "15m", "30m", "1h", "D"]))  # 1m, 5m, 15m, 30m, 1h, D
+    interval = fields.Str(required=True, validate=validate.OneOf([
+        # Seconds intervals
+        "5s", "10s", "15s", "30s", "45s",
+        # Minutes intervals
+        "1m", "2m", "3m", "5m", "10m", "15m", "20m", "30m",
+        # Hours intervals
+        "1h", "2h", "4h",
+        # Daily interval
+        "D"
+    ]))
     start_date = fields.Date(required=True, format='%Y-%m-%d')  # YYYY-MM-DD
     end_date = fields.Date(required=True, format='%Y-%m-%d')    # YYYY-MM-DD
     # OI is now always included by default for F&O exchanges


### PR DESCRIPTION
Fyers 'seconds' timeframe - historical data Updated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds support for seconds timeframes (5s–45s) in Fyers historical data and updates validation to match. Enforces the 30 trading-day limit for seconds data by clamping start_date and logging a warning.

- **New Features**
  - HistorySchema now accepts: 5s, 10s, 15s, 30s, 45s; plus expanded minutes (1m–30m), hours (1h, 2h, 4h), and D.
  - Seconds data is chunked in 25-day windows; start_date is adjusted if older than 30 trading days with a warning.

<sup>Written for commit 432afdfc8009ae077b00f10e4ac7dd209b302e97. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

