### PR TITLE
Intervals for historical data Validation Updated

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -33,7 +33,8 @@
       "Bash(find:*)",
       "Bash(copy:*)",
       "Bash(del /F \"D:\\openalgo-sandbox-test\\openalgo\\websocket_proxy\\server_optimized.py\")",
-      "Bash(move \"D:\\openalgo-sandbox-test\\openalgo\\websocket_proxy\\OPTIMIZATION_SUMMARY.md\" \"D:\\openalgo-sandbox-test\\openalgo\\docs\\WEBSOCKET_OPTIMIZATION.md\")"
+      "Bash(move \"D:\\openalgo-sandbox-test\\openalgo\\websocket_proxy\\OPTIMIZATION_SUMMARY.md\" \"D:\\openalgo-sandbox-test\\openalgo\\docs\\WEBSOCKET_OPTIMIZATION.md\")",
+      "WebFetch(domain:docs.openalgo.in)"
     ],
     "deny": [],
     "ask": []

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -78,6 +78,11 @@ class SplitOrderSchema(Schema):
     action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
     quantity = fields.Int(required=True, validate=validate.Range(min=1, error="Total quantity must be a positive integer."))  # Total quantity to split
     splitsize = fields.Int(required=True, validate=validate.Range(min=1, error="Split size must be a positive integer."))  # Size of each split
+    pricetype = fields.Str(missing='MARKET', validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"]))
+    product = fields.Str(missing='MIS', validate=validate.OneOf(["MIS", "NRML", "CNC"]))
+    price = fields.Float(missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number."))
+    trigger_price = fields.Float(missing=0.0, validate=validate.Range(min=0, error="Trigger price must be a non-negative number."))
+    disclosed_quantity = fields.Int(missing=0, validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."))
 
 class OptionsOrderSchema(Schema):
     apikey = fields.Str(required=True)


### PR DESCRIPTION
Intervals for historical data Validation Updated



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expanded allowed intervals in HistorySchema to accept more granular and higher-level timeframes for historical data requests. This reduces validation errors and supports 1s, 3h, weekly, and monthly queries.

- **New Features**
  - Added intervals: 1s, 3h, W, M.

<sup>Written for commit 470ea639356091fd1fa17d39b1a7e61c465777df. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



