### PR TITLE
issue #642 Flattrade PNL tracker fixed

### DIFF
--- a/blueprints/pnltracker.py
+++ b/blueprints/pnltracker.py
@@ -41,7 +41,8 @@ def parse_trade_timestamp(timestamp_str, fallback_date=None):
             if dt.tz is None:
                 return dt.tz_localize('UTC').tz_convert(ist)
             return dt.tz_convert(ist)
-        except:
+        except Exception as e:
+            logger.warning(f"Failed to parse numeric timestamp {timestamp_str}: {e}")
             return None
     
     if not isinstance(timestamp_str, str):
@@ -88,8 +89,8 @@ def parse_trade_timestamp(timestamp_str, fallback_date=None):
         if dt.tz is None:
             return dt.tz_localize(ist)
         return dt.tz_convert(ist)
-    except:
-        pass
+    except Exception as e:
+        logger.warning(f"Failed to auto-parse timestamp '{timestamp_str}': {e}")
     
     return None
 


### PR DESCRIPTION
Safe fallback chain - Tries multiple formats in order, never crashes
Minimal code change - One centralized function, three lines of code replaced at each call site
Easy to extend - Just add new formats to the formats list for future brokers



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a universal trade timestamp parser in pnltracker and switches all parsing to it. Fixes Flattrade PNL time parsing, prevents crashes, and outputs IST-aware times. Fixes #642.

- **Bug Fixes**
  - Correctly parses Flattrade (“HH:MM:SS DD-MM-YYYY”), AngelOne (“DD-Mon-YYYY HH:MM:SS”), ISO, Unix epoch, and time-only values.
  - Handles missing or malformed timestamps with safe fallbacks; no hard failures.

- **Refactors**
  - Centralized logic in parse_trade_timestamp and replaced ad-hoc parsing at call sites.
  - Unified first_trade_time and per-trade parsed_time calculation using the helper.

<sup>Written for commit 9e4c01ef18acac67d30170c77099de5e2ce903fe. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



