### PR TITLE
fix: add error display in Search component for failed API calls

### DIFF
--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -49,6 +49,7 @@ export default function Search() {
   const [searchParams] = useSearchParams()
   const [results, setResults] = useState<SearchResult[]>([])
   const [isLoading, setIsLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
   const [sortKey, setSortKey] = useState<SortKey | null>(null)
   const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
   const [currentPage, setCurrentPage] = useState(1)
@@ -61,6 +62,7 @@ export default function Search() {
 
   const fetchResults = async () => {
     setIsLoading(true)
+    setError(null)
     try {
       // Build URL with all search params - use the API endpoint
       const params = new URLSearchParams()
@@ -90,10 +92,14 @@ export default function Search() {
         const data = await response.json()
         setResults(data.results || [])
       } else {
+        setError('Search failed. Please try again.')
+        showToast.error('Failed to search symbols')
         setResults([])
       }
     } catch (error) {
       console.error('Search error:', error)
+      setError('Failed to search symbols. Please check your connection.')
+      showToast.error('Failed to search symbols')
       setResults([])
     } finally {
       setIsLoading(false)
@@ -221,7 +227,11 @@ export default function Search() {
                 {paginatedResults.length === 0 ? (
                   <TableRow>
                     <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
-                      No results found
+                      {error ? (
+                        <span className="text-destructive">{error}</span>
+                      ) : (
+                        'No results found'
+                      )}
                     </TableCell>
                   </TableRow>
                 ) : (


### PR DESCRIPTION
  ## Summary
  - Add error state and visible error feedback when symbol search API fails
  - Show toast notification on search failure
  - Display inline error message (in red) distinguishing failures from empty results

  Closes #891

  ## What this fixes
  When the search API call failed, the error was only logged to `console.error()`
  and results were silently set to `[]`. Users couldn't distinguish between
  "no results found" and "search failed". Now both failure paths (bad HTTP
  response and network error) show a toast and an inline error message.

  ## Files changed
  - `frontend/src/pages/Search.tsx` — added error state, toast notifications, and inline error display

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds visible error feedback to the Search page when the symbol search API call fails. Users now see a toast and an inline red error message, clearly distinguishing failures from empty results.

- **Bug Fixes**
  - Added an error state and reset it at the start of each fetch.
  - Show a toast on HTTP errors and network failures.
  - Replace “No results found” with an inline red error message when an error occurs.

<sup>Written for commit d1dc4c25f64819bcd3e958ee0b126943c3f1b62a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

