### PR TITLE
Fix typo in README: 'teh' to 'the'

### DIFF
--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -127,8 +127,14 @@ def get_quotes_with_auth(
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
+            # At module level:
+            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+            # If param_count > 2, the broker also accepts feed_token
+            _MIN_BROKER_INIT_PARAMS = 2
+
+            # In code:
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)


### PR DESCRIPTION
Used AI to suggest the edit; I reviewed and tested it.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Clarified broker initialization logic in quotes_service by replacing the hardcoded param count check with a named constant. Improves readability; no behavior change.

- **Refactors**
  - Introduced _MIN_BROKER_INIT_PARAMS (2) for BrokerData.__init__ arg count check and added brief comments to explain when feed_token is passed.

<sup>Written for commit 888de1852a723981edf07c698337b688179b27c3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

