### PR TITLE
Fix: Decouple Web Session Expiry from API Token Revocation

### DIFF
--- a/app.py
+++ b/app.py
@@ -305,7 +305,7 @@ def create_app():
         # Check if user is logged in and session is expired
         if session.get('logged_in') and not is_session_valid():
             logger.info(f"Session expired for user: {session.get('user')} - revoking tokens")
-            revoke_user_tokens()
+            revoke_user_tokens(revoke_db_tokens=False)
             session.clear()
             # Don't redirect here, let individual routes handle it
     


### PR DESCRIPTION


# Fix: Decouple Web Session Expiry from API Token Revocation

## Description
Fixes https://github.com/marketcalls/openalgo/issues/707
This PR resolves a critical issue where the **Background Algo Trading Bot** (via API) stops working when the **Web Dashboard Session** expires.

### The Problem
Currently, the `check_session_expiry` hook (and other session validators) calls `revoke_user_tokens()` unconditionally when a web session is deemed invalid or expired.
This function (`revoke_user_tokens`) sets `is_revoked=True` in the `auth` database table.
Since the `Auth` table is shared between the Web UI and the API Key system, this action inadvertently **invalidates the API Key**.

**Impact**: If a user's browser tab is left open and the session expires (e.g., at 3 AM), the backend bot will start failing with "Invalid openalgo apikey" errors, causing missed trades.

### The Solution
I have decoupled the "Web Logout" from "Database Revocation" during auto-expiry events.

1.  **Modified `utils/session.py`**:
    *   Updated `revoke_user_tokens` to accept an optional `revoke_db_tokens` argument (defaulting to `True` to maintain backward compatibility for explicit logouts).
    *   Added logic to skip `upsert_auth(..., revoke=True)` if `revoke_db_tokens` is `False`.

2.  **Modified `app.py` & Decorators**:
    *   Updated the `check_session_expiry` hook to call `revoke_user_tokens(revoke_db_tokens=False)`.
    *   Updated `check_session_validity` and `invalidate_session_if_invalid` decorators to also use `revoke_db_tokens=False`.

## Result
*   **Web Expiry**: The user is logged out of the browser (Session Cleared), but the Database Token remains valid. The Bot continues to trade.
*   **Explicit Logout**: The user clicks Logout, which calls `auth_bp.logout`. This still uses the default destructive behavior (or calls `upsert_auth` directly), ensuring security is maintained when explicitly requested.

## Testing
*   Verified that `revoke_user_tokens(revoke_db_tokens=False)` logs "Skipped DB revocation" and does not update the `auth` table.
*   Verified that `revoke_user_tokens(revoke_db_tokens=True)` correctly revokes the token.

---
*Contribution by @[sv26000]*


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Decouples web session auto-expiry from API token revocation so the trading bot keeps running when the dashboard session expires. Explicit logout still revokes tokens for security.

- **Bug Fixes**
  - Added revoke_db_tokens flag to revoke_user_tokens (default True for backward compatibility).
  - check_session_expiry now calls revoke_user_tokens(False) and clears the browser session without revoking the API key.
  - Auto-expiry preserves API access; explicit logout continues to revoke tokens.

<sup>Written for commit 5ee939ff868ec1f8068cd6b30af16b033368344b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

