### PR TITLE
fix: handle position fetch failure in Upstox margin calculation

### DIFF
--- a/broker/upstox/api/funds.py
+++ b/broker/upstox/api/funds.py
@@ -84,15 +84,16 @@ def get_margin_data(auth_token):
             ]
         )
 
-        position_book = get_positions(auth_token)
-        position_book = map_order_data(position_book)
-
-        def sum_realised_unrealised(position_book):
-            total_realised = sum(position.get("realised", 0) for position in position_book)
-            total_unrealised = sum(position.get("unrealised", 0) for position in position_book)
-            return total_realised, total_unrealised
-
-        total_realised, total_unrealised = sum_realised_unrealised(position_book)
+        total_realised = 0.0
+        total_unrealised = 0.0
+        try:
+            position_book = get_positions(auth_token)
+            if position_book and position_book.get("status") == "success" and "data" in position_book:
+                position_book = map_order_data(position_book)
+                total_realised = sum(position.get("realised", 0) for position in position_book)
+                total_unrealised = sum(position.get("unrealised", 0) for position in position_book)
+        except Exception as e:
+            logger.warning(f"Failed to fetch positions for margin calc: {e}")
 
         # Get holdings and calculate collateral
         holdings_response = get_holdings(auth_token)


### PR DESCRIPTION
## Summary
- `get_positions()` in Upstox funds API could return an error or `None`, crashing the entire funds/margin page
- Added error handling with safe defaults (`0.0`) so margin data still loads when position fetch fails
- Same pattern as the Zerodha funds fix (#956)

## Test plan
- [ ] Open funds/margin page with active positions — verify realised/unrealised PnL shows correctly
- [ ] Open funds/margin page with no positions — verify page loads without error
- [ ] Simulate position API failure — verify page still loads with 0.0 PnL values

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a crash in the Upstox funds/margin page when get_positions() returns None or an error. We now validate the response, default realised/unrealised PnL to 0.0, and log a warning so margin data still loads.

<sup>Written for commit 8cb2442c2d4eed5bfff55383e2f3e30de8fb24c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

