### PR TITLE
fix: resolve stale auth cache causing 403 errors in WebSocket proxy

### DIFF
--- a/database/cache_invalidation.py
+++ b/database/cache_invalidation.py
@@ -1,0 +1,172 @@
+# database/cache_invalidation.py
+"""
+ZeroMQ-based cache invalidation for multi-process deployments.
+
+This module provides cross-process cache invalidation using ZeroMQ pub/sub.
+When auth tokens are updated or revoked in the Flask process, invalidation
+messages are published to all subscribed processes (e.g., WebSocket proxy).
+
+This solves the stale cache issue described in GitHub issue #765.
+"""
+
+import json
+import os
+import threading
+
+import zmq
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Cache invalidation message types
+CACHE_INVALIDATION_PREFIX = "CACHE_INVALIDATE"
+AUTH_CACHE_TYPE = "AUTH"
+FEED_CACHE_TYPE = "FEED"
+ALL_CACHE_TYPE = "ALL"
+
+# Singleton publisher instance
+_publisher_instance = None
+_publisher_lock = threading.Lock()
+
+
+class CacheInvalidationPublisher:
+    """
+    ZeroMQ publisher for broadcasting cache invalidation events.
+
+    Uses the same ZMQ port as market data (from ZMQ_PORT env var).
+    Messages are prefixed with CACHE_INVALIDATE to distinguish from market data.
+    """
+
+    def __init__(self):
+        self.context = None
+        self.socket = None
+        self._initialized = False
+        self._lock = threading.Lock()
+
+    def _ensure_initialized(self):
+        """Lazily initialize ZMQ connection on first use"""
+        if self._initialized:
+            return True
+
+        with self._lock:
+            if self._initialized:
+                return True
+
+            try:
+                self.context = zmq.Context()
+                self.socket = self.context.socket(zmq.PUB)
+
+                zmq_host = os.getenv("ZMQ_HOST", "127.0.0.1")
+                zmq_port = os.getenv("ZMQ_PORT", "5555")
+
+                # Connect as publisher (broker adapters bind, we connect)
+                self.socket.connect(f"tcp://{zmq_host}:{zmq_port}")
+
+                # Set socket options
+                self.socket.setsockopt(zmq.LINGER, 1000)  # 1 second linger on close
+                self.socket.setsockopt(zmq.SNDHWM, 100)   # High water mark
+
+                self._initialized = True
+                logger.debug(f"Cache invalidation publisher connected to tcp://{zmq_host}:{zmq_port}")
+                return True
+
+            except Exception as e:
+                logger.error(f"Failed to initialize cache invalidation publisher: {e}")
+                return False
+
+    def publish_invalidation(self, user_id: str, cache_type: str = ALL_CACHE_TYPE):
+        """
+        Publish a cache invalidation message for a specific user.
+
+        Args:
+            user_id: The user whose cache should be invalidated
+            cache_type: Type of cache to invalidate (AUTH, FEED, or ALL)
+        """
+        if not self._ensure_initialized():
+            logger.warning(f"Cache invalidation skipped - publisher not initialized for user: {user_id}")
+            return False
+
+        try:
+            # Create topic and message
+            topic = f"{CACHE_INVALIDATION_PREFIX}_{cache_type}_{user_id}"
+            message = {
+                "action": "invalidate",
+                "user_id": user_id,
+                "cache_type": cache_type,
+            }
+
+            # Send as multipart message (topic + data)
+            self.socket.send_multipart([
+                topic.encode("utf-8"),
+                json.dumps(message).encode("utf-8")
+            ])
+
+            logger.info(f"Published cache invalidation for user: {user_id}, type: {cache_type}")
+            return True
+
+        except Exception as e:
+            logger.error(f"Failed to publish cache invalidation for user {user_id}: {e}")
+            return False
+
+    def close(self):
+        """Close ZMQ connections"""
+        try:
+            if self.socket:
+                self.socket.close()
+            if self.context:
+                self.context.term()
+            self._initialized = False
+            logger.debug("Cache invalidation publisher closed")
+        except Exception as e:
+            logger.error(f"Error closing cache invalidation publisher: {e}")
+
+
+def get_cache_invalidation_publisher() -> CacheInvalidationPublisher:
+    """
+    Get the singleton cache invalidation publisher instance.
+
+    Returns:
+        CacheInvalidationPublisher: The publisher instance
+    """
+    global _publisher_instance
+
+    if _publisher_instance is None:
+        with _publisher_lock:
+            if _publisher_instance is None:
+                _publisher_instance = CacheInvalidationPublisher()
+
+    return _publisher_instance
+
+
+def publish_auth_cache_invalidation(user_id: str):
+    """
+    Convenience function to publish auth cache invalidation.
+
+    Args:
+        user_id: The user whose auth cache should be invalidated
+    """
+    publisher = get_cache_invalidation_publisher()
+    return publisher.publish_invalidation(user_id, AUTH_CACHE_TYPE)
+
+
+def publish_feed_cache_invalidation(user_id: str):
+    """
+    Convenience function to publish feed cache invalidation.
+
+    Args:
+        user_id: The user whose feed cache should be invalidated
+    """
+    publisher = get_cache_invalidation_publisher()
+    return publisher.publish_invalidation(user_id, FEED_CACHE_TYPE)
+
+
+def publish_all_cache_invalidation(user_id: str):
+    """
+    Convenience function to publish all cache invalidation.
+
+    Args:
+        user_id: The user whose all caches should be invalidated
+    """
+    publisher = get_cache_invalidation_publisher()
+    return publisher.publish_invalidation(user_id, ALL_CACHE_TYPE)

--- a/websocket_proxy/broker_factory.py
+++ b/websocket_proxy/broker_factory.py
@@ -156,10 +156,17 @@ class _PooledAdapterWrapper:
 
         return self._pool
 
-    def initialize(self, broker_name: str, user_id: str, auth_data: dict = None):
-        """Initialize the pool with user credentials"""
+    def initialize(self, broker_name: str, user_id: str, auth_data: dict = None, force: bool = False):
+        """Initialize the pool with user credentials
+
+        Args:
+            broker_name: The broker name
+            user_id: The user ID
+            auth_data: Optional authentication data
+            force: If True, force re-initialization with fresh credentials (issue #765)
+        """
         pool = self._ensure_pool(user_id)
-        return pool.initialize(broker_name, user_id, auth_data)
+        return pool.initialize(broker_name, user_id, auth_data, force=force)
 
     def connect(self):
         """Connect the pool"""
@@ -216,6 +223,79 @@ class _PooledAdapterWrapper:
         """Publish market data through the pool"""
         if self._pool:
             self._pool.publish_market_data(topic, data)
+
+    # =========================================================================
+    # Authentication Helper Methods (Issue #765 - Stale Token Handling)
+    # =========================================================================
+    # These methods delegate to the underlying adapter or implement the logic
+    # directly for handling stale auth tokens in multi-process deployments.
+
+    def is_auth_error(self, error_message: str) -> bool:
+        """
+        Check if an error message indicates an authentication failure.
+
+        Args:
+            error_message: The error message string
+
+        Returns:
+            True if the error indicates authentication failure (401/403)
+        """
+        if not error_message:
+            return False
+
+        error_lower = str(error_message).lower()
+        auth_error_indicators = [
+            "401",
+            "403",
+            "unauthorized",
+            "forbidden",
+            "authentication failed",
+            "auth failed",
+            "invalid token",
+            "token expired",
+            "access denied",
+            "invalid credentials",
+            "session expired",
+        ]
+        return any(indicator in error_lower for indicator in auth_error_indicators)
+
+    def clear_auth_cache_for_user(self, user_id: str):
+        """
+        Clear all cached authentication data for a user.
+
+        Call this when you detect stale credentials (e.g., 403 error from broker).
+
+        Args:
+            user_id: The user's ID
+        """
+        try:
+            from database.auth_db import (
+                auth_cache,
+                broker_cache,
+                feed_token_cache,
+            )
+
+            cache_key_auth = f"auth-{user_id}"
+            cache_key_feed = f"feed-{user_id}"
+
+            caches_cleared = []
+            if cache_key_auth in auth_cache:
+                del auth_cache[cache_key_auth]
+                caches_cleared.append("auth_cache")
+            if cache_key_feed in feed_token_cache:
+                del feed_token_cache[cache_key_feed]
+                caches_cleared.append("feed_token_cache")
+            if cache_key_auth in broker_cache:
+                del broker_cache[cache_key_auth]
+                caches_cleared.append("broker_cache")
+
+            if caches_cleared:
+                self.logger.info(f"Cleared auth caches for user {user_id}: {', '.join(caches_cleared)}")
+            else:
+                self.logger.debug(f"No cached auth data found for user {user_id}")
+
+        except Exception as e:
+            self.logger.error(f"Error clearing auth cache for user {user_id}: {e}")
 
 
 def get_pool_stats(broker_name: str = None) -> dict:


### PR DESCRIPTION
…#765)

This fix addresses the process-local auth cache issue in Docker deployments where Flask and WebSocket proxy run in separate processes with isolated caches.

Changes:
- Add database/cache_invalidation.py for ZeroMQ-based cache invalidation
- Add bypass_cache parameter to get_auth_token() for fresh DB queries
- Publish cache invalidation on logout/token revocation
- Add retry logic in server.py to detect connection failures and retry with fresh credentials from database
- Add force parameter to ConnectionPool.initialize() for re-initialization
- Add auth helper methods to _PooledAdapterWrapper and BaseBrokerWebSocketAdapter

When WebSocket connection fails due to stale cached token, the system now:
1. Detects the failure (401/403 or CONNECTION_FAILED)
2. Clears local auth caches
3. Force re-initializes the adapter with fresh token from database
4. Retries the connection

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes stale auth caches across processes that caused 401/403 in the WebSocket proxy; addresses #765. Adds ZeroMQ cache invalidation and automatic retry with fresh tokens to keep connections working.

- **Bug Fixes**
  - Added ZeroMQ pub/sub cache invalidation (database/cache_invalidation.py); ZMQ listener now handles CACHE_INVALIDATE and clears local auth caches.
  - get_auth_token supports bypass_cache and get_auth_token_fresh; publishes invalidation on upsert, logout, and token revocation.
  - Server detects auth/connection errors (401/403/CONNECTION_FAILED), clears caches, force re-initializes the adapter, and retries connect.
  - ConnectionPool.initialize accepts force for re-init; broker adapters and factory include helpers to detect auth errors, clear caches, and fetch fresh tokens.

<sup>Written for commit ab6733a34e3694bead4cf4725225b989405a6584. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

