### PR TITLE
fix: Kotak option chain LTP streaming - subscribe both depth and LTP …

### DIFF
--- a/broker/kotak/streaming/kotak_adapter.py
+++ b/broker/kotak/streaming/kotak_adapter.py
@@ -456,7 +456,9 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 # (Kotak sends depth and LTP as separate streams;
                 # "dps" only sends bid/ask, "mws" sends LTP)
                 success = self.subscribe_depth(exchange, symbol, mode)
-                self.subscribe_quote(exchange, symbol, mode)
+                quote_success = self.subscribe_quote(exchange, symbol, mode)
+                if not quote_success:
+                    logger.warning(f"Depth subscribed but quote (LTP) subscription failed for {exchange}:{symbol}")
             else:
                 logger.error(f"Unknown subscribe mode: {mode}")
                 return self._create_error_response(
@@ -500,6 +502,7 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.unsubscribe_quote(exchange, symbol, mode)
             elif mode == 3:
                 self.unsubscribe_depth(exchange, symbol, mode)
+                self.unsubscribe_quote(exchange, symbol, mode)
 
             # Clean up tracking and cache - following AliceBlue pattern
             sub_key = f"{exchange}|{symbol}|{mode}"


### PR DESCRIPTION
…streams

Kotak sends depth (bid/ask) and LTP as separate WebSocket streams (dps vs mws). When option chain subscribed in Depth mode, only the dps stream was active, so LTP never updated. This fix:

- Subscribes to both depth (dps) and quote (mws) streams for mode 3
- Uses LTP cache as fallback when depth-only packets arrive
- Uses depth cache when LTP-only packets arrive for mode 3
- Conditionally includes LTP in depth publishes only when valid (>0), letting the frontend fall back to polled REST data otherwise

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing LTP updates for Kotak option chain in Depth mode by subscribing to both depth (dps) and quote (mws) streams and merging them via caches. Adds quote unsubscribe and warning on quote subscribe failure to keep mode 3 in sync without leaks.

- **Bug Fixes**
  - Subscribe to both dps and mws for mode 3 (Depth).
  - Use LTP cache when depth packets have no LTP, and depth cache when LTP-only packets arrive.
  - Include LTP in depth publishes only when valid (>0); otherwise omit to allow frontend REST fallback.
  - Unsubscribe quote on mode 3 removal to prevent resource leaks; warn if quote subscribe fails.

<sup>Written for commit e4cc8fd56f838c4520dc50138a9bbcb8108804c4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

