### PR TITLE
feat: add Kubernetes deployment manifests

### DIFF
--- a/kubernetes/.gitignore
+++ b/kubernetes/.gitignore
@@ -1,0 +1,27 @@
+# Kubernetes secrets and sensitive files
+secrets.yaml
+*.secret.yaml
+*-secret.yaml
+
+# Environment files
+.env
+.env.*
+!.env.template
+
+# Backups
+backup/
+*.backup
+
+# Temporary files
+*.tmp
+*.swp
+*~
+
+# IDE files
+.vscode/
+.idea/
+*.iml
+
+# OS files
+.DS_Store
+Thumbs.db

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -89,7 +89,7 @@ kubectl apply -f kubernetes/ingress.yaml
 Or deploy everything at once:
 
 ```bash
-kubectl apply -f kubernetes/
+kubectl apply  -k kubernetes/
 ```
 
 ### 5. Verify Deployment

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -1,0 +1,542 @@
+# OpenAlgo Kubernetes Deployment
+
+This directory contains Kubernetes manifests for deploying OpenAlgo algorithmic trading platform to a Kubernetes cluster.
+
+## Architecture
+
+OpenAlgo is deployed as a StatefulSet with persistent storage for:
+- **Database**: SQLite database files (`/app/db`)
+- **Logs**: Application and strategy logs (`/app/log`)
+- **Strategies**: User Python trading strategies (`/app/strategies`)
+- **Keys**: API keys and certificates (`/app/keys`)
+- **Temp**: Temporary files for scipy/numba (`/app/tmp`)
+
+The application exposes two ports:
+- **5000**: Flask HTTP API
+- **8765**: WebSocket for real-time updates
+
+## Prerequisites
+
+- Kubernetes cluster (v1.19+)
+- kubectl configured to access your cluster
+- Ingress controller installed (nginx, Traefik, etc.)
+- StorageClass available for PersistentVolumes
+- Docker image: `openalgo:latest` available in your cluster
+
+## Quick Start
+
+### 1. Build the Docker Image
+
+```bash
+# From the project root
+docker build -t openalgo:latest .
+
+# If using a private registry, tag and push:
+docker tag openalgo:latest your-registry.com/openalgo:latest
+docker push your-registry.com/openalgo:latest
+```
+
+### 2. Configure Secrets
+
+Copy the secrets template and fill in your actual values:
+
+```bash
+cp kubernetes/secrets-template.yaml kubernetes/secrets.yaml
+
+# Edit secrets.yaml with your actual configuration
+# IMPORTANT: Add secrets.yaml to .gitignore!
+nano kubernetes/secrets.yaml
+```
+
+Update the `.env` section with your broker API keys and other sensitive configuration.
+
+### 3. Update Configuration
+
+Edit `kubernetes/ingress.yaml` and replace `openalgo.yourdomain.com` with your actual domain.
+
+Optionally, adjust storage sizes in `kubernetes/pvcs.yaml` based on your needs:
+- Database: 5Gi (default)
+- Logs: 2Gi (default)
+- Strategies: 1Gi (default)
+- Keys: 100Mi (default)
+- Temp: 1Gi (default)
+
+### 4. Deploy to Kubernetes
+
+```bash
+# Create namespace
+kubectl apply -f kubernetes/namespace.yaml
+
+# Create PersistentVolumeClaims
+kubectl apply -f kubernetes/pvcs.yaml
+
+# Create ConfigMap
+kubectl apply -f kubernetes/configmap.yaml
+
+# Create Secret (using your filled-in secrets.yaml)
+kubectl apply -f kubernetes/secrets.yaml
+
+# Deploy application
+kubectl apply -f kubernetes/statefulset.yaml
+
+# Create Service
+kubectl apply -f kubernetes/service.yaml
+
+# Create Ingress (for external access)
+kubectl apply -f kubernetes/ingress.yaml
+```
+
+Or deploy everything at once:
+
+```bash
+kubectl apply -f kubernetes/
+```
+
+### 5. Verify Deployment
+
+```bash
+# Check pods
+kubectl get pods -n openalgo
+
+# Check services
+kubectl get svc -n openalgo
+
+# Check ingress
+kubectl get ingress -n openalgo
+
+# View logs
+kubectl logs -f statefulset/openalgo -n openalgo
+
+# Check pod health
+kubectl describe pod -n openalgo
+```
+
+### 6. Access the Application
+
+Once deployed, access OpenAlgo via:
+- **HTTP**: `http://openalgo.yourdomain.com` (or your configured domain)
+- **HTTPS**: `https://openalgo.yourdomain.com` (if TLS is configured)
+
+For local testing without a domain:
+
+```bash
+# Port forward
+kubectl port-forward -n openalgo svc/openalgo 5000:5000
+
+# Access at http://localhost:5000
+```
+
+## Configuration
+
+### Environment Variables
+
+Edit `kubernetes/configmap.yaml` for non-sensitive configuration:
+- `FLASK_ENV`: Flask environment (production/development)
+- `FLASK_DEBUG`: Enable Flask debug mode (0 or 1)
+- `TZ`: Timezone (default: Asia/Kolkata)
+
+### Secrets
+
+All sensitive configuration goes in `kubernetes/secrets.yaml`:
+- API keys and secrets
+- Database credentials (if using external DB)
+- Flask SECRET_KEY
+- Any other sensitive values from your `.env` file
+
+### Resource Limits
+
+Adjust CPU and memory in `kubernetes/statefulset.yaml`:
+
+```yaml
+resources:
+  requests:
+    memory: "1Gi"   # Minimum required
+    cpu: "500m"
+  limits:
+    memory: "4Gi"   # Maximum allowed
+    cpu: "2000m"
+```
+
+### Storage Class
+
+The manifests use `local-path` as the default StorageClass. Change this in `kubernetes/pvcs.yaml` if your cluster uses a different storage class:
+
+```bash
+# List available storage classes
+kubectl get storageclass
+
+# Common options:
+# - local-path (K3s default)
+# - standard (many cloud providers)
+# - gp2, gp3 (AWS EBS)
+# - pd-standard, pd-ssd (Google Cloud)
+```
+
+## Ingress Configuration
+
+### Nginx Ingress Controller
+
+The default configuration uses nginx. Key annotations:
+
+```yaml
+nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+nginx.ingress.kubernetes.io/websocket-services: "openalgo"
+```
+
+### Traefik Ingress Controller
+
+For Traefik, update `kubernetes/ingress.yaml`:
+
+```yaml
+spec:
+  ingressClassName: traefik
+```
+
+And use Traefik annotations:
+
+```yaml
+annotations:
+  traefik.ingress.kubernetes.io/router.entrypoints: websecure
+  traefik.ingress.kubernetes.io/router.tls: "true"
+```
+
+### TLS/HTTPS Setup
+
+For automatic TLS with cert-manager:
+
+```yaml
+metadata:
+  annotations:
+    cert-manager.io/cluster-issuer: "letsencrypt-prod"
+spec:
+  tls:
+  - hosts:
+    - openalgo.yourdomain.com
+    secretName: openalgo-tls
+```
+
+## Scaling Considerations
+
+**Important**: OpenAlgo uses SQLite as its database, which is file-based and does not support concurrent writes from multiple instances. Therefore:
+
+- **Do not scale replicas > 1** with the current StatefulSet configuration
+- For high availability, consider migrating to PostgreSQL or MySQL
+- The StatefulSet ensures the single pod maintains a stable identity and persistent storage
+
+If you need to scale horizontally:
+1. Migrate from SQLite to PostgreSQL/MySQL
+2. Update the Deployment to use an external database
+3. Change from StatefulSet to Deployment
+4. Increase replicas as needed
+
+## Backup and Recovery
+
+### Manual Backup
+
+```bash
+# Backup database
+kubectl cp openalgo/openalgo-0:/app/db ./backup/db
+
+# Backup strategies
+kubectl cp openalgo/openalgo-0:/app/strategies ./backup/strategies
+
+# Backup keys
+kubectl cp openalgo/openalgo-0:/app/keys ./backup/keys
+```
+
+### Automated Backup
+
+Consider using [Velero](https://velero.io/) for automated Kubernetes backup:
+
+```bash
+# Install Velero
+velero install --provider <your-provider>
+
+# Create backup schedule
+velero schedule create openalgo-daily \
+  --schedule="0 2 * * *" \
+  --include-namespaces openalgo
+```
+
+### Restore from Backup
+
+```bash
+# Restore files to pod
+kubectl cp ./backup/db openalgo/openalgo-0:/app/db
+kubectl cp ./backup/strategies openalgo/openalgo-0:/app/strategies
+kubectl cp ./backup/keys openalgo/openalgo-0:/app/keys
+
+# Restart pod to apply changes
+kubectl delete pod openalgo-0 -n openalgo
+```
+
+## Monitoring
+
+### Check Pod Status
+
+```bash
+# Pod status
+kubectl get pods -n openalgo -w
+
+# Detailed pod information
+kubectl describe pod openalgo-0 -n openalgo
+
+# Pod events
+kubectl get events -n openalgo --sort-by='.lastTimestamp'
+```
+
+### View Logs
+
+```bash
+# Current logs
+kubectl logs -f openalgo-0 -n openalgo
+
+# Previous logs (if pod restarted)
+kubectl logs openalgo-0 -n openalgo --previous
+
+# Logs from specific time
+kubectl logs openalgo-0 -n openalgo --since=1h
+```
+
+### Health Checks
+
+The application includes health checks at `/auth/check-setup`:
+
+```bash
+# Port forward
+kubectl port-forward -n openalgo svc/openalgo 5000:5000
+
+# Test health endpoint
+curl http://localhost:5000/auth/check-setup
+```
+
+### Prometheus Integration (Optional)
+
+If using Prometheus, create a ServiceMonitor:
+
+```yaml
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: openalgo
+  namespace: openalgo
+spec:
+  selector:
+    matchLabels:
+      app: openalgo
+  endpoints:
+  - port: http
+    path: /metrics  # If metrics endpoint exists
+    interval: 30s
+```
+
+## Troubleshooting
+
+### Pod Fails to Start
+
+```bash
+# Check pod status
+kubectl get pods -n openalgo
+
+# View pod details
+kubectl describe pod openalgo-0 -n openalgo
+
+# Check logs
+kubectl logs openalgo-0 -n openalgo
+```
+
+Common issues:
+- **ImagePullBackOff**: Image not available. Check image name and pull secrets.
+- **CrashLoopBackOff**: Application crashing. Check logs for errors.
+- **Pending**: PVC not bound. Check PersistentVolumeClaims and StorageClass.
+
+### PVC Not Binding
+
+```bash
+# Check PVC status
+kubectl get pvc -n openalgo
+
+# Describe PVC for details
+kubectl describe pvc openalgo-db -n openalgo
+
+# Check available storage classes
+kubectl get storageclass
+```
+
+Fix: Update `storageClassName` in `pvcs.yaml` to match your cluster's storage class.
+
+### Ingress Not Working
+
+```bash
+# Check ingress status
+kubectl get ingress -n openalgo
+
+# Describe ingress
+kubectl describe ingress openalgo -n openalgo
+
+# Check ingress controller logs
+kubectl logs -n ingress-nginx deployment/ingress-nginx-controller
+```
+
+Fix: Ensure:
+1. Ingress controller is installed
+2. Domain DNS points to your cluster
+3. IngressClass matches your controller
+
+### WebSocket Connection Issues
+
+If WebSocket connections fail:
+
+1. Verify ingress annotations for WebSocket support:
+```yaml
+nginx.ingress.kubernetes.io/websocket-services: "openalgo"
+nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+```
+
+2. Check service has sessionAffinity:
+```yaml
+sessionAffinity: ClientIP
+```
+
+3. Test WebSocket directly:
+```bash
+kubectl port-forward -n openalgo svc/openalgo 8765:8765
+# Test WebSocket on localhost:8765
+```
+
+### Database Permission Issues
+
+If seeing permission errors:
+
+```bash
+# Check PVC permissions
+kubectl exec -it openalgo-0 -n openalgo -- ls -la /app/db
+
+# Fix permissions if needed
+kubectl exec -it openalgo-0 -n openalgo -- chown -R 1000:1000 /app/db
+```
+
+### Memory Issues
+
+If pods are OOMKilled:
+
+1. Increase memory limits in `statefulset.yaml`:
+```yaml
+resources:
+  limits:
+    memory: "8Gi"  # Increase from 4Gi
+```
+
+2. Check shared memory usage (2Gi emptyDir):
+```bash
+kubectl exec -it openalgo-0 -n openalgo -- df -h /dev/shm
+```
+
+## Upgrading
+
+### Update Application
+
+```bash
+# Build new image
+docker build -t openalgo:v2.0.0 .
+docker tag openalgo:v2.0.0 your-registry.com/openalgo:v2.0.0
+docker push your-registry.com/openalgo:v2.0.0
+
+# Update StatefulSet image
+kubectl set image statefulset/openalgo openalgo=your-registry.com/openalgo:v2.0.0 -n openalgo
+
+# Or edit statefulset directly
+kubectl edit statefulset openalgo -n openalgo
+
+# Monitor rollout
+kubectl rollout status statefulset/openalgo -n openalgo
+```
+
+### Rollback
+
+```bash
+# View revision history
+kubectl rollout history statefulset/openalgo -n openalgo
+
+# Rollback to previous version
+kubectl rollout undo statefulset/openalgo -n openalgo
+
+# Rollback to specific revision
+kubectl rollout undo statefulset/openalgo -n openalgo --to-revision=2
+```
+
+## Security Best Practices
+
+1. **Don't commit secrets**: Add `kubernetes/secrets.yaml` to `.gitignore`
+2. **Use external secret management**: Consider using sealed-secrets, Vault, or cloud provider secret managers
+3. **Enable TLS**: Always use HTTPS in production
+4. **Network policies**: Restrict traffic between namespaces
+5. **RBAC**: Create service accounts with minimal permissions
+6. **Security scanning**: Scan images with Trivy or similar tools
+7. **Keep updated**: Regularly update the application and base images
+
+### Example NetworkPolicy
+
+```yaml
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openalgo-netpol
+  namespace: openalgo
+spec:
+  podSelector:
+    matchLabels:
+      app: openalgo
+  policyTypes:
+  - Ingress
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-nginx  # Only allow ingress controller
+    ports:
+    - protocol: TCP
+      port: 5000
+    - protocol: TCP
+      port: 8765
+```
+
+## Uninstalling
+
+```bash
+# Delete all resources
+kubectl delete -f kubernetes/
+
+# Or delete namespace (removes everything)
+kubectl delete namespace openalgo
+
+# Warning: This will delete all data!
+# Backup first if needed.
+```
+
+## Production Checklist
+
+Before deploying to production:
+
+- [ ] Backup strategy in place
+- [ ] TLS/HTTPS configured
+- [ ] Secrets properly secured (not in git)
+- [ ] Resource limits tested and tuned
+- [ ] Monitoring and alerting configured
+- [ ] Health checks validated
+- [ ] Ingress and DNS configured
+- [ ] Storage class appropriate for production
+- [ ] Network policies configured (if required)
+- [ ] Documentation updated with environment-specific details
+
+## Support
+
+For issues, questions, or contributions:
+- GitHub Issues: https://github.com/marketcalls/openalgo/issues
+- Documentation: https://docs.openalgo.in
+- Community: [Add community links]
+
+## License
+
+Same as OpenAlgo project license.

--- a/kubernetes/README.md
+++ b/kubernetes/README.md
@@ -540,3 +540,44 @@ For issues, questions, or contributions:
 ## License
 
 Same as OpenAlgo project license.
+
+
+
+## ⚠️ Important: Configure Secrets First
+
+The `secrets-template.yaml` is intentionally **NOT** included in `kustomization.yaml` to prevent accidental deployment with placeholder credentials.
+
+**Before deploying, you MUST:**
+
+1. Copy the template:
+```bash
+   cp kubernetes/secrets-template.yaml kubernetes/secrets.yaml
+```
+
+2. Edit `secrets.yaml` with your actual broker credentials and API keys:
+```bash
+   nano kubernetes/secrets.yaml  # or use your preferred editor
+```
+
+3. Ensure `secrets.yaml` is in `.gitignore`:
+```bash
+   echo "kubernetes/secrets.yaml" >> .gitignore
+```
+
+4. **Only then** proceed with deployment:
+```bash
+   kubectl apply -k kubernetes/
+```
+
+**Why this matters:** Deploying with placeholder secrets expose your deployment to security risks. The deployment will fail without proper secrets configured - this is by design.
+### NetworkPolicy Support
+
+**⚠️ Important for K3s users:**
+
+K3s with default Flannel CNI does **not** support NetworkPolicy enforcement. The policy will be created but not enforced. 
+
+If you need NetworkPolicy enforcement, you must:
+- Use K3s with Calico: `curl -sfL https://get.k3s.io | INSTALL_K3S_EXEC="--flannel-backend=none --disable-network-policy" sh -`
+- Then install Calico or Cilium
+
+For testing/homelab use, NetworkPolicy enforcement is optional. For production, it's highly recommended.

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -16,6 +16,14 @@ data:
   
   # Timezone
   TZ: "Asia/Kolkata"
+  # Thread limiting for scientific libraries (numpy, scipy, pandas)
+  # Prevents thread oversubscription in containerized environments
+  # Ref: Issue #787 - limits each library to single-threaded mode
+  OPENBLAS_NUM_THREADS: "1"
+  OMP_NUM_THREADS: "1"
+  MKL_NUM_THREADS: "1"
+  NUMEXPR_NUM_THREADS: "1"
+  NUMBA_NUM_THREADS: "1"
   
   # Add other non-sensitive environment variables here
   # Example:

--- a/kubernetes/configmap.yaml
+++ b/kubernetes/configmap.yaml
@@ -1,0 +1,23 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: openalgo-config
+  namespace: openalgo
+  labels:
+    app: openalgo
+data:
+  # Flask configuration
+  FLASK_ENV: "production"
+  FLASK_DEBUG: "0"
+  
+  # Port configuration (for reference, actual ports in Deployment)
+  FLASK_PORT: "5000"
+  WEBSOCKET_PORT: "8765"
+  
+  # Timezone
+  TZ: "Asia/Kolkata"
+  
+  # Add other non-sensitive environment variables here
+  # Example:
+  # LOG_LEVEL: "INFO"
+  # MAX_WORKERS: "4"

--- a/kubernetes/deploy.sh
+++ b/kubernetes/deploy.sh
@@ -1,0 +1,215 @@
+#!/bin/bash
+# OpenAlgo Kubernetes Deployment Script
+
+set -e  # Exit on error
+
+# Colors for output
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+NC='\033[0m' # No Color
+
+# Configuration
+NAMESPACE="openalgo"
+KUBECTL="kubectl"
+
+# Functions
+print_info() {
+    echo -e "${GREEN}[INFO]${NC} $1"
+}
+
+print_warn() {
+    echo -e "${YELLOW}[WARN]${NC} $1"
+}
+
+print_error() {
+    echo -e "${RED}[ERROR]${NC} $1"
+}
+
+check_prerequisites() {
+    print_info "Checking prerequisites..."
+    
+    # Check kubectl
+    if ! command -v kubectl &> /dev/null; then
+        print_error "kubectl not found. Please install kubectl first."
+        exit 1
+    fi
+    
+    # Check cluster connection
+    if ! kubectl cluster-info &> /dev/null; then
+        print_error "Cannot connect to Kubernetes cluster. Check your kubeconfig."
+        exit 1
+    fi
+    
+    print_info "Prerequisites check passed!"
+}
+
+check_secrets() {
+    if [ ! -f "secrets.yaml" ]; then
+        print_error "secrets.yaml not found!"
+        print_warn "Please copy secrets-template.yaml to secrets.yaml and fill in your values:"
+        print_warn "  cp secrets-template.yaml secrets.yaml"
+        print_warn "  nano secrets.yaml"
+        exit 1
+    fi
+    
+    # Check if secrets still contain template values
+    if grep -q "change-this-to-secure-random-string" secrets.yaml; then
+        print_warn "secrets.yaml still contains template values!"
+        print_warn "Please update secrets.yaml with your actual configuration."
+        read -p "Continue anyway? (y/N) " -n 1 -r
+        echo
+        if [[ ! $REPLY =~ ^[Yy]$ ]]; then
+            exit 1
+        fi
+    fi
+}
+
+deploy() {
+    print_info "Deploying OpenAlgo to Kubernetes..."
+    
+    # Create namespace
+    print_info "Creating namespace: $NAMESPACE"
+    $KUBECTL apply -f namespace.yaml
+    
+    # Create PVCs
+    print_info "Creating PersistentVolumeClaims..."
+    $KUBECTL apply -f pvcs.yaml
+    
+    # Wait for PVCs to bind
+    print_info "Waiting for PVCs to bind..."
+    $KUBECTL wait --for=jsonpath='{.status.phase}'=Bound pvc --all -n $NAMESPACE --timeout=60s || {
+        print_warn "Some PVCs are not bound yet. This might be normal if using dynamic provisioning."
+    }
+    
+    # Create ConfigMap
+    print_info "Creating ConfigMap..."
+    $KUBECTL apply -f configmap.yaml
+    
+    # Create Secrets
+    print_info "Creating Secrets..."
+    $KUBECTL apply -f secrets.yaml
+    
+    # Deploy application
+    print_info "Deploying application StatefulSet..."
+    $KUBECTL apply -f statefulset.yaml
+    
+    # Create Service
+    print_info "Creating Service..."
+    $KUBECTL apply -f service.yaml
+    
+    # Create Ingress
+    print_info "Creating Ingress..."
+    $KUBECTL apply -f ingress.yaml
+    
+    print_info "Deployment initiated successfully!"
+    print_info "Waiting for pod to be ready..."
+    
+    $KUBECTL wait --for=condition=ready pod -l app=openalgo -n $NAMESPACE --timeout=300s || {
+        print_warn "Pod not ready after 5 minutes. Check pod status:"
+        print_warn "  kubectl get pods -n $NAMESPACE"
+        print_warn "  kubectl logs -f statefulset/openalgo -n $NAMESPACE"
+    }
+}
+
+status() {
+    print_info "Checking OpenAlgo deployment status..."
+    
+    echo
+    print_info "Pods:"
+    $KUBECTL get pods -n $NAMESPACE
+    
+    echo
+    print_info "Services:"
+    $KUBECTL get svc -n $NAMESPACE
+    
+    echo
+    print_info "Ingress:"
+    $KUBECTL get ingress -n $NAMESPACE
+    
+    echo
+    print_info "PersistentVolumeClaims:"
+    $KUBECTL get pvc -n $NAMESPACE
+    
+    echo
+    print_info "To view logs:"
+    echo "  kubectl logs -f statefulset/openalgo -n $NAMESPACE"
+    
+    echo
+    print_info "To access the application:"
+    echo "  kubectl port-forward -n $NAMESPACE svc/openalgo 5000:5000"
+    echo "  Then open http://localhost:5000"
+}
+
+undeploy() {
+    print_warn "This will delete all OpenAlgo resources including data!"
+    read -p "Are you sure? (yes/NO) " -r
+    echo
+    if [[ ! $REPLY == "yes" ]]; then
+        print_info "Cancelled."
+        exit 0
+    fi
+    
+    print_info "Undeploying OpenAlgo..."
+    
+    $KUBECTL delete -f ingress.yaml || true
+    $KUBECTL delete -f service.yaml || true
+    $KUBECTL delete -f statefulset.yaml || true
+    $KUBECTL delete -f secrets.yaml || true
+    $KUBECTL delete -f configmap.yaml || true
+    $KUBECTL delete -f pvcs.yaml || true
+    $KUBECTL delete -f namespace.yaml || true
+    
+    print_info "OpenAlgo undeployed successfully!"
+}
+
+logs() {
+    print_info "Streaming logs from OpenAlgo..."
+    $KUBECTL logs -f statefulset/openalgo -n $NAMESPACE
+}
+
+shell() {
+    print_info "Opening shell in OpenAlgo pod..."
+    $KUBECTL exec -it openalgo-0 -n $NAMESPACE -- /bin/bash
+}
+
+# Main script
+case "${1:-}" in
+    deploy)
+        check_prerequisites
+        check_secrets
+        deploy
+        echo
+        status
+        ;;
+    status)
+        check_prerequisites
+        status
+        ;;
+    undeploy)
+        check_prerequisites
+        undeploy
+        ;;
+    logs)
+        check_prerequisites
+        logs
+        ;;
+    shell)
+        check_prerequisites
+        shell
+        ;;
+    *)
+        echo "OpenAlgo Kubernetes Deployment Script"
+        echo
+        echo "Usage: $0 {deploy|status|undeploy|logs|shell}"
+        echo
+        echo "Commands:"
+        echo "  deploy    - Deploy OpenAlgo to Kubernetes"
+        echo "  status    - Check deployment status"
+        echo "  undeploy  - Remove OpenAlgo from Kubernetes (deletes data!)"
+        echo "  logs      - Stream application logs"
+        echo "  shell     - Open shell in OpenAlgo pod"
+        echo
+        exit 1
+        ;;
+esac

--- a/kubernetes/ingress.yaml
+++ b/kubernetes/ingress.yaml
@@ -1,0 +1,56 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: openalgo
+  namespace: openalgo
+  labels:
+    app: openalgo
+  annotations:
+    # Uncomment and configure based on your ingress controller
+    
+    # For nginx ingress controller:
+    # nginx.ingress.kubernetes.io/rewrite-target: /
+    # nginx.ingress.kubernetes.io/ssl-redirect: "true"
+    
+    # For WebSocket support:
+    nginx.ingress.kubernetes.io/proxy-read-timeout: "3600"
+    nginx.ingress.kubernetes.io/proxy-send-timeout: "3600"
+    nginx.ingress.kubernetes.io/websocket-services: "openalgo"
+    
+    # For cert-manager (automatic TLS):
+    # cert-manager.io/cluster-issuer: "letsencrypt-prod"
+    
+    # For Traefik ingress controller:
+    # traefik.ingress.kubernetes.io/router.entrypoints: websecure
+    # traefik.ingress.kubernetes.io/router.tls: "true"
+spec:
+  ingressClassName: nginx  # Change to your ingress class: nginx, traefik, etc.
+  
+  # TLS configuration (uncomment and configure your domain)
+  # tls:
+  # - hosts:
+  #   - openalgo.yourdomain.com
+  #   secretName: openalgo-tls
+  
+  rules:
+  - host: openalgo.yourdomain.com  # CHANGE THIS to your actual domain
+    http:
+      paths:
+      - path: /
+        pathType: Prefix
+        backend:
+          service:
+            name: openalgo
+            port:
+              number: 5000
+  
+  # Alternative: Access via IP (for testing)
+  # - http:
+  #     paths:
+  #     - path: /
+  #       pathType: Prefix
+  #       backend:
+  #         service:
+  #           name: openalgo
+  #           port:
+  #             number: 5000

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -13,6 +13,8 @@ resources:
   - statefulset.yaml
   - service.yaml
   - ingress.yaml
+  - secrets.yaml
+  - networkpolicy.yaml
 
 # Common labels applied to all resources
 commonLabels:

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -1,0 +1,51 @@
+apiVersion: kustomize.config.k8s.io/v1beta1
+kind: Kustomization
+
+namespace: openalgo
+
+resources:
+  - namespace.yaml
+  - pvcs.yaml
+  - configmap.yaml
+  - secrets-template.yaml  # Change to secrets.yaml after configuration
+  - statefulset.yaml
+  - service.yaml
+  - ingress.yaml
+
+# Common labels applied to all resources
+commonLabels:
+  app.kubernetes.io/name: openalgo
+  app.kubernetes.io/version: "1.0.0"
+  app.kubernetes.io/managed-by: kustomize
+
+# Metadata applied to all resources
+commonAnnotations:
+  description: "OpenAlgo Algorithmic Trading Platform"
+
+# Image configurations (uncomment and customize)
+# images:
+#   - name: openalgo
+#     newName: your-registry.com/openalgo
+#     newTag: v1.0.0
+
+# ConfigMap generator (alternative to configmap.yaml)
+# configMapGenerator:
+#   - name: openalgo-config
+#     literals:
+#       - FLASK_ENV=production
+#       - FLASK_DEBUG=0
+
+# Secret generator (DO NOT USE for actual secrets, use external secret management)
+# secretGenerator:
+#   - name: openalgo-secret
+#     files:
+#       - .env=path/to/.env
+
+# Patches for environment-specific customizations
+# patchesStrategicMerge:
+#   - overlays/production.yaml
+
+# Replicas (for Deployment only, not StatefulSet with SQLite)
+# replicas:
+#   - name: openalgo
+#     count: 1

--- a/kubernetes/kustomization.yaml
+++ b/kubernetes/kustomization.yaml
@@ -7,7 +7,9 @@ resources:
   - namespace.yaml
   - pvcs.yaml
   - configmap.yaml
-  - secrets-template.yaml  # Change to secrets.yaml after configuration
+  # secrets-template.yaml is intentionally NOT included here.
+  # Users MUST copy it to secrets.yaml and configure before deploying
+  # This prevents accidental deployment with placeholder credentials
   - statefulset.yaml
   - service.yaml
   - ingress.yaml

--- a/kubernetes/namespace.yaml
+++ b/kubernetes/namespace.yaml
@@ -1,0 +1,8 @@
+apiVersion: v1
+kind: Namespace
+metadata:
+  name: openalgo
+  labels:
+    name: openalgo
+    app.kubernetes.io/name: openalgo
+    app.kubernetes.io/component: trading-platform

--- a/kubernetes/networkpolicy.yaml
+++ b/kubernetes/networkpolicy.yaml
@@ -1,0 +1,65 @@
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: openalgo-netpol
+  namespace: openalgo
+  labels:
+    app: openalgo
+spec:
+  podSelector:
+    matchLabels:
+      app: openalgo
+  policyTypes:
+  - Ingress
+  - Egress
+  
+  # Allow incoming traffic from ingress controller
+  ingress:
+  - from:
+    - namespaceSelector:
+        matchLabels:
+          name: ingress-nginx
+    ports:
+    - protocol: TCP
+      port: 5000  # Web UI
+    - protocol: TCP
+      port: 8765  # WebSocket
+  
+  # Allow all pods in the same namespace to communicate
+  - from:
+    - podSelector: {}
+    ports:
+    - protocol: TCP
+      port: 5000
+    - protocol: TCP
+      port: 8765
+
+  # Allow outgoing traffic
+  egress:
+  # DNS resolution
+  - to:
+    - namespaceSelector:
+        matchLabels:
+          kubernetes.io/metadata.name: kube-system
+    ports:
+    - protocol: UDP
+      port: 53
+  
+  # External API calls (broker APIs, etc.)
+  - to:
+    - namespaceSelector: {}
+    ports:
+    - protocol: TCP
+      port: 443  # HTTPS
+    - protocol: TCP
+      port: 80   # HTTP
+  
+  # Allow outbound to any IP (for broker APIs)
+  - to:
+    - ipBlock:
+        cidr: 0.0.0.0/0
+    ports:
+    - protocol: TCP
+      port: 443
+    - protocol: TCP
+      port: 80

--- a/kubernetes/networkpolicy.yaml
+++ b/kubernetes/networkpolicy.yaml
@@ -18,7 +18,7 @@ spec:
   - from:
     - namespaceSelector:
         matchLabels:
-          name: ingress-nginx
+          kubernetes.io/metadata.name: ingress-nginx
     ports:
     - protocol: TCP
       port: 5000  # Web UI

--- a/kubernetes/pvcs.yaml
+++ b/kubernetes/pvcs.yaml
@@ -1,0 +1,85 @@
+---
+# Database storage
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openalgo-db
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: database
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 5Gi
+  storageClassName: local-path  # Change to your storage class
+---
+# Application logs
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openalgo-logs
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: logs
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 2Gi
+  storageClassName: local-path
+---
+# Trading strategies
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openalgo-strategies
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: strategies
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path
+---
+# API keys and certificates
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openalgo-keys
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: keys
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 100Mi
+  storageClassName: local-path
+---
+# Temporary files
+apiVersion: v1
+kind: PersistentVolumeClaim
+metadata:
+  name: openalgo-tmp
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: temp
+spec:
+  accessModes:
+    - ReadWriteOnce
+  resources:
+    requests:
+      storage: 1Gi
+  storageClassName: local-path

--- a/kubernetes/secrets-template.yaml
+++ b/kubernetes/secrets-template.yaml
@@ -22,13 +22,14 @@ stringData:
   # Example placeholder - replace with actual values:
   .env: |
     # OpenAlgo Configuration
+    #⚠️  CRITICAL: Replace ALL placeholder values before deploying!
     # Copy your .env file contents here
     # This is mounted as /app/.env in the container
     
     # Flask
     FLASK_ENV=production
     FLASK_DEBUG=0
-    SECRET_KEY=change-this-to-secure-random-string
+    SECRET_KEY=__REPLACE_WITH_RANDOM_STRING_REQUIRED__
     
     # Add your actual configuration below
     # BROKER_API_KEY=your-key

--- a/kubernetes/secrets-template.yaml
+++ b/kubernetes/secrets-template.yaml
@@ -1,0 +1,35 @@
+apiVersion: v1
+kind: Secret
+metadata:
+  name: openalgo-secret
+  namespace: openalgo
+  labels:
+    app: openalgo
+type: Opaque
+stringData:
+  # Database credentials (if using external database)
+  # DATABASE_URL: "postgresql://user:password@host:5432/openalgo"
+  
+  # API keys and tokens
+  # Replace with your actual values or use external secret management
+  # SECRET_KEY: "your-flask-secret-key-here"
+  # API_KEY: "your-broker-api-key"
+  # API_SECRET: "your-broker-api-secret"
+  
+  # Add all sensitive values from your .env file here
+  # DO NOT commit actual secrets to git!
+  
+  # Example placeholder - replace with actual values:
+  .env: |
+    # OpenAlgo Configuration
+    # Copy your .env file contents here
+    # This is mounted as /app/.env in the container
+    
+    # Flask
+    FLASK_ENV=production
+    FLASK_DEBUG=0
+    SECRET_KEY=change-this-to-secure-random-string
+    
+    # Add your actual configuration below
+    # BROKER_API_KEY=your-key
+    # BROKER_API_SECRET=your-secret

--- a/kubernetes/service.yaml
+++ b/kubernetes/service.yaml
@@ -1,0 +1,24 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: openalgo
+  namespace: openalgo
+  labels:
+    app: openalgo
+spec:
+  type: ClusterIP
+  selector:
+    app: openalgo
+  ports:
+  - name: http
+    port: 5000
+    targetPort: 5000
+    protocol: TCP
+  - name: websocket
+    port: 8765
+    targetPort: 8765
+    protocol: TCP
+  sessionAffinity: ClientIP  # Important for WebSocket connections
+  sessionAffinityConfig:
+    clientIP:
+      timeoutSeconds: 10800  # 3 hours

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -1,0 +1,126 @@
+apiVersion: apps/v1
+kind: StatefulSet
+metadata:
+  name: openalgo
+  namespace: openalgo
+  labels:
+    app: openalgo
+    component: application
+spec:
+  serviceName: openalgo
+  replicas: 1  # Single instance due to SQLite
+  selector:
+    matchLabels:
+      app: openalgo
+  template:
+    metadata:
+      labels:
+        app: openalgo
+        component: application
+    spec:
+      containers:
+      - name: openalgo
+        image: openalgo:latest
+        imagePullPolicy: IfNotPresent
+        
+        ports:
+        - name: http
+          containerPort: 5000
+          protocol: TCP
+        - name: websocket
+          containerPort: 8765
+          protocol: TCP
+        
+        # Environment variables from ConfigMap
+        envFrom:
+        - configMapRef:
+            name: openalgo-config
+        
+        # Volume mounts
+        volumeMounts:
+        - name: db
+          mountPath: /app/db
+        - name: logs
+          mountPath: /app/log
+        - name: strategies
+          mountPath: /app/strategies
+        - name: keys
+          mountPath: /app/keys
+        - name: tmp
+          mountPath: /app/tmp
+        - name: shm
+          mountPath: /dev/shm
+        - name: env-secret
+          mountPath: /app/.env
+          subPath: .env
+          readOnly: true
+        
+        # Health checks
+        livenessProbe:
+          httpGet:
+            path: /auth/check-setup
+            port: 5000
+          initialDelaySeconds: 60
+          periodSeconds: 30
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        readinessProbe:
+          httpGet:
+            path: /auth/check-setup
+            port: 5000
+          initialDelaySeconds: 40
+          periodSeconds: 10
+          timeoutSeconds: 10
+          failureThreshold: 3
+        
+        # Resource limits
+        resources:
+          requests:
+            memory: "1Gi"
+            cpu: "500m"
+          limits:
+            memory: "4Gi"
+            cpu: "2000m"
+        
+        # Security context
+        securityContext:
+          runAsNonRoot: true
+          runAsUser: 1000
+          runAsGroup: 1000
+          allowPrivilegeEscalation: false
+          readOnlyRootFilesystem: false  # Application needs to write to certain dirs
+          capabilities:
+            drop:
+            - ALL
+      
+      # Volumes
+      volumes:
+      - name: db
+        persistentVolumeClaim:
+          claimName: openalgo-db
+      - name: logs
+        persistentVolumeClaim:
+          claimName: openalgo-logs
+      - name: strategies
+        persistentVolumeClaim:
+          claimName: openalgo-strategies
+      - name: keys
+        persistentVolumeClaim:
+          claimName: openalgo-keys
+      - name: tmp
+        persistentVolumeClaim:
+          claimName: openalgo-tmp
+      - name: shm
+        emptyDir:
+          medium: Memory
+          sizeLimit: 2Gi
+      - name: env-secret
+        secret:
+          secretName: openalgo-secret
+          items:
+          - key: .env
+            path: .env
+      
+      # Restart policy
+      restartPolicy: Always

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -20,7 +20,7 @@ spec:
     spec:
       containers:
       - name: openalgo
-        image: openalgo:latest
+        image: felixopk101/openalgo:latest 
         imagePullPolicy: IfNotPresent
         
         ports:
@@ -60,7 +60,7 @@ spec:
           httpGet:
             path: /auth/check-setup
             port: 5000
-          initialDelaySeconds: 60
+          initialDelaySeconds: 120
           periodSeconds: 30
           timeoutSeconds: 10
           failureThreshold: 3

--- a/kubernetes/statefulset.yaml
+++ b/kubernetes/statefulset.yaml
@@ -20,8 +20,8 @@ spec:
     spec:
       containers:
       - name: openalgo
-        image: felixopk101/openalgo:latest 
-        imagePullPolicy: IfNotPresent
+        image:  marketcalls/openalgo:latest
+        imagePullPolicy: Always
         
         ports:
         - name: http


### PR DESCRIPTION
## Description

Hi! I've added Kubernetes deployment manifests for OpenAlgo. I've been running a K3s homelab and wanted to deploy OpenAlgo there, so I created a complete set of manifests that should work on any Kubernetes cluster.

## What I've Added

I've included everything needed for a production-ready deployment:

- **StatefulSet** for the main application with persistent storage for the database, logs, trading strategies, API keys, and temporary files
- **Services** configured for internal networking, including WebSocket support for real-time updates
- **Ingress** setup for external access (includes TLS configuration)
- **ConfigMap** and **Secrets** for managing application configuration
- **5 PersistentVolumeClaims** to ensure all data persists across pod restarts
- **Deployment script** (`deploy.sh`) to automate the entire setup process
- **Kustomize support** for customizing deployments across different environments
- **Detailed README** covering architecture, deployment steps, configuration, troubleshooting, backups, and a production checklist

## Technical Details

The manifests include:
- Health checks using OpenAlgo's `/auth/check-setup` endpoint
- Resource limits (1-4Gi memory, 500m-2000m CPU)
- Security contexts running as non-root with dropped capabilities
- Session affinity for WebSocket connections
- 2GB shared memory allocation for scipy/numba operations
- Proper volume permissions and security configurations

## Testing

I've tested these manifests in my personal K3s homelab and everything works:
- Pod starts up successfully
- Health checks pass
- All 5 storage volumes bind correctly
- Application is accessible and functional
- WebSocket connections work properly
- Data persists when pods restart

**My test setup:**
- K3s v1.33.6 (single node cluster)
- local-path storage provisioner
- nginx ingress controller

## Why This Is Useful

- Works on any Kubernetes distribution (K3s, GKE, EKS, AKS, microk8s, etc.)
- Production-ready out of the box
- Comprehensive documentation for both beginners and experienced users
- Simple one-command deployment: `./deploy.sh deploy`
- Good foundation for scaling (includes notes on migrating to PostgreSQL)

## Important Notes

- Currently set up for a single replica since OpenAlgo uses SQLite (file-based database)
- I've included documentation on how to migrate to PostgreSQL for multi-replica setups
- The `secrets-template.yaml` file is just a template - users need to fill in their actual configuration from `.sample.env`
- Follows Kubernetes security best practices throughout
- No actual secrets are committed to the repository

## Setup Requirements

Users will need to configure `secrets.yaml` with their environment variables from `.sample.env` before deploying. The README has step-by-step instructions for this.

## Verification

- [x] Tested in real Kubernetes cluster
- [x] All manifests validated
- [x] Documentation is complete
- [x] Security best practices followed
- [x] Health checks working
- [x] Resource limits configured
- [x] Secrets properly templated
- [x] Deploy script tested
<img width="1347" height="591" alt="Screenshot from 2026-02-03 21-00-03" src="https://github.com/user-attachments/assets/0702a1c3-36bd-438a-a474-7dd2e0defc74" />
<img width="1347" height="552" alt="Screenshot from 2026-02-03 20-53-31" src="https://github.com/user-attachments/assets/34b78478-5ef0-4585-9f2b-27735eaffc46" />
<img width="1347" height="552" alt="Screenshot from 2026-02-03 20-53-21" src="https://github.com/user-attachments/assets/f33cfac4-c23e-4516-b32c-7b0d2f0c219b" />
<img width="1347" height="552" alt="Screenshot from 2026-02-03 20-52-55" src="https://github.com/user-attachments/assets/02bae8aa-6a86-43e9-98ed-5995c512e7ef" />
<img width="1347" height="552" alt="Screenshot from 2026-02-03 20-52-34" src="https://github.com/user-attachments/assets/a060d812-deac-4e25-a7f6-88cf3c524985" />
<img width="1347" height="552" alt="Screenshot from 2026-02-03 20-52-20" src="https://github.com/user-attachments/assets/ce0023e1-b5ee-44b6-b7d1-b1060428c8e5" />
<img width="1347" height="474" alt="Screenshot from 2026-02-03 20-52-03" src="https://github.com/user-attachments/assets/fe5ab86a-e828-4730-b228-01afbffce729" />
<img width="1347" height="635" alt="Screenshot from 2026-02-03 20-51-31" src="https://github.com/user-attachments/assets/19232fdd-886b-4862-8052-208f9b7b8dbd" />
<img width="1347" height="635" alt="Screenshot from 2026-02-03 20-50-51" src="https://github.com/user-attachments/assets/2886a53d-eb04-49ed-95a1-170c82e393a6" />

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Kubernetes deployment to run OpenAlgo on any cluster. Provides manifests, automation, and docs for a secure single-replica setup with persistent storage, WebSocket-ready ingress, and updated permission troubleshooting for non-root pods.

- **New Features**
  - StatefulSet (1 replica for SQLite) with 5 PVCs: db, logs, strategies, keys, tmp; non‑root security, resource limits, /auth/check-setup probes, 2Gi /dev/shm, session affinity for WebSockets.
  - ClusterIP Service and nginx Ingress with WebSocket support, plus a NetworkPolicy to restrict ingress/egress; kustomize base included.
  - ConfigMap for non-sensitive env, including thread-limiting vars (OPENBLAS/OMP/MKL/NUMEXPR/NUMBA); official image marketcalls/openalgo:latest with imagePullPolicy: Always.
  - deploy.sh for one-command apply/status/logs/shell and a detailed README for setup, scaling, backup, and updated permission guidance (fsGroup and PVC recreation steps).

- **Migration**
  - Copy secrets-template.yaml to secrets.yaml and populate with your .env values (do not commit); kustomize includes secrets.yaml, template excluded to prevent accidental deploy.
  - Update ingress host and storageClass if needed.
  - Deploy with ./deploy.sh deploy; for kustomize, copy secrets.yaml first, then kubectl apply -k kubernetes.
  - Keep replicas at 1 with SQLite; README includes steps to move to PostgreSQL before scaling.

<sup>Written for commit 309b2a435937ad1b95ef31e838ef4bc988f0e4e9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

