### PR TITLE
fix: add aria-label to inline edit inputs for accessibility

### DIFF
--- a/frontend/src/pages/admin/FreezeQty.tsx
+++ b/frontend/src/pages/admin/FreezeQty.tsx
@@ -329,6 +329,7 @@ export default function FreezeQtyPage() {
                               onChange={(e) => setEditValue(e.target.value)}
                               className="w-24 h-8"
                               min={1}
+                              aria-label={`Freeze quantity for ${entry.symbol}`}
                             />
                             <Button
                               size="icon"

--- a/frontend/src/pages/admin/Holidays.tsx
+++ b/frontend/src/pages/admin/Holidays.tsx
@@ -553,6 +553,7 @@ export default function HolidaysPage() {
                             updateSpecialSessionTime(ex.exchange, 'start_time', e.target.value)
                           }
                           className="w-[110px]"
+                          aria-label={`Start time for ${ex.exchange}`}
                         />
                         <span className="text-muted-foreground">to</span>
                         <Input
@@ -562,6 +563,7 @@ export default function HolidaysPage() {
                             updateSpecialSessionTime(ex.exchange, 'end_time', e.target.value)
                           }
                           className="w-[110px]"
+                          aria-label={`End time for ${ex.exchange}`}
                         />
                         <Button
                           variant="ghost"

--- a/frontend/src/pages/admin/MarketTimings.tsx
+++ b/frontend/src/pages/admin/MarketTimings.tsx
@@ -184,6 +184,7 @@ export default function MarketTimingsPage() {
                             value={editStartTime}
                             onChange={(e) => setEditStartTime(e.target.value)}
                             className="w-28 h-8"
+                            aria-label={`Start time for ${timing.exchange}`}
                           />
                         ) : (
                           <span className="font-mono">{timing.start_time}</span>
@@ -196,6 +197,7 @@ export default function MarketTimingsPage() {
                             value={editEndTime}
                             onChange={(e) => setEditEndTime(e.target.value)}
                             className="w-28 h-8"
+                            aria-label={`End time for ${timing.exchange}`}
                           />
                         ) : (
                           <span className="font-mono">{timing.end_time}</span>


### PR DESCRIPTION
## Summary
- Add `aria-label` to time inputs in MarketTimings inline edit mode
- Add `aria-label` to freeze quantity input in FreezeQty inline edit mode
- Add `aria-label` to special session time inputs in Holidays dialog

Closes #890

## What this fixes
Screen readers couldn't identify inline edit input fields because they had no `aria-label` or associated `<label>` element. 
This violates WCAG 2.1 guidelines 1.3.1 (Info and Relationships) and 3.3.2 (Labels or Instructions).

Each label is dynamic and includes the exchange/symbol name for better context (e.g., "Start time for NSE", "Freeze quantity for NIFTY").

## Files changed
- `frontend/src/pages/admin/MarketTimings.tsx` — 2 inputs (start time, end time)
- `frontend/src/pages/admin/FreezeQty.tsx` — 1 input (freeze quantity)
- `frontend/src/pages/admin/Holidays.tsx` — 2 inputs (special session start/end time)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added aria-labels to inline edit inputs so screen readers can identify them. Labels are dynamic and include the exchange or symbol for context.

- **Bug Fixes**
  - MarketTimings: start/end time inputs.
  - FreezeQty: freeze quantity input.
  - Holidays: special session start/end time inputs.

<sup>Written for commit 261df587b5be2afda3ccb67e80081aab9b926977. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

