### PR TITLE
Nubra Symbol Fixed

### DIFF
--- a/broker/nubra/database/master_contract_db.py
+++ b/broker/nubra/database/master_contract_db.py
@@ -281,58 +281,6 @@ def process_nubra_indexes(path):
     # Use broker symbol as token
     df['token'] = df['brsymbol'].astype(str)
     
-    # Standardize common index symbols to OpenAlgo format (referencing Angel broker)
-    # Handle all variations including spaces, underscores, and different cases
-    # First strip whitespace to ensure clean matching
-    df['symbol'] = df['symbol'].str.strip()
-    
-    df['symbol'] = df['symbol'].replace({
-        # NSE Indexes - standardize to common OpenAlgo format
-        'Nifty 50': 'NIFTY',
-        'NIFTY 50': 'NIFTY',
-        'NIFTY_50': 'NIFTY',
-        'Nifty_50': 'NIFTY',
-        'Nifty Next 50': 'NIFTYNXT50',
-        'NIFTY NEXT 50': 'NIFTYNXT50',
-        'NIFTY_NEXT_50': 'NIFTYNXT50',
-        'Nifty Next50': 'NIFTYNXT50',
-        'NIFTYNEXT50': 'NIFTYNXT50',
-        'Nifty Fin Service': 'FINNIFTY',
-        'NIFTY FIN SERVICE': 'FINNIFTY',
-        'NIFTY_FIN_SERVICE': 'FINNIFTY',
-        'Nifty Financial Services': 'FINNIFTY',
-        'NIFTY FINANCIAL SERVICES': 'FINNIFTY',
-        'Nifty Bank': 'BANKNIFTY',
-        'NIFTY BANK': 'BANKNIFTY',
-        'NIFTY_BANK': 'BANKNIFTY',
-        'NIFTY MID SELECT': 'MIDCPNIFTY',
-        'Nifty Midcap Select': 'MIDCPNIFTY',
-        'Nifty MidCap Select': 'MIDCPNIFTY',
-        'NIFTY_MIDCAP_SELECT': 'MIDCPNIFTY',
-        'India VIX': 'INDIAVIX',
-        'INDIA VIX': 'INDIAVIX',
-        'INDIA_VIX': 'INDIAVIX',
-        'India_VIX': 'INDIAVIX',
-        'INDIAVIX': 'INDIAVIX',
-        # BSE Indexes - standardize to common OpenAlgo format
-        'S&P BSE SENSEX': 'SENSEX',
-        'BSE SENSEX': 'SENSEX',
-        'Bse Sensex': 'SENSEX',
-        'BSE_SENSEX': 'SENSEX',
-        'SENSEX': 'SENSEX',
-        'BSE BANKEX': 'BANKEX',
-        'Bse Bankex': 'BANKEX',
-        'BSE_BANKEX': 'BANKEX',
-        'BANKEX': 'BANKEX',
-        'SNSX50': 'SENSEX50',
-        'BSE SENSEX 50': 'SENSEX50',
-        'Bse Sensex 50': 'SENSEX50',
-        'BSE_SENSEX_50': 'SENSEX50',
-        'SENSEX 50': 'SENSEX50',
-        'SENSEX_50': 'SENSEX50',
-        'SENSEX50': 'SENSEX50',
-    })
-    
     # Map to OpenAlgo index exchange format
     # NSE indexes → NSE_INDEX, BSE indexes → BSE_INDEX
     df['exchange'] = df['brexchange'].apply(
@@ -342,6 +290,11 @@ def process_nubra_indexes(path):
             else x + '_INDEX'
         )
     )
+    
+    # Common Index Symbol Formats 
+    df['symbol'] = df['symbol'].replace({
+        'INDIA_VIX': 'INDIAVIX',
+    })
     
     # Index-specific fields
     df['instrumenttype'] = 'INDEX'


### PR DESCRIPTION
Nubra Symbol Fixed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switched master contract sync from Angel to Nubra and fixed F&O symbol/expiry formats. Added index support and standardized symbols for consistent OpenAlgo behavior.

- **New Features**
  - Download Nubra instruments (auth) and indexes (public CSV), merge, and insert into symtoken.
  - Map exchanges: NSE/BSE derivatives → NFO/BFO; indexes → NSE_INDEX/BSE_INDEX; preserve brexchange and brsymbol; token stored as string.
  - Build OpenAlgo symbols: FUT = BASE+DDMMMYY+FUT; OPT = BASE+DDMMMYY+STRIKE+CE/PE.

- **Bug Fixes**
  - Correct expiry parsing (DB: DD-MMM-YY; symbol: DDMMMYY) and scale option strikes.
  - Standardize common index symbols (e.g., INDIAVIX) and prevent duplicate inserts by filtering on token.

<sup>Written for commit 7635d0f10486ada0cc25a0d0552c5adac1232f95. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

