### PR TITLE
Replace traceback.print_exc() with logger.exception() across services

### DIFF
--- a/blueprints/historify.py
+++ b/blueprints/historify.py
@@ -8,7 +8,6 @@ Note: The /historify page is served by react_app.py (React frontend).
 
 import os
 import tempfile
-import traceback
 
 from flask import Blueprint, Response, jsonify, request, send_file, session
 
@@ -35,8 +34,7 @@ def get_watchlist():
         success, response, status_code = service_get_watchlist()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -55,8 +53,7 @@ def add_watchlist():
         success, response, status_code = add_to_watchlist(symbol, exchange, display_name)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error adding to watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error adding to watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -74,8 +71,7 @@ def remove_watchlist():
         success, response, status_code = remove_from_watchlist(symbol, exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error removing from watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error removing from watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -95,8 +91,7 @@ def bulk_remove_watchlist():
         success, response, status_code = bulk_remove_from_watchlist(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk removing from watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk removing from watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -113,8 +108,7 @@ def bulk_add_watchlist():
         success, response, status_code = bulk_add_to_watchlist(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk adding to watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk adding to watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -160,8 +154,7 @@ def download_data():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error downloading data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -195,8 +188,7 @@ def download_watchlist():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error downloading watchlist data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading watchlist data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -227,8 +219,7 @@ def get_chart_data():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting chart data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting chart data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -242,8 +233,7 @@ def get_catalog():
         success, response, status_code = get_data_catalog()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting catalog: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting catalog: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -261,8 +251,7 @@ def get_symbol_info():
         success, response, status_code = get_symbol_data_info(symbol, exchange, interval)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting symbol info: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting symbol info: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -303,8 +292,7 @@ def export_data():
 
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error exporting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error exporting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -355,8 +343,7 @@ def download_export():
             headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     except Exception as e:
-        logger.error(f"Error downloading export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading export: {e}")
         # Clean up file on error
         if file_path and os.path.exists(file_path):
             try:
@@ -406,8 +393,7 @@ def get_export_preview():
 
         return jsonify({"status": "success", "data": preview}), 200
     except Exception as e:
-        logger.error(f"Error getting export preview: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting export preview: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -550,8 +536,7 @@ def bulk_export():
         ), 200
 
     except Exception as e:
-        logger.error(f"Error in bulk export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in bulk export: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -601,8 +586,7 @@ def download_bulk_export():
             headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     except Exception as e:
-        logger.error(f"Error downloading bulk export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading bulk export: {e}")
         # Clean up file on error
         if file_path and os.path.exists(file_path):
             try:
@@ -640,8 +624,7 @@ def get_intervals():
         success, response, status_code = get_supported_timeframes(api_key)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting intervals: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -655,8 +638,7 @@ def get_historify_intervals():
         success, response, status_code = service_get_intervals()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting historify intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting historify intervals: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -670,8 +652,7 @@ def get_exchanges():
         success, response, status_code = service_get_exchanges()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting exchanges: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting exchanges: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -685,8 +666,7 @@ def get_stats():
         success, response, status_code = service_get_stats()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting stats: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting stats: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -705,8 +685,7 @@ def delete_data():
         success, response, status_code = delete_symbol_data(symbol, exchange, interval)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error deleting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -726,8 +705,7 @@ def bulk_delete_data():
         success, response, status_code = bulk_delete_symbol_data(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk deleting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk deleting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -811,8 +789,7 @@ def upload_data():
                 os.remove(temp_path)
 
     except Exception as e:
-        logger.error(f"Error uploading data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error uploading data: {e}")
         # Clean up temp file on error
         if temp_file and os.path.exists(temp_file.name):
             os.remove(temp_file.name)
@@ -886,8 +863,7 @@ def get_fno_underlyings():
         success, response, status_code = service_get_underlyings(exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO underlyings: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO underlyings: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -910,8 +886,7 @@ def get_fno_expiries():
         success, response, status_code = service_get_expiries(underlying, exchange, instrumenttype)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO expiries: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO expiries: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -944,8 +919,7 @@ def get_fno_chain():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -965,8 +939,7 @@ def get_futures_chain():
         success, response, status_code = service_get_futures(underlying, exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting futures chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting futures chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -995,8 +968,7 @@ def get_option_chain():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting option chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting option chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1018,8 +990,7 @@ def get_jobs():
         success, response, status_code = get_all_jobs(status, limit)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting jobs: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting jobs: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1067,8 +1038,7 @@ def create_job():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error creating job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error creating job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1082,8 +1052,7 @@ def get_job_status(job_id):
         success, response, status_code = service_get_job_status(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting job status: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting job status: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1097,8 +1066,7 @@ def cancel_job(job_id):
         success, response, status_code = service_cancel_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error cancelling job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error cancelling job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1112,8 +1080,7 @@ def pause_job(job_id):
         success, response, status_code = service_pause_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error pausing job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error pausing job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1127,8 +1094,7 @@ def resume_job_endpoint(job_id):
         success, response, status_code = service_resume_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error resuming job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error resuming job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1155,8 +1121,7 @@ def retry_job(job_id):
         success, response, status_code = retry_failed_items(job_id, api_key)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error retrying job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error retrying job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1170,8 +1135,7 @@ def delete_job(job_id):
         success, response, status_code = service_delete_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error deleting job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1194,8 +1158,7 @@ def get_catalog_grouped():
         success, response, status_code = get_catalog_grouped_service(group_by)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting grouped catalog: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting grouped catalog: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1209,8 +1172,7 @@ def get_catalog_with_metadata():
         success, response, status_code = get_catalog_with_metadata_service()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting catalog with metadata: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting catalog with metadata: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1230,8 +1192,7 @@ def enrich_metadata():
         success, response, status_code = enrich_and_save_metadata(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error enriching metadata: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error enriching metadata: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1259,8 +1220,7 @@ def get_schedules():
 
         return jsonify({"status": "success", "data": schedules, "count": len(schedules)}), 200
     except Exception as e:
-        logger.error(f"Error getting schedules: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting schedules: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1354,8 +1314,7 @@ def create_schedule():
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error creating schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error creating schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1381,8 +1340,7 @@ def get_schedule(schedule_id):
         return jsonify({"status": "success", "data": schedule}), 200
 
     except Exception as e:
-        logger.error(f"Error getting schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1447,8 +1405,7 @@ def update_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error updating schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error updating schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1468,8 +1425,7 @@ def delete_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error deleting schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1489,8 +1445,7 @@ def enable_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error enabling schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error enabling schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1510,8 +1465,7 @@ def disable_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error disabling schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error disabling schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1531,8 +1485,7 @@ def pause_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error pausing schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error pausing schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1552,8 +1505,7 @@ def resume_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error resuming schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error resuming schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1573,8 +1525,7 @@ def trigger_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error triggering schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error triggering schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1591,6 +1542,5 @@ def get_schedule_executions(schedule_id):
         return jsonify({"status": "success", "data": executions, "count": len(executions)}), 200
 
     except Exception as e:
-        logger.error(f"Error getting executions: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting executions: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500

--- a/blueprints/pnltracker.py
+++ b/blueprints/pnltracker.py
@@ -1,6 +1,5 @@
 import threading
 import time as time_module
-import traceback
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from importlib import import_module
@@ -1102,6 +1101,5 @@ def get_pnl_data():
         ), 200
 
     except Exception as e:
-        logger.error(f"Error calculating intraday PnL: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error calculating intraday PnL: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500

--- a/broker/groww/api/data.py
+++ b/broker/groww/api/data.py
@@ -1,7 +1,6 @@
 import json
 import os
 import time
-import traceback
 from datetime import datetime, timedelta
 from typing import Any, Dict, List, Optional, Union
 
@@ -920,10 +919,8 @@ class BrokerData:
             return df
 
         except Exception as e:
-            logger.error(f"Error getting historical data: {str(e)}")
-            import traceback
+            logger.exception(f"Error getting historical data: {str(e)}")
 
-            traceback.print_exc()
             # Return empty DataFrame with expected columns on error
             return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
 
@@ -1763,8 +1760,7 @@ class BrokerData:
             return depth_response
 
         except Exception as e:
-            logger.error(f"Error getting market depth: {str(e)}")
-            traceback.print_exc()
+            logger.exception(f"Error getting market depth: {str(e)}")
             return {}
 
     def get_market_depth(self, symbol_list, timeout: int = 5) -> dict[str, Any]:

--- a/broker/groww/api/order_api.py
+++ b/broker/groww/api/order_api.py
@@ -1733,10 +1733,7 @@ def direct_place_order_api(data, auth):
             return res, response_data, None
 
     except Exception as e:
-        logger.error(f"Error placing order: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Error placing order: {e}")
 
         class ResponseObject:
             def __init__(self, status_code):
@@ -1833,10 +1830,7 @@ def direct_place_order(
         return response
 
     except Exception as e:
-        logger.error(f"Direct order error: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Direct order error: {e}")
         return {"status": "error", "message": str(e)}
 
 
@@ -2035,10 +2029,7 @@ def place_smartorder_api(data, auth):
         return None, response, None
 
     except Exception as e:
-        logger.error(f"Error in smart order placement: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Error in smart order placement: {e}")
         response = {"status": "error", "message": f"Smart order error: {str(e)}"}
         return None, response, None
 
@@ -2833,10 +2824,7 @@ def direct_modify_order(data, auth):
             return ResponseObject(200), response
 
     except Exception as e:
-        logger.error(f"Error in direct_modify_order: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Error in direct_modify_order: {e}")
 
         # Create a response object to maintain compatibility with existing code
         class ResponseObject:

--- a/broker/zerodha/streaming/zerodha_websocket.py
+++ b/broker/zerodha/streaming/zerodha_websocket.py
@@ -190,10 +190,8 @@ class ZerodhaWebSocket:
                     else:
                         self.logger.error(f"❌ Runtime error in WebSocket thread: {e}")
                 except Exception as e:
-                    self.logger.error(f"❌ Error in WebSocket thread: {e}")
-                    import traceback
-
-                    traceback.print_exc()
+                    self.logger.exception(f"❌ Error in WebSocket thread: {e}")
+                    
                 finally:
                     # Clean up the event loop
                     try:

--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -54,8 +53,7 @@ class BasketOrder(Resource):
             return make_response(jsonify(response_data), status_code)
 
         except Exception:
-            logger.error("An unexpected error occurred in BasketOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in BasketOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -62,8 +61,7 @@ class CancelAllOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelAllOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelAllOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_order.py
+++ b/restx_api/cancel_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -61,8 +60,7 @@ class CancelOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/chart_api.py
+++ b/restx_api/chart_api.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -47,8 +46,7 @@ class ChartPreferencesResource(Resource):
             return make_response(jsonify(response_data), status_code)
 
         except Exception as e:
-            logger.error(f"Unexpected error in chart GET endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in chart GET endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )
@@ -89,8 +87,7 @@ class ChartPreferencesResource(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in chart POST endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in chart POST endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -62,8 +61,7 @@ class ClosePosition(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in ClosePosition endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in ClosePosition endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/depth.py
+++ b/restx_api/depth.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -44,8 +43,7 @@ class Depth(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in depth endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in depth endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -40,8 +39,7 @@ class Funds(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in funds endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in funds endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -39,8 +38,7 @@ class Ping(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in ping endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in ping endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -51,8 +50,7 @@ class PnLSymbols(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in pnl/symbols endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in pnl/symbols endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/services/cancel_all_order_service.py
+++ b/services/cancel_all_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -140,8 +139,7 @@ def cancel_all_orders_with_auth(
             order_data, auth_token
         )
     except Exception as e:
-        logger.error(f"Error in broker_module.cancel_all_orders_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.cancel_all_orders_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to cancel all orders due to internal error",

--- a/services/cancel_order_service.py
+++ b/services/cancel_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -114,8 +113,7 @@ def cancel_order_with_auth(
         # Use the dynamically imported module's function to cancel the order
         response_message, status_code = broker_module.cancel_order(orderid, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.cancel_order: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.cancel_order: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to cancel order due to internal error",

--- a/services/close_position_service.py
+++ b/services/close_position_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -133,8 +132,7 @@ def close_position_with_auth(
         api_key = position_data.get("apikey", "")
         response_code, status_code = broker_module.close_all_positions(api_key, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.close_all_positions: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.close_all_positions: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to close positions due to internal error",

--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import Auth, db_session, get_auth_token_broker, verify_api_key
@@ -113,8 +112,7 @@ def get_depth_with_auth(
 
         return True, {"status": "success", "data": depth}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_depth: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_depth: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/funds_service.py
+++ b/services/funds_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -76,8 +75,7 @@ def get_funds_with_auth(
 
         return True, {"status": "success", "data": funds}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_margin_data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_margin_data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -1,6 +1,5 @@
 import importlib
 import time
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -138,8 +137,7 @@ def get_history_with_auth(
 
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_history: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_history: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 
@@ -214,8 +212,7 @@ def get_history_from_db(
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
 
     except Exception as e:
-        logger.error(f"Error fetching history from DB: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error fetching history from DB: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/holdings_service.py
+++ b/services/holdings_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -136,8 +135,7 @@ def get_holdings_with_auth(
             200,
         )
     except Exception as e:
-        logger.error(f"Error processing holdings data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing holdings data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/intervals_service.py
+++ b/services/intervals_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -80,8 +79,7 @@ def get_intervals_with_auth(auth_token: str, broker: str) -> tuple[bool, dict[st
 
         return True, {"status": "success", "data": intervals}, 200
     except Exception as e:
-        logger.error(f"Error getting supported intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting supported intervals: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/margin_service.py
+++ b/services/margin_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.apilog_db import async_log_order, executor
@@ -198,8 +197,7 @@ def calculate_margin_with_auth(
         executor.submit(async_log_order, "margin", original_data, error_response)
         return False, error_response, 501
     except Exception as e:
-        logger.error(f"Error in broker_module.calculate_margin_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.calculate_margin_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to calculate margin due to internal error",

--- a/services/modify_order_service.py
+++ b/services/modify_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -114,8 +113,7 @@ def modify_order_with_auth(
         # Use the dynamically imported module's function to modify the order
         response_message, status_code = broker_module.modify_order(order_data, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.modify_order: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.modify_order: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to modify order due to internal error",

--- a/services/openposition_service.py
+++ b/services/openposition_service.py
@@ -1,5 +1,4 @@
 import copy
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 import requests
@@ -175,8 +174,7 @@ def get_open_position_with_auth(
         return True, response_data, 200
 
     except Exception as e:
-        logger.error(f"Error processing open position: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing open position: {e}")
         error_response = {"status": "error", "message": str(e)}
         log_executor.submit(async_log_order, "openposition", original_data, error_response)
         return False, error_response, 500

--- a/services/orderbook_service.py
+++ b/services/orderbook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -176,8 +175,7 @@ def get_orderbook_with_auth(
             200,
         )
     except Exception as e:
-        logger.error(f"Error processing order data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing order data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -183,8 +182,7 @@ def place_order_with_auth(
         # Call the broker's place_order_api function
         res, response_data, order_id = broker_module.place_order_api(order_data, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.place_order_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.place_order_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to place order due to internal error",

--- a/services/place_smart_order_service.py
+++ b/services/place_smart_order_service.py
@@ -1,7 +1,6 @@
 import copy
 import importlib
 import time
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.analyzer_db import async_log_analyzer
@@ -266,8 +265,7 @@ def place_smart_order_with_auth(
             )
 
     except Exception as e:
-        logger.error(f"Error in broker_module.place_smartorder_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.place_smartorder_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to place smart order due to internal error",
@@ -279,8 +277,7 @@ def place_smart_order_with_auth(
     try:
         time.sleep(float(smart_order_delay))
     except Exception:
-        logger.error(f"Invalid SMART_ORDER_DELAY value: {smart_order_delay}")
-        traceback.print_exc()
+        logger.exception(f"Invalid SMART_ORDER_DELAY value: {smart_order_delay}")
 
     if res and res.status == 200:
         return True, order_response_data, 200

--- a/services/positionbook_service.py
+++ b/services/positionbook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -135,8 +134,7 @@ def get_positionbook_with_auth(
 
         return True, {"status": "success", "data": formatted_positions}, 200
     except Exception as e:
-        logger.error(f"Error processing positions data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing positions data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -150,8 +149,7 @@ def get_quotes_with_auth(
             logger.debug(f"Quote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_quotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_quotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 
@@ -321,8 +319,7 @@ def get_multiquotes_with_auth(
             logger.debug(f"Multiquote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_multiquotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_multiquotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 

--- a/services/symbol_service.py
+++ b/services/symbol_service.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -78,8 +77,7 @@ def get_symbol_info_with_auth(
         return False, error_response, 404
 
     except Exception as e:
-        logger.error(f"Error retrieving symbol information: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error retrieving symbol information: {e}")
         error_response = {"status": "error", "message": str(e)}
         return False, error_response, 500
 

--- a/services/tradebook_service.py
+++ b/services/tradebook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -131,8 +130,7 @@ def get_tradebook_with_auth(
 
         return True, {"status": "success", "data": formatted_trades}, 200
     except Exception as e:
-        logger.error(f"Error processing trade data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing trade data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/upgrade/migrate_historify.py
+++ b/upgrade/migrate_historify.py
@@ -237,10 +237,7 @@ def upgrade():
         return True
 
     except Exception as e:
-        logger.error(f"Migration failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Migration failed: {e}")
         return False
 
 

--- a/upgrade/migrate_historify_scheduler.py
+++ b/upgrade/migrate_historify_scheduler.py
@@ -178,10 +178,7 @@ def upgrade():
         return True
 
     except Exception as e:
-        logger.error(f"Migration failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Migration failed: {e}")
         return False
 
 

--- a/upgrade/migrate_sandbox.py
+++ b/upgrade/migrate_sandbox.py
@@ -391,10 +391,7 @@ def upgrade():
         return True
 
     except Exception as e:
-        logger.error(f"❌ Migration failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"❌ Migration failed: {e}")
         return False
 
 

--- a/upgrade/migrate_sandbox_pnl.py
+++ b/upgrade/migrate_sandbox_pnl.py
@@ -147,10 +147,7 @@ def upgrade():
         return True
 
     except Exception as e:
-        logger.error(f"Migration failed: {e}")
-        import traceback
-
-        traceback.print_exc()
+        logger.exception(f"Migration failed: {e}")
         return False
 
 


### PR DESCRIPTION
Fixes #892 

Replaced **traceback.print_exc()** with **logger.exception()** across services to ensure stack traces are captured within the logging system.
Removed unused traceback imports after cleanup.

Closes #892 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized exception logging by replacing traceback.print_exc() with logger.exception() across the codebase, so stack traces go to our log handlers. Also removed unused traceback imports; no API behavior changes.

- **Refactors**
  - Unified error logging with logger.exception() in blueprints, REST endpoints, services, broker clients, and upgrade scripts.
  - Stack traces now flow into configured logging for monitoring and alerts.
  - Cleaned up unused traceback imports.
  - Addresses #892 to centralize and standardize error logging.

<sup>Written for commit 55c5c0d94577555ee482da2fa62566badf22c4c2. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

