### PR TITLE
Replace broker init arg counts with constants

### DIFF
--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -4,14 +4,11 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import Auth, db_session, get_auth_token_broker, verify_api_key
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_ARGS_WITH_AUTH, BROKER_INIT_ARGS_WITH_FEED, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
 logger = get_logger(__name__)
-
-BROKER_INIT_ARGS_WITH_AUTH = 2
-BROKER_INIT_ARGS_WITH_FEED = 3
 
 
 def validate_symbol_exchange(symbol: str, exchange: str) -> tuple[bool, str | None]:

--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -10,6 +10,9 @@ from utils.logging import get_logger
 # Initialize logger
 logger = get_logger(__name__)
 
+BROKER_INIT_ARGS_WITH_AUTH = 2
+BROKER_INIT_ARGS_WITH_FEED = 3
+
 
 def validate_symbol_exchange(symbol: str, exchange: str) -> tuple[bool, str | None]:
     """
@@ -96,9 +99,9 @@ def get_depth_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 3:  # More than self, auth_token, and feed_token
+            if param_count > BROKER_INIT_ARGS_WITH_FEED:  # More than self, auth_token, and feed_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token, user_id)
-            elif param_count > 2:  # More than self and auth_token
+            elif param_count > BROKER_INIT_ARGS_WITH_AUTH:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -7,13 +7,11 @@ import pandas as pd
 
 from database.auth_db import get_auth_token_broker
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_ARGS_WITH_AUTH, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
 logger = get_logger(__name__)
-
-BROKER_INIT_ARGS_WITH_AUTH = 2
 
 # Rate limiter: max 3 broker history API requests per second
 # Uses minimum interval between calls to prevent burst requests

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -13,6 +13,8 @@ from utils.logging import get_logger
 # Initialize logger
 logger = get_logger(__name__)
 
+BROKER_INIT_ARGS_WITH_AUTH = 2
+
 # Rate limiter: max 3 broker history API requests per second
 # Uses minimum interval between calls to prevent burst requests
 _last_history_call: float = 0.0
@@ -118,7 +120,7 @@ def get_history_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_ARGS_WITH_AUTH:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -4,13 +4,11 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_ARGS_WITH_AUTH, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
 logger = get_logger(__name__)
-
-BROKER_INIT_ARGS_WITH_AUTH = 2
 
 
 def validate_symbol_exchange(symbol: str, exchange: str) -> tuple[bool, str | None]:

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -10,6 +10,8 @@ from utils.logging import get_logger
 # Initialize logger
 logger = get_logger(__name__)
 
+BROKER_INIT_ARGS_WITH_AUTH = 2
+
 
 def validate_symbol_exchange(symbol: str, exchange: str) -> tuple[bool, str | None]:
     """
@@ -128,7 +130,7 @@ def get_quotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_ARGS_WITH_AUTH:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)
@@ -260,7 +262,7 @@ def get_multiquotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_ARGS_WITH_AUTH:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -63,6 +63,10 @@ EXCHANGE_BADGE_COLORS = {
     EXCHANGE_BSE_INDEX: "badge-neutral",
 }
 
+# Broker init arg counts
+BROKER_INIT_ARGS_WITH_AUTH = 2
+BROKER_INIT_ARGS_WITH_FEED = 3
+
 # Required Fields for Order Placement
 REQUIRED_ORDER_FIELDS = ["apikey", "strategy", "symbol", "exchange", "action", "quantity"]
 


### PR DESCRIPTION
- replace magic numbers in broker __init__ arg count checks with named constants\n- apply to depth, history, and quotes services\n\nFixes #895

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced magic numbers in BrokerData __init__ arg-count checks with named constants, and centralized them in utils/constants. Updated depth, history, and quotes services to use BROKER_INIT_ARGS_WITH_AUTH and BROKER_INIT_ARGS_WITH_FEED for safer, clearer broker init handling (fixes #895).

<sup>Written for commit f651d19367721bc0ff45c992fcf4031584ccc675. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

