### PR TITLE
Update app.py

### DIFF
--- a/app.py
+++ b/app.py
@@ -5,6 +5,13 @@ load_and_check_env_variables()
 import re
 import sys
 
+import mimetypes
+mimetypes.add_type("application/javascript", ".js")
+mimetypes.add_type("text/css", ".css")
+mimetypes.add_type("application/json", ".json")
+mimetypes.add_type("application/font-woff", ".woff")
+mimetypes.add_type("application/font-woff2", ".woff2")
+
 # Initialize logging EARLY to suppress verbose startup logs
 from utils.logging import get_logger, log_startup_banner, highlight_url  # Import centralized logging
 


### PR DESCRIPTION
"Fix MIME type issue when serving frontend assets"
New version 2.0.0.0 frontend page not working #746

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the frontend not loading in v2.0.0.0 by registering MIME types for JS, CSS, JSON, and web fonts so static files are served with the correct Content-Type. Addresses #746.

- **Bug Fixes**
  - Add MIME types for .js, .css, .json, .woff, .woff2 at startup.

<sup>Written for commit 608973e6dcf17aa0a6cd1b5a162172cc9650eadc. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

