### PR TITLE
Angel - Common Index (NSE & BSE) symbols Update

### DIFF
--- a/broker/angel/database/master_contract_db.py
+++ b/broker/angel/database/master_contract_db.py
@@ -279,15 +279,35 @@ def process_angel_json(path):
     )
 
     # Common Index Symbol Formats
+    # For NSE_INDEX, derive symbol from 'name' column
+    # and normalize to OpenAlgo common format (uppercase, no spaces/hyphens)
+    idx_mask = df["exchange"] == "NSE_INDEX"
+    df.loc[idx_mask, "symbol"] = (
+        df.loc[idx_mask, "name"]
+        .str.upper()
+        .str.replace(" ", "", regex=False)
+        .str.replace("-", "", regex=False)
+    )
 
+    # For BSE_INDEX, derive symbol from 'name' column
+    # and normalize to OpenAlgo common format (uppercase, no spaces/hyphens)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = (
+        df.loc[bse_idx_mask, "name"]
+        .str.upper()
+        .str.replace(" ", "", regex=False)
+        .str.replace("-", "", regex=False)
+    )
+
+    # Override for major indices where normalized name differs from OpenAlgo standard
     df["symbol"] = df["symbol"].replace(
         {
-            "Nifty 50": "NIFTY",
-            "Nifty Next 50": "NIFTYNXT50",
-            "Nifty Fin Service": "FINNIFTY",
-            "Nifty Bank": "BANKNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "India VIX": "INDIAVIX",
+            "NIFTY50": "NIFTY",
+            "NIFTYBANK": "BANKNIFTY",
+            "NIFTYFINSERVICE": "FINNIFTY",
+            "NIFTYNEXT50": "NIFTYNXT50",
+            "NIFTYMIDSELECT": "MIDCPNIFTY",
+            "NIFTYMIDCAPSELECT": "MIDCPNIFTY",
             "SNSX50": "SENSEX50",
         }
     )


### PR DESCRIPTION
Angel - Common Index (NSE & BSE) symbols Update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes NSE_INDEX and BSE_INDEX symbols by deriving from the index name and normalizing to OpenAlgo’s common format, preventing mismatches and improving lookups.

- **Refactors**
  - For NSE_INDEX and BSE_INDEX, set symbol from name (uppercase, no spaces, no hyphens).
  - Added overrides to match OpenAlgo standards: NIFTY50→NIFTY, NIFTYBANK→BANKNIFTY, NIFTYFINSERVICE→FINNIFTY, NIFTYNEXT50→NIFTYNXT50, NIFTYMIDSELECT/NIFTYMIDCAPSELECT→MIDCPNIFTY, SNSX50→SENSEX50.

<sup>Written for commit 61b556756a0c3f870c2928761feb901c1876a0e1. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

