### PR TITLE
fix: add missing expiryCode to Dhan intraday chart requests

### DIFF
--- a/broker/dhan/api/data.py
+++ b/broker/dhan/api/data.py
@@ -428,9 +428,8 @@ class BrokerData:
                     "oi": True,
                 }
 
-                # Add expiryCode only for EQUITY
-                if instrument_type == "EQUITY":
-                    request_data["expiryCode"] = 0
+                # Add expiryCode for all instruments (required by Dhan API)
+                request_data["expiryCode"] = 0
 
                 logger.debug(f"Making daily history request to {endpoint}")
                 logger.debug(f"Request data: {json.dumps(request_data, indent=2)}")
@@ -485,6 +484,7 @@ class BrokerData:
                         "fromDate": from_time,
                         "toDate": to_time,
                         "oi": True,
+                        "expiryCode": 0,
                     }
 
                     logger.debug(f"Making intraday history request to {endpoint}")
@@ -543,6 +543,7 @@ class BrokerData:
                             "fromDate": from_time,
                             "toDate": to_time,
                             "oi": True,
+                            "expiryCode": 0,
                         }
 
                         logger.debug(f"Making intraday history request to {endpoint}")


### PR DESCRIPTION
## Summary

- **Dhan Charts API** requires the `expiryCode` parameter in chart requests for all instrument types
- The intraday endpoint (`/v2/charts/intraday`) was missing this parameter entirely, causing **"No data available for the specified period"** errors when fetching 1m/5m/15m candles for F&O instruments (options, futures)
- The daily endpoint (`/v2/charts/historical`) only added `expiryCode` for EQUITY, missing it for F&O instruments

## Changes

1. **Daily endpoint**: Add `expiryCode: 0` for all instrument types (was only added for EQUITY)
2. **Intraday same-day**: Add missing `expiryCode: 0` parameter
3. **Intraday multi-day chunks**: Add missing `expiryCode: 0` parameter

## Impact

Without this fix, any strategy or API call fetching intraday candles for options (OPTIDX, OPTSTK) or futures (FUTIDX, FUTSTK) via the Dhan broker consistently fails with "No data available".

## Test plan

- [x] Verified fix resolves intraday candle fetch for NIFTY options (both CE and PE)
- [ ] Verify daily chart requests still work for EQUITY, F&O instruments
- [ ] Verify intraday chart requests work across all supported intervals (1m, 5m, 15m, 25m, 1h)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add expiryCode: 0 to all Dhan chart requests to restore intraday candles for options and futures. Fixes “No data available” errors on intraday intervals.

- **Bug Fixes**
  - Daily: include expiryCode for all instruments (was EQUITY only).
  - Intraday: include expiryCode for same-day requests.
  - Intraday: include expiryCode for multi-day chunked requests.

<sup>Written for commit 80ea15cf4b4c977434b9eaf2bb723ea2a9fbbd52. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

