### PR TITLE
Fix: Address PR #854 review - WebSocket manager critical fixes

### DIFF
--- a/frontend/src/hooks/useLivePrice.ts
+++ b/frontend/src/hooks/useLivePrice.ts
@@ -85,7 +85,6 @@ export function useLivePrice<T extends PriceableItem>(
     useMultiQuotesFallback = true,
     multiQuotesRefreshInterval = 30000,
     pauseWhenHidden = true,
-    pauseDelay = 5000,
   } = options
 
   const { apiKey } = useAuthStore()
@@ -114,8 +113,6 @@ export function useLivePrice<T extends PriceableItem>(
     symbols,
     mode: 'LTP',
     enabled: enabled && items.length > 0,
-    pauseWhenHidden,
-    pauseDelay,
   })
 
   // Effective live status

--- a/frontend/src/hooks/useLiveQuote.ts
+++ b/frontend/src/hooks/useLiveQuote.ts
@@ -107,7 +107,6 @@ export function useLiveQuote(
     useDepthFallback = true,
     staleThreshold = 5000,
     refreshInterval = 30000,
-    pauseWhenHidden = true,
   } = options
 
   const { apiKey } = useAuthStore()
@@ -134,7 +133,6 @@ export function useLiveQuote(
     symbols,
     mode,
     enabled: enabled && hasSymbol,
-    pauseWhenHidden,
   })
 
   const wsData = marketData.get(`${exchange}:${symbol}`)?.data

--- a/frontend/src/hooks/useOptionChainLive.ts
+++ b/frontend/src/hooks/useOptionChainLive.ts
@@ -98,7 +98,6 @@ export function useOptionChainLive(
     symbols: wsSymbols,
     mode: 'Depth', // Get LTP + Bid/Ask depth
     enabled: enabled && wsSymbols.length > 0,
-    pauseWhenHidden,
   })
 
   // Track last LTP update time using ref to avoid triggering effect loops


### PR DESCRIPTION
- Remove duplicate visibility handling from useMarketData hook (Context already manages it)
- Clear API key from memory on disconnect for security
- Normalize symbols/exchanges to uppercase at subscribe time for consistent cache keys

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves WebSocket market data stability and security by normalizing subscription keys, removing duplicate visibility handling, and clearing the API key on disconnect. Reduces cache misses, duplicate subscriptions, and risk of key lingering in memory.

- **Bug Fixes**
  - Normalize symbol/exchange to uppercase in subscribe/unsubscribe/getCachedData and incoming events to ensure consistent cache keys and fan-out.
  - Clear API key in memory on disconnect for better security.
  - Remove pauseWhenHidden/pauseDelay from hooks; rely on context-managed visibility control to avoid double pausing/resuming.

<sup>Written for commit 68f7706bcd08160dfc06eb8084509a83d389fde3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

