### PR TITLE
feat(api): add multioptiongreeks batch endpoint for faster Greeks loading

### DIFF
--- a/blueprints/playground.py
+++ b/blueprints/playground.py
@@ -109,7 +109,7 @@ def categorize_endpoint(path):
 
     # Data endpoints
     if any(x in path_lower for x in ['/quotes', '/multiquotes', '/depth', '/history', '/intervals', '/symbol',
-                                      '/search', '/expiry', '/optionsymbol', '/optiongreeks', '/optionchain',
+                                      '/search', '/expiry', '/optionsymbol', '/optiongreeks', '/multioptiongreeks', '/optionchain',
                                       '/ticker', '/syntheticfuture', '/instruments']):
         return 'data'
 

--- a/collections/openalgo/multioptiongreeks.bru
+++ b/collections/openalgo/multioptiongreeks.bru
@@ -1,0 +1,27 @@
+meta {
+  name: Multi Option Greeks
+  type: http
+  seq: 16
+}
+
+post {
+  url: http://127.0.0.1:5000/api/v1/multioptiongreeks
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+      "apikey": "",
+      "symbols": [
+        {
+          "symbol": "NIFTY27JAN2626000CE",
+          "exchange": "NFO"
+        },
+        {
+          "symbol": "NIFTY27JAN2626000PE",
+          "exchange": "NFO"
+        }
+      ]
+  }
+}

--- a/restx_api/__init__.py
+++ b/restx_api/__init__.py
@@ -34,6 +34,7 @@ from .option_symbol import api as option_symbol_ns
 from .options_order import api as options_order_ns
 from .options_multiorder import api as options_multiorder_ns
 from .option_greeks import api as option_greeks_ns
+from .multi_option_greeks import api as multi_option_greeks_ns
 from .synthetic_future import api as synthetic_future_ns
 from .analyzer import api as analyzer_ns
 from .ping import api as ping_ns
@@ -75,6 +76,7 @@ api.add_namespace(option_symbol_ns, path='/optionsymbol')
 api.add_namespace(options_order_ns, path='/optionsorder')
 api.add_namespace(options_multiorder_ns, path='/optionsmultiorder')
 api.add_namespace(option_greeks_ns, path='/optiongreeks')
+api.add_namespace(multi_option_greeks_ns, path='/multioptiongreeks')
 api.add_namespace(synthetic_future_ns, path='/syntheticfuture')
 api.add_namespace(analyzer_ns, path='/analyzer')
 api.add_namespace(ping_ns, path='/ping')

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -134,3 +134,22 @@ class MarketHolidaysSchema(Schema):
 class MarketTimingsSchema(Schema):
     apikey = fields.Str(required=True)      # API Key for authentication
     date = fields.Str(required=True)        # Date in YYYY-MM-DD format
+
+class OptionSymbolRequest(Schema):
+    """Schema for a single option symbol request in batch"""
+    symbol = fields.Str(required=True)      # Option symbol (e.g., NIFTY28NOV2424000CE)
+    exchange = fields.Str(required=True, validate=validate.OneOf(["NFO", "BFO", "CDS", "MCX"]))
+    underlying_symbol = fields.Str(required=False)   # Optional: Specify underlying symbol
+    underlying_exchange = fields.Str(required=False)  # Optional: Specify underlying exchange
+
+class MultiOptionGreeksSchema(Schema):
+    """Schema for batch option greeks requests"""
+    apikey = fields.Str(required=True)      # API Key for authentication
+    symbols = fields.List(
+        fields.Nested(OptionSymbolRequest), 
+        required=True, 
+        validate=validate.Length(min=1, max=50)  # Max 50 symbols per request
+    )
+    interest_rate = fields.Float(required=False, validate=validate.Range(min=0, max=100))  # Common interest rate for all
+    expiry_time = fields.Str(required=False)  # Optional: Common expiry time for all
+

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -1,0 +1,129 @@
+from flask_restx import Namespace, Resource
+from flask import request, jsonify, make_response
+from marshmallow import ValidationError
+from limiter import limiter
+import os
+
+from .data_schemas import MultiOptionGreeksSchema
+from services.option_greeks_service import get_multi_option_greeks
+from database.auth_db import verify_api_key
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Rate limit for multi option greeks API (same as multiquotes)
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
+api = Namespace('multioptiongreeks', description='Batch Option Greeks API')
+
+# Initialize schema
+multi_option_greeks_schema = MultiOptionGreeksSchema()
+
+
+@api.route('', strict_slashes=False)
+class MultiOptionGreeks(Resource):
+    @limiter.limit(API_RATE_LIMIT)
+    def post(self):
+        """
+        Calculate Option Greeks for multiple symbols in a single request
+        
+        This endpoint calculates option Greeks (Delta, Gamma, Theta, Vega, Rho) 
+        and Implied Volatility for multiple option symbols using Black-76 model.
+        
+        Required fields:
+        - apikey: API key for authentication
+        - symbols: List of option symbol requests, each containing:
+            - symbol: Option symbol (e.g., NIFTY28NOV2424000CE)
+            - exchange: Exchange code (NFO, BFO, CDS, MCX)
+            - underlying_symbol: (Optional) Underlying symbol
+            - underlying_exchange: (Optional) Underlying exchange
+        
+        Optional fields:
+        - interest_rate: Risk-free interest rate (annualized %). Applied to all symbols.
+        - expiry_time: Custom expiry time in HH:MM format. Applied to all symbols.
+        
+        Example Request:
+        {
+            "apikey": "your_api_key",
+            "symbols": [
+                {"symbol": "NIFTY30DEC2524000CE", "exchange": "NFO"},
+                {"symbol": "NIFTY30DEC2524000PE", "exchange": "NFO"},
+                {"symbol": "NIFTY30DEC2526000CE", "exchange": "NFO", "underlying_symbol": "NIFTY30DEC25FUT", "underlying_exchange": "NFO"}
+            ],
+            "interest_rate": 7.0
+        }
+        
+        Example Response:
+        {
+            "status": "success",
+            "data": [
+                {
+                    "status": "success",
+                    "symbol": "NIFTY30DEC2524000CE",
+                    "exchange": "NFO",
+                    "implied_volatility": 15.25,
+                    "greeks": {"delta": 0.52, "gamma": 0.0001, "theta": -4.97, "vega": 30.76, "rho": 0.001}
+                },
+                ...
+            ],
+            "summary": {"total": 3, "success": 2, "failed": 1}
+        }
+        """
+        try:
+            # Get request data
+            data = request.json
+
+            if data is None:
+                return make_response(jsonify({
+                    'status': 'error',
+                    'message': 'Request body is missing or invalid JSON'
+                }), 400)
+
+            # Validate request data
+            try:
+                validated_data = multi_option_greeks_schema.load(data)
+            except ValidationError as err:
+                logger.warning(f"Validation error in multi option greeks request: {err.messages}")
+                return make_response(jsonify({
+                    'status': 'error',
+                    'message': 'Validation failed',
+                    'errors': err.messages
+                }), 400)
+
+            # Extract validated data
+            api_key = validated_data.get('apikey')
+            symbols = validated_data.get('symbols')
+            interest_rate = validated_data.get('interest_rate')
+            expiry_time = validated_data.get('expiry_time')
+
+            # Verify API key
+            if not verify_api_key(api_key):
+                logger.warning(f"Invalid API key used for multi option greeks: {api_key[:10]}...")
+                return make_response(jsonify({
+                    'status': 'error',
+                    'message': 'Invalid openalgo apikey'
+                }), 401)
+
+            # Get multi option Greeks
+            logger.info(f"Calculating Greeks for {len(symbols)} symbols")
+
+            success, response, status_code = get_multi_option_greeks(
+                symbols=symbols,
+                interest_rate=interest_rate,
+                expiry_time=expiry_time,
+                api_key=api_key
+            )
+
+            if success:
+                logger.info(f"Multi Greeks calculated: {response.get('summary', {})}")
+            else:
+                logger.error(f"Failed to calculate multi Greeks: {response.get('message')}")
+
+            return make_response(jsonify(response), status_code)
+
+        except Exception as e:
+            logger.exception(f"Unexpected error in multi option greeks endpoint: {e}")
+            return make_response(jsonify({
+                'status': 'error',
+                'message': 'Internal server error while calculating option Greeks'
+            }), 500)

--- a/test/test_multi_option_greeks_api.py
+++ b/test/test_multi_option_greeks_api.py
@@ -1,0 +1,232 @@
+"""
+Test script for Multi Option Greeks API
+
+This script demonstrates how to use the /api/v1/multioptiongreeks endpoint
+to calculate option Greeks for multiple symbols in a single request.
+
+Prerequisites:
+1. Install py_vollib library: pip install py_vollib
+2. OpenAlgo must be running
+3. Markets should be open for live prices
+
+Usage:
+    cd c:\\Users\\Karthik\\Downloads\\openalgo-chart\\openalgo\\test
+    python test_multi_option_greeks_api.py
+"""
+
+import sys
+import os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import requests
+import json
+
+# Configuration
+BASE_URL = "http://127.0.0.1:5000"
+API_KEY = "your_api_key_here"  # Replace with your actual API key
+
+
+def test_multiple_nifty_options():
+    """Test 1: Multiple NIFTY Options (CE + PE)"""
+    print("\n" + "="*60)
+    print("Test 1: Multiple NIFTY Options (CE + PE)")
+    print("="*60)
+    
+    url = f"{BASE_URL}/api/v1/multioptiongreeks"
+    
+    payload = {
+        "apikey": API_KEY,
+        "symbols": [
+            {"symbol": "NIFTY30DEC2526000CE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2526000PE", "exchange": "NFO"}
+        ]
+    }
+    
+    print(f"\nRequest Payload:")
+    print(json.dumps(payload, indent=2))
+    
+    try:
+        response = requests.post(url, json=payload)
+        print(f"\nResponse Status: {response.status_code}")
+        result = response.json()
+        print(f"Response Body:")
+        print(json.dumps(result, indent=2))
+        
+        if result.get('status') in ['success', 'partial']:
+            print(f"\n📊 Summary: {result.get('summary', {})}")
+            for data in result.get('data', []):
+                if data.get('status') == 'success':
+                    print(f"   {data['symbol']}: IV={data.get('implied_volatility', 'N/A')}%, Delta={data.get('greeks', {}).get('delta', 'N/A')}")
+    
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def test_with_custom_underlying():
+    """Test 2: Options with Custom Underlying (Futures)"""
+    print("\n" + "="*60)
+    print("Test 2: Options with Custom Underlying (Futures)")
+    print("="*60)
+    
+    url = f"{BASE_URL}/api/v1/multioptiongreeks"
+    
+    payload = {
+        "apikey": API_KEY,
+        "symbols": [
+            {
+                "symbol": "NIFTY30DEC2526000CE", 
+                "exchange": "NFO",
+                "underlying_symbol": "NIFTY30DEC25FUT",
+                "underlying_exchange": "NFO"
+            },
+            {
+                "symbol": "NIFTY30DEC2526000PE", 
+                "exchange": "NFO",
+                "underlying_symbol": "NIFTY30DEC25FUT",
+                "underlying_exchange": "NFO"
+            }
+        ],
+        "interest_rate": 7.0
+    }
+    
+    print(f"\nRequest Payload:")
+    print(json.dumps(payload, indent=2))
+    
+    try:
+        response = requests.post(url, json=payload)
+        print(f"\nResponse Status: {response.status_code}")
+        result = response.json()
+        print(f"Response Body:")
+        print(json.dumps(result, indent=2))
+        
+        if result.get('status') in ['success', 'partial']:
+            print(f"\n📊 Using Futures as Underlying - Summary: {result.get('summary', {})}")
+    
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def test_mixed_options():
+    """Test 3: Mixed Options - Different Strikes"""
+    print("\n" + "="*60)
+    print("Test 3: Mixed Options - Different Strikes")
+    print("="*60)
+    
+    url = f"{BASE_URL}/api/v1/multioptiongreeks"
+    
+    payload = {
+        "apikey": API_KEY,
+        "symbols": [
+            {"symbol": "NIFTY30DEC2524000CE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2525000CE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2526000CE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2524000PE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2525000PE", "exchange": "NFO"},
+            {"symbol": "NIFTY30DEC2526000PE", "exchange": "NFO"}
+        ]
+    }
+    
+    print(f"\nRequest Payload: (6 symbols)")
+    print(json.dumps(payload, indent=2))
+    
+    try:
+        response = requests.post(url, json=payload)
+        print(f"\nResponse Status: {response.status_code}")
+        result = response.json()
+        
+        if result.get('status') in ['success', 'partial']:
+            print(f"\n📊 Summary: {result.get('summary', {})}")
+            for data in result.get('data', []):
+                if data.get('status') == 'success':
+                    print(f"   {data['symbol']}: Delta={data.get('greeks', {}).get('delta', 'N/A'):.4f}")
+        else:
+            print(json.dumps(result, indent=2))
+    
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def test_invalid_symbol():
+    """Test 4: Error Handling - Invalid Symbol"""
+    print("\n" + "="*60)
+    print("Test 4: Error Handling - Mixed Valid/Invalid Symbols")
+    print("="*60)
+    
+    url = f"{BASE_URL}/api/v1/multioptiongreeks"
+    
+    payload = {
+        "apikey": API_KEY,
+        "symbols": [
+            {"symbol": "NIFTY30DEC2526000CE", "exchange": "NFO"},
+            {"symbol": "INVALID_SYMBOL", "exchange": "NFO"}
+        ]
+    }
+    
+    print(f"\nRequest Payload:")
+    print(json.dumps(payload, indent=2))
+    
+    try:
+        response = requests.post(url, json=payload)
+        print(f"\nResponse Status: {response.status_code}")
+        result = response.json()
+        print(f"Response Body:")
+        print(json.dumps(result, indent=2))
+        
+        print(f"\n✓ Expected: status='partial', summary showing 1 success, 1 failed")
+    
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+def test_empty_symbols():
+    """Test 5: Error Handling - Empty Symbols Array"""
+    print("\n" + "="*60)
+    print("Test 5: Error Handling - Empty Symbols Array")
+    print("="*60)
+    
+    url = f"{BASE_URL}/api/v1/multioptiongreeks"
+    
+    payload = {
+        "apikey": API_KEY,
+        "symbols": []
+    }
+    
+    print(f"\nRequest Payload:")
+    print(json.dumps(payload, indent=2))
+    
+    try:
+        response = requests.post(url, json=payload)
+        print(f"\nResponse Status: {response.status_code}")
+        result = response.json()
+        print(f"Response Body:")
+        print(json.dumps(result, indent=2))
+        
+        print(f"\n✓ Expected: Validation error (min 1 symbol required)")
+    
+    except Exception as e:
+        print(f"Error: {e}")
+
+
+if __name__ == "__main__":
+    print("\n" + "="*60)
+    print("OpenAlgo Multi Option Greeks API Test Suite")
+    print("="*60)
+    print(f"\nBase URL: {BASE_URL}")
+    print(f"API Key: {API_KEY[:10]}..." if len(API_KEY) > 10 else f"API Key: {API_KEY}")
+    print("\n⚠️  Prerequisites:")
+    print("  1. Install py_vollib: pip install py_vollib")
+    print("  2. OpenAlgo must be running")
+    print("  3. Markets should be open for live prices")
+    print("  4. Update symbols to current/future expiry dates")
+    print("="*60)
+    
+    # Run tests
+    test_multiple_nifty_options()
+    test_with_custom_underlying()
+    test_mixed_options()
+    test_invalid_symbol()
+    test_empty_symbols()
+    
+    print("\n" + "="*60)
+    print("All tests completed!")
+    print("="*60)

--- a/utils/latency_monitor.py
+++ b/utils/latency_monitor.py
@@ -262,6 +262,7 @@ def init_latency_monitoring(app):
         'expiry': 'EXPIRY',
         'margin': 'MARGIN',
         'option_greeks': 'GREEKS',
+        'multi_option_greeks': 'MULTI_GREEKS',
         'option_symbol': 'OPTION_SYMBOL',
         'synthetic_future': 'SYNTHETIC',
         'ticker': 'TICKER',


### PR DESCRIPTION
- Add /api/v1/multioptiongreeks endpoint for batch processing up to 50 symbols
- Add MultiOptionGreeksSchema for request validation
- Add get_multi_option_greeks() service with parallel ThreadPoolExecutor
- Register namespace and add latency monitoring
- Add Bruno collection for API testing
- Update playground categorization

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a batch Option Greeks API to compute Greeks for up to 50 symbols in one call, reducing load time on multi-symbol views. The endpoint runs in parallel and returns per-symbol results plus a summary.

- **New Features**
  - POST /api/v1/multioptiongreeks: accepts apikey, symbols[] (symbol, exchange), optional underlying_symbol/_exchange, interest_rate, expiry_time.
  - Response includes per-symbol Greeks/IV and an overall summary; status is success/partial/error; preserves input order.
  - Parallel execution with ThreadPoolExecutor (up to 10 workers) for faster batch processing; rate-limited (10 per second).
  - Registered namespace, added MULTI_GREEKS latency metric, updated playground categorization; added Bruno request and a test script.

<sup>Written for commit a77e3329f66fda007ba97ca660978de21e54e9b0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

