### PR TITLE
docs: add update mode documentation for multi-instance installer

### DIFF
--- a/install/Docker-Multi-SSL-README.md
+++ b/install/Docker-Multi-SSL-README.md
@@ -94,6 +94,35 @@ docker compose restart
 docker compose logs -f
 ```
 
+## Updating Existing Instances
+
+When you run the script with existing domains, it will detect them and offer smart update options:
+
+```
+Instance for domain.com already exists. Update code only? (y=update, n=skip, r=reinstall):
+```
+
+| Option | Behavior |
+|--------|----------|
+| **y (Update)** | Pulls latest code, preserves `.env` file (passwords remain valid), skips all config prompts |
+| **n (Skip)** | Skips this domain entirely |
+| **r (Reinstall)** | Fresh install with new config (⚠️ regenerates security keys, invalidates existing passwords) |
+
+### What Gets Preserved During Updates
+
+When you choose **Update (y)**:
+- ✅ `.env` file (APP_KEY, PEPPER, broker credentials)
+- ✅ User passwords and login sessions
+- ✅ SSL certificates
+- ✅ Database (stored in Docker volumes)
+
+### Portainer Smart Detection
+
+If Portainer is already running, the script will:
+1. Detect the existing installation
+2. Offer to check for version updates
+3. Skip redundant configuration prompts
+
 ## Troubleshooting
 
 1.  **Healthcheck Failures**:


### PR DESCRIPTION
## Summary
Adds documentation for the new update mode feature introduced in PR #770.

## Changes to Docker-Multi-SSL-README.md

### New Section: Updating Existing Instances
- Documents the y/n/r prompt for existing domains:
  - **y (Update)**: Preserves .env and passwords
  - **n (Skip)**: Skips domain
  - **r (Reinstall)**: Fresh install with warning
- Lists what gets preserved during updates
- Documents Portainer smart detection feature

This helps users understand how to safely update their existing installations without losing configuration or invalidating passwords.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added update mode docs to the multi-instance installer README, covering the y/n/r prompt, what is preserved on Update, and Portainer smart detection. Helps users safely update existing instances without losing configuration, passwords, SSL certs, or data volumes.

<sup>Written for commit 63dada637f4e5d0e72bf20eb225468117b652aa1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

