### PR TITLE
Issue #704 prevent invalid trigger price error on limit order modifcation

### DIFF
--- a/broker/flattrade/mapping/transform_data.py
+++ b/broker/flattrade/mapping/transform_data.py
@@ -109,7 +109,7 @@ def transform_modify_order_data(data, token):
     if symbol and '&' in symbol:
         symbol = symbol.replace('&', '%26')
 
-    return {
+    result = {
         "uid": data["apikey"],
         "exch": data["exchange"],
         "norenordno": data["orderid"],
@@ -118,9 +118,15 @@ def transform_modify_order_data(data, token):
         "qty": str(data["quantity"]),
         "tsym": symbol,
         "ret": "DAY",
-        "trgprc": str(data.get("trigger_price") or 0),  # Required for SL/SL-M orders
         "dscqty": str(data.get("disclosed_quantity") or 0)
     }
+    
+    # Only include trigger price for SL/SL-M orders
+    # Sending trgprc=0 for LIMIT orders causes "Trigger price invalid - 0.00" error
+    if data["pricetype"] in ["SL", "SL-M"]:
+        result["trgprc"] = str(data.get("trigger_price") or 0)
+    
+    return result
 
 
 


### PR DESCRIPTION
Only include trigger price for SL/SL-M orders. Tested with flattrade issue fixed. Not sure whether shoonya also has issue or not

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevent “Trigger price invalid - 0.00” errors on Flattrade when modifying LIMIT orders by only sending trgprc for SL/SL-M orders. Fixes issue #704.

<sup>Written for commit 05c6a5384b655289dd21ddef4bcfe91a4288cb56. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

