### PR TITLE
Dhan Websocket - 20 level depth activated

### DIFF
--- a/broker/dhan/streaming/dhan_adapter.py
+++ b/broker/dhan/streaming/dhan_adapter.py
@@ -400,6 +400,9 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """
         unsubscribed_count = 0
 
+        # Stop fallback monitor first
+        self.stop_fallback_monitor()
+
         with self.lock:
             # Count total subscriptions before clearing
             unsubscribed_count = len(self.subscriptions_5depth) + len(self.subscriptions_20depth)
@@ -584,7 +587,8 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
                             break
                 
                 if not subscription:
-                    self.logger.warning(f"Received 20-depth data for unsubscribed token: {security_id}, segment: {exchange_segment}")
+                    # Debug level - this is expected during disconnect
+                    self.logger.debug(f"Received 20-depth data for unsubscribed token: {security_id}, segment: {exchange_segment}")
                     # Clear accumulator
                     del self.depth_20_accumulator[security_id]
                     return


### PR DESCRIPTION
Dhan Websocket - 20 level depth activated

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable 20-level order book depth on Dhan WebSocket for NSE/NFO with automatic upgrade when supported, with a safe fallback to 5-level where needed. Also improves disconnect and unsubscribe flows for cleaner shutdown and quieter logs.

- **New Features**
  - Auto-upgrade to 20-level depth for NSE/NFO in depth mode when supported by the capability registry.
  - Start a 20→5 depth fallback monitor to handle unsupported exchanges dynamically.

- **Bug Fixes**
  - unsubscribe_all now stops the fallback monitor first and clears both 5/20-depth subscriptions.
  - Graceful disconnect: send DISCONNECT only if previously connected, safely close the socket, and join the thread.
  - Reduce noisy logs: treat unsubscribed 20-depth packets and shutdown closes as debug, warn only on unexpected disconnects.

<sup>Written for commit 73ae017b256e5b550ffc89922241e4b25a0535d6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

