### PR TITLE
add underlying index previous close

### DIFF
--- a/services/option_chain_service.py
+++ b/services/option_chain_service.py
@@ -241,14 +241,16 @@ def get_option_chain(
                 'message': f"Failed to fetch LTP for {quote_symbol}: {quote_response.get('message', 'Unknown error')}"
             }, status_code
 
-        underlying_ltp = quote_response.get('data', {}).get('ltp')
+        underlying_data = quote_response.get('data', {})
+        underlying_ltp = underlying_data.get('ltp')
+        underlying_prev_close = underlying_data.get('prev_close', 0)
         if underlying_ltp is None:
             return False, {
                 'status': 'error',
                 'message': f'Could not determine LTP for {quote_symbol}'
             }, 500
 
-        logger.info(f"Underlying LTP: {underlying_ltp}")
+        logger.info(f"Underlying LTP: {underlying_ltp}, Prev Close: {underlying_prev_close}")
 
         # Step 4: Get options exchange and available strikes
         options_exchange = get_option_exchange(quote_exchange)
@@ -374,6 +376,7 @@ def get_option_chain(
             'status': 'success',
             'underlying': base_symbol,
             'underlying_ltp': underlying_ltp,
+            'underlying_prev_close': underlying_prev_close,
             'expiry_date': final_expiry,
             'atm_strike': atm_strike,
             'chain': chain


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Expose the underlying index previous close in the option chain response and logs. We read prev_close from the quote API (default 0) and return it as underlying_prev_close alongside underlying_ltp.

<sup>Written for commit 1a987c3edbd4b59110718c6e732eb154141778d5. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

