### PR TITLE
docs(database): add Google-style docstrings to database module functions

### DIFF
--- a/database/apilog_db.py
+++ b/database/apilog_db.py
@@ -44,6 +44,11 @@ class OrderLog(Base):
 
 
 def init_db():
+    """Initialize the API log database tables.
+
+    Creates the ``order_logs`` table if it does not already exist,
+    using the shared ``db_init_helper`` for consistent logging.
+    """
     from database.db_init_helper import init_db_with_logging
 
     init_db_with_logging(Base, engine, "API Log DB", logger)
@@ -54,6 +59,16 @@ executor = ThreadPoolExecutor(10)  # Increased from 2 to 10 for better concurren
 
 
 def async_log_order(api_type, request_data, response_data):
+    """Persist an API order log entry to the database.
+
+    Serializes request and response data as JSON and stores them
+    in the ``order_logs`` table with the current IST timestamp.
+
+    Args:
+        api_type: The type of API call (e.g. ``'placeorder'``, ``'cancelorder'``).
+        request_data: Dictionary of the original request payload.
+        response_data: Dictionary of the broker/service response.
+    """
     try:
         # Serialize JSON data for storage
         request_json = json.dumps(request_data)

--- a/database/apilog_db.py
+++ b/database/apilog_db.py
@@ -61,8 +61,10 @@ executor = ThreadPoolExecutor(10)  # Increased from 2 to 10 for better concurren
 def async_log_order(api_type, request_data, response_data):
     """Persist an API order log entry to the database.
 
-    Serializes request and response data as JSON and stores them
-    in the ``order_logs`` table with the current IST timestamp.
+    Note: Despite its name, this function executes **synchronously**.
+    It is designed to be submitted to a ``ThreadPoolExecutor`` by
+    callers so that the database write does not block the main
+    request thread.
 
     Args:
         api_type: The type of API call (e.g. ``'placeorder'``, ``'cancelorder'``).

--- a/database/auth_db.py
+++ b/database/auth_db.py
@@ -326,17 +326,13 @@ def get_auth_token_fresh(name):
 
 
 def get_auth_token_dbquery(name):
-    """Query the database directly for an auth token.
-
-    Bypasses the in-memory TTL cache and fetches the ``Auth`` row
-    for the given user name.  Returns the full ``Auth`` ORM object
-    so that callers can decrypt the token or inspect revocation status.
+    """Fetch the auth token record directly from the database.
 
     Args:
         name: The user identifier (username) to look up.
 
     Returns:
-        The ``Auth`` ORM instance if a valid, non-revoked record exists,
+        The ``Auth`` ORM instance if a valid record exists,
         otherwise ``None``.
     """
     try:
@@ -359,18 +355,13 @@ def get_auth_token_dbquery(name):
 
 
 def get_feed_token(name):
-    """Get the decrypted feed token for a user.
-
-    Uses a TTL cache (keyed ``feed-{name}``) to minimise database
-    round-trips.  Falls back to ``get_feed_token_dbquery`` on a
-    cache miss.
+    """Get the feed token for a user.
 
     Args:
         name: The user identifier (username) to look up.
 
     Returns:
-        The decrypted feed token string, or ``None`` if the token is
-        unavailable, revoked, or the name is empty.
+        The feed token string, or ``None`` if unavailable.
     """
     # Handle None or empty name gracefully
     if not name:
@@ -394,17 +385,13 @@ def get_feed_token(name):
 
 
 def get_feed_token_dbquery(name):
-    """Query the database directly for a feed token.
-
-    Bypasses the in-memory TTL cache and fetches the ``Auth`` row
-    for the given user name.  Returns the full ``Auth`` ORM object
-    so that callers can decrypt the feed token.
+    """Fetch the feed token record directly from the database.
 
     Args:
         name: The user identifier (username) to look up.
 
     Returns:
-        The ``Auth`` ORM instance if a valid, non-revoked record exists,
+        The ``Auth`` ORM instance if a valid record exists,
         otherwise ``None``.
     """
     try:

--- a/database/auth_db.py
+++ b/database/auth_db.py
@@ -177,6 +177,12 @@ class ApiKeys(Base):
 
 
 def init_db():
+    """Initialize the authentication database tables.
+
+    Creates the ``auth`` and ``api_keys`` tables if they do not
+    already exist, using the shared ``db_init_helper`` for
+    consistent startup logging.
+    """
     from database.db_init_helper import init_db_with_logging
 
     init_db_with_logging(Base, engine, "Auth DB", logger)
@@ -320,6 +326,19 @@ def get_auth_token_fresh(name):
 
 
 def get_auth_token_dbquery(name):
+    """Query the database directly for an auth token.
+
+    Bypasses the in-memory TTL cache and fetches the ``Auth`` row
+    for the given user name.  Returns the full ``Auth`` ORM object
+    so that callers can decrypt the token or inspect revocation status.
+
+    Args:
+        name: The user identifier (username) to look up.
+
+    Returns:
+        The ``Auth`` ORM instance if a valid, non-revoked record exists,
+        otherwise ``None``.
+    """
     try:
         # Handle None or empty name gracefully
         if not name:
@@ -340,7 +359,19 @@ def get_auth_token_dbquery(name):
 
 
 def get_feed_token(name):
-    """Get decrypted feed token"""
+    """Get the decrypted feed token for a user.
+
+    Uses a TTL cache (keyed ``feed-{name}``) to minimise database
+    round-trips.  Falls back to ``get_feed_token_dbquery`` on a
+    cache miss.
+
+    Args:
+        name: The user identifier (username) to look up.
+
+    Returns:
+        The decrypted feed token string, or ``None`` if the token is
+        unavailable, revoked, or the name is empty.
+    """
     # Handle None or empty name gracefully
     if not name:
         logger.debug("get_feed_token called with empty/None name, returning None")
@@ -363,6 +394,19 @@ def get_feed_token(name):
 
 
 def get_feed_token_dbquery(name):
+    """Query the database directly for a feed token.
+
+    Bypasses the in-memory TTL cache and fetches the ``Auth`` row
+    for the given user name.  Returns the full ``Auth`` ORM object
+    so that callers can decrypt the feed token.
+
+    Args:
+        name: The user identifier (username) to look up.
+
+    Returns:
+        The ``Auth`` ORM instance if a valid, non-revoked record exists,
+        otherwise ``None``.
+    """
     try:
         # Handle None or empty name gracefully
         if not name:

--- a/database/symbol.py
+++ b/database/symbol.py
@@ -241,20 +241,7 @@ def fno_search_symbols_db(
         if primary_term:
 
             def sort_key(r):
-                """Return a tuple that sorts results by relevance to the primary search term.
-
-                Sorting priority:
-                    1. Exact match on name/underlying.
-                    2. Name starts with search term.
-                    3. Symbol starts with search term.
-                    4. Alphabetical by symbol.
-
-                Args:
-                    r: A symbol result dictionary with ``name`` and ``symbol`` keys.
-
-                Returns:
-                    A comparison tuple used by ``list.sort``.
-                """
+                """Sort results by relevance: exact match, prefix match, then alphabetical."""
                 name = r["name"] or ""
                 symbol = r["symbol"] or ""
                 # Priority 1: Exact match on name/underlying
@@ -308,18 +295,7 @@ def get_distinct_expiries(exchange: str = None, underlying: str = None) -> list[
 
         # Sort expiries chronologically
         def parse_expiry(exp_str):
-            """Parse an expiry date string into a datetime for chronological sorting.
-
-            Tries ``%d-%b-%y`` first (e.g. ``26-DEC-24``), then
-            ``%d-%b-%Y`` (e.g. ``26-DEC-2024``).  Returns
-            ``datetime.max`` for unparseable strings so they sort last.
-
-            Args:
-                exp_str: Expiry date string from the database.
-
-            Returns:
-                A ``datetime`` instance used as a sort key.
-            """
+            """Parse an expiry date string into a datetime for chronological sorting."""
             try:
                 return datetime.strptime(exp_str, "%d-%b-%y")
             except ValueError:

--- a/database/symbol.py
+++ b/database/symbol.py
@@ -241,6 +241,20 @@ def fno_search_symbols_db(
         if primary_term:
 
             def sort_key(r):
+                """Return a tuple that sorts results by relevance to the primary search term.
+
+                Sorting priority:
+                    1. Exact match on name/underlying.
+                    2. Name starts with search term.
+                    3. Symbol starts with search term.
+                    4. Alphabetical by symbol.
+
+                Args:
+                    r: A symbol result dictionary with ``name`` and ``symbol`` keys.
+
+                Returns:
+                    A comparison tuple used by ``list.sort``.
+                """
                 name = r["name"] or ""
                 symbol = r["symbol"] or ""
                 # Priority 1: Exact match on name/underlying
@@ -294,6 +308,18 @@ def get_distinct_expiries(exchange: str = None, underlying: str = None) -> list[
 
         # Sort expiries chronologically
         def parse_expiry(exp_str):
+            """Parse an expiry date string into a datetime for chronological sorting.
+
+            Tries ``%d-%b-%y`` first (e.g. ``26-DEC-24``), then
+            ``%d-%b-%Y`` (e.g. ``26-DEC-2024``).  Returns
+            ``datetime.max`` for unparseable strings so they sort last.
+
+            Args:
+                exp_str: Expiry date string from the database.
+
+            Returns:
+                A ``datetime`` instance used as a sort key.
+            """
             try:
                 return datetime.strptime(exp_str, "%d-%b-%y")
             except ValueError:
@@ -342,7 +368,11 @@ def get_distinct_underlyings(exchange: str = None) -> list[str]:
 
 
 def init_db():
-    """Initialize the database"""
+    """Initialize the master contract database tables.
+
+    Creates the ``symtoken`` table if it does not already exist,
+    using the shared ``db_init_helper`` for consistent startup logging.
+    """
     from database.db_init_helper import init_db_with_logging
 
     init_db_with_logging(Base, engine, "Master Contract DB", logger)

--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -556,20 +556,7 @@ class BrokerSymbolCache:
         primary_term = query_terms[0] if query_terms else None
 
         def sort_key(s):
-            """Return a sort-key tuple that ranks FNO results by relevance.
-
-            Sorting priority:
-                1. Exact match on extracted underlying.
-                2. Underlying starts with the primary search term.
-                3. Symbol starts with the primary search term.
-                4. Alphabetical by symbol.
-
-            Args:
-                s: A ``SymbolData`` instance from the cache.
-
-            Returns:
-                A comparison tuple used by ``list.sort``.
-            """
+            """Sort FNO results by relevance: exact underlying, prefix match, then alphabetical."""
             # Priority 1: Exact match on underlying (e.g., "NIFTY" matches underlying="NIFTY" exactly)
             underlying_exact = (
                 0 if (primary_term and s.underlying and s.underlying == primary_term) else 1
@@ -1055,17 +1042,7 @@ def get_distinct_expiries_cached(
 
         # Sort expiries chronologically
         def parse_expiry(exp_str):
-            """Parse an expiry date string into a datetime for chronological sorting.
-
-            Tries ``%d-%b-%y`` first, then ``%d-%b-%Y``.  Returns
-            ``datetime.max`` for unparseable strings so they sort last.
-
-            Args:
-                exp_str: Expiry date string from the database.
-
-            Returns:
-                A ``datetime`` instance used as a sort key.
-            """
+            """Parse an expiry date string into a datetime for chronological sorting."""
             try:
                 return datetime.strptime(exp_str, "%d-%b-%y")
             except ValueError:

--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -556,6 +556,20 @@ class BrokerSymbolCache:
         primary_term = query_terms[0] if query_terms else None
 
         def sort_key(s):
+            """Return a sort-key tuple that ranks FNO results by relevance.
+
+            Sorting priority:
+                1. Exact match on extracted underlying.
+                2. Underlying starts with the primary search term.
+                3. Symbol starts with the primary search term.
+                4. Alphabetical by symbol.
+
+            Args:
+                s: A ``SymbolData`` instance from the cache.
+
+            Returns:
+                A comparison tuple used by ``list.sort``.
+            """
             # Priority 1: Exact match on underlying (e.g., "NIFTY" matches underlying="NIFTY" exactly)
             underlying_exact = (
                 0 if (primary_term and s.underlying and s.underlying == primary_term) else 1
@@ -1041,6 +1055,17 @@ def get_distinct_expiries_cached(
 
         # Sort expiries chronologically
         def parse_expiry(exp_str):
+            """Parse an expiry date string into a datetime for chronological sorting.
+
+            Tries ``%d-%b-%y`` first, then ``%d-%b-%Y``.  Returns
+            ``datetime.max`` for unparseable strings so they sort last.
+
+            Args:
+                exp_str: Expiry date string from the database.
+
+            Returns:
+                A ``datetime`` instance used as a sort key.
+            """
             try:
                 return datetime.strptime(exp_str, "%d-%b-%y")
             except ValueError:

--- a/database/tv_search.py
+++ b/database/tv_search.py
@@ -4,13 +4,15 @@ from database.symbol import SymToken
 
 
 def search_symbols(symbol, exchange):
-    """Search for symbols matching an exact symbol-exchange pair.
+    """Look up symbols by exact symbol-exchange match.
 
-    Used by TradingView integration to resolve symbol identifiers.
+    Performs an exact-match query against the ``SymToken`` table
+    and returns all rows where both ``symbol`` and ``exchange``
+    match the provided values.
 
     Args:
-        symbol: The OpenAlgo-format symbol string to search for.
-        exchange: The exchange code (e.g. ``'NSE'``, ``'NFO'``).
+        symbol: The symbol string to match exactly.
+        exchange: The exchange code to match exactly (e.g. ``'NSE'``, ``'NFO'``).
 
     Returns:
         A list of ``SymToken`` ORM instances matching the query.

--- a/database/tv_search.py
+++ b/database/tv_search.py
@@ -4,4 +4,15 @@ from database.symbol import SymToken
 
 
 def search_symbols(symbol, exchange):
+    """Search for symbols matching an exact symbol-exchange pair.
+
+    Used by TradingView integration to resolve symbol identifiers.
+
+    Args:
+        symbol: The OpenAlgo-format symbol string to search for.
+        exchange: The exchange code (e.g. ``'NSE'``, ``'NFO'``).
+
+    Returns:
+        A list of ``SymToken`` ORM instances matching the query.
+    """
     return SymToken.query.filter(SymToken.symbol == symbol, SymToken.exchange == exchange).all()

--- a/database/user_db.py
+++ b/database/user_db.py
@@ -98,12 +98,33 @@ class User(Base):
 
 
 def init_db():
+    """Initialize the user database tables.
+
+    Creates the ``users`` table if it does not already exist,
+    using the shared ``db_init_helper`` for consistent startup
+    logging.
+    """
     from database.db_init_helper import init_db_with_logging
 
     init_db_with_logging(Base, engine, "User DB", logger)
 
 
 def add_user(username, email, password, is_admin=False):
+    """Create a new user with Argon2-hashed password and TOTP secret.
+
+    Generates a random TOTP secret for the user, hashes the
+    password with Argon2 + pepper, and persists the record.
+
+    Args:
+        username: Unique username for the new account.
+        email: Unique email address for the new account.
+        password: Plaintext password (will be hashed before storage).
+        is_admin: Whether the user should have administrator privileges.
+
+    Returns:
+        The newly created ``User`` instance on success, or ``None``
+        if a user with the same username or email already exists.
+    """
     try:
         # Generate TOTP secret for the user
         totp_secret = pyotp.random_base32()

--- a/database/user_db.py
+++ b/database/user_db.py
@@ -110,10 +110,10 @@ def init_db():
 
 
 def add_user(username, email, password, is_admin=False):
-    """Create a new user with Argon2-hashed password and TOTP secret.
+    """Create a new user with a securely hashed password.
 
-    Generates a random TOTP secret for the user, hashes the
-    password with Argon2 + pepper, and persists the record.
+    Hashes the provided password, generates a two-factor authentication
+    secret, and persists the new user record to the database.
 
     Args:
         username: Unique username for the new account.


### PR DESCRIPTION
TL;DR: I was exploring the database/ module and noticed most functions had no docstrings — so hovering over them in VS Code gave you nothing useful. This PR adds proper Google-style docstrings to 14 functions across 6 files. No logic changes, just docs. 

Description
Adds Google-style docstrings (summary + Args + Returns) to 14 undocumented or minimally-documented functions across 6 files in the database/ module, improving IDE tooltip support and developer onboarding.

Related Issues
Closes #980

Changes Made

database/apilog_db.py
: Added docstrings to 

init_db()
 and 

async_log_order()

database/auth_db.py
: Added docstrings to 

init_db()
, 

get_auth_token_dbquery()
, 

get_feed_token()
, and 

get_feed_token_dbquery()

database/symbol.py
: Improved 

init_db()
, added docstrings to 

sort_key()
 and 

parse_expiry()

database/token_db_enhanced.py
: Added docstrings to 

sort_key()
 and 

parse_expiry()

database/tv_search.py
: Added docstring to 

search_symbols()

database/user_db.py
: Added docstrings to 

init_db()
 and 

add_user()
Testing
All 7 CI-safe tests pass
All 6 modified files compile cleanly
No new ruff violations introduced
Screenshots
N/A — documentation-only changes, no UI impact.

Checklist
 Code follows PEP 8 guidelines
 Added docstrings to all functions
 Tested locally and verified working
 No breaking changes to existing code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Google-style docstrings to 14 functions across 6 database files (apilog_db.py, auth_db.py, symbol.py, token_db_enhanced.py, tv_search.py, user_db.py) to improve IDE tooltips and onboarding. Incorporates review feedback by sanitizing sensitive details, fixing inaccuracies, and simplifying closure docstrings; no runtime changes. Closes #980.

<sup>Written for commit fab0f660ee5555af144593fc81644a2038aa5ab4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

