### PR TITLE
fix: resolve file descriptor leaks in Flattrade streaming adapters

### DIFF
--- a/broker/flattrade/streaming/flattrade_adapter.py
+++ b/broker/flattrade/streaming/flattrade_adapter.py
@@ -392,19 +392,21 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def disconnect(self) -> None:
         """Disconnect from Flattrade WebSocket endpoint"""
-        self.running = False
+        # Use lock to prevent race with _attempt_reconnection
+        with self.lock:
+            self.running = False
 
-        # Cancel any pending reconnection timer to prevent zombie connections
-        if self._reconnect_timer:
-            self._reconnect_timer.cancel()
-            self._reconnect_timer = None
-            self.logger.debug("Cancelled pending reconnection timer")
+            # Cancel any pending reconnection timer to prevent zombie connections
+            if self._reconnect_timer:
+                self._reconnect_timer.cancel()
+                self._reconnect_timer = None
+                self.logger.debug("Cancelled pending reconnection timer")
 
-        if self.ws_client:
-            self.ws_client.stop()
-            self.ws_client = None
+            if self.ws_client:
+                self.ws_client.stop()
+                self.ws_client = None
 
-        # Clean up market data cache
+        # Clean up market data cache (outside lock - has its own lock)
         self.market_cache.clear()
 
         # Clean up ZeroMQ resources
@@ -702,68 +704,77 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def _schedule_reconnection(self) -> None:
         """Schedule reconnection with exponential backoff"""
-        if self.reconnect_attempts >= Config.MAX_RECONNECT_ATTEMPTS:
-            self.logger.error("Maximum reconnection attempts reached")
-            self.running = False
-            return
+        # Use lock to prevent race with disconnect()
+        with self.lock:
+            # Double-check running inside lock
+            if not self.running:
+                self.logger.debug("Skipping reconnection schedule - adapter stopped")
+                return
 
-        delay = min(
-            Config.BASE_RECONNECT_DELAY * (2**self.reconnect_attempts), Config.MAX_RECONNECT_DELAY
-        )
+            if self.reconnect_attempts >= Config.MAX_RECONNECT_ATTEMPTS:
+                self.logger.error("Maximum reconnection attempts reached")
+                self.running = False
+                return
 
-        self.logger.info(f"Reconnecting in {delay}s (attempt {self.reconnect_attempts + 1})")
+            delay = min(
+                Config.BASE_RECONNECT_DELAY * (2**self.reconnect_attempts), Config.MAX_RECONNECT_DELAY
+            )
 
-        # Cancel any existing timer before creating new one
-        if self._reconnect_timer:
-            self._reconnect_timer.cancel()
+            self.logger.info(f"Reconnecting in {delay}s (attempt {self.reconnect_attempts + 1})")
 
-        # Store timer reference so it can be cancelled on disconnect
-        self._reconnect_timer = threading.Timer(delay, self._attempt_reconnection)
-        self._reconnect_timer.daemon = True  # Don't block process exit
-        self._reconnect_timer.start()
+            # Cancel any existing timer before creating new one
+            if self._reconnect_timer:
+                self._reconnect_timer.cancel()
+
+            # Store timer reference so it can be cancelled on disconnect
+            self._reconnect_timer = threading.Timer(delay, self._attempt_reconnection)
+            self._reconnect_timer.daemon = True  # Don't block process exit
+            self._reconnect_timer.start()
 
     def _attempt_reconnection(self) -> None:
         """Attempt to reconnect to WebSocket"""
-        # Clear timer reference since we're now executing
-        self._reconnect_timer = None
+        # Use lock to prevent race with disconnect()
+        with self.lock:
+            # Clear timer reference since we're now executing
+            self._reconnect_timer = None
 
-        # Don't reconnect if we've been stopped
-        if not self.running:
-            self.logger.debug("Reconnection cancelled - adapter no longer running")
-            return
+            # Don't reconnect if we've been stopped (check inside lock to prevent race)
+            if not self.running:
+                self.logger.debug("Reconnection cancelled - adapter no longer running")
+                return
 
-        self.reconnect_attempts += 1
+            self.reconnect_attempts += 1
 
-        try:
-            # CRITICAL: Clean up old WebSocket client to prevent FD leaks
-            if self.ws_client:
-                self.logger.debug("Cleaning up old WebSocket client before reconnection")
-                try:
-                    self.ws_client.stop()
-                except Exception as cleanup_err:
-                    self.logger.warning(f"Error cleaning up old WebSocket: {cleanup_err}")
-                self.ws_client = None
+            try:
+                # CRITICAL: Clean up old WebSocket client to prevent FD leaks
+                if self.ws_client:
+                    self.logger.debug("Cleaning up old WebSocket client before reconnection")
+                    try:
+                        self.ws_client.stop()
+                    except Exception as cleanup_err:
+                        self.logger.warning(f"Error cleaning up old WebSocket: {cleanup_err}")
+                    self.ws_client = None
 
-            # Recreate WebSocket client
-            self.ws_client = FlattradeWebSocket(
-                user_id=self.actid,
-                actid=self.actid,
-                susertoken=self.susertoken,
-                on_message=self._on_message,
-                on_error=self._on_error,
-                on_close=self._on_close,
-                on_open=self._on_open,
-            )
+                # Recreate WebSocket client
+                self.ws_client = FlattradeWebSocket(
+                    user_id=self.actid,
+                    actid=self.actid,
+                    susertoken=self.susertoken,
+                    on_message=self._on_message,
+                    on_error=self._on_error,
+                    on_close=self._on_close,
+                    on_open=self._on_open,
+                )
 
-            if self.ws_client.connect():
-                self.connected = True
-                self.reconnect_attempts = 0
-                self.logger.info("Reconnected successfully")
-            else:
-                self.logger.error("Reconnection failed")
+                if self.ws_client.connect():
+                    self.connected = True
+                    self.reconnect_attempts = 0
+                    self.logger.info("Reconnected successfully")
+                else:
+                    self.logger.error("Reconnection failed")
 
-        except Exception as e:
-            self.logger.error(f"Reconnection error: {e}")
+            except Exception as e:
+                self.logger.error(f"Reconnection error: {e}")
 
     def _resubscribe_all(self):
         """Resubscribe to all active subscriptions after reconnect"""

--- a/broker/flattrade/streaming/flattrade_websocket.py
+++ b/broker/flattrade/streaming/flattrade_websocket.py
@@ -181,7 +181,10 @@ class FlattradeWebSocket:
             self.ws_thread.join(timeout=self.THREAD_JOIN_TIMEOUT)
             if self.ws_thread.is_alive():
                 self.logger.warning("WebSocket thread did not terminate within timeout")
-        self.ws_thread = None  # Release reference regardless of outcome
+                # Don't clear reference - thread still running, could interfere with reconnect
+                return
+        # Only clear reference if thread actually stopped
+        self.ws_thread = None
 
     # WebSocket Event Handlers
     def _on_open(self, ws) -> None:
@@ -320,7 +323,10 @@ class FlattradeWebSocket:
             self._heartbeat_thread.join(timeout=self.HEARTBEAT_JOIN_TIMEOUT)
             if self._heartbeat_thread.is_alive():
                 self.logger.warning("Heartbeat thread did not terminate within timeout")
-        self._heartbeat_thread = None  # Release reference
+                # Don't clear reference - thread still running, could cause duplicate heartbeats
+                return
+        # Only clear reference if thread actually stopped
+        self._heartbeat_thread = None
 
     def _heartbeat_worker(self) -> None:
         """Heartbeat worker thread - sends periodic heartbeats and monitors connection"""


### PR DESCRIPTION
fix: resolve file descriptor leaks in Flattrade streaming adapters

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes file descriptor leaks in Flattrade streaming adapters by properly cleaning up WebSocket clients, threads, and timers. Prevents zombie connections, race conditions, and ensures clean shutdowns and reconnections.

- **Bug Fixes**
  - Track and cancel reconnection timers; run them as daemons to not block process exit.
  - On reconnect, stop and clear the previous WebSocket client and release the WebSocket reference to free descriptors.
  - Add locks around disconnect/reconnect; skip reconnection when the adapter is stopped to avoid stale sockets.
  - Join WebSocket and heartbeat threads with timeouts, and only clear references if threads actually terminate.

<sup>Written for commit 0890ebf2ef6593d27d4bb46ce03fa0880a26afd9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

