### PR TITLE
websocket pooling - zmq setup fixed

### DIFF
--- a/websocket_proxy/base_adapter.py
+++ b/websocket_proxy/base_adapter.py
@@ -126,10 +126,10 @@ class BaseBrokerWebSocketAdapter(ABC):
 
         try:
             if use_shared_zmq and shared_publisher:
-                # Use shared publisher - don't create own socket
-                self.socket = None
+                # Use shared publisher's socket instead of creating own
+                self.socket = shared_publisher.socket
                 self.zmq_port = shared_publisher.zmq_port
-                self.context = None
+                self.context = shared_publisher.context
                 self.logger.info(f"Using shared ZMQ publisher on port {self.zmq_port}")
             else:
                 # Initialize own ZeroMQ context and socket


### PR DESCRIPTION
websocket pooling - zmq setup fixed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shared ZMQ setup in the websocket proxy to use the shared publisher’s socket and context, enabling proper pooling and preventing publish failures when use_shared_zmq is enabled.

- **Bug Fixes**
  - Use shared_publisher.socket and shared_publisher.context instead of setting them to None.
  - Keep using shared_publisher.zmq_port and log the shared setup.

<sup>Written for commit 05cb78e4e3c135fc2d518cb1fb30dd8a3e0c9bc6. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

