### PR TITLE
fix: normalize tick_size from paise to rupees for dhan, firstock, kotak, nubra, shoonya

### DIFF
--- a/broker/dhan/database/master_contract_db.py
+++ b/broker/dhan/database/master_contract_db.py
@@ -233,7 +233,7 @@ def process_dhan_csv(path):
     df["expiry"] = df["SEM_EXPIRY_DATE"].str.upper()
     df["strike"] = df["SEM_STRIKE_PRICE"]
     df["lotsize"] = df["SEM_LOT_UNITS"]
-    df["tick_size"] = df["SEM_TICK_SIZE"]
+    df["tick_size"] = pd.to_numeric(df["SEM_TICK_SIZE"], errors="coerce") / 100
     df["brsymbol"] = df["SEM_TRADING_SYMBOL"]
 
     # Apply the function

--- a/broker/firstock/database/master_contract_db.py
+++ b/broker/firstock/database/master_contract_db.py
@@ -218,7 +218,7 @@ def process_firstock_nse_data(output_path):
 
     # Handle missing or invalid numeric values
     df["lotsize"] = pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
-    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
+    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100
 
     # Reorder the columns to match the database structure
     columns_to_keep = [
@@ -319,7 +319,7 @@ def process_firstock_nfo_data(output_path):
 
     # Handle numeric values
     df["lotsize"] = pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
-    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
+    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100
 
     # Reorder columns
     columns_to_keep = [
@@ -385,7 +385,7 @@ def process_firstock_bse_data(output_path):
 
     # Handle missing or invalid numeric values
     df["lotsize"] = pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
-    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
+    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100
 
     # Reorder the columns to match the database structure
     columns_to_keep = [
@@ -486,7 +486,7 @@ def process_firstock_bfo_data(output_path):
 
     # Handle numeric values
     df["lotsize"] = pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
-    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
+    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100
 
     # Reorder columns
     columns_to_keep = [

--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -150,7 +150,7 @@ def process_kotak_nse_csv(path):
     filtereddataframe["expiry"] = df["pExpiryDate"]
     filtereddataframe["strike"] = df["dStrikePrice;"]
     filtereddataframe["lotsize"] = df["lLotSize"]
-    filtereddataframe["tick_size"] = df["dTickSize "]
+    filtereddataframe["tick_size"] = pd.to_numeric(df["dTickSize "], errors="coerce") / 100
     filtereddataframe["brsymbol"] = df["pTrdSymbol"]
     filtereddataframe["symbol"] = df["pSymbolName"]
 
@@ -199,7 +199,7 @@ def process_kotak_bse_csv(path):
     filtereddataframe["expiry"] = df["pExpiryDate"]
     filtereddataframe["strike"] = df["dStrikePrice"]
     filtereddataframe["lotsize"] = df["lLotSize"]
-    filtereddataframe["tick_size"] = df["dTickSize"]
+    filtereddataframe["tick_size"] = pd.to_numeric(df["dTickSize"], errors="coerce") / 100
     filtereddataframe["brsymbol"] = df["pTrdSymbol"]
     filtereddataframe["symbol"] = df["pSymbolName"]
 
@@ -266,7 +266,7 @@ def process_kotak_nfo_csv(path):
     tokensymbols["strike"] = tokensymbols["strike"].apply(lambda x: int(x) if x.is_integer() else x)
 
     tokensymbols["lotsize"] = df["lLotSize"]
-    tokensymbols["tick_size"] = df["dTickSize"]
+    tokensymbols["tick_size"] = pd.to_numeric(df["dTickSize"], errors="coerce") / 100
     tokensymbols["brsymbol"] = df["pTrdSymbol"]
     tokensymbols["brexchange"] = df["pExchSeg"]
     tokensymbols["exchange"] = "NFO"
@@ -444,7 +444,7 @@ def process_kotak_cds_csv(path):
     tokensymbols["strike"] = tokensymbols["strike"].apply(lambda x: int(x) if x.is_integer() else x)
 
     tokensymbols["lotsize"] = df["lLotSize"]
-    tokensymbols["tick_size"] = df["dTickSize"]
+    tokensymbols["tick_size"] = pd.to_numeric(df["dTickSize"], errors="coerce") / 100
     tokensymbols["brsymbol"] = df["pTrdSymbol"]
     tokensymbols["brexchange"] = df["pExchSeg"]
     tokensymbols["exchange"] = "CDS"
@@ -483,7 +483,7 @@ def process_kotak_mcx_csv(path):
     tokensymbols["strike"] = tokensymbols["strike"].apply(lambda x: int(x) if x.is_integer() else x)
 
     tokensymbols["lotsize"] = df["lLotSize"]
-    tokensymbols["tick_size"] = df["dTickSize"]
+    tokensymbols["tick_size"] = pd.to_numeric(df["dTickSize"], errors="coerce") / 100
     tokensymbols["brsymbol"] = df["pTrdSymbol"]
     tokensymbols["brexchange"] = df["pExchSeg"]
     tokensymbols["exchange"] = "MCX"
@@ -522,7 +522,7 @@ def process_kotak_bfo_csv(path):
     tokensymbols["strike"] = tokensymbols["strike"].apply(lambda x: int(x) if x.is_integer() else x)
 
     tokensymbols["lotsize"] = df["lLotSize"]
-    tokensymbols["tick_size"] = df["dTickSize"]
+    tokensymbols["tick_size"] = pd.to_numeric(df["dTickSize"], errors="coerce") / 100
     tokensymbols["brsymbol"] = df["pTrdSymbol"]
     tokensymbols["brexchange"] = df["pExchSeg"]
     tokensymbols["exchange"] = "BFO"

--- a/broker/nubra/database/master_contract_db.py
+++ b/broker/nubra/database/master_contract_db.py
@@ -140,7 +140,7 @@ def process_nubra_json(path):
     # IMPORTANT: Use ref_id as token because Nubra's order API uses ref_id, not exchange token
     df['token'] = df['ref_id'].astype(str)  # ref_id is what Nubra order API needs
     df['lotsize'] = df['lot_size']
-    df['tick_size'] = df['tick_size'].astype(float)
+    df['tick_size'] = pd.to_numeric(df['tick_size'], errors='coerce') / 100
     df['name'] = df['asset']
     df['brsymbol'] = df['stock_name']
 

--- a/broker/shoonya/database/master_contract_db.py
+++ b/broker/shoonya/database/master_contract_db.py
@@ -194,8 +194,8 @@ def process_shoonya_nse_data(output_path):
         pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
     )  # Convert to int, default to 0
     df["tick_size"] = (
-        pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
-    )  # Convert to float, default to 0.0
+        pd.to_numeric(df["tick_size"], errors="coerce") / 100
+    )  # Convert from paise to rupees
 
     # Reorder the columns to match the database structure
     columns_to_keep = [
@@ -675,8 +675,8 @@ def process_shoonya_bse_data(output_path):
         pd.to_numeric(df["lotsize"], errors="coerce").fillna(0).astype(int)
     )  # Convert to int, default to 0
     df["tick_size"] = (
-        pd.to_numeric(df["tick_size"], errors="coerce").fillna(0).astype(float)
-    )  # Convert to float, default to 0.0
+        pd.to_numeric(df["tick_size"], errors="coerce") / 100
+    )  # Convert from paise to rupees
 
     # Reorder the columns to match the database structure
     columns_to_keep = [


### PR DESCRIPTION
…ak, nubra, shoonya

These brokers provide tick_size in paise (e.g., 10 instead of 0.1) in their master contract data. Added /100 conversion to match the rupee format used by other brokers (zerodha, fyers, upstox, etc.), fixing inconsistent values returned by the /api/v1/symbol endpoint.

Fixes #915

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize tick_size from paise to rupees for Dhan, Firstock, Kotak, Nubra, and Shoonya. This fixes inconsistent tick sizes returned by /api/v1/symbol and aligns them with other brokers using rupee format.

- **Bug Fixes**
  - Convert paise tick_size to rupees by dividing by 100 during master contract parsing.
  - Applied across broker parsers (including Kotak NSE/BSE/NFO/CDS/MCX) for consistent output.

<sup>Written for commit 79b98b1324195cf66d92cb2477e6b038f5a803d5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

