### PR TITLE
Motilal - TLS certification issue Fixed

### DIFF
--- a/broker/motilal/api/motilal_websocket.py
+++ b/broker/motilal/api/motilal_websocket.py
@@ -1118,13 +1118,15 @@ class MotilalWebSocket:
         Get the latest index value.
 
         Args:
-            exchange (str): Exchange code
+            exchange (str): Exchange code (full name like NSE, BSE, etc.)
             index_code (str): Index code
 
         Returns:
             dict: Latest index data or None if not available
         """
-        key = f"{exchange}:{index_code}"
+        # Convert exchange to single char for key lookup (binary parser stores with single-char exchange)
+        exchange_char = self._map_exchange_to_char(exchange)
+        key = f"{exchange_char}:{index_code}"
         with self.lock:
             index = self.last_index.get(key)
             if index:


### PR DESCRIPTION
Motilal - TLS certification issue Fixed



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enable TLS certificate verification for the Motilal WebSocket and reduce noisy logs. Fix instrument key mapping to align quotes and index lookups with parsed market data.

- **Bug Fixes**
  - Enable SSL certificate verification by removing sslopt override in run_forever().
  - Use single-char exchange codes when building keys in market data processing and in get_quote() and get_index(), matching the binary parser to prevent missing lookups.

- **Refactors**
  - Downgraded verbose info logs to debug for binary message reception and packet parsing.

<sup>Written for commit 3a32cdd6b02498eae4c989a75f51c502a377d1b0. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



