### PR TITLE
style: add type hints to helper functions in restx_api/ticker.py

### DIFF
--- a/restx_api/ticker.py
+++ b/restx_api/ticker.py
@@ -1,6 +1,6 @@
 import importlib
 import os
-from datetime import UTC, datetime, timedelta, timezone
+from datetime import UTC, datetime, timedelta, timezone, date
 
 import pandas as pd
 import pytz
@@ -17,6 +17,7 @@ from .data_schemas import TickerSchema
 from types import ModuleType
 
 
+
 API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("ticker", description="Stock Ticker Data API")
 
@@ -27,7 +28,7 @@ logger = get_logger(__name__)
 ticker_schema = TickerSchema()
 
 
-def import_broker_module(broker_name: str)-> ModuleType | None:
+def import_broker_module(broker_name: str) -> ModuleType | None:
     try:
         module_path = f"broker.{broker_name}.api.data"
         broker_module = importlib.import_module(module_path)
@@ -49,7 +50,7 @@ class TextResponse(Response):
         self._json = value
 
 
-def convert_timestamp(timestamp: float, interval: str)-> str | tuple[str,str]:
+def convert_timestamp(timestamp: float, interval: str) -> str | tuple[str, str]:
     """Convert timestamp to appropriate format based on interval"""
     # Convert timestamp to datetime in UTC
     dt = datetime.fromtimestamp(timestamp, tz=UTC)
@@ -67,10 +68,10 @@ def convert_timestamp(timestamp: float, interval: str)-> str | tuple[str,str]:
 
 
 def validate_and_adjust_date_range(
-    start_date:str,
-    end_date: str,
-    interval: str
-    )->tuple[str, str, bool]:
+    start_date: str | date,
+    end_date: str | date,
+    interval: str,
+) -> tuple[str | date, str | date, bool]:
     """
     Validate and adjust date range based on interval to prevent large queries
 


### PR DESCRIPTION
Adds type hints to import_broker_module, convert_timestamp, and validate_and_adjust_date_range in restx_api/ticker.py.

Closes #894

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added precise type hints to helper functions in restx_api/ticker.py to improve type safety and IDE tooling. No runtime behavior changes.

- **Refactors**
  - import_broker_module(broker_name: str) -> ModuleType | None
  - convert_timestamp(timestamp: float, interval: str) -> str | tuple[str, str]
  - validate_and_adjust_date_range(start_date: str | date, end_date: str | date, interval: str) -> tuple[str | date, str | date, bool]

<sup>Written for commit c815a0ac0bebb2a7dae27bfa996c3ad088df79be. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

