### PR TITLE
fix: filter out expired dates from expiry API response

### DIFF
--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -1039,7 +1039,9 @@ def get_distinct_expiries_cached(
             for exp_set in cache.expiries_by_exchange.values():
                 expiries.update(exp_set)
 
-        # Sort expiries chronologically
+        # Sort expiries chronologically and filter out past dates
+        today = datetime.now().replace(hour=0, minute=0, second=0, microsecond=0)
+
         def parse_expiry(exp_str):
             try:
                 return datetime.strptime(exp_str, "%d-%b-%y")
@@ -1049,7 +1051,10 @@ def get_distinct_expiries_cached(
                 except ValueError:
                     return datetime.max
 
-        return sorted(list(expiries), key=parse_expiry)
+        return [
+            exp for exp in sorted(list(expiries), key=parse_expiry)
+            if parse_expiry(exp) >= today
+        ]
 
     # Fallback to database
     try:


### PR DESCRIPTION
## Summary
- `get_distinct_expiries_cached()` returns all expiry dates from master contracts including past dates
- This causes Option Chain, OI Tracker, OI Profile, IV Smile, Max Pain, GEX Dashboard, IV Chart, Straddle Chart, and Vol Surface pages to default to an expired expiry (e.g., yesterday's expiry), showing all-zero data
- Filter expiries to only return today and future dates (`>= today`), so the frontend always defaults to the nearest valid expiry

## Impact
All pages that use the `/search/api/expiries` endpoint are affected. The fix is in the shared backend function, so all pages benefit automatically.

## Test plan
- [ ] Open Option Chain on the day after an expiry — verify it defaults to the next valid expiry, not yesterday's
- [ ] Verify expiry dropdown does not show past dates
- [ ] Verify OI Profile, OI Tracker, IV Smile, Max Pain pages also default correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated get_distinct_expiries_cached to filter out past dates, returning only today and future expiries. This fixes wrong defaults across Option Chain and related pages, preventing all-zero data after an expiry.

<sup>Written for commit 8e93ce259d67acb86ef6e1a596413a05c8fbdd05. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

