### PR TITLE
nifty50 heatmap python example

### DIFF
--- a/examples/python/nifty50_heatmap1.py
+++ b/examples/python/nifty50_heatmap1.py
@@ -1,0 +1,99 @@
+from openalgo import api
+import pandas as pd
+import plotly.express as px
+
+# ---------------------------------------------------
+# OpenAlgo Client
+# ---------------------------------------------------
+client = api(
+    api_key="10c68486a5ad64b1f93f02e38b44e90a736282c4619e96505237b437893b513d",
+    host="http://127.0.0.1:5000"
+)
+
+print("🔁 OpenAlgo Python Bot is running.")
+
+# ---------------------------------------------------
+# NIFTY 50 SYMBOLS
+# ---------------------------------------------------
+symbols = [
+    "INDIGO","TRENT","HINDUNILVR","HCLTECH","WIPRO","INFY","TATACONSUM",
+    "TATASTEEL","ITC","ASIANPAINT","SBILIFE","LT","SHRIRAMFIN","BEL","SBIN",
+    "COALINDIA","KOTAKBANK","TCS","SUNPHARMA","MAXHEALTH","NESTLEIND",
+    "RELIANCE","ETERNAL","APOLLOHOSP","ICICIBANK","GRASIM","ULTRACEMCO",
+    "ADANIENT","AXISBANK","DRREDDY","TECHM","TMPV","JIOFIN","NTPC",
+    "BAJFINANCE","BHARTIARTL","POWERGRID","HINDALCO","HDFCBANK","TITAN",
+    "HDFCLIFE","MARUTI","BAJAJFINSV","ADANIPORTS","CIPLA","JSWSTEEL",
+    "BAJAJ-AUTO","ONGC","EICHERMOT","M&M"
+]
+
+# ---------------------------------------------------
+# FETCH LIVE QUOTES
+# ---------------------------------------------------
+quote_symbols = [{"symbol": s, "exchange": "NSE"} for s in symbols]
+response = client.multiquotes(symbols=quote_symbols)
+
+rows = []
+
+print("\n📊 Live Market Data:")
+for item in response["results"]:
+    symbol = item["symbol"]
+    ltp = item["data"]["ltp"]
+    prev_close = item["data"]["prev_close"]
+
+    change_pct = round(((ltp - prev_close) / prev_close) * 100, 2)
+
+    # Print immediately (rule)
+    print(f"{symbol} | LTP: {ltp} | Change: {change_pct}%")
+
+    rows.append([symbol, change_pct])
+
+# ---------------------------------------------------
+# PREPARE + SORT DATA
+# ---------------------------------------------------
+df = pd.DataFrame(rows, columns=["Symbol", "Change"])
+
+# 🔥 SORT: TOP GAINERS → BOTTOM LOSERS
+df = df.sort_values("Change", ascending=False).reset_index(drop=True)
+
+# Grid: 10 columns x 5 rows
+cols = 10
+df["row"] = df.index // cols
+df["col"] = df.index % cols
+
+pivot_values = df.pivot(index="row", columns="col", values="Change")
+pivot_labels = df.pivot(index="row", columns="col", values="Symbol")
+
+# ---------------------------------------------------
+# HEATMAP PLOT
+# ---------------------------------------------------
+fig = px.imshow(
+    pivot_values,
+    color_continuous_scale="RdYlGn",
+    aspect="auto"
+)
+
+fig.update_traces(
+    text=pivot_labels.values,
+    texttemplate="%{text}<br>%{z:.2f}%",
+    hovertemplate="Symbol: %{text}<br>Change: %{z:.2f}%"
+)
+
+fig.update_layout(
+    title="🔥 NIFTY 50 Sorted Heatmap (%)",
+    xaxis=dict(type="category", title=""),
+    yaxis=dict(type="category", autorange="reversed", title=""),
+    template="plotly_dark",
+    height=600
+)
+
+# ---------------------------------------------------
+# SAVE IMAGE (NO HTML OUTPUT)
+# ---------------------------------------------------
+fig.write_image(
+    "nifty50_heatmap.png",
+    width=1200,
+    height=600,
+    scale=2
+)
+
+print("\n✅ Heatmap saved as nifty50_heatmap.png")


### PR DESCRIPTION
nifty50 heatmap python example

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Python example that fetches live NIFTY 50 quotes from OpenAlgo and generates a sorted heatmap saved as a PNG. Helps quickly visualize top gainers to losers.

- **New Features**
  - Added examples/python/nifty50_heatmap1.py to fetch NSE quotes and print LTP and % change.
  - Builds a 10x5 heatmap sorted by % change using pandas and plotly, with labels and hover.
  - Saves nifty50_heatmap.png (static image, no HTML).

- **Dependencies**
  - Requires pandas, plotly, and kaleido (for write_image).
  - Set your OpenAlgo api_key and host (defaults to http://127.0.0.1:5000).

<sup>Written for commit f87d0dbad922be53792971a0c6a6a46f3531812b. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

