### PR TITLE
fix post to get request

### DIFF
--- a/collections/openalgo/instruments.bru
+++ b/collections/openalgo/instruments.bru
@@ -4,7 +4,7 @@ meta {
   seq: 17
 }
 
-post {
+get {
   url: http://127.0.0.1:5000/api/v1/instruments
   body: json
   auth: none


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Fixed the instruments request in collections/openalgo/instruments.bru by changing POST to GET to match the API and prevent 405/400 errors when fetching instruments.

- **Bug Fixes**
  - Updated HTTP method to GET for /api/v1/instruments (read-only endpoint, no request body).

<sup>Written for commit 4b3e89a68fa51d23817d3089eb1fa00bb855d8a7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

