### PR TITLE
Openalgo sdk version updated from 1.0.44 to 1.0.45

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -82,7 +82,7 @@ dependencies = [
   "nest-asyncio==1.6.0",
   "numba==0.63.0b1",
   "numpy==2.3.5",
-  "openalgo==1.0.44",
+  "openalgo==1.0.45",
   "ordered-set==4.1.0",
   "orjson==3.11.3",
   "packaging==24.1",

--- a/requirements-nginx.txt
+++ b/requirements-nginx.txt
@@ -76,7 +76,7 @@ nbformat==5.10.4
 nest-asyncio==1.6.0
 numba==0.63.0b1
 numpy==2.3.5
-openalgo==1.0.44
+openalgo==1.0.45
 ordered-set==4.1.0
 orjson==3.11.3
 packaging==24.1

--- a/requirements.txt
+++ b/requirements.txt
@@ -76,7 +76,7 @@ nbformat==5.10.4
 nest-asyncio==1.6.0
 numba==0.63.0b1
 numpy==2.3.5
-openalgo==1.0.44
+openalgo==1.0.45
 ordered-set==4.1.0
 orjson==3.11.3
 packaging==24.1

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 3
+revision = 2
 requires-python = ">=3.12"
 
 [[package]]
@@ -1128,7 +1128,7 @@ wheels = [
 
 [[package]]
 name = "openalgo"
-version = "1.0.44"
+version = "1.0.45"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "httpx" },
@@ -1137,9 +1137,9 @@ dependencies = [
     { name = "pandas" },
     { name = "websocket-client" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/1f/75/593eda5e22f59be1ebd54c3d8e17231b26fb21a9ec6c2aa6753d798ccdee/openalgo-1.0.44.tar.gz", hash = "sha256:b31ce9c95a0c12eb91a98e8cf65b672e4bdedf165f7cf1c4b293dc542cb38b70", size = 112581, upload-time = "2025-12-18T11:02:03.109Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/8d/cc/56369016ca6740dda275e83723ede4b7097d2f46f5ec1358ff87209bd5dc/openalgo-1.0.45.tar.gz", hash = "sha256:adb6793dd749a30ce2271a557c2009ca8249bf1253faeb191c204d8aeeaf61da", size = 112710, upload-time = "2025-12-24T06:51:28.629Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/bc/7f/695c4a21385cc6d0aaab0a875dbeeb1858d5c4a1d1ba83a2a01ae0caa791/openalgo-1.0.44-py3-none-any.whl", hash = "sha256:d68e8373839b183c35f3b818ed65b536ee370ff69e6a24fdc93c3fe8f2281a5d", size = 114137, upload-time = "2025-12-18T11:02:01.339Z" },
+    { url = "https://files.pythonhosted.org/packages/56/9f/7cad2a813274213774fe210c2e7f2f0c23986eb3a707c5ed59da385fcc80/openalgo-1.0.45-py3-none-any.whl", hash = "sha256:35f578185174e3789f738184593740f47a158c343c03ce7d4afc7c381960bb22", size = 114262, upload-time = "2025-12-24T06:51:26.145Z" },
 ]
 
 [[package]]
@@ -1373,7 +1373,7 @@ requires-dist = [
     { name = "nest-asyncio", specifier = "==1.6.0" },
     { name = "numba", specifier = "==0.63.0b1" },
     { name = "numpy", specifier = "==2.3.5" },
-    { name = "openalgo", specifier = "==1.0.44" },
+    { name = "openalgo", specifier = "==1.0.45" },
     { name = "ordered-set", specifier = "==4.1.0" },
     { name = "orjson", specifier = "==3.11.3" },
     { name = "packaging", specifier = "==24.1" },


### PR DESCRIPTION
Openalgo sdk version updated from 1.0.44 to 1.0.45

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgraded Openalgo SDK from 1.0.44 to 1.0.45 across pyproject.toml, requirements, and uv.lock. Picks up the latest upstream fixes and keeps dependencies in sync.

<sup>Written for commit 66b8976afcefdfae5a15328390801e43cbfa0135. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

