### PR TITLE
fix: release WebSocket port on shutdown via await self.stop()

### DIFF
--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -172,6 +172,11 @@ class WebSocketProxy:
                 except aio.CancelledError:
                     pass
 
+                # Properly stop the server and release the port.
+                # This calls server.wait_closed() which ensures the socket
+                # is fully released before the event loop shuts down.
+                await self.stop()
+
             except Exception as e:
                 logger.exception(f"Failed to start WebSocket server: {e}")
                 raise


### PR DESCRIPTION
## Summary
- The `start()` method's shutdown path never calls the async `stop()` method, so `server.wait_closed()` is never executed
- This leaves the WebSocket port in TIME_WAIT state after shutdown, requiring manual port cleanup (`lsof -ti:8765 | xargs kill`) before restarting
- The sync `cleanup_websocket_server()` atexit handler cannot `await` anything, so it only calls `server.close()` which stops accepting connections but doesn't release the socket

**Fix:** Add `await self.stop()` after the shutdown signal is received in `start()`, so the full async cleanup (wait_closed, ZMQ teardown, client disconnect) runs on the event loop before it shuts down.

## Root cause

```
start() shutdown path (before fix):
  await stop          <- unblocks when running=False
  monitor_task.cancel()
  return              <- exits without releasing port!

start() shutdown path (after fix):
  await stop          <- unblocks when running=False
  monitor_task.cancel()
  await self.stop()   <- properly closes server + wait_closed()
  return              <- port is released
```

## Test plan
- [ ] Start OpenAlgo, then Ctrl+C to stop
- [ ] Immediately restart — should bind to the same WebSocket port without "Address already in use" error
- [ ] Verify WebSocket connections work normally after restart

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure the WebSocket port is released on shutdown by awaiting self.stop() in start(), which runs server.wait_closed(). This prevents TIME_WAIT lingering and avoids "Address already in use" errors on immediate restart.

<sup>Written for commit 62061b0402f74ee33504566fdc4df160031430fd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

