### PR TITLE
Fyers Option chain - bid and ask fixed

### DIFF
--- a/broker/fyers/api/data.py
+++ b/broker/fyers/api/data.py
@@ -238,11 +238,15 @@ class BrokerData:
                 if quote_item.get('s') == 'ok':
                     symbol_name = quote_item.get('n', '')
                     quotes_map[symbol_name] = quote_item.get('v', {})
+        else:
+            logger.warning(f"Quotes API error: {quotes_response.get('message', 'Unknown error')}")
 
         # Parse depth response - dict format (only for OI)
         depth_map = {}
         if depth_response.get('s') == 'ok':
             depth_map = depth_response.get('d', {})
+        else:
+            logger.warning(f"Depth API error: {depth_response.get('message', 'Unknown error')}")
 
         # Build results by merging data from both endpoints
         results = []


### PR DESCRIPTION
Fyers Option chain - bid and ask fixed



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes incorrect bid/ask in the Fyers option chain for multi-symbol requests. Uses /data/quotes for accurate bid/ask and /data/depth only for OI to ensure correct top-of-book data.

- **Bug Fixes**
  - Worked around Fyers bulk depth bug where bids/asks were concatenated across symbols.
  - Merged quotes (bid/ask, OHLC, LTP, volume) with depth OI per symbol, with fallbacks.
  - Added warnings for API errors and when a symbol has no data.

<sup>Written for commit b44f2d499b4ed35f9bd5cbf8ed31f34587382482. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->



