### PR TITLE
Magin API docs Updated and Margin API updated for Angel and Upstox

### DIFF
--- a/broker/angel/mapping/margin_data.py
+++ b/broker/angel/mapping/margin_data.py
@@ -17,32 +17,54 @@ def transform_margin_positions(positions):
         List of positions in Angel Broking format
     """
     transformed_positions = []
+    skipped_positions = []
 
     for position in positions:
         try:
-            # Get the token for the symbol
-            token = get_token(position['symbol'], position['exchange'])
+            symbol = position['symbol']
+            exchange = position['exchange']
 
-            if not token:
-                logger.warning(f"Token not found for symbol: {position['symbol']} on exchange: {position['exchange']}")
+            # Get the token for the symbol
+            token = get_token(symbol, exchange)
+
+            # Validate token exists and is not None
+            if not token or token is None or str(token).lower() == 'none':
+                logger.warning(f"Token not found for symbol: {symbol} on exchange: {exchange}")
+                skipped_positions.append(f"{symbol} ({exchange})")
+                continue
+
+            # Validate token is a valid number/string (Angel expects numeric token)
+            token_str = str(token).strip()
+            if not token_str or not token_str.replace('.', '').replace('-', '').isdigit():
+                logger.warning(f"Invalid token format for {symbol} ({exchange}): '{token_str}'")
+                skipped_positions.append(f"{symbol} ({exchange}) - invalid token: {token_str}")
                 continue
 
             # Transform the position
             transformed_position = {
-                "exchange": position['exchange'],
+                "exchange": exchange,
                 "qty": int(position['quantity']),
                 "price": float(position.get('price', 0)),
                 "productType": map_product_type(position['product']),
-                "token": str(token),
+                "token": token_str,
                 "tradeType": position['action'].upper(),
                 "orderType": map_order_type(position['pricetype'])
             }
 
             transformed_positions.append(transformed_position)
+            logger.debug(f"Successfully transformed position: {symbol} ({exchange}) with token: {token_str}")
 
         except Exception as e:
             logger.error(f"Error transforming position: {position}, Error: {e}")
+            skipped_positions.append(f"{position.get('symbol', 'unknown')} - Error: {str(e)}")
             continue
+
+    # Log summary
+    if skipped_positions:
+        logger.warning(f"Skipped {len(skipped_positions)} position(s) due to missing/invalid tokens: {', '.join(skipped_positions)}")
+
+    if transformed_positions:
+        logger.info(f"Successfully transformed {len(transformed_positions)} position(s) for margin calculation")
 
     return transformed_positions
 
@@ -77,13 +99,13 @@ def map_order_type(pricetype):
 
 def parse_margin_response(response_data):
     """
-    Parse Angel Broking margin response to OpenAlgo standard format.
+    Parse Angel Broking margin calculator response to OpenAlgo standard format.
 
     Args:
-        response_data: Raw response from Angel Broking API
+        response_data: Raw response from Angel Broking margin calculator API
 
     Returns:
-        Standardized margin response
+        Standardized margin response matching OpenAlgo format
     """
     try:
         if not response_data or not isinstance(response_data, dict):
@@ -99,18 +121,33 @@ def parse_margin_response(response_data):
                 'message': response_data.get('message', 'Failed to calculate margin')
             }
 
-        # Extract margin data
+        # Extract margin data from Angel's margin calculator response
         data = response_data.get('data', {})
+        margin_components = data.get('marginComponents', {})
 
-        # Return standardized format
+        # Extract values from Angel's response
+        total_margin_required = data.get('totalMarginRequired', 0)
+        span_margin = margin_components.get('spanMargin', 0)
+        net_premium = margin_components.get('netPremium', 0)
+        margin_benefit = margin_components.get('marginBenefit', 0)
+
+        # Calculate exposure margin
+        # Formula: Exposure Margin = Total Margin - SPAN Margin - Premium + Margin Benefit
+        # This is derived since Angel doesn't provide exposure margin explicitly
+        exposure_margin = total_margin_required - span_margin - net_premium + margin_benefit
+
+        # Ensure exposure margin is not negative
+        if exposure_margin < 0:
+            exposure_margin = 0
+
+        # Return standardized format matching OpenAlgo API specification
         return {
             'status': 'success',
             'data': {
-                'available_margin': data.get('availablecash', 0),
-                'used_margin': data.get('m2munrealized', 0),
-                'collateral': data.get('collateral', 0),
-                'total_margin_required': data.get('marginused', 0),
-                'raw_response': data  # Include raw response for debugging
+                'total_margin_required': total_margin_required,
+                'span_margin': span_margin,
+                'exposure_margin': exposure_margin,
+                'margin_benefit': margin_benefit
             }
         }
 

--- a/broker/upstox/mapping/margin_data.py
+++ b/broker/upstox/mapping/margin_data.py
@@ -1,7 +1,7 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Upstox Margin API https://upstox.com/developer/api-documentation/margin
 
-from database.token_db import get_br_symbol
+from database.token_db import get_token
 from broker.upstox.mapping.transform_data import map_product_type
 from utils.logging import get_logger
 
@@ -18,19 +18,33 @@ def transform_margin_positions(positions):
         List of positions in Upstox format
     """
     transformed_positions = []
+    skipped_positions = []
 
     for position in positions:
         try:
-            # Get the broker symbol/instrument key for Upstox
-            instrument_key = get_br_symbol(position['symbol'], position['exchange'])
+            symbol = position['symbol']
+            exchange = position['exchange']
 
-            if not instrument_key:
-                logger.warning(f"Instrument key not found for: {position['symbol']} on exchange: {position['exchange']}")
+            # Get the instrument key for Upstox (format: EXCHANGE_SEGMENT|TOKEN)
+            # Note: get_token() returns instrument_key for Upstox, not get_br_symbol()
+            instrument_key = get_token(symbol, exchange)
+
+            # Validate instrument key exists and is not None
+            if not instrument_key or instrument_key is None or str(instrument_key).lower() == 'none':
+                logger.warning(f"Instrument key not found for: {symbol} on exchange: {exchange}")
+                skipped_positions.append(f"{symbol} ({exchange})")
+                continue
+
+            # Validate instrument key format (Upstox format: EXCHANGE_SEGMENT|TOKEN)
+            instrument_key_str = str(instrument_key).strip()
+            if not instrument_key_str or '|' not in instrument_key_str:
+                logger.warning(f"Invalid instrument key format for {symbol} ({exchange}): '{instrument_key_str}'")
+                skipped_positions.append(f"{symbol} ({exchange}) - invalid key: {instrument_key_str}")
                 continue
 
             # Transform the position
             transformed_position = {
-                "instrument_key": instrument_key,
+                "instrument_key": instrument_key_str,
                 "quantity": int(position['quantity']),
                 "transaction_type": position['action'].upper(),
                 "product": map_product_type(position['product'])
@@ -41,10 +55,19 @@ def transform_margin_positions(positions):
                 transformed_position['price'] = float(position['price'])
 
             transformed_positions.append(transformed_position)
+            logger.debug(f"Successfully transformed position: {symbol} ({exchange}) with key: {instrument_key_str}")
 
         except Exception as e:
             logger.error(f"Error transforming position: {position}, Error: {e}")
+            skipped_positions.append(f"{position.get('symbol', 'unknown')} - Error: {str(e)}")
             continue
+
+    # Log summary
+    if skipped_positions:
+        logger.warning(f"Skipped {len(skipped_positions)} position(s) due to missing/invalid instrument keys: {', '.join(skipped_positions)}")
+
+    if transformed_positions:
+        logger.info(f"Successfully transformed {len(transformed_positions)} position(s) for margin calculation")
 
     return transformed_positions
 
@@ -53,10 +76,10 @@ def parse_margin_response(response_data):
     Parse Upstox margin response to OpenAlgo standard format.
 
     Args:
-        response_data: Raw response from Upstox API
+        response_data: Raw response from Upstox margin API
 
     Returns:
-        Standardized margin response
+        Standardized margin response matching OpenAlgo format
     """
     try:
         if not response_data or not isinstance(response_data, dict):
@@ -78,43 +101,35 @@ def parse_margin_response(response_data):
                 'message': error_message
             }
 
-        # Extract margin data
+        # Extract margin data from Upstox response
         data = response_data.get('data', {})
+
+        # Extract top-level margin values
+        required_margin = data.get('required_margin', 0)
+        final_margin = data.get('final_margin', 0)
+
+        # Calculate margin benefit (difference between required and final margin)
+        margin_benefit = required_margin - final_margin
 
         # Extract margin breakdown (array of margins per instrument)
         margins = data.get('margins', [])
 
-        # Calculate aggregated margin breakdown
+        # Aggregate margin components from all instruments
         total_span = 0
         total_exposure = 0
-        total_equity = 0
-        total_net_premium = 0
-        total_additional = 0
-        total_tender = 0
 
         for margin in margins:
             total_span += margin.get('span_margin', 0)
             total_exposure += margin.get('exposure_margin', 0)
-            total_equity += margin.get('equity_margin', 0)
-            total_net_premium += margin.get('net_buy_premium', 0)
-            total_additional += margin.get('additional_margin', 0)
-            total_tender += margin.get('tender_margin', 0)
 
-        # Return standardized format
+        # Return standardized format matching OpenAlgo API specification
         return {
             'status': 'success',
             'data': {
-                'required_margin': data.get('required_margin', 0),
-                'final_margin': data.get('final_margin', 0),
+                'total_margin_required': required_margin,
                 'span_margin': total_span,
                 'exposure_margin': total_exposure,
-                'equity_margin': total_equity,
-                'net_buy_premium': total_net_premium,
-                'additional_margin': total_additional,
-                'tender_margin': total_tender,
-                'total_instruments': len(margins),
-                'individual_margins': margins,
-                'raw_response': data  # Include raw response for debugging
+                'margin_benefit': margin_benefit
             }
         }
 

--- a/docs/MARGIN_API_DOCUMENTATION.md
+++ b/docs/MARGIN_API_DOCUMENTATION.md
@@ -74,16 +74,6 @@ Custom Domain:  POST https://<your-custom-domain>/api/v1/margin
             "quantity": "75",
             "price": "125.50",
             "trigger_price": "0"
-        },
-        {
-            "symbol": "RELIANCE",
-            "exchange": "NSE",
-            "action": "BUY",
-            "product": "CNC",
-            "pricetype": "MARKET",
-            "quantity": "5",
-            "price": "0",
-            "trigger_price": "0"
         }
     ]
 }
@@ -98,10 +88,8 @@ Custom Domain:  POST https://<your-custom-domain>/api/v1/margin
         "total_margin_required": 328482.00,
         "span_margin": 258482.00,
         "exposure_margin": 70000.00,
-        "available_balance": 500000.00,
-        "insufficient_balance": 0.00,
-        "brokerage": 150.00
-    }
+        "margin_benefit": 500000.00
+        }
 }
 ```
 


### PR DESCRIPTION
Magin API docs Updated and Margin API updated for Angel and Upstox

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the Margin API for Angel and Upstox to the OpenAlgo format, with stricter token/instrument key validation and clearer logging. Updated docs to reflect the new response fields.

- **Refactors**
  - Angel: validate tokens (non-null, numeric), skip and log invalid positions; compute exposure_margin from totalMarginRequired, spanMargin, netPremium, marginBenefit; return total_margin_required, span_margin, exposure_margin, margin_benefit.
  - Upstox: use get_token for instrument_key, validate format (EXCHANGE_SEGMENT|TOKEN); aggregate span/exposure across instruments; return total_margin_required, span_margin, exposure_margin, margin_benefit.
  - Added summary logging for skipped and transformed positions.

- **Migration**
  - Response fields updated; removed available_balance, used_margin, collateral, equity_margin, net_buy_premium, additional_margin, tender_margin, raw_response, individual_margins.
  - Clients should read total_margin_required, span_margin, exposure_margin, margin_benefit.

<sup>Written for commit 1cfa3bc4bffd1a9da64d4676fee77d1f0645b92d. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

