### PR TITLE
Dhan Option chain fixed -field parameter mismatch

### DIFF
--- a/broker/dhan/api/data.py
+++ b/broker/dhan/api/data.py
@@ -751,7 +751,7 @@ class BrokerData:
 
             # Check if security_id exists in segment_data
             security_id_found = str(security_id) in segment_data if segment_data else False
-            logger.info(f"Looking for {exchange_segment}:{security_id} - segment has {len(segment_data) if segment_data else 0} items, security_id found: {security_id_found}")
+            logger.debug(f"Looking for {exchange_segment}:{security_id} - segment has {len(segment_data) if segment_data else 0} items, security_id found: {security_id_found}")
 
             if not quote_data:
                 logger.warning(f"No quote data found for {original['symbol']} (requested: {exchange_segment}:{security_id})")
@@ -764,7 +764,7 @@ class BrokerData:
 
             # Debug: Log the actual quote_data structure to identify field names
             raw_last_price = quote_data.get('last_price') or quote_data.get('lastPrice')
-            logger.info(f"Quote data for {original['symbol']}: keys={list(quote_data.keys())}, last_price={raw_last_price}, volume={quote_data.get('volume')}")
+            logger.debug(f"Quote data for {original['symbol']}: keys={list(quote_data.keys())}, last_price={raw_last_price}, volume={quote_data.get('volume')}")
 
             # Parse and format quote data - handle both snake_case and camelCase
             ohlc = quote_data.get('ohlc', {})


### PR DESCRIPTION
Dhan Option chain fixed -field parameter mismatch



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dhan quote parsing by aligning API field names and normalizing types, so LTP, OI, and volume show correctly in option chain and batch quotes. Adds safer handling and clearer logs to troubleshoot missing data.

- **Bug Fixes**
  - Support both last_price/lastPrice and oi/open_interest; coerce volume/oi to int.
  - Read OHLC from ohlc object; set prev_close from ohlc.close.
  - Guard against null depth; return oi=0 when no quote data.
  - Add focused logs for request segments, security IDs, and response keys to spot mismatches.

<sup>Written for commit 52c43c5fded093b607b98cfc77e9fdc370dbdd2e. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



