### PR TITLE
fix: prevent ZeroDivisionError in Kotak Neo positions during market-o…

### DIFF
--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -246,6 +246,8 @@ def transform_positions_data(positions_data):
             transformed_position["average_price"] = round(float(position.get('sellAmt', 0)) / sell_qty, 2)
         elif transformed_position['quantity'] != 0:
             transformed_position["average_price"] = 0.0
+            
+        transformed_data.append(transformed_position)
         
     return transformed_data
 


### PR DESCRIPTION
## Description
Fixes `ZeroDivisionError` in Kotak Neo position transformation during market-off hours that causes application crash and forced logout.

## Related Issues
Closes #667

## Changes Made
- Added zero-division validation before calculating average price
- Implemented safety checks for `flBuyQty` and `flSellQty` 
- Used `.get()` method with default values for safer data access
- Set `average_price` to `0.0` as fallback when quantities are zero
- Maintains original calculation logic for normal market hours
- 
## Review Updates
- Addressed @cubic-dev-ai feedback: changed final `else` to `elif transformed_position['quantity'] != 0` to preserve existing `avgnetprice` for balanced positions (quantity == 0) instead of overwriting all remaining cases.

## Testing
- Tested during market-off hours (weekend) with 12 active carry-forward positions
- Verified no `ZeroDivisionError` occurs
- Confirmed no forced logout or session termination
- Validated positions page displays correctly with average price showing `0` (expected behavior during off-hours)
- Positions data loads and functions normally

## Screenshots
**Before the fix:** Clicking on the Positions tab during market-off hours would immediately crash the application with a `ZeroDivisionError` and automatically log me out, preventing any access to position data.

**After the fix:** The Positions page now loads successfully and displays all 12 active positions without any crashes or forced logout. Average prices show as `0` during market-off hours, which is the expected behavior when quantity data is unavailable.

<img width="1920" height="644" alt="image" src="https://github.com/user-attachments/assets/7881752f-1574-491b-9262-7f8077a48424" />


## Checklist
- [x] Code follows PEP 8 guidelines
- [x] Tested locally and verified working
- [x] No breaking changes to existing code
- [x] Handles edge case (market-off hours with zero quantities)





<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a ZeroDivisionError in Kotak Neo positions during market-off hours by guarding average price calculations and preserving avgnetprice for balanced positions. This stops positions page crashes; average price shows 0 only when buy/sell quantities are missing for non-zero positions.

- **Bug Fixes**
  - Compute average_price only when flBuyQty/flSellQty > 0.
  - Preserve avgnetprice when net quantity == 0.
  - Use position.get(...) with defaults; fallback average_price = 0.0 only when quantity != 0 but denominator is 0.

<sup>Written for commit 46ee12bf6518a2c4a921cee9a82518401c7df4f7. Summary will update automatically on new commits.</sup>

<!-- End of auto-generated description by cubic. -->





