### PR TITLE
feat: Return order IDs in closeposition API response

### DIFF
--- a/broker/aliceblue/api/order_api.py
+++ b/broker/aliceblue/api/order_api.py
@@ -298,8 +298,9 @@ def close_all_positions(current_api_key, auth):
     # logger.info(f"{positions_response}")
     # Check if the positions data is null or empty
     if positions_response is None or not positions_response:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -328,13 +329,17 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            _, api_response, _ = place_order_api(place_order_payload, AUTH_TOKEN)
+            _, api_response, order_id = place_order_api(place_order_payload, AUTH_TOKEN)
 
             logger.info(f"{api_response}")
 
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/angel/api/order_api.py
+++ b/broker/angel/api/order_api.py
@@ -251,8 +251,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response["data"] is None or not positions_response["data"]:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response["status"]:
         # Loop through each position to close
         for position in positions_response["data"]:
@@ -283,15 +284,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/compositedge/api/order_api.py
+++ b/broker/compositedge/api/order_api.py
@@ -228,8 +228,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -262,15 +263,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/dhan/api/order_api.py
+++ b/broker/dhan/api/order_api.py
@@ -273,8 +273,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response is None or not positions_response:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -308,13 +309,17 @@ def close_all_positions(current_api_key, auth):
             logger.debug(f"Close position payload: {place_order_payload}")
 
             # Place the order to close the position
-            _, api_response, _ = place_order_api(place_order_payload, AUTH_TOKEN)
+            _, api_response, order_id = place_order_api(place_order_payload, AUTH_TOKEN)
 
             logger.debug(f"Close position response: {api_response}")
 
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/dhan_sandbox/api/order_api.py
+++ b/broker/dhan_sandbox/api/order_api.py
@@ -251,8 +251,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response is None or not positions_response:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -286,13 +287,17 @@ def close_all_positions(current_api_key, auth):
             logger.debug(f"Close position payload: {place_order_payload}")
 
             # Place the order to close the position
-            _, api_response, _ = place_order_api(place_order_payload, AUTH_TOKEN)
+            _, api_response, order_id = place_order_api(place_order_payload, AUTH_TOKEN)
 
             logger.debug(f"Close position response: {api_response}")
 
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/fivepaisa/api/order_api.py
+++ b/broker/fivepaisa/api/order_api.py
@@ -389,8 +389,9 @@ def close_all_positions(current_api_key: str, auth: str) -> dict[str, Any]:
         positions_response["body"]["NetPositionDetail"] is None
         or not positions_response["body"]["NetPositionDetail"]
     ):
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response["body"]["NetPositionDetail"]:
         # Loop through each position to close
         for position in positions_response["body"]["NetPositionDetail"]:
@@ -422,15 +423,15 @@ def close_all_positions(current_api_key: str, auth: str) -> dict[str, Any]:
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid: str, auth: str) -> dict[str, Any]:

--- a/broker/fivepaisaxts/api/order_api.py
+++ b/broker/fivepaisaxts/api/order_api.py
@@ -228,8 +228,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -262,15 +263,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/flattrade/api/order_api.py
+++ b/broker/flattrade/api/order_api.py
@@ -221,8 +221,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response is None or positions_response[0]["stat"] == "Not_Ok":
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -253,15 +254,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/fyers/api/order_api.py
+++ b/broker/fyers/api/order_api.py
@@ -291,22 +291,23 @@ def close_all_positions(current_api_key, auth):
         logger.debug(f"Close all positions response: {json.dumps(response_data, indent=2)}")
 
         # Check if the request was successful
+        # Note: Fyers exit_all endpoint doesn't return individual order IDs
         if response_data.get("s") == "ok":
-            return {"status": "success", "message": "All positions closed successfully"}, 200
+            return {"status": "success", "message": "All positions closed successfully", "order_ids": []}, 200
         else:
             error_msg = response_data.get("message", "Failed to close positions")
             logger.warning(f"Failed to close all positions: {error_msg}")
-            return {"status": "error", "message": error_msg}, response.status_code
+            return {"status": "error", "message": error_msg, "order_ids": []}, response.status_code
 
     except httpx.HTTPError as e:
         logger.exception("HTTP error during close all positions")
-        return {"status": "error", "message": f"HTTP error: {e}"}, 500
+        return {"status": "error", "message": f"HTTP error: {e}", "order_ids": []}, 500
     except json.JSONDecodeError as e:
         logger.exception("JSON decode error during close all positions")
-        return {"status": "error", "message": f"JSON decode error: {e}"}, 500
+        return {"status": "error", "message": f"JSON decode error: {e}", "order_ids": []}, 500
     except Exception as e:
         logger.exception("Unexpected error during close all positions")
-        return {"status": "error", "message": f"General error: {e}"}, 500
+        return {"status": "error", "message": f"General error: {e}", "order_ids": []}, 500
 
 
 def cancel_order(orderid, auth):

--- a/broker/ibulls/api/order_api.py
+++ b/broker/ibulls/api/order_api.py
@@ -315,8 +315,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -349,15 +350,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/iifl/api/order_api.py
+++ b/broker/iifl/api/order_api.py
@@ -225,8 +225,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -260,15 +261,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/indmoney/api/order_api.py
+++ b/broker/indmoney/api/order_api.py
@@ -482,8 +482,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if not all_positions:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if all_positions:
         # Loop through each position to close
         for position in all_positions:
@@ -540,13 +541,17 @@ def close_all_positions(current_api_key, auth):
             logger.debug(f"Close position payload: {place_order_payload}")
 
             # Place the order to close the position
-            _, api_response, _ = place_order_api(place_order_payload, AUTH_TOKEN)
+            _, api_response, order_id = place_order_api(place_order_payload, AUTH_TOKEN)
 
             logger.debug(f"Close position response: {api_response}")
 
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/jainamxts/api/order_api.py
+++ b/broker/jainamxts/api/order_api.py
@@ -252,8 +252,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -286,15 +287,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -223,8 +223,9 @@ def close_all_positions(current_api_key, auth_token):
     # logger.info(f"{positions_response}")
     # Check if the positions data is null or empty
     if positions_response["data"] is None or not positions_response["data"]:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response["data"]:
         # Loop through each position to close
         for position in positions_response["data"]:
@@ -264,15 +265,17 @@ def close_all_positions(current_api_key, auth_token):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth_token)
+            res, response, order_id = place_order_api(place_order_payload, auth_token)
 
-            # logger.info(f"{res}")
             logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth_token):

--- a/broker/motilal/api/order_api.py
+++ b/broker/motilal/api/order_api.py
@@ -387,8 +387,9 @@ def close_all_positions(current_api_key, auth):
         or positions_response.get("data") is None
         or not positions_response["data"]
     ):
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response.get("status") == "SUCCESS":
         # Loop through each position to close
         for position in positions_response["data"]:
@@ -434,15 +435,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/mstock/api/order_api.py
+++ b/broker/mstock/api/order_api.py
@@ -299,8 +299,9 @@ def close_all_positions(current_api_key, auth):
     # Check if the positions data is null or empty
     if positions_response.get("data") is None or not positions_response.get("data"):
         logger.info("No open positions to close")
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # Check status explicitly (mStock Type B returns "true" string or True boolean)
     if positions_response.get("status") in [True, "true"]:
         logger.info(f"Closing {len(positions_response['data'])} positions")
@@ -365,13 +366,16 @@ def close_all_positions(current_api_key, auth):
 
             # Place the order to close the position
             try:
-                res, response, orderid = place_order_api(place_order_payload, auth)
-                logger.info(f"Position closed - OrderID: {orderid}, Response: {response}")
+                res, response, order_id = place_order_api(place_order_payload, auth)
+                logger.info(f"Position closed - OrderID: {order_id}, Response: {response}")
+                # Collect the order ID if available
+                if order_id:
+                    order_ids.append(order_id)
             except Exception as e:
                 logger.error(f"Error closing position for {symbol}: {e}")
                 continue
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/nubra/api/order_api.py
+++ b/broker/nubra/api/order_api.py
@@ -251,8 +251,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response["data"] is None or not positions_response["data"]:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response["status"]:
         # Loop through each position to close
         for position in positions_response["data"]:
@@ -283,15 +284,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/samco/api/order_api.py
+++ b/broker/samco/api/order_api.py
@@ -260,8 +260,9 @@ def close_all_positions(current_api_key, auth):
     positions_response = get_positions(auth)
 
     if not positions_response.get("positionDetails"):
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response.get("status") == "Success":
         for position in positions_response["positionDetails"]:
             # Get net quantity and handle Samco's direction via transactionType
@@ -297,9 +298,13 @@ def close_all_positions(current_api_key, auth):
 
             logger.info(f"Close position payload: {place_order_payload}")
 
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/shoonya/api/order_api.py
+++ b/broker/shoonya/api/order_api.py
@@ -214,8 +214,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response is None or positions_response[0]["stat"] == "Not_Ok":
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -246,15 +247,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/wisdom/api/order_api.py
+++ b/broker/wisdom/api/order_api.py
@@ -228,8 +228,9 @@ def close_all_positions(current_api_key, auth):
 
     positions_list = positions_response.get("result", {}).get("positionList", [])
     if not positions_list:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     # If response has positions
     for position in positions_list:
         # Skip if net quantity is zero
@@ -262,15 +263,15 @@ def close_all_positions(current_api_key, auth):
         }
 
         # Place the order to close the position
-        res, response, orderid = place_order_api(place_order_payload, auth)
+        res, response, order_id = place_order_api(place_order_payload, auth)
 
-        # logger.info(f"{res}")
-        # logger.info(f"{response}")
-        # logger.info(f"{orderid}")
+        # Collect the order ID if available
+        if order_id:
+            order_ids.append(order_id)
 
         # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/zebu/api/order_api.py
+++ b/broker/zebu/api/order_api.py
@@ -207,8 +207,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response is None or positions_response[0]["stat"] == "Not_Ok":
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response:
         # Loop through each position to close
         for position in positions_response:
@@ -239,15 +240,15 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"{place_order_payload}")
 
             # Place the order to close the position
-            res, response, orderid = place_order_api(place_order_payload, auth)
+            res, response, order_id = place_order_api(place_order_payload, auth)
 
-            # logger.info(f"{res}")
-            # logger.info(f"{response}")
-            # logger.info(f"{orderid}")
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
 
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/broker/zerodha/api/order_api.py
+++ b/broker/zerodha/api/order_api.py
@@ -250,8 +250,9 @@ def close_all_positions(current_api_key, auth):
 
     # Check if the positions data is null or empty
     if positions_response["data"] is None or not positions_response["data"]:
-        return {"message": "No Open Positions Found"}, 200
+        return {"message": "No Open Positions Found", "order_ids": []}, 200
 
+    order_ids = []
     if positions_response["status"]:
         # Loop through each position to close
         for position in positions_response["data"]["net"]:
@@ -280,13 +281,17 @@ def close_all_positions(current_api_key, auth):
             logger.info(f"Close position payload: {place_order_payload}")
 
             # Place the order to close the position
-            _, api_response, _ = place_order_api(place_order_payload, AUTH_TOKEN)
+            _, api_response, order_id = place_order_api(place_order_payload, AUTH_TOKEN)
 
             logger.info(f"Close position response: {api_response}")
 
+            # Collect the order ID if available
+            if order_id:
+                order_ids.append(order_id)
+
             # Note: Ensure place_order_api handles any errors and logs accordingly
 
-    return {"status": "success", "message": "All Open Positions SquaredOff"}, 200
+    return {"status": "success", "message": "All Open Positions SquaredOff", "order_ids": order_ids}, 200
 
 
 def cancel_order(orderid, auth):

--- a/docs/api/order-management/closeposition.md
+++ b/docs/api/order-management/closeposition.md
@@ -24,7 +24,8 @@ Custom Domain:  POST https://<your-custom-domain>/api/v1/closeposition
 ```json
 {
   "message": "All Open Positions Squared Off",
-  "status": "success"
+  "status": "success",
+  "order_ids": ["order123", "order456"]
 }
 ```
 
@@ -33,7 +34,8 @@ Custom Domain:  POST https://<your-custom-domain>/api/v1/closeposition
 ```json
 {
   "message": "No open positions to close",
-  "status": "success"
+  "status": "success",
+  "order_ids": []
 }
 ```
 
@@ -50,6 +52,7 @@ Custom Domain:  POST https://<your-custom-domain>/api/v1/closeposition
 |-------|------|-------------|
 | status | string | "success" or "error" |
 | message | string | Result message |
+| order_ids | array | List of order IDs for the closing orders placed |
 | mode | string | "live" or "analyze" |
 
 ## How It Works

--- a/services/close_position_service.py
+++ b/services/close_position_service.py
@@ -143,7 +143,16 @@ def close_position_with_auth(
         return False, error_response, 500
 
     if status_code == 200:
-        response_data = {"status": "success", "message": "All Open Positions Squared Off"}
+        # Extract order_ids from broker response if available
+        order_ids = []
+        if isinstance(response_code, dict):
+            order_ids = response_code.get("order_ids", [])
+        
+        response_data = {
+            "status": "success",
+            "message": "All Open Positions Squared Off",
+            "order_ids": order_ids
+        }
         # Emit SocketIO event asynchronously (non-blocking)
         socketio.start_background_task(
             socketio.emit,

--- a/services/sandbox_service.py
+++ b/services/sandbox_service.py
@@ -424,6 +424,7 @@ def sandbox_close_position(
                     "message": message,
                     "closed_positions": closed_count,
                     "failed_closures": failed_count,
+                    "order_ids": [],  # No real order IDs in sandbox mode
                     "mode": "analyze",
                 },
                 200,

--- a/services/sandbox_service.py
+++ b/services/sandbox_service.py
@@ -390,6 +390,7 @@ def sandbox_close_position(
                     {
                         "status": "success",
                         "message": "No open positions to close",
+                        "order_ids": [],  # Consistent with success response
                         "mode": "analyze",
                     },
                     200,


### PR DESCRIPTION
## Summary
Fixes #785

This PR modifies the `closeposition` API to return order IDs generated when squaring off positions.

## Changes Made

### Broker Modules (23 files)
Updated `close_all_positions()` in each broker's `order_api.py` to:
1. Initialize an `order_ids = []` list
2. Capture order IDs from `place_order_api()` calls
3. Include `order_ids` in the return response

**Brokers updated:**
- zerodha, dhan, angel, fyers, upstox, kotak
- aliceblue, shoonya, flattrade, samco, zebu, iifl
- nubra, wisdom, compositedge, fivepaisaxts, dhan_sandbox
- ibulls, indmoney, jainamxts, motilal, mstock, fivepaisa

### Service Layer
- `close_position_service.py`: Extracts `order_ids` from broker response and includes them in API response
- `sandbox_service.py`: Returns empty `order_ids` array for sandbox mode

### Documentation
- Updated `docs/api/order-management/closeposition.md` with new response format

## New API Response Format
```json
{
  "status": "success",
  "message": "All Open Positions Squared Off",
  "order_ids": ["order123", "order456"]
}
```

## Testing
- All syntax checks passed for service files and broker modules

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds order_ids to the closeposition API response so clients can track and reconcile square‑off orders. This extends broker implementations, passes IDs through the service layer, and updates docs.

- **New Features**
  - closeposition now returns order_ids for all orders placed during square‑off.
  - All broker close_all_positions methods collect and return IDs; brokers without per‑order IDs (e.g., Fyers exit_all) return an empty array.
  - Service layer passes order_ids through; sandbox returns an empty array.
  - Docs updated with the new response format.

- **Migration**
  - No breaking changes; order_ids is an added field.
  - Optionally update clients to log or reconcile using order_ids.

<sup>Written for commit 0c4a633c006c9de072c7673dcdd22a095f7de806. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

