### PR TITLE
Fyers- OI updated in quotes and multiquotes

### DIFF
--- a/broker/fyers/api/data.py
+++ b/broker/fyers/api/data.py
@@ -108,6 +108,9 @@ class BrokerData:
                 raise Exception(error_msg)
 
             depth_data = response.get('d', {}).get(br_symbol, {})
+            if not depth_data:
+                logger.warning(f"No depth data found for {br_symbol} in API response.")
+                raise Exception(f"No quote data available for {exchange}:{symbol}")
 
             # Get bid/ask from depth data
             bids = depth_data.get('bids', [])


### PR DESCRIPTION
Fyers- OI updated in quotes and multiquotes



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated Fyers single and multi quotes to use the depth endpoint so Open Interest is included and bid/ask are read from level-1 depth. This makes quote fields consistent across both endpoints.

- **New Features**
  - Adds OI to single-quote and multiquote responses.

- **Refactors**
  - Switched from /data/quotes to /data/depth?symbol=...&ohlcv_flag=1.
  - Parsed fields from depth: o, h, l, ltp, c, v, oi, and bid/ask from bids[0]/ask[0].

<sup>Written for commit 54f210cf09454d14a8deb50b3e37bf8bf25909a5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



