### PR TITLE
fix: replace volatile in-memory queue with SQLite-backed persistent order queue

### DIFF
--- a/app.py
+++ b/app.py
@@ -82,6 +82,7 @@ from database.latency_db import init_latency_db as ensure_latency_tables_exists
 from database.sandbox_db import init_db as ensure_sandbox_tables_exists
 from database.settings_db import init_db as ensure_settings_tables_exists
 from database.strategy_db import init_db as ensure_strategy_tables_exists
+from database.order_queue_db import init_db as ensure_order_queue_tables_exists
 from database.symbol import init_db as ensure_master_contract_tables_exists
 from database.telegram_db import get_bot_config
 from database.traffic_db import init_logs_db as ensure_traffic_logs_exists
@@ -507,6 +508,7 @@ def setup_environment(app):
             ("Qty Freeze DB", ensure_qty_freeze_tables_exists),
             ("Historify DB", ensure_historify_tables_exists),
             ("Flow DB", ensure_flow_tables_exists),
+            ("Order Queue DB", ensure_order_queue_tables_exists),
         ]
 
         db_init_start = time.time()

--- a/database/order_queue_db.py
+++ b/database/order_queue_db.py
@@ -1,0 +1,264 @@
+"""
+database/order_queue_db.py
+
+Persistent, SQLite-backed order queue for the OpenAlgo Strategy Manager.
+
+Replaces the ephemeral in-memory queue.Queue used in blueprints/strategy.py,
+providing at-least-once delivery guarantees: orders survive app restarts, OOM
+kills, and SIGTERM signals.
+
+On startup, any order left in the 'processing' state (i.e. the process was
+killed mid-flight) is automatically recovered and re-queued.
+
+Order lifecycle:
+    enqueue_order()  →  status = 'pending'
+    fetch_next_pending() + mark_processing()  →  status = 'processing'
+    mark_sent()     →  status = 'sent'      (terminal, success)
+    mark_failed()   →  retry_count += 1
+                       status = 'pending'   (if retry_count < MAX_RETRIES)
+                       status = 'failed'    (dead-letter, if retry_count >= MAX_RETRIES)
+"""
+
+import json
+import logging
+import os
+from datetime import datetime
+
+from sqlalchemy import Column, DateTime, Integer, String, Text, create_engine, func
+from sqlalchemy.orm import declarative_base, scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
+
+logger = logging.getLogger(__name__)
+
+# ---------------------------------------------------------------------------
+# Configuration
+# ---------------------------------------------------------------------------
+DATABASE_URL = os.getenv("DATABASE_URL")
+MAX_RETRIES = int(os.getenv("ORDER_QUEUE_MAX_RETRIES", "3"))
+
+# ---------------------------------------------------------------------------
+# Engine — follows the same pattern used in every other OpenAlgo database file
+# ---------------------------------------------------------------------------
+if DATABASE_URL and "sqlite" in DATABASE_URL:
+    _engine = create_engine(
+        DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"check_same_thread": False},
+    )
+else:
+    _engine = create_engine(
+        DATABASE_URL,
+        pool_size=10,
+        max_overflow=20,
+        pool_timeout=10,
+    )
+
+_db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=_engine)
+)
+Base = declarative_base()
+Base.query = _db_session.query_property()
+
+
+# ---------------------------------------------------------------------------
+# Model
+# ---------------------------------------------------------------------------
+class PersistentOrder(Base):
+    """Durable order queue entry — survives process restarts."""
+
+    __tablename__ = "order_queue"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    endpoint = Column(String(50), nullable=False)       # 'placeorder' | 'placesmartorder'
+    payload_json = Column(Text, nullable=False)          # JSON-serialised order payload
+    status = Column(String(20), nullable=False, default="pending")
+    retry_count = Column(Integer, default=0, nullable=False)
+    error_message = Column(Text, nullable=True)
+    created_at = Column(DateTime, default=datetime.utcnow, nullable=False)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+    sent_at = Column(DateTime, nullable=True)
+
+    def get_payload(self) -> dict:
+        try:
+            return json.loads(self.payload_json)
+        except Exception:
+            return {}
+
+
+# ---------------------------------------------------------------------------
+# Database initialisation
+# ---------------------------------------------------------------------------
+def init_db() -> None:
+    """Create the order_queue table if it does not already exist."""
+    try:
+        Base.metadata.create_all(bind=_engine)
+        logger.info("Order queue DB initialised.")
+    except Exception:
+        logger.exception("Failed to initialise order queue DB.")
+
+
+# ---------------------------------------------------------------------------
+# Write helpers
+# ---------------------------------------------------------------------------
+def enqueue_order(endpoint: str, payload: dict) -> int | None:
+    """
+    Persist a new order with status='pending'.
+    Returns the database row ID on success, None on failure.
+    """
+    try:
+        entry = PersistentOrder(
+            endpoint=endpoint,
+            payload_json=json.dumps(payload),
+            status="pending",
+        )
+        _db_session.add(entry)
+        _db_session.commit()
+        logger.debug(
+            "Enqueued order id=%d endpoint=%s symbol=%s",
+            entry.id,
+            endpoint,
+            payload.get("symbol", "?"),
+        )
+        return entry.id
+    except Exception:
+        logger.exception("Failed to enqueue order.")
+        _db_session.rollback()
+        return None
+
+
+def mark_processing(order_id: int) -> None:
+    """Mark an order as actively being processed (prevents duplicate pick-up)."""
+    try:
+        entry = _db_session.get(PersistentOrder, order_id)
+        if entry:
+            entry.status = "processing"
+            entry.updated_at = datetime.utcnow()
+            _db_session.commit()
+    except Exception:
+        logger.exception("Failed to mark order %d as processing.", order_id)
+        _db_session.rollback()
+
+
+def mark_sent(order_id: int) -> None:
+    """Mark an order as successfully delivered to the broker API."""
+    try:
+        entry = _db_session.get(PersistentOrder, order_id)
+        if entry:
+            entry.status = "sent"
+            entry.sent_at = datetime.utcnow()
+            entry.updated_at = datetime.utcnow()
+            _db_session.commit()
+    except Exception:
+        logger.exception("Failed to mark order %d as sent.", order_id)
+        _db_session.rollback()
+
+
+def mark_failed(order_id: int, error: str = "") -> None:
+    """
+    Record a delivery failure.
+    - If retry_count < MAX_RETRIES: reset to 'pending' for retry.
+    - If retry_count >= MAX_RETRIES: move to 'failed' (dead-letter).
+    """
+    try:
+        entry = _db_session.get(PersistentOrder, order_id)
+        if entry:
+            entry.retry_count += 1
+            entry.error_message = error[:500]
+            entry.updated_at = datetime.utcnow()
+            if entry.retry_count >= MAX_RETRIES:
+                entry.status = "failed"
+                payload = entry.get_payload()
+                logger.warning(
+                    "Order id=%d symbol=%s moved to dead-letter after %d attempts. "
+                    "Last error: %s",
+                    order_id,
+                    payload.get("symbol", "?"),
+                    MAX_RETRIES,
+                    error[:200],
+                )
+            else:
+                entry.status = "pending"
+            _db_session.commit()
+    except Exception:
+        logger.exception("Failed to update failure status for order %d.", order_id)
+        _db_session.rollback()
+
+
+# ---------------------------------------------------------------------------
+# Read helpers
+# ---------------------------------------------------------------------------
+def fetch_next_pending(endpoint: str) -> PersistentOrder | None:
+    """Fetch the oldest pending order for the given endpoint, or None if empty."""
+    try:
+        return (
+            PersistentOrder.query.filter_by(endpoint=endpoint, status="pending")
+            .order_by(PersistentOrder.created_at.asc())
+            .first()
+        )
+    except Exception:
+        logger.exception("Failed to fetch next pending order for endpoint=%s.", endpoint)
+        return None
+
+
+def recover_stale_processing_orders() -> int:
+    """
+    On startup, reset any orders stuck in 'processing' back to 'pending'.
+    These are orders that were mid-flight when the process was killed last time.
+    Returns the number of orders recovered.
+    """
+    try:
+        stale = PersistentOrder.query.filter_by(status="processing").all()
+        count = len(stale)
+        for entry in stale:
+            entry.status = "pending"
+            entry.updated_at = datetime.utcnow()
+        _db_session.commit()
+        if count:
+            logger.warning(
+                "Recovered %d stale 'processing' order(s) from the previous session.", count
+            )
+        return count
+    except Exception:
+        logger.exception("Failed to recover stale processing orders.")
+        _db_session.rollback()
+        return 0
+
+
+def get_failed_orders(limit: int = 50) -> list[dict]:
+    """Return the most recent dead-letter (failed) orders — for display in the UI/logs."""
+    try:
+        rows = (
+            PersistentOrder.query.filter_by(status="failed")
+            .order_by(PersistentOrder.updated_at.desc())
+            .limit(limit)
+            .all()
+        )
+        return [
+            {
+                "id": r.id,
+                "endpoint": r.endpoint,
+                "symbol": r.get_payload().get("symbol", "?"),
+                "strategy": r.get_payload().get("strategy", "?"),
+                "retry_count": r.retry_count,
+                "error": r.error_message,
+                "created_at": str(r.created_at),
+            }
+            for r in rows
+        ]
+    except Exception:
+        logger.exception("Failed to fetch failed orders.")
+        return []
+
+
+def queue_depth() -> dict:
+    """Return per-status order counts — useful for monitoring dashboards."""
+    try:
+        rows = (
+            _db_session.query(PersistentOrder.status, func.count(PersistentOrder.id))
+            .group_by(PersistentOrder.status)
+            .all()
+        )
+        return {status: count for status, count in rows}
+    except Exception:
+        logger.exception("Failed to get queue depth.")
+        return {}


### PR DESCRIPTION
…rder queue

The Python Strategy Manager previously used queue.Queue (ephemeral RAM) to buffer orders. Any orders pending at process exit were silently lost with no error, no alert, and no recovery path.

This commit introduces a durable SQLite-backed order queue (database/order_queue_db.py) with full order lifecycle tracking:

  pending  processing  sent
                        failed (dead-letter after MAX_RETRIES)

Key changes:
- database/order_queue_db.py (new): persistent queue with enqueue, fetch, mark_processing, mark_sent, mark_failed, startup recovery, and queue_depth monitoring helpers
- blueprints/strategy.py: process_orders() now reads from SQLite; worker thread changed from daemon=True to daemon=False for graceful shutdown; SIGTERM/SIGINT handlers added to signal clean exit
- app.py: order_queue DB initialised in parallel with all other DBs

On restart, any order stuck in 'processing' state is automatically recovered and retried — providing crash recovery with zero manual intervention. Failed orders after MAX_RETRIES are preserved in a dead-letter state for inspection.

Zero new dependencies: uses existing SQLite/SQLAlchemy stack.
Configurable via ORDER_QUEUE_MAX_RETRIES env var (default: 3).

Fixes #949


 ## Summary

Fixes #949 

Replaces the ephemeral `queue.Queue` in `blueprints/strategy.py` with a **SQLite-backed persistent order queue**, giving the Strategy Manager at-least-once delivery guarantees for all orders.

Before this fix, any orders buffered in RAM at the moment of an app restart, OOM kill, or SIGTERM were silently discarded — no error, no log entry, no recovery.

## Changes

### `database/order_queue_db.py` *(new file)*

Self-contained SQLite-backed queue with full order lifecycle:

| Function | Purpose |
|---|---|
| `init_db()` | Creates `order_queue` table on first run |
| `enqueue_order(endpoint, payload)` | Persists order with `status='pending'` |
| `fetch_next_pending(endpoint)` | Fetches oldest pending order |
| `mark_processing(id)` | Marks order as in-flight (prevents double-pickup) |
| `mark_sent(id)` | Records successful delivery |
| `mark_failed(id, error)` | Increments retry count; dead-letters after `MAX_RETRIES` |
| `recover_stale_processing_orders()` | On startup: resets stuck `processing` orders to `pending` |
| `get_failed_orders()` | Returns dead-letter orders for UI/logging |
| `queue_depth()` | Per-status counts for monitoring |

### `blueprints/strategy.py` *(modified)*

| Change | Detail |
|---|---|
| Removed `queue.Queue()` | Replaced with `order_queue_db` calls |
| `process_orders()` rewritten | Uses persistent queue; marks each order through its lifecycle |
| `queue_order()` updated | Calls `enqueue_order()` — public signature unchanged |
| Worker thread: `daemon=False` | Allows graceful flush on shutdown (was `daemon=True`) |
| SIGTERM/SIGINT handlers added | `_shutdown_event.set()` lets worker exit cleanly |
| Startup recovery | `recover_stale_processing_orders()` called on first start |

### `app.py` *(modified — 2 lines)*

`ensure_order_queue_tables_exists` added to the parallel DB init list.

## Order Lifecycle

```
enqueue_order()
      │
      ▼
  [pending]  ──fetch_next_pending()──►  [processing]
                                              │
                       ┌──────────────────────┤
                       │                      │
                  API call OK           API call fails
                       │                      │
                       ▼                      ▼
                    [sent]         retry_count < MAX_RETRIES?
                                        │            │
                                       yes           no
                                        │            │
                                        ▼            ▼
                                    [pending]     [failed]
                                    (retry)     (dead-letter)
```

On app **restart**, orders stuck in `[processing]` are automatically reset to `[pending]` — crash recovery with zero manual intervention.

## Backward Compatibility

- `queue_order(endpoint, payload)` signature is **unchanged** — all callers require zero modification
- Zero new dependencies — uses existing SQLite/SQLAlchemy stack
- Configurable via `.env`: `ORDER_QUEUE_MAX_RETRIES` (default: `3`)

## Testing

```bash
# Start OpenAlgo
uv run app.py

# Trigger a strategy webhook that generates several orders

# Kill mid-queue (simulate OOM / force restart)
# Windows: taskkill /F /PID <pid>
# Linux:   kill -9 <pid>

# Restart OpenAlgo — watch the startup logs for:
# "Recovered N order(s) that were in-flight during last shutdown."

# Verify orders were retried and sent:
sqlite3 openalgo.db "SELECT id, status, retry_count FROM order_queue;"
```

## Files Changed

```
database/order_queue_db.py     (new — 200 lines)
blueprints/strategy.py         (modified — core queue logic replaced)
app.py                         (modified — 2 lines added)
```


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaces the in-memory order queues with a SQLite-backed persistent queue to stop losing orders on shutdown and add crash-safe retries. Fixes #949.

- **New Features**
  - Durable queue with lifecycle: pending → processing → sent/failed; retries with dead-letter after ORDER_QUEUE_MAX_RETRIES.
  - Processor reads from SQLite, recovers in-flight orders on restart; rate limits unchanged (1/s smart, 10/s regular).
  - Graceful shutdown via non-daemon worker and SIGTERM/SIGINT; queue_depth and failed-order helpers; DB init added in app.py; no new dependencies.

- **Migration**
  - No caller changes; queue_order(endpoint, payload) is unchanged.
  - Tables auto-create on start; set ORDER_QUEUE_MAX_RETRIES if needed (default 3).

<sup>Written for commit eff325d4d2aed74613541ff6d1eb939afbcfdc87. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

