### PR TITLE
feat(a11y): add aria-label and title to icon-only buttons

### DIFF
--- a/frontend/src/pages/ApiKey.tsx
+++ b/frontend/src/pages/ApiKey.tsx
@@ -206,6 +206,8 @@ export default function ApiKey() {
                 className="h-8 w-8 shrink-0"
                 onClick={() => setShowApiKey(!showApiKey)}
                 disabled={!hasApiKey}
+                title={showApiKey ? 'Hide API key' : 'Show API key'}
+                aria-label={showApiKey ? 'Hide API key' : 'Show API key'}
               >
                 {showApiKey ? <EyeOff className="h-4 w-4" /> : <Eye className="h-4 w-4" />}
               </Button>

--- a/frontend/src/pages/admin/FreezeQty.tsx
+++ b/frontend/src/pages/admin/FreezeQty.tsx
@@ -336,6 +336,8 @@ export default function FreezeQtyPage() {
                               className="h-8 w-8"
                               onClick={() => handleSaveEdit(entry.id)}
                               disabled={isSaving}
+                              title="Save changes"
+                              aria-label={`Save freeze quantity for ${entry.symbol}`}
                             >
                               <Save className="h-4 w-4" />
                             </Button>
@@ -344,6 +346,8 @@ export default function FreezeQtyPage() {
                               variant="ghost"
                               className="h-8 w-8"
                               onClick={() => setEditingId(null)}
+                              title="Cancel editing"
+                              aria-label={`Cancel editing ${entry.symbol}`}
                             >
                               <X className="h-4 w-4" />
                             </Button>
@@ -360,6 +364,8 @@ export default function FreezeQtyPage() {
                               variant="ghost"
                               className="h-8 w-8"
                               onClick={() => handleEdit(entry)}
+                              title="Edit freeze quantity"
+                              aria-label={`Edit freeze quantity for ${entry.symbol}`}
                             >
                               <Pencil className="h-4 w-4" />
                             </Button>
@@ -368,6 +374,8 @@ export default function FreezeQtyPage() {
                               variant="ghost"
                               className="h-8 w-8 text-destructive hover:text-destructive"
                               onClick={() => setDeleteEntry(entry)}
+                              title="Delete entry"
+                              aria-label={`Delete freeze quantity for ${entry.symbol}`}
                             >
                               <Trash2 className="h-4 w-4" />
                             </Button>

--- a/frontend/src/pages/admin/Holidays.tsx
+++ b/frontend/src/pages/admin/Holidays.tsx
@@ -333,6 +333,8 @@ export default function HolidaysPage() {
                 size="icon"
                 onClick={() => setCurrentYear((y) => y - 1)}
                 disabled={!years.includes(currentYear - 1)}
+                title="Previous year"
+                aria-label="Previous year"
               >
                 <ChevronLeft className="h-4 w-4" />
               </Button>
@@ -356,6 +358,8 @@ export default function HolidaysPage() {
                 size="icon"
                 onClick={() => setCurrentYear((y) => y + 1)}
                 disabled={!years.includes(currentYear + 1)}
+                title="Next year"
+                aria-label="Next year"
               >
                 <ChevronRight className="h-4 w-4" />
               </Button>
@@ -412,6 +416,8 @@ export default function HolidaysPage() {
                           variant="ghost"
                           className="h-8 w-8 text-destructive hover:text-destructive"
                           onClick={() => setDeleteHoliday(holiday)}
+                          title="Delete holiday"
+                          aria-label={`Delete holiday ${holiday.holiday_name}`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>
@@ -569,6 +575,8 @@ export default function HolidaysPage() {
                           size="icon"
                           className="h-8 w-8 text-destructive hover:text-destructive"
                           onClick={() => removeSpecialSessionExchange(ex.exchange)}
+                          title="Remove exchange"
+                          aria-label={`Remove ${ex.exchange} from special session`}
                         >
                           <Trash2 className="h-4 w-4" />
                         </Button>

--- a/frontend/src/pages/admin/MarketTimings.tsx
+++ b/frontend/src/pages/admin/MarketTimings.tsx
@@ -211,6 +211,8 @@ export default function MarketTimingsPage() {
                               className="h-8 w-8"
                               onClick={() => handleSaveEdit(timing.exchange)}
                               disabled={isSaving}
+                              title="Save changes"
+                              aria-label={`Save timing changes for ${timing.exchange}`}
                             >
                               <Save className="h-4 w-4" />
                             </Button>
@@ -219,6 +221,8 @@ export default function MarketTimingsPage() {
                               variant="ghost"
                               className="h-8 w-8"
                               onClick={() => setEditingExchange(null)}
+                              title="Cancel editing"
+                              aria-label={`Cancel editing ${timing.exchange}`}
                             >
                               <X className="h-4 w-4" />
                             </Button>
@@ -229,6 +233,8 @@ export default function MarketTimingsPage() {
                             variant="ghost"
                             className="h-8 w-8"
                             onClick={() => handleEdit(timing)}
+                            title="Edit timing"
+                            aria-label={`Edit timing for ${timing.exchange}`}
                           >
                             <Pencil className="h-4 w-4" />
                           </Button>


### PR DESCRIPTION
## Summary

Fixes #888 — Icon-only buttons across admin pages and the API key page now have `aria-label` and `title` attributes for accessibility and hover tooltips.

## Changes

### Files updated:
- **`admin/MarketTimings.tsx`** — Save, Cancel, Edit buttons (the file mentioned in the issue)
- **`admin/Holidays.tsx`** — Previous/Next year navigation, Delete holiday, Remove exchange buttons
- **`admin/FreezeQty.tsx`** — Save, Cancel, Edit, Delete buttons
- **`ApiKey.tsx`** — Show/Hide API key toggle

### What was added:
- `title` attributes for hover tooltips visible to all users
- `aria-label` attributes with contextual info (e.g. includes the exchange name or symbol) for screen readers

### Notes:
- `Login.tsx` already had `aria-label` on its password toggle — no changes needed
- Labels are contextual where possible (e.g. `Edit timing for NSE` rather than just `Edit`)
- This covers the admin pages as a first pass; remaining pages can be addressed in follow-up PRs

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds aria-label and title to icon-only buttons across admin pages and the API key page to improve accessibility and show hover tooltips. Fixes #888.

- **Bug Fixes**
  - Admin pages (MarketTimings, Holidays, FreezeQty): Save, Cancel, Edit, Delete, and navigation buttons now include contextual aria-label and title.
  - ApiKey: Show/Hide toggle now labeled with aria-label and title.
  - Labels include exchange or symbol names for clearer screen reader context.

<sup>Written for commit 9ce142a43c091d67bb7f9eed05584d5591add89c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

