### PR TITLE
fix kotak funds mapping issue

### DIFF
--- a/broker/kotak/api/funds.py
+++ b/broker/kotak/api/funds.py
@@ -70,7 +70,7 @@ def get_margin_data(auth_token):
         # Process and return the margin data
         # Note: Based on the API docs, the response fields are at root level
         processed_margin_data = {
-            "availablecash": f"{float(margin_data.get('CollateralValue', 0)):.2f}",
+            "availablecash": f"{float(margin_data.get('CollateralValue', 0)) + float(margin_data.get('RmsPayInAmt', 0)) - float(margin_data.get('RmsPayOutAmt', 0)):.2f}",
             "collateral": f"{float(margin_data.get('Collateral', 0)):.2f}",
             "m2munrealized": f"{float(margin_data.get('UnrealizedMtomPrsnt', 0)):.2f}",
             "m2mrealized": f"{float(margin_data.get('RealizedMtomPrsnt', 0)):.2f}",


### PR DESCRIPTION
Now it shows correct cash balance and collateral balance



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed incorrect mapping of cash and collateral in Kotak margin data so balances display correctly.

- **Bug Fixes**
  - availablecash now calculates CollateralValue + RmsPayInAmt - RmsPayOutAmt; collateral reads Collateral.

<sup>Written for commit f4bc699ae310326a9102e547ec2d0ffaa9f4ed43. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



