### PR TITLE
feat: add built-in backtesting engine

### DIFF
--- a/BACKTEST_ENGINE_PLAN.md
+++ b/BACKTEST_ENGINE_PLAN.md
@@ -1,0 +1,1605 @@
+# Built-in Backtesting Engine — Implementation Plan
+
+## Core Design Principle
+
+**Zero-code-change compatibility**: A Python strategy written for live trading (using `openalgo` SDK) should run as a backtest with **no modifications**. The engine swaps the live `api` client with a `BacktestClient` that replays historical data and simulates execution.
+
+---
+
+## Existing Infrastructure Leveraged
+
+### Historify (DuckDB) — Data Source
+- **Database**: `db/historify.duckdb`
+- **Main table**: `market_data` with columns: `symbol`, `exchange`, `interval`, `timestamp` (BIGINT epoch seconds), `open`, `high`, `low`, `close` (DOUBLE), `volume`, `oi` (BIGINT)
+- **Storage intervals**: Only `1m` and `D` are physically stored
+- **Computed intervals**: `5m`, `15m`, `30m`, `1h` aggregated on-the-fly from 1m data
+- **Custom intervals**: Any `Nm` or `Nh` dynamically computed; `W`, `M`, `Q`, `Y` from daily data
+- **Candle alignment**: Intraday candles align to exchange market open (NSE: 09:15 IST, MCX: 09:00 IST)
+- **Key query function**: `get_ohlcv(symbol, exchange, interval, start_timestamp, end_timestamp)` returns pandas DataFrame
+- **Export function**: `export_to_dataframe()` returns DataFrame with datetime index ready for backtesting
+- **Performance**: <50ms for 1-year intraday queries due to columnar storage + vectorized aggregation
+- **Supported exchanges**: NSE, BSE, NFO, BFO, MCX, CDS, BCD, NSE_INDEX, BSE_INDEX
+- **Metadata**: `data_catalog` table provides instant answers to "do I have data for X from Y to Z?" without scanning main table
+
+### Sandbox — Execution Model Reference
+- **Order types**: MARKET, LIMIT, SL, SL-M all supported
+- **Position netting**: Weighted average price, partial closes, reversals
+- **Margin system**: Leverage-based (Equity MIS: 5x, CNC: 1x, Futures: 10x, Options: 1x)
+- **P&L tracking**: Realized + unrealized, daily settlement, accumulated all-time
+- **Fill logic**: MARKET fills at bid/ask; LIMIT fills at limit price when LTP crosses; SL triggers then fills
+- **No slippage model**: Only implicit via bid/ask spread
+- **No commission model**: P&L is gross
+
+### OpenAlgo SDK — Strategy Interface
+- Strategies use `from openalgo import api` and call methods like `client.history()`, `client.placeorder()`, `client.placesmartorder()`, `client.quotes()`, `client.positionbook()`, `client.funds()`, etc.
+- `client.history(source="db")` already fetches from Historify DuckDB
+- Strategies typically run in `while True` loops with `time.sleep()` between iterations
+
+### Python Strategy Hosting
+- Each strategy runs in a **separate subprocess** with resource limits
+- Config stored in `strategies/strategy_configs.json`
+- Logs captured to `log/strategies/`
+- SSE (Server-Sent Events) for real-time UI updates
+- Frontend uses CodeMirror-based Python editor
+
+---
+
+## Phase 1: Backtest Engine Core (Backend)
+
+### Step 1 — Database Schema
+
+**New file**: `database/backtest_db.py`
+**New database**: `db/backtest.db` (SQLite, separate from all other databases)
+
+**Why separate DB**: Keeps backtests isolated, can grow large without affecting live trading, easy to purge old results.
+
+#### Table: BacktestRun
+
+One row per backtest execution.
+
+```python
+class BacktestRun(db.Model):
+    __tablename__ = 'backtest_runs'
+
+    id                    = db.Column(db.String(50), primary_key=True)  # BT-YYYYMMDD-HHMMSS-{uuid8}
+    user_id               = db.Column(db.String(50), index=True, nullable=False)
+    name                  = db.Column(db.String(200), nullable=False)
+    strategy_id           = db.Column(db.String(50), nullable=True)  # links to python_strategy if applicable
+    strategy_code         = db.Column(db.Text, nullable=False)  # snapshot of code at run time
+
+    # Configuration
+    symbols               = db.Column(db.Text, nullable=False)  # JSON: [{"symbol":"SBIN","exchange":"NSE"}]
+    start_date            = db.Column(db.String(10), nullable=False)  # YYYY-MM-DD
+    end_date              = db.Column(db.String(10), nullable=False)
+    interval              = db.Column(db.String(10), nullable=False)  # 1m, 5m, 15m, 1h, D
+    initial_capital       = db.Column(db.Numeric(15, 2), nullable=False)
+    slippage_pct          = db.Column(db.Numeric(6, 4), default=0.05)  # 0.05%
+    commission_per_order  = db.Column(db.Numeric(10, 2), default=20.00)  # Rs.20 flat
+    commission_pct        = db.Column(db.Numeric(6, 4), default=0.00)  # or percentage-based
+    data_source           = db.Column(db.String(10), default='db')  # 'db' (Historify) or 'api' (broker)
+
+    # Results (populated after run)
+    status                = db.Column(db.String(20), default='pending')  # pending/running/completed/failed/cancelled
+    final_capital         = db.Column(db.Numeric(15, 2), nullable=True)
+    total_return_pct      = db.Column(db.Numeric(10, 4), nullable=True)
+    cagr                  = db.Column(db.Numeric(10, 4), nullable=True)
+    sharpe_ratio          = db.Column(db.Numeric(10, 4), nullable=True)
+    sortino_ratio         = db.Column(db.Numeric(10, 4), nullable=True)
+    max_drawdown_pct      = db.Column(db.Numeric(10, 4), nullable=True)
+    calmar_ratio          = db.Column(db.Numeric(10, 4), nullable=True)
+    win_rate              = db.Column(db.Numeric(10, 4), nullable=True)
+    profit_factor         = db.Column(db.Numeric(10, 4), nullable=True)
+    total_trades          = db.Column(db.Integer, default=0)
+    winning_trades        = db.Column(db.Integer, default=0)
+    losing_trades         = db.Column(db.Integer, default=0)
+    avg_win               = db.Column(db.Numeric(15, 2), nullable=True)
+    avg_loss              = db.Column(db.Numeric(15, 2), nullable=True)
+    max_win               = db.Column(db.Numeric(15, 2), nullable=True)
+    max_loss              = db.Column(db.Numeric(15, 2), nullable=True)
+    expectancy            = db.Column(db.Numeric(15, 2), nullable=True)
+    avg_holding_bars      = db.Column(db.Integer, nullable=True)
+
+    # Serialized data
+    equity_curve_json     = db.Column(db.Text, nullable=True)  # JSON array of {timestamp, equity, drawdown}
+    monthly_returns_json  = db.Column(db.Text, nullable=True)  # JSON for calendar heatmap
+    error_message         = db.Column(db.Text, nullable=True)
+
+    # Timestamps
+    created_at            = db.Column(db.DateTime, default=func.now())
+    started_at            = db.Column(db.DateTime, nullable=True)
+    completed_at          = db.Column(db.DateTime, nullable=True)
+    duration_ms           = db.Column(db.Integer, nullable=True)  # execution time
+```
+
+#### Table: BacktestTrade
+
+Every simulated trade recorded for analysis.
+
+```python
+class BacktestTrade(db.Model):
+    __tablename__ = 'backtest_trades'
+
+    id              = db.Column(db.Integer, primary_key=True, autoincrement=True)
+    backtest_id     = db.Column(db.String(50), db.ForeignKey('backtest_runs.id'), index=True, nullable=False)
+    trade_num       = db.Column(db.Integer, nullable=False)  # sequential trade number
+
+    symbol          = db.Column(db.String(50), nullable=False)
+    exchange        = db.Column(db.String(20), nullable=False)
+    action          = db.Column(db.String(10), nullable=False)  # BUY/SELL
+    quantity        = db.Column(db.Integer, nullable=False)
+    entry_price     = db.Column(db.Numeric(10, 2), nullable=False)
+    exit_price      = db.Column(db.Numeric(10, 2), nullable=True)  # null if still open at end
+    entry_time      = db.Column(db.DateTime, nullable=False)
+    exit_time       = db.Column(db.DateTime, nullable=True)
+
+    pnl             = db.Column(db.Numeric(15, 2), default=0)  # gross P&L
+    pnl_pct         = db.Column(db.Numeric(10, 4), default=0)
+    commission      = db.Column(db.Numeric(10, 2), default=0)
+    slippage_cost   = db.Column(db.Numeric(10, 2), default=0)
+    net_pnl         = db.Column(db.Numeric(15, 2), default=0)  # pnl - commission - slippage
+
+    bars_held       = db.Column(db.Integer, default=0)
+    product         = db.Column(db.String(20), nullable=True)
+    strategy_tag    = db.Column(db.String(100), nullable=True)
+
+    __table_args__ = (
+        db.Index('idx_backtest_trade', 'backtest_id', 'trade_num'),
+    )
+```
+
+#### Initialization
+
+```python
+def init_backtest_db():
+    """Initialize backtest database. Called from app.py parallel DB init."""
+    db_path = os.path.join(os.path.dirname(__file__), '..', 'db', 'backtest.db')
+    engine = create_engine(f'sqlite:///{db_path}')
+    Base.metadata.create_all(engine)
+```
+
+Add `init_backtest_db()` to the parallel database initialization in `app.py` (line ~484).
+
+---
+
+### Step 2 — Backtest Client
+
+**New file**: `services/backtest_client.py`
+
+A drop-in replacement for the `openalgo.api` class that intercepts all SDK calls and simulates execution on historical data.
+
+```python
+class BacktestClient:
+    """
+    Drop-in replacement for openalgo.api that simulates execution on historical data.
+
+    All public methods mirror the openalgo SDK interface exactly so that strategies
+    written for live trading work in backtest mode with zero code changes.
+    """
+
+    def __init__(self, config):
+        # Configuration
+        self.initial_capital = float(config['initial_capital'])
+        self.capital = float(config['initial_capital'])
+        self.slippage_pct = float(config.get('slippage_pct', 0.0005))
+        self.commission_per_order = float(config.get('commission_per_order', 20.0))
+        self.commission_pct = float(config.get('commission_pct', 0.0))
+
+        # Data store (populated by engine before run)
+        self.data = {}                 # {symbol_key: DataFrame} preloaded OHLCV
+        self.current_bar_index = {}    # {symbol_key: int} current position in replay
+        self.current_timestamp = None  # current bar's timestamp
+
+        # State tracking
+        self.positions = {}            # {symbol_key: {qty, avg_price, product, margin}}
+        self.orders = []               # all orders placed
+        self.trades = []               # completed round-trip trades
+        self.open_entries = {}         # {symbol_key: {entry_price, entry_time, entry_bar, qty, action}}
+        self.pending_orders = []       # SL/LIMIT orders waiting for trigger
+        self.equity_curve = []         # [{timestamp, equity, drawdown}]
+        self.peak_equity = float(config['initial_capital'])
+        self._order_counter = 0
+        self._trade_counter = 0
+
+    # ─── SDK-Compatible Methods ──────────────────────────────────────────
+
+    def history(self, symbol, exchange, interval, start_date, end_date, source='db'):
+        """
+        Returns historical data UP TO current bar (no look-ahead bias).
+        This is the CRITICAL method that prevents cheating in backtests.
+        """
+        key = f"{symbol}:{exchange}"
+        if key not in self.data:
+            return pd.DataFrame()
+        df = self.data[key]
+        current_idx = self.current_bar_index.get(key, len(df) - 1)
+        return df.iloc[:current_idx + 1].copy()
+
+    def quotes(self, symbol, exchange):
+        """Returns current bar's OHLCV as a quote snapshot."""
+        bar = self._get_current_bar(symbol, exchange)
+        if bar is None:
+            return {'status': 'error', 'message': 'No data'}
+        prev_close = self._get_prev_close(symbol, exchange)
+        return {
+            'status': 'success',
+            'data': {
+                'ltp': float(bar['close']),
+                'open': float(bar['open']),
+                'high': float(bar['high']),
+                'low': float(bar['low']),
+                'close': float(bar['close']),
+                'volume': int(bar['volume']),
+                'bid': float(bar['close']),
+                'ask': float(bar['close']),
+                'prev_close': float(prev_close) if prev_close else float(bar['open']),
+                'oi': int(bar.get('oi', 0)),
+            }
+        }
+
+    def multiquotes(self, symbols):
+        """Returns quotes for multiple symbols."""
+        results = {}
+        for sym in symbols:
+            q = self.quotes(sym['symbol'], sym['exchange'])
+            if q['status'] == 'success':
+                results[f"{sym['symbol']}:{sym['exchange']}"] = q['data']
+        return {'status': 'success', 'data': results}
+
+    def placeorder(self, strategy='', symbol='', action='', exchange='',
+                   price_type='MARKET', product='MIS', quantity=1,
+                   price=0, trigger_price=0, **kwargs):
+        """Simulate order execution using current bar data."""
+        bar = self._get_current_bar(symbol, exchange)
+        if bar is None:
+            return {'status': 'error', 'message': 'No data for symbol'}
+
+        self._order_counter += 1
+        order_id = f'BT-{self._order_counter:06d}'
+
+        if price_type == 'MARKET':
+            exec_price = self._apply_slippage(float(bar['close']), action)
+            self._execute_fill(symbol, exchange, action, int(quantity),
+                               exec_price, product, strategy, bar)
+            return {'orderid': order_id, 'status': 'success'}
+
+        elif price_type in ('LIMIT', 'SL', 'SL-M'):
+            # Queue as pending order, checked on each bar
+            self.pending_orders.append({
+                'order_id': order_id,
+                'symbol': symbol,
+                'exchange': exchange,
+                'action': action,
+                'quantity': int(quantity),
+                'price_type': price_type,
+                'price': float(price),
+                'trigger_price': float(trigger_price),
+                'product': product,
+                'strategy': strategy,
+                'placed_bar': self.current_bar_index.get(f"{symbol}:{exchange}", 0),
+            })
+            return {'orderid': order_id, 'status': 'success'}
+
+        return {'status': 'error', 'message': f'Unknown price_type: {price_type}'}
+
+    def placesmartorder(self, strategy='', symbol='', action='', exchange='',
+                        price_type='MARKET', product='MIS', quantity=1,
+                        position_size=0, **kwargs):
+        """Position-aware order placement (mirrors live behavior)."""
+        key = f"{symbol}:{exchange}"
+        current_qty = self.positions.get(key, {}).get('qty', 0)
+
+        if action == 'BUY':
+            needed = int(position_size) - current_qty
+            if needed > 0:
+                return self.placeorder(strategy=strategy, symbol=symbol, action='BUY',
+                                       exchange=exchange, price_type=price_type,
+                                       product=product, quantity=needed, **kwargs)
+            elif needed < 0:
+                return self.placeorder(strategy=strategy, symbol=symbol, action='SELL',
+                                       exchange=exchange, price_type=price_type,
+                                       product=product, quantity=abs(needed), **kwargs)
+        elif action == 'SELL':
+            needed = current_qty - int(position_size)
+            if needed > 0:
+                return self.placeorder(strategy=strategy, symbol=symbol, action='SELL',
+                                       exchange=exchange, price_type=price_type,
+                                       product=product, quantity=needed, **kwargs)
+            elif needed < 0:
+                return self.placeorder(strategy=strategy, symbol=symbol, action='BUY',
+                                       exchange=exchange, price_type=price_type,
+                                       product=product, quantity=abs(needed), **kwargs)
+
+        return {'status': 'success', 'message': 'No action needed'}
+
+    def cancelorder(self, order_id='', **kwargs):
+        """Cancel a pending order."""
+        self.pending_orders = [o for o in self.pending_orders if o['order_id'] != order_id]
+        return {'status': 'success'}
+
+    def cancelallorder(self, strategy='', **kwargs):
+        """Cancel all pending orders."""
+        if strategy:
+            self.pending_orders = [o for o in self.pending_orders if o.get('strategy') != strategy]
+        else:
+            self.pending_orders.clear()
+        return {'status': 'success'}
+
+    def closeposition(self, strategy='', **kwargs):
+        """Close all open positions."""
+        for key, pos in list(self.positions.items()):
+            if pos['qty'] != 0:
+                symbol, exchange = key.split(':')
+                action = 'SELL' if pos['qty'] > 0 else 'BUY'
+                self.placeorder(strategy=strategy, symbol=symbol, action=action,
+                                exchange=exchange, price_type='MARKET',
+                                product=pos.get('product', 'MIS'),
+                                quantity=abs(pos['qty']))
+        return {'status': 'success'}
+
+    def positionbook(self):
+        """Return current positions."""
+        positions = []
+        for key, pos in self.positions.items():
+            if pos['qty'] != 0:
+                symbol, exchange = key.split(':')
+                bar = self._get_current_bar(symbol, exchange)
+                ltp = float(bar['close']) if bar is not None else pos['avg_price']
+                pnl = (ltp - pos['avg_price']) * pos['qty']
+                positions.append({
+                    'symbol': symbol, 'exchange': exchange,
+                    'product': pos.get('product', 'MIS'),
+                    'quantity': str(pos['qty']),
+                    'average_price': str(pos['avg_price']),
+                    'ltp': str(ltp), 'pnl': str(round(pnl, 2)),
+                })
+        return {'status': 'success', 'data': positions}
+
+    def orderbook(self):
+        """Return all orders."""
+        return {'status': 'success', 'data': self.orders}
+
+    def tradebook(self):
+        """Return all executed trades."""
+        return {'status': 'success', 'data': [
+            {'symbol': t['symbol'], 'exchange': t['exchange'],
+             'action': t['action'], 'quantity': t['quantity'],
+             'price': t['entry_price'], 'strategy': t.get('strategy_tag', '')}
+            for t in self.trades
+        ]}
+
+    def funds(self):
+        """Return fund balances."""
+        unrealized = self._total_unrealized()
+        return {
+            'status': 'success',
+            'data': {
+                'availablecash': str(round(self.capital, 2)),
+                'collateral': '0',
+                'm2mrealized': str(round(self.capital - self.initial_capital, 2)),
+                'm2munrealized': str(round(unrealized, 2)),
+            }
+        }
+
+    def openposition(self, strategy='', symbol='', exchange='', product='MIS'):
+        """Check if a position exists for a symbol."""
+        key = f"{symbol}:{exchange}"
+        pos = self.positions.get(key, {})
+        qty = pos.get('qty', 0)
+        return {'status': 'success', 'quantity': str(qty)}
+
+    # ─── Internal Methods ────────────────────────────────────────────────
+
+    def _get_current_bar(self, symbol, exchange):
+        """Get the current bar for a symbol."""
+        key = f"{symbol}:{exchange}"
+        if key not in self.data:
+            return None
+        idx = self.current_bar_index.get(key, 0)
+        df = self.data[key]
+        if idx >= len(df):
+            return None
+        return df.iloc[idx]
+
+    def _get_prev_close(self, symbol, exchange):
+        """Get previous bar's close price."""
+        key = f"{symbol}:{exchange}"
+        idx = self.current_bar_index.get(key, 0)
+        if idx <= 0:
+            return None
+        return self.data[key].iloc[idx - 1]['close']
+
+    def _apply_slippage(self, price, action):
+        """Apply slippage to execution price."""
+        if action == 'BUY':
+            return round(price * (1 + self.slippage_pct / 100), 2)
+        return round(price * (1 - self.slippage_pct / 100), 2)
+
+    def _calculate_commission(self, trade_value):
+        """Calculate commission for a trade."""
+        if self.commission_pct > 0:
+            return round(trade_value * self.commission_pct / 100, 2)
+        return self.commission_per_order
+
+    def _execute_fill(self, symbol, exchange, action, qty, exec_price, product, strategy, bar):
+        """Execute a fill: update positions, deduct commission, record trade."""
+        key = f"{symbol}:{exchange}"
+        trade_value = qty * exec_price
+        commission = self._calculate_commission(trade_value)
+        slippage_cost = abs(exec_price - float(bar['close'])) * qty
+
+        # Deduct commission
+        self.capital -= commission
+
+        # Record order
+        self.orders.append({
+            'symbol': symbol, 'exchange': exchange, 'action': action,
+            'quantity': qty, 'price': exec_price, 'product': product,
+            'strategy': strategy, 'status': 'complete',
+            'timestamp': self.current_timestamp,
+        })
+
+        # Update position
+        pos = self.positions.get(key, {'qty': 0, 'avg_price': 0, 'product': product})
+        old_qty = pos['qty']
+
+        if action == 'BUY':
+            new_qty = old_qty + qty
+        else:  # SELL
+            new_qty = old_qty - qty
+
+        # Determine if this is opening, adding, reducing, or closing
+        if old_qty == 0:
+            # New position
+            pos['avg_price'] = exec_price
+            pos['qty'] = new_qty
+            pos['product'] = product
+            # Record entry for trade tracking
+            self.open_entries[key] = {
+                'entry_price': exec_price, 'entry_time': self.current_timestamp,
+                'entry_bar': self.current_bar_index.get(key, 0),
+                'qty': abs(new_qty), 'action': action, 'strategy': strategy,
+            }
+
+        elif (old_qty > 0 and action == 'BUY') or (old_qty < 0 and action == 'SELL'):
+            # Adding to position — weighted average
+            total_cost = abs(old_qty) * pos['avg_price'] + qty * exec_price
+            pos['qty'] = new_qty
+            pos['avg_price'] = round(total_cost / abs(new_qty), 2)
+
+        else:
+            # Reducing or closing or reversing
+            close_qty = min(abs(old_qty), qty)
+
+            # Calculate P&L for closed portion
+            if old_qty > 0:
+                pnl = (exec_price - pos['avg_price']) * close_qty
+            else:
+                pnl = (pos['avg_price'] - exec_price) * close_qty
+
+            # Credit P&L
+            self.capital += pnl
+
+            # Record completed trade
+            entry = self.open_entries.get(key, {})
+            self._trade_counter += 1
+            self.trades.append({
+                'trade_num': self._trade_counter,
+                'symbol': symbol, 'exchange': exchange,
+                'action': 'LONG' if old_qty > 0 else 'SHORT',
+                'quantity': close_qty,
+                'entry_price': pos['avg_price'],
+                'exit_price': exec_price,
+                'entry_time': entry.get('entry_time'),
+                'exit_time': self.current_timestamp,
+                'pnl': round(pnl, 2),
+                'pnl_pct': round(pnl / (pos['avg_price'] * close_qty) * 100, 4) if pos['avg_price'] > 0 else 0,
+                'commission': commission,
+                'slippage_cost': round(slippage_cost, 2),
+                'net_pnl': round(pnl - commission, 2),
+                'bars_held': self.current_bar_index.get(key, 0) - entry.get('entry_bar', 0),
+                'product': product,
+                'strategy_tag': strategy,
+            })
+
+            pos['qty'] = new_qty
+
+            if new_qty == 0:
+                # Position fully closed
+                pos['avg_price'] = 0
+                self.open_entries.pop(key, None)
+            elif (old_qty > 0 and new_qty < 0) or (old_qty < 0 and new_qty > 0):
+                # Position reversed — open new entry for excess
+                excess = abs(new_qty)
+                pos['avg_price'] = exec_price
+                self.open_entries[key] = {
+                    'entry_price': exec_price, 'entry_time': self.current_timestamp,
+                    'entry_bar': self.current_bar_index.get(key, 0),
+                    'qty': excess, 'action': action, 'strategy': strategy,
+                }
+
+        self.positions[key] = pos
+
+    def process_pending_orders(self):
+        """Called each bar to check SL/LIMIT order triggers against current bar's OHLC."""
+        remaining = []
+        for order in self.pending_orders:
+            key = f"{order['symbol']}:{order['exchange']}"
+            bar = self._get_current_bar(order['symbol'], order['exchange'])
+            if bar is None:
+                remaining.append(order)
+                continue
+
+            triggered = False
+            exec_price = 0
+
+            if order['price_type'] == 'LIMIT':
+                if order['action'] == 'BUY' and float(bar['low']) <= order['price']:
+                    exec_price = order['price']
+                    triggered = True
+                elif order['action'] == 'SELL' and float(bar['high']) >= order['price']:
+                    exec_price = order['price']
+                    triggered = True
+
+            elif order['price_type'] == 'SL':
+                if order['action'] == 'BUY' and float(bar['high']) >= order['trigger_price']:
+                    exec_price = min(order['price'], float(bar['high']))
+                    triggered = True
+                elif order['action'] == 'SELL' and float(bar['low']) <= order['trigger_price']:
+                    exec_price = max(order['price'], float(bar['low']))
+                    triggered = True
+
+            elif order['price_type'] == 'SL-M':
+                if order['action'] == 'BUY' and float(bar['high']) >= order['trigger_price']:
+                    exec_price = self._apply_slippage(float(bar['close']), 'BUY')
+                    triggered = True
+                elif order['action'] == 'SELL' and float(bar['low']) <= order['trigger_price']:
+                    exec_price = self._apply_slippage(float(bar['close']), 'SELL')
+                    triggered = True
+
+            if triggered:
+                self._execute_fill(order['symbol'], order['exchange'], order['action'],
+                                   order['quantity'], exec_price, order['product'],
+                                   order['strategy'], bar)
+            else:
+                remaining.append(order)
+
+        self.pending_orders = remaining
+
+    def record_equity(self, timestamp):
+        """Snapshot equity at each bar for equity curve generation."""
+        unrealized = self._total_unrealized()
+        equity = self.capital + unrealized
+        self.peak_equity = max(self.peak_equity, equity)
+        drawdown = (self.peak_equity - equity) / self.peak_equity if self.peak_equity > 0 else 0
+        self.equity_curve.append({
+            'timestamp': int(timestamp) if not isinstance(timestamp, int) else timestamp,
+            'equity': round(equity, 2),
+            'drawdown': round(drawdown, 6),
+        })
+
+    def close_all_positions_at_end(self):
+        """Force-close all open positions at the last bar price."""
+        for key, pos in list(self.positions.items()):
+            if pos['qty'] != 0:
+                symbol, exchange = key.split(':')
+                bar = self._get_current_bar(symbol, exchange)
+                if bar is not None:
+                    action = 'SELL' if pos['qty'] > 0 else 'BUY'
+                    exec_price = self._apply_slippage(float(bar['close']), action)
+                    self._execute_fill(symbol, exchange, action, abs(pos['qty']),
+                                       exec_price, pos.get('product', 'MIS'), 'backtest_close', bar)
+
+    def _total_unrealized(self):
+        """Calculate total unrealized P&L across all positions."""
+        total = 0
+        for key, pos in self.positions.items():
+            if pos['qty'] != 0:
+                symbol, exchange = key.split(':')
+                bar = self._get_current_bar(symbol, exchange)
+                if bar is not None:
+                    ltp = float(bar['close'])
+                    if pos['qty'] > 0:
+                        total += (ltp - pos['avg_price']) * pos['qty']
+                    else:
+                        total += (pos['avg_price'] - ltp) * abs(pos['qty'])
+        return total
+
+    def advance_to(self, timestamp):
+        """Advance all symbols to the given timestamp."""
+        self.current_timestamp = timestamp
+        for key, df in self.data.items():
+            timestamps = df['timestamp'].values if 'timestamp' in df.columns else df.index.values
+            # Find the latest bar at or before this timestamp
+            mask = timestamps <= timestamp
+            if mask.any():
+                self.current_bar_index[key] = int(mask.sum()) - 1
+```
+
+---
+
+### Step 3 — Backtest Engine
+
+**New file**: `services/backtest_engine.py`
+
+The orchestrator that loads data, replays bars, and runs strategy code.
+
+```python
+class BacktestEngine:
+    """
+    Bar-by-bar replay engine.
+
+    Two execution modes:
+    1. Event-driven: Strategy has while True + time.sleep() loop.
+       Engine patches sleep -> bar advance, runs 1 iteration per bar.
+    2. Vectorized: Strategy computes signals on full DataFrame at once.
+       Faster, but strategy must follow vectorized pattern.
+    """
+
+    def __init__(self):
+        self.cancelled = set()  # backtest IDs that have been cancelled
+
+    def run(self, backtest_run, strategy_code):
+        """
+        Main entry point. Loads data, creates client, runs strategy, returns results.
+
+        Args:
+            backtest_run: BacktestRun model instance with all configuration
+            strategy_code: Python source code of the strategy
+
+        Returns:
+            dict with all results, metrics, trades, equity curve
+        """
+        import json
+        from database.historify_db import get_ohlcv
+
+        symbols = json.loads(backtest_run.symbols)
+        start_ts = int(datetime.strptime(backtest_run.start_date, '%Y-%m-%d').timestamp())
+        end_ts = int(datetime.strptime(backtest_run.end_date + ' 23:59:59', '%Y-%m-%d %H:%M:%S').timestamp())
+
+        # 1. Load historical data from Historify (DuckDB)
+        data = {}
+        for sym in symbols:
+            df = get_ohlcv(
+                symbol=sym['symbol'],
+                exchange=sym['exchange'],
+                interval=backtest_run.interval,
+                start_timestamp=start_ts,
+                end_timestamp=end_ts,
+            )
+            if df.empty:
+                raise ValueError(f"No data found for {sym['symbol']}:{sym['exchange']} "
+                                 f"in interval {backtest_run.interval} "
+                                 f"from {backtest_run.start_date} to {backtest_run.end_date}. "
+                                 f"Please download data via Historify first.")
+            data[f"{sym['symbol']}:{sym['exchange']}"] = df
+
+        # 2. Build unified timeline (sorted union of all symbols' timestamps)
+        all_timestamps = set()
+        for df in data.values():
+            if 'timestamp' in df.columns:
+                all_timestamps.update(df['timestamp'].tolist())
+        timeline = sorted(all_timestamps)
+
+        if not timeline:
+            raise ValueError("No data points found in the specified date range.")
+
+        # 3. Initialize BacktestClient
+        client = BacktestClient(config={
+            'initial_capital': float(backtest_run.initial_capital),
+            'slippage_pct': float(backtest_run.slippage_pct),
+            'commission_per_order': float(backtest_run.commission_per_order),
+            'commission_pct': float(backtest_run.commission_pct),
+        })
+        client.data = data
+
+        # 4. Patch and run strategy
+        patcher = StrategyPatcher()
+        iteration_fn = patcher.patch(strategy_code, client)
+
+        # 5. Bar-by-bar replay
+        total_bars = len(timeline)
+        for bar_idx, timestamp in enumerate(timeline):
+            # Check cancellation
+            if backtest_run.id in self.cancelled:
+                break
+
+            # Advance all symbols to this timestamp
+            client.advance_to(timestamp)
+
+            # Process pending SL/LIMIT orders against current bar
+            client.process_pending_orders()
+
+            # Execute one iteration of strategy logic
+            try:
+                iteration_fn()
+            except _BarComplete:
+                pass  # Normal: strategy called time.sleep(), we advance to next bar
+            except Exception as e:
+                # Log error but continue (strategy might recover)
+                pass
+
+            # Record equity snapshot
+            client.record_equity(timestamp)
+
+            # Emit progress every 100 bars (for SSE)
+            if bar_idx % 100 == 0:
+                self._emit_progress(backtest_run.id, bar_idx, total_bars)
+
+        # 6. Force-close open positions at last bar
+        client.close_all_positions_at_end()
+
+        # 7. Final equity snapshot
+        if timeline:
+            client.record_equity(timeline[-1])
+
+        # 8. Calculate statistics
+        metrics = calculate_metrics(
+            trades=client.trades,
+            equity_curve=client.equity_curve,
+            initial_capital=float(backtest_run.initial_capital),
+            interval=backtest_run.interval,
+        )
+
+        return {
+            'metrics': metrics,
+            'trades': client.trades,
+            'equity_curve': client.equity_curve,
+            'total_bars': total_bars,
+        }
+
+    def cancel(self, backtest_id):
+        self.cancelled.add(backtest_id)
+
+    def _emit_progress(self, backtest_id, current_bar, total_bars):
+        """Emit progress via Socket.IO for real-time UI updates."""
+        try:
+            from extensions import socketio
+            progress = round(current_bar / total_bars * 100, 1)
+            socketio.emit('backtest_progress', {
+                'backtest_id': backtest_id,
+                'progress': progress,
+                'current_bar': current_bar,
+                'total_bars': total_bars,
+            })
+        except Exception:
+            pass  # Non-critical
+
+
+class _BarComplete(Exception):
+    """Raised when strategy calls time.sleep() — signals engine to advance to next bar."""
+    pass
+```
+
+---
+
+### Step 4 — Strategy Patcher
+
+**New file**: `services/backtest_patcher.py`
+
+Transforms live strategy code to run in backtest mode. Two approaches (use simpler first, upgrade to AST later):
+
+#### Approach A: Regex + Namespace Injection (simpler, ship first)
+
+```python
+class StrategyPatcher:
+    """
+    Transform live strategy code for backtest execution.
+
+    Approach: Inject a modified namespace where:
+    - `from openalgo import api` is intercepted
+    - `api(...)` constructor returns the BacktestClient
+    - `time.sleep(...)` raises _BarComplete to yield control
+    - `datetime.now()` returns current bar timestamp
+    - The while-True loop body is extracted as a single-iteration function
+    """
+
+    def patch(self, source_code, client):
+        """
+        Returns a callable that executes one iteration of the strategy.
+        """
+        import re
+
+        # Remove openalgo imports (we inject our own)
+        code = re.sub(r'from\s+openalgo\s+import\s+api', '# [backtest] openalgo import intercepted', source_code)
+        code = re.sub(r'import\s+openalgo', '# [backtest] openalgo import intercepted', code)
+
+        # Replace while True loop with single iteration
+        # Pattern: find the main while True block and extract its body
+        code = self._extract_loop_body(code)
+
+        # Build namespace
+        namespace = {
+            '__builtins__': __builtins__,
+            'api': lambda **kwargs: client,  # intercept api() constructor
+            'pd': __import__('pandas'),
+            'np': __import__('numpy'),
+            'os': self._safe_os(),
+            'time': self._backtest_time_module(client),
+            'datetime': __import__('datetime'),
+            'json': __import__('json'),
+            'math': __import__('math'),
+        }
+
+        # Execute the patched code to define functions
+        exec(compile(code, '<backtest_strategy>', 'exec'), namespace)
+
+        # Return the iteration function
+        if '_backtest_iteration' in namespace:
+            return namespace['_backtest_iteration']
+
+        # Fallback: look for common entry points
+        for name in ['main', 'run', 'strategy', 'execute']:
+            if name in namespace and callable(namespace[name]):
+                return namespace[name]
+
+        raise ValueError("Could not find strategy entry point. "
+                         "Strategy must have a main(), run(), or while True loop.")
+
+    def _extract_loop_body(self, code):
+        """
+        Find the innermost while True loop and convert it to a function.
+
+        Transforms:
+            while True:
+                ... strategy logic ...
+                time.sleep(15)
+
+        Into:
+            def _backtest_iteration():
+                ... strategy logic ...
+                # time.sleep removed
+        """
+        import textwrap
+        lines = code.split('\n')
+        result = []
+        in_while_loop = False
+        while_indent = 0
+        loop_body = []
+
+        for line in lines:
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if not in_while_loop:
+                # Check for while True pattern
+                if re.match(r'while\s+(True|1)\s*:', stripped):
+                    in_while_loop = True
+                    while_indent = indent
+                    result.append(' ' * indent + 'def _backtest_iteration():')
+                    continue
+                result.append(line)
+            else:
+                if stripped == '' or indent > while_indent:
+                    # Inside while loop body
+                    # Skip time.sleep() calls
+                    if re.match(r'time\.sleep\s*\(', stripped):
+                        continue
+                    result.append(line)
+                else:
+                    # Exited while loop
+                    in_while_loop = False
+                    result.append(line)
+
+        return '\n'.join(result)
+
+    def _backtest_time_module(self, client):
+        """Create a mock time module where sleep() raises _BarComplete."""
+        import types
+        mock_time = types.ModuleType('time')
+        mock_time.sleep = lambda *args: (_ for _ in ()).throw(_BarComplete())
+        mock_time.time = lambda: client.current_timestamp or 0
+        return mock_time
+
+    def _safe_os(self):
+        """Create a restricted os module (allow getenv, block filesystem writes)."""
+        import types
+        mock_os = types.ModuleType('os')
+        mock_os.getenv = __import__('os').getenv
+        mock_os.environ = __import__('os').environ
+        mock_os.path = __import__('os').path
+        return mock_os
+```
+
+#### Approach B: AST-Based (future upgrade for robustness)
+
+For strategies with complex patterns (nested loops, generators, async), upgrade to `ast` module:
+- Parse source code into AST
+- Walk the tree and transform nodes
+- Replace `time.sleep()` calls with `raise _BarComplete()`
+- Replace `datetime.now()` with `client.current_time()`
+- Extract loop bodies into functions
+- Recompile modified AST
+
+This is more robust but more complex. Ship Approach A first.
+
+---
+
+### Step 5 — Performance Metrics Calculator
+
+**New file**: `services/backtest_metrics.py`
+
+```python
+import numpy as np
+import pandas as pd
+
+
+def calculate_metrics(trades, equity_curve, initial_capital, interval):
+    """
+    Calculate all performance metrics from backtest results.
+
+    Args:
+        trades: list of trade dicts from BacktestClient
+        equity_curve: list of {timestamp, equity, drawdown} dicts
+        initial_capital: starting capital (float)
+        interval: bar interval string ('1m', '5m', '15m', '30m', '1h', 'D')
+
+    Returns:
+        dict with all computed metrics
+    """
+    if not equity_curve:
+        return _empty_metrics()
+
+    equity = pd.Series([e['equity'] for e in equity_curve])
+    returns = equity.pct_change().dropna()
+
+    # Annualization factor (trading bars per year)
+    bars_per_year = {
+        '1m': 252 * 375,   # 375 minutes per trading day
+        '5m': 252 * 75,
+        '15m': 252 * 25,
+        '30m': 252 * 12,
+        '1h': 252 * 6,
+        'D': 252,
+    }.get(interval, 252)
+
+    metrics = {}
+
+    # ── Return Metrics ──
+    final_equity = equity.iloc[-1]
+    metrics['final_capital'] = round(float(final_equity), 2)
+    metrics['total_return_pct'] = round((final_equity - initial_capital) / initial_capital * 100, 4)
+
+    # CAGR
+    total_bars = len(equity)
+    if total_bars > 1 and final_equity > 0 and initial_capital > 0:
+        years = total_bars / bars_per_year
+        if years > 0:
+            metrics['cagr'] = round(((final_equity / initial_capital) ** (1 / years) - 1) * 100, 4)
+        else:
+            metrics['cagr'] = 0
+    else:
+        metrics['cagr'] = 0
+
+    # ── Risk Metrics ──
+    if len(returns) > 1 and returns.std() > 0:
+        metrics['sharpe_ratio'] = round(float(returns.mean() / returns.std() * np.sqrt(bars_per_year)), 4)
+    else:
+        metrics['sharpe_ratio'] = 0
+
+    downside_returns = returns[returns < 0]
+    if len(downside_returns) > 1 and downside_returns.std() > 0:
+        metrics['sortino_ratio'] = round(float(returns.mean() / downside_returns.std() * np.sqrt(bars_per_year)), 4)
+    else:
+        metrics['sortino_ratio'] = 0
+
+    metrics['max_drawdown_pct'] = round(max((e['drawdown'] for e in equity_curve), default=0) * 100, 4)
+
+    if metrics['max_drawdown_pct'] > 0:
+        metrics['calmar_ratio'] = round(metrics['cagr'] / metrics['max_drawdown_pct'], 4)
+    else:
+        metrics['calmar_ratio'] = 0
+
+    # ── Trade Metrics ──
+    if trades:
+        wins = [t for t in trades if t['net_pnl'] > 0]
+        losses = [t for t in trades if t['net_pnl'] <= 0]
+
+        metrics['total_trades'] = len(trades)
+        metrics['winning_trades'] = len(wins)
+        metrics['losing_trades'] = len(losses)
+        metrics['win_rate'] = round(len(wins) / len(trades) * 100, 4) if trades else 0
+
+        gross_profit = sum(t['net_pnl'] for t in wins)
+        gross_loss = abs(sum(t['net_pnl'] for t in losses))
+
+        metrics['profit_factor'] = round(gross_profit / gross_loss, 4) if gross_loss > 0 else float('inf')
+        metrics['avg_win'] = round(np.mean([t['net_pnl'] for t in wins]), 2) if wins else 0
+        metrics['avg_loss'] = round(np.mean([t['net_pnl'] for t in losses]), 2) if losses else 0
+        metrics['max_win'] = round(max([t['net_pnl'] for t in wins]), 2) if wins else 0
+        metrics['max_loss'] = round(min([t['net_pnl'] for t in losses]), 2) if losses else 0
+        metrics['expectancy'] = round(
+            (metrics['win_rate'] / 100 * metrics['avg_win']) +
+            ((1 - metrics['win_rate'] / 100) * metrics['avg_loss']),
+            2
+        )
+        metrics['avg_holding_bars'] = round(np.mean([t['bars_held'] for t in trades]))
+
+        # Total commissions and slippage
+        metrics['total_commission'] = round(sum(t.get('commission', 0) for t in trades), 2)
+        metrics['total_slippage'] = round(sum(t.get('slippage_cost', 0) for t in trades), 2)
+    else:
+        metrics.update({
+            'total_trades': 0, 'winning_trades': 0, 'losing_trades': 0,
+            'win_rate': 0, 'profit_factor': 0, 'avg_win': 0, 'avg_loss': 0,
+            'max_win': 0, 'max_loss': 0, 'expectancy': 0, 'avg_holding_bars': 0,
+            'total_commission': 0, 'total_slippage': 0,
+        })
+
+    # ── Monthly Returns (for calendar heatmap) ──
+    try:
+        equity_ts = pd.Series(
+            [e['equity'] for e in equity_curve],
+            index=pd.to_datetime([e['timestamp'] for e in equity_curve], unit='s')
+        )
+        monthly = equity_ts.resample('M').last().pct_change().dropna() * 100
+        metrics['monthly_returns'] = {
+            str(k.date()): round(float(v), 2) for k, v in monthly.items()
+        }
+    except Exception:
+        metrics['monthly_returns'] = {}
+
+    return metrics
+
+
+def _empty_metrics():
+    """Return empty metrics when no data is available."""
+    return {
+        'final_capital': 0, 'total_return_pct': 0, 'cagr': 0,
+        'sharpe_ratio': 0, 'sortino_ratio': 0, 'max_drawdown_pct': 0,
+        'calmar_ratio': 0, 'total_trades': 0, 'winning_trades': 0,
+        'losing_trades': 0, 'win_rate': 0, 'profit_factor': 0,
+        'avg_win': 0, 'avg_loss': 0, 'max_win': 0, 'max_loss': 0,
+        'expectancy': 0, 'avg_holding_bars': 0,
+        'total_commission': 0, 'total_slippage': 0,
+        'monthly_returns': {},
+    }
+```
+
+---
+
+### Step 6 — Blueprint & API Endpoints
+
+**New file**: `blueprints/backtest.py`
+
+#### Blueprint Routes (UI)
+
+| Route | Method | Purpose |
+|-------|--------|---------|
+| `/backtest` | GET | Backtest dashboard (list all runs) |
+| `/backtest/new` | GET | New backtest configuration page |
+| `/backtest/<id>` | GET | View backtest results |
+| `/backtest/compare` | GET | Compare multiple backtests |
+
+#### API Endpoints
+
+| Endpoint | Method | Purpose |
+|----------|--------|---------|
+| `/backtest/api/run` | POST | Start a new backtest |
+| `/backtest/api/status/<id>` | GET | Get status + progress |
+| `/backtest/api/results/<id>` | GET | Full results (metrics + trades + equity curve) |
+| `/backtest/api/cancel/<id>` | POST | Cancel running backtest |
+| `/backtest/api/list` | GET | List all backtests for user |
+| `/backtest/api/delete/<id>` | DELETE | Delete backtest and its trades |
+| `/backtest/api/export/<id>` | GET | Export results as CSV/JSON |
+| `/backtest/api/check-data` | POST | Check Historify data availability for symbols |
+| `/backtest/api/forward-test/<id>` | POST | Deploy strategy to Sandbox for forward testing |
+| `/backtest/api/events` | GET (SSE) | Real-time progress updates |
+
+#### Execution Model
+
+Run backtests as **background threads** (not subprocesses — they need access to DuckDB in-process).
+
+```python
+from concurrent.futures import ThreadPoolExecutor
+
+# Max 3 concurrent backtests
+backtest_executor = ThreadPoolExecutor(max_workers=3, thread_name_prefix='backtest')
+
+@backtest_bp.route('/api/run', methods=['POST'])
+@login_required
+def run_backtest():
+    config = request.json
+
+    # Validate configuration
+    # ...
+
+    # Create BacktestRun record
+    run = BacktestRun(id=generate_id(), user_id=current_user.id, ...)
+    db.session.add(run)
+    db.session.commit()
+
+    # Submit to thread pool
+    future = backtest_executor.submit(_run_backtest_task, run.id, config['strategy_code'])
+
+    return {'status': 'success', 'backtest_id': run.id}
+
+
+def _run_backtest_task(backtest_id, strategy_code):
+    """Background task that runs the backtest."""
+    run = BacktestRun.query.get(backtest_id)
+    run.status = 'running'
+    run.started_at = datetime.now()
+    db.session.commit()
+
+    try:
+        engine = BacktestEngine()
+        results = engine.run(run, strategy_code)
+
+        # Save results
+        run.status = 'completed'
+        run.completed_at = datetime.now()
+        run.duration_ms = int((run.completed_at - run.started_at).total_seconds() * 1000)
+
+        # Populate all metric columns from results['metrics']
+        for key, value in results['metrics'].items():
+            if hasattr(run, key):
+                setattr(run, key, value)
+
+        run.equity_curve_json = json.dumps(results['equity_curve'])
+        run.monthly_returns_json = json.dumps(results['metrics'].get('monthly_returns', {}))
+
+        # Save individual trades
+        for trade in results['trades']:
+            bt_trade = BacktestTrade(backtest_id=backtest_id, **trade)
+            db.session.add(bt_trade)
+
+        db.session.commit()
+
+        # Notify UI
+        socketio.emit('backtest_complete', {'backtest_id': backtest_id, 'status': 'completed'})
+
+    except Exception as e:
+        run.status = 'failed'
+        run.error_message = str(e)
+        run.completed_at = datetime.now()
+        db.session.commit()
+        socketio.emit('backtest_complete', {'backtest_id': backtest_id, 'status': 'failed', 'error': str(e)})
+```
+
+---
+
+## Phase 2: Frontend
+
+### Step 7 — React Pages
+
+**New files to create:**
+
+```
+frontend/src/pages/backtest/
+    BacktestIndex.tsx        # List all backtests with status
+    NewBacktest.tsx           # Configuration + code editor
+    BacktestResults.tsx       # Full results dashboard
+    CompareBacktests.tsx      # Side-by-side comparison
+
+frontend/src/api/backtest.ts         # API client functions
+frontend/src/types/backtest.ts       # TypeScript type definitions
+```
+
+#### BacktestIndex.tsx
+
+Table of past backtests showing:
+- Name, symbols, date range, interval
+- Status badges: `pending`, `running` (with progress %), `completed`, `failed`
+- Key metrics columns: Return %, Sharpe, Max DD, Win Rate, Trades
+- SSE-based real-time status updates (reuse pattern from PythonStrategyIndex.tsx)
+- Actions: View Results, Re-run, Compare, Delete
+
+#### NewBacktest.tsx
+
+Configuration form with:
+
+```
++--------------------------------------------------+
+| New Backtest                                      |
++--------------------------------------------------+
+|                                                   |
+| Strategy: [Select existing v] or [Write new]      |
+|                                                   |
+| +-----------------------------------------------+ |
+| | # Python Editor (CodeMirror)                  | |
+| | from openalgo import api                      | |
+| | client = api(api_key='...', host='...')       | |
+| | ...                                           | |
+| +-----------------------------------------------+ |
+|                                                   |
+| -- Configuration -------------------------------- |
+|                                                   |
+| Symbols:   [SBIN:NSE] [+ Add]                    |
+| Interval:  [5m v]                                 |
+| Period:    [2024-01-01] to [2024-12-31]           |
+| Capital:   [Rs.10,00,000]                         |
+|                                                   |
+| -- Costs ---------------------------------------- |
+|                                                   |
+| Slippage:     [0.05] %                            |
+| Commission:   [Rs.20] per order                   |
+| Data Source:  (*) Local DB  ( ) Broker API        |
+|                                                   |
+|          [> Run Backtest]                         |
+|                                                   |
+| -- Data Availability -------------------------    |
+| SBIN:NSE 1m: 2023-06-01 to 2025-02-28 (450K) OK |
+| Missing: None                                     |
++--------------------------------------------------+
+```
+
+Key features:
+- Strategy selector dropdown (loads from existing Python strategies)
+- CodeMirror Python editor (reuse existing `PythonEditor` component)
+- Multi-symbol input with exchange selector
+- Date range pickers
+- Data availability check (queries Historify `data_catalog` before run)
+- Real-time progress after submission (SSE)
+
+#### BacktestResults.tsx
+
+Full results dashboard:
+
+```
++--------------------------------------------------+
+| Backtest: EMA Crossover - SBIN 5m                 |
+| Period: 2024-01-01 to 2024-12-31                  |
++--------------------------------------------------+
+|                                                   |
+| +------+ +------+ +------+ +------+ +--------+   |
+| |Return| |Sharpe| |MaxDD | |Wins  | |Profit  |   |
+| |+24.3%| | 1.82 | |-8.2% | | 58%  | |Factor  |   |
+| |      | |      | |      | |      | |  1.74  |   |
+| +------+ +------+ +------+ +------+ +--------+   |
+|                                                   |
+| -- Equity Curve --------------------------------  |
+| +-----------------------------------------------+ |
+| | Lightweight Charts: equity line + DD overlay  | |
+| +-----------------------------------------------+ |
+|                                                   |
+| -- Monthly Returns Heatmap ---------------------  |
+| +-----------------------------------------------+ |
+| | Jan  Feb  Mar  Apr  May  Jun ...              | |
+| | +2.1 -0.8 +3.4 +1.2 -1.5 +4.2 ...           | |
+| +-----------------------------------------------+ |
+|                                                   |
+| -- Trade Log -----------------------------------  |
+| +-----------------------------------------------+ |
+| | #  Symbol  Action  Entry  Exit  P&L  Bars     | |
+| | 1  SBIN    BUY     780    812   +32  14       | |
+| | 2  SBIN    SELL    812    795   +17   8       | |
+| | ...                                           | |
+| +-----------------------------------------------+ |
+|                                                   |
+| [Export CSV] [Re-run] [Forward Test in Sandbox]   |
+|                                                   |
++--------------------------------------------------+
+```
+
+Components used:
+- `lightweight-charts` (already in deps) for equity curve + drawdown overlay
+- CSS grid heatmap for monthly returns (green/red cells, no extra dependency)
+- shadcn `Table` for trade log with column sorting and filtering
+- shadcn `Card` for metric summary cards
+- Buttons: Export CSV, Re-run (copies config to NewBacktest), Forward Test
+
+#### CompareBacktests.tsx
+
+Side-by-side comparison of 2-4 backtests:
+- Overlaid equity curves on same chart
+- Metric comparison table (rows = metrics, columns = backtests)
+- Select backtests via checkboxes on BacktestIndex
+
+---
+
+### Step 8 — Frontend API Layer & Routes
+
+#### API Client (`frontend/src/api/backtest.ts`)
+
+```typescript
+import { webClient, apiClient } from './client'
+
+export const backtestApi = {
+  run: (config: BacktestConfig) =>
+    webClient.post('/backtest/api/run', config),
+
+  getStatus: (id: string) =>
+    webClient.get(`/backtest/api/status/${id}`),
+
+  getResults: (id: string) =>
+    webClient.get(`/backtest/api/results/${id}`),
+
+  cancel: (id: string) =>
+    webClient.post(`/backtest/api/cancel/${id}`),
+
+  list: () =>
+    webClient.get('/backtest/api/list'),
+
+  delete: (id: string) =>
+    webClient.delete(`/backtest/api/delete/${id}`),
+
+  exportCSV: (id: string) =>
+    webClient.get(`/backtest/api/export/${id}`, { responseType: 'blob' }),
+
+  checkData: (symbols: SymbolConfig[], interval: string, startDate: string, endDate: string) =>
+    webClient.post('/backtest/api/check-data', { symbols, interval, startDate, endDate }),
+
+  forwardTest: (id: string) =>
+    webClient.post(`/backtest/api/forward-test/${id}`),
+
+  streamEvents: () =>
+    new EventSource('/backtest/api/events'),
+}
+```
+
+#### TypeScript Types (`frontend/src/types/backtest.ts`)
+
+```typescript
+export interface BacktestConfig {
+  name: string
+  strategy_id?: string
+  strategy_code: string
+  symbols: { symbol: string; exchange: string }[]
+  start_date: string
+  end_date: string
+  interval: string
+  initial_capital: number
+  slippage_pct: number
+  commission_per_order: number
+  data_source: 'db' | 'api'
+}
+
+export interface BacktestRun {
+  id: string
+  name: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  symbols: { symbol: string; exchange: string }[]
+  start_date: string
+  end_date: string
+  interval: string
+  initial_capital: number
+  // Metrics
+  total_return_pct: number
+  cagr: number
+  sharpe_ratio: number
+  sortino_ratio: number
+  max_drawdown_pct: number
+  calmar_ratio: number
+  win_rate: number
+  profit_factor: number
+  total_trades: number
+  // ... other fields
+  created_at: string
+  duration_ms: number
+  error_message?: string
+}
+
+export interface BacktestTrade {
+  trade_num: number
+  symbol: string
+  exchange: string
+  action: 'LONG' | 'SHORT'
+  quantity: number
+  entry_price: number
+  exit_price: number
+  entry_time: string
+  exit_time: string
+  pnl: number
+  net_pnl: number
+  bars_held: number
+}
+
+export interface EquityCurvePoint {
+  timestamp: number
+  equity: number
+  drawdown: number
+}
+
+export interface DataAvailability {
+  symbol: string
+  exchange: string
+  interval: string
+  has_data: boolean
+  first_date: string
+  last_date: string
+  record_count: number
+}
+```
+
+#### Routes (add to `frontend/src/App.tsx`)
+
+```typescript
+const BacktestIndex = lazy(() => import('@/pages/backtest/BacktestIndex'))
+const NewBacktest = lazy(() => import('@/pages/backtest/NewBacktest'))
+const BacktestResults = lazy(() => import('@/pages/backtest/BacktestResults'))
+const CompareBacktests = lazy(() => import('@/pages/backtest/CompareBacktests'))
+
+// Inside protected routes:
+<Route path="/backtest" element={<BacktestIndex />} />
+<Route path="/backtest/new" element={<NewBacktest />} />
+<Route path="/backtest/:id" element={<BacktestResults />} />
+<Route path="/backtest/compare" element={<CompareBacktests />} />
+```
+
+#### Navigation (add to `frontend/src/config/navigation.ts`)
+
+Add "Backtest" item under Strategies section, with icon `FlaskConical` or `TestTube` from lucide-react.
+
+---
+
+## Phase 3: Sandbox Bridge (Backtest to Forward Test to Live)
+
+### Step 9 — One-Click Forward Test
+
+On the BacktestResults page, a "Forward Test in Sandbox" button that:
+
+1. Copies the strategy code to Python Strategies (`strategies/scripts/`)
+2. Auto-enables Analyzer mode (sandbox)
+3. Starts the strategy with market-hours scheduler
+4. Links backtest results to the forward test for comparison
+
+```python
+@backtest_bp.route('/api/forward-test/<backtest_id>', methods=['POST'])
+@login_required
+def start_forward_test(backtest_id):
+    run = BacktestRun.query.get(backtest_id)
+    if not run:
+        return {'status': 'error', 'message': 'Backtest not found'}, 404
+
+    # 1. Save strategy as Python Strategy
+    strategy_id = save_as_python_strategy(
+        code=run.strategy_code,
+        name=f"FWD-{run.name}",
+        schedule={'start_time': '09:15', 'stop_time': '15:30', 'days': ['mon','tue','wed','thu','fri']}
+    )
+
+    # 2. Enable analyzer mode
+    from database.settings_db import update_setting
+    update_setting('analyze_mode', 'true')
+
+    # 3. Start strategy
+    from blueprints.python_strategy import start_strategy
+    start_strategy(strategy_id)
+
+    return {
+        'status': 'success',
+        'strategy_id': strategy_id,
+        'message': 'Strategy deployed to Sandbox mode. Monitor at /python'
+    }
+```
+
+### Step 10 — Go Live
+
+From forward test results (Python Strategy page), a "Go Live" button that:
+1. Disables analyzer mode
+2. Shows confirmation modal with warning
+3. Restarts the same strategy in live mode
+
+---
+
+## Phase 4: Advanced Features (Post-MVP)
+
+### Step 11 — Parameter Optimization
+
+Grid search across parameter combinations:
+
+```python
+# User defines parameter grid in UI:
+params = {
+    'fast_period': [5, 10, 15, 20],
+    'slow_period': [20, 30, 50],
+}
+# Engine runs all 12 combinations as separate backtests
+# Results shown as heatmap (rows=fast_period, cols=slow_period, color=return%)
+# Overfitting warning: use walk-forward validation (train/test split)
+```
+
+### Step 12 — Multi-Symbol Portfolio Backtest
+
+Support strategies that trade multiple symbols with:
+- Shared capital pool
+- Portfolio-level drawdown tracking
+- Correlation analysis between strategy returns
+- Per-symbol allocation limits
+
+### Step 13 — Benchmark Comparison
+
+Compare backtest returns against:
+- Buy & hold (same symbol)
+- Nifty 50 index
+- Fixed deposit rate (7% annualized)
+- Other backtests (overlay equity curves)
+
+---
+
+## File Summary — What Gets Created
+
+```
+# Backend (Python)
+database/backtest_db.py              # Schema + init (BacktestRun, BacktestTrade)
+services/backtest_engine.py          # Bar replay orchestrator
+services/backtest_client.py          # Mock openalgo.api client (drop-in replacement)
+services/backtest_patcher.py         # Strategy code transformation (regex + namespace injection)
+services/backtest_metrics.py         # Performance metric calculations
+blueprints/backtest.py               # UI routes + API endpoints + SSE progress
+
+# Frontend (React/TypeScript)
+frontend/src/api/backtest.ts         # API client functions
+frontend/src/types/backtest.ts       # TypeScript type definitions
+frontend/src/pages/backtest/
+  BacktestIndex.tsx                  # Dashboard listing all backtests
+  NewBacktest.tsx                    # Configuration form + code editor
+  BacktestResults.tsx                # Results visualization (charts + metrics + trades)
+  CompareBacktests.tsx               # Side-by-side comparison
+
+# Database
+db/backtest.db                       # Auto-created on first run
+
+# Migrations
+upgrade/migrate_backtest.py          # DB initialization script (idempotent)
+```
+
+---
+
+## Files Modified
+
+```
+app.py                                # Add init_backtest_db() to parallel DB init (~line 484)
+                                       # Register backtest blueprint (~line 240)
+                                       # Add DB session cleanup for backtest DB (~line 650)
+
+frontend/src/App.tsx                   # Add backtest routes (4 lazy imports + Route elements)
+frontend/src/config/navigation.ts      # Add "Backtest" nav item under Strategies section
+```
+
+---
+
+## Implementation Order
+
+| Step | What | Depends On | Effort |
+|------|------|-----------|--------|
+| 1 | `database/backtest_db.py` | Nothing | 1 day |
+| 2 | `services/backtest_client.py` | Step 1 | 3 days |
+| 3 | `services/backtest_engine.py` | Step 2 | 3 days |
+| 4 | `services/backtest_patcher.py` | Step 3 | 2 days |
+| 5 | `services/backtest_metrics.py` | Step 3 | 1 day |
+| 6 | `blueprints/backtest.py` | Steps 1-5 | 2 days |
+| 7 | Frontend pages (4 files + api + types) | Step 6 | 4 days |
+| 8 | Route + nav integration | Step 7 | 0.5 day |
+| 9 | Forward test bridge | Steps 6, 7 | 1 day |
+| 10 | Go live button | Step 9 | 0.5 day |
+| 11-13 | Advanced features (optimization, portfolio, benchmarks) | All above | 5+ days |
+
+**Total MVP (Steps 1-10): ~18 working days**
+
+---
+
+## Key Risks & Mitigations
+
+| Risk | Mitigation |
+|------|-----------|
+| **Strategy patching fragility** | Start with regex approach (Step 4 Approach A). Test with all example strategies in `strategies/examples/` and `examples/python/`. Fall back to subprocess mode with env-var SDK interception if needed |
+| **Look-ahead bias** | `BacktestClient.history()` strictly returns data up to current bar only. Code review checkpoint |
+| **Slow on 1m data (90K+ bars)** | DuckDB vectorized queries are fast (<50ms). Profile and optimize hot paths. Add progress bar. Downsample equity curve if >100K points |
+| **Strategy uses external APIs** | Document limitation: backtest only works with `openalgo` SDK calls. External HTTP calls will fail. Show clear error message |
+| **Memory for large equity curves** | Downsample equity curve (every Nth bar) if >100K points. Full data stays in DB |
+| **Concurrent backtests** | ThreadPoolExecutor with max 3 workers. Queue additional requests. Show "queued" status in UI |
+| **DuckDB thread safety** | DuckDB supports concurrent reads. Each backtest thread gets its own connection |
+| **Strategy infinite loops** | Timeout per backtest (configurable, default 5 minutes). Kill thread on timeout |
+
+---
+
+## Testing Strategy
+
+### Unit Tests
+- `test/test_backtest_client.py`: Test all SDK methods against known historical data
+- `test/test_backtest_metrics.py`: Test metric calculations with known trade sequences
+- `test/test_backtest_patcher.py`: Test strategy patching with various code patterns
+
+### Integration Tests
+- Run backtests with example strategies (`ema_crossover.py`, `supertrend.py`)
+- Compare results with VectorBT reference implementation (`backtesting_vectorbt.py`)
+- Verify no look-ahead bias: results should be identical when run bar-by-bar vs full dataset
+
+### Manual Testing
+- Run via UI at `/backtest/new`
+- Verify equity curve chart renders correctly
+- Verify trade log matches expected fills
+- Test cancellation mid-run
+- Test with missing data (should show clear error)
+- Test forward test deployment to sandbox

--- a/app.py
+++ b/app.py
@@ -20,6 +20,7 @@ from flask import Flask, session
 from flask_wtf.csrf import CSRFProtect  # Import CSRF protection
 
 from blueprints.admin import admin_bp  # Import the admin blueprint
+from blueprints.backtest import backtest_bp  # Import the backtest blueprint
 from blueprints.analyzer import analyzer_bp  # Import the analyzer blueprint
 from blueprints.apikey import api_key_bp
 from blueprints.auth import auth_bp
@@ -79,6 +80,7 @@ from database.chartink_db import init_db as ensure_chartink_tables_exists
 from database.flow_db import init_db as ensure_flow_tables_exists
 from database.historify_db import init_database as ensure_historify_tables_exists
 from database.latency_db import init_latency_db as ensure_latency_tables_exists
+from database.backtest_db import init_db as ensure_backtest_tables_exists
 from database.sandbox_db import init_db as ensure_sandbox_tables_exists
 from database.settings_db import init_db as ensure_settings_tables_exists
 from database.strategy_db import init_db as ensure_strategy_tables_exists
@@ -253,6 +255,7 @@ def create_app():
     app.register_blueprint(flow_bp)  # Register Flow blueprint
     app.register_blueprint(broker_credentials_bp)  # Register Broker credentials blueprint
     app.register_blueprint(system_permissions_bp)  # Register System permissions blueprint
+    app.register_blueprint(backtest_bp)  # Register Backtest blueprint
 
     # Exempt webhook endpoints from CSRF protection after app initialization
     with app.app_context():
@@ -507,6 +510,7 @@ def setup_environment(app):
             ("Qty Freeze DB", ensure_qty_freeze_tables_exists),
             ("Historify DB", ensure_historify_tables_exists),
             ("Flow DB", ensure_flow_tables_exists),
+            ("Backtest DB", ensure_backtest_tables_exists),
         ]
 
         db_init_start = time.time()
@@ -677,6 +681,12 @@ def shutdown_database_sessions(exception=None):
     except Exception as e:
         logger.error(f"Error removing health_session: {e}")
 
+    try:
+        from database.backtest_db import db_session as backtest_session
+        backtest_session.remove()
+    except Exception as e:
+        logger.error(f"Error removing backtest_session: {e}")
+
 
 # Integrate the WebSocket proxy server with the Flask app
 # Check if running in Docker (standalone mode) or local (integrated mode)
@@ -844,4 +854,4 @@ if __name__ == "__main__":
             "*.bak",
         ]
     }
-    socketio.run(app, host=host_ip, port=port, debug=debug, reloader_options=reloader_options)
+    socketio.run(app, host=host_ip, port=port, debug=debug, reloader_options=reloader_options, allow_unsafe_werkzeug=True)

--- a/blueprints/backtest.py
+++ b/blueprints/backtest.py
@@ -1,0 +1,555 @@
+# blueprints/backtest.py
+"""
+Backtest Blueprint
+
+API routes for backtesting engine: run, status, results, list, cancel, delete, export.
+SSE endpoint for live progress streaming.
+Note: The /backtest pages are served by react_app.py (React frontend).
+"""
+
+import csv
+import io
+import json
+import os
+import traceback
+from concurrent.futures import ThreadPoolExecutor
+from queue import Empty, Queue
+
+from flask import Blueprint, Response, jsonify, request, session, stream_with_context
+
+from database.backtest_db import (
+    BacktestRun,
+    BacktestTrade,
+    db_session,
+    delete_backtest,
+    get_backtest_run,
+    get_backtest_trades,
+    get_user_backtests,
+)
+from limiter import limiter
+from services.backtest_engine import (
+    cancel_backtest,
+    generate_backtest_id,
+    get_active_backtests,
+    start_backtest,
+    validate_data_availability,
+)
+from utils.logging import get_logger
+from utils.session import check_session_validity
+
+logger = get_logger(__name__)
+
+# Rate limits
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "50 per second")
+
+# Thread pool for backtest execution (max 3 concurrent)
+_executor = ThreadPoolExecutor(max_workers=3, thread_name_prefix="backtest")
+
+# Progress queues for SSE — {backtest_id: Queue}
+_progress_queues = {}
+
+backtest_bp = Blueprint("backtest_bp", __name__, url_prefix="/backtest")
+
+
+@backtest_bp.errorhandler(429)
+def ratelimit_handler(e):
+    """Handle rate limit exceeded errors"""
+    return jsonify(
+        {"status": "error", "message": "Rate limit exceeded. Please try again later."}
+    ), 429
+
+
+# ─── Run a Backtest ───────────────────────────────────────────────
+
+@backtest_bp.route("/api/run", methods=["POST"])
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def run_backtest():
+    """Launch a new backtest run."""
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"status": "error", "message": "No JSON body"}), 400
+
+        # Validate required fields
+        required = ["strategy_code", "symbols", "start_date", "end_date", "interval"]
+        missing = [f for f in required if not data.get(f)]
+        if missing:
+            return jsonify({
+                "status": "error",
+                "message": f"Missing required fields: {', '.join(missing)}",
+            }), 400
+
+        # Build config
+        backtest_id = generate_backtest_id()
+        symbols = data.get("symbols", [])
+        if isinstance(symbols, str):
+            symbols = [s.strip() for s in symbols.split(",") if s.strip()]
+
+        config = {
+            "backtest_id": backtest_id,
+            "user_id": session.get("user"),
+            "name": data.get("name", f"Backtest {backtest_id}"),
+            "strategy_id": data.get("strategy_id"),
+            "strategy_code": data["strategy_code"],
+            "symbols": symbols,
+            "exchange": data.get("exchange", "NSE"),
+            "start_date": data["start_date"],
+            "end_date": data["end_date"],
+            "interval": data["interval"],
+            "initial_capital": float(data.get("initial_capital", 100000)),
+            "slippage_pct": float(data.get("slippage_pct", 0.05)),
+            "commission_per_order": float(data.get("commission_per_order", 20.0)),
+            "commission_pct": float(data.get("commission_pct", 0.0)),
+            "data_source": data.get("data_source", "db"),
+        }
+
+        # Create progress queue for SSE
+        progress_queue = Queue(maxsize=200)
+        _progress_queues[backtest_id] = progress_queue
+
+        def progress_callback(bt_id, pct, message):
+            q = _progress_queues.get(bt_id)
+            if q:
+                try:
+                    q.put_nowait({"backtest_id": bt_id, "progress": pct, "message": message})
+                except Exception:
+                    pass  # Queue full — skip update
+
+        # Submit to thread pool
+        def _run_and_cleanup():
+            try:
+                result = start_backtest(config, progress_callback)
+                # Signal completion via queue
+                q = _progress_queues.get(backtest_id)
+                if q:
+                    q.put_nowait({
+                        "backtest_id": backtest_id,
+                        "progress": 100,
+                        "message": "done",
+                        "status": result.get("status", "completed"),
+                    })
+            except Exception as e:
+                logger.exception(f"Backtest thread error: {e}")
+                q = _progress_queues.get(backtest_id)
+                if q:
+                    q.put_nowait({
+                        "backtest_id": backtest_id,
+                        "progress": 0,
+                        "message": str(e),
+                        "status": "failed",
+                    })
+            finally:
+                # Cleanup queue after a delay (let SSE drain)
+                import threading
+                def _cleanup():
+                    import time
+                    time.sleep(30)
+                    _progress_queues.pop(backtest_id, None)
+                threading.Thread(target=_cleanup, daemon=True).start()
+
+        _executor.submit(_run_and_cleanup)
+
+        return jsonify({
+            "status": "success",
+            "backtest_id": backtest_id,
+            "message": "Backtest started",
+        }), 202
+
+    except Exception as e:
+        logger.error(f"Error starting backtest: {e}")
+        traceback.print_exc()
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── SSE Progress Stream ─────────────────────────────────────────
+
+@backtest_bp.route("/api/events/<backtest_id>")
+@check_session_validity
+def backtest_events(backtest_id):
+    """SSE endpoint for live backtest progress updates."""
+    def generate():
+        q = _progress_queues.get(backtest_id)
+        if not q:
+            # Check if backtest already completed
+            run = get_backtest_run(backtest_id)
+            if run and run.status in ("completed", "failed", "cancelled"):
+                yield f"data: {json.dumps({'backtest_id': backtest_id, 'progress': 100, 'message': 'done', 'status': run.status})}\n\n"
+            else:
+                yield f"data: {json.dumps({'backtest_id': backtest_id, 'progress': 0, 'message': 'Not found'})}\n\n"
+            return
+
+        while True:
+            try:
+                event = q.get(timeout=30)  # 30s heartbeat timeout
+                yield f"data: {json.dumps(event)}\n\n"
+                # Check if done
+                if event.get("status") in ("completed", "failed", "cancelled"):
+                    break
+                if event.get("message") == "done":
+                    break
+            except Empty:
+                # Send heartbeat to keep connection alive
+                yield f"data: {json.dumps({'heartbeat': True})}\n\n"
+
+    return Response(
+        stream_with_context(generate()),
+        mimetype="text/event-stream",
+        headers={
+            "Cache-Control": "no-cache",
+            "X-Accel-Buffering": "no",
+        },
+    )
+
+
+# ─── Status & Results ─────────────────────────────────────────────
+
+@backtest_bp.route("/api/status/<backtest_id>")
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def backtest_status(backtest_id):
+    """Get current status of a backtest run."""
+    try:
+        run = get_backtest_run(backtest_id)
+        if not run:
+            return jsonify({"status": "error", "message": "Backtest not found"}), 404
+
+        return jsonify({
+            "status": "success",
+            "data": {
+                "backtest_id": run.id,
+                "name": run.name,
+                "status": run.status,
+                "created_at": str(run.created_at) if run.created_at else None,
+                "started_at": str(run.started_at) if run.started_at else None,
+                "completed_at": str(run.completed_at) if run.completed_at else None,
+                "duration_ms": run.duration_ms,
+                "error_message": run.error_message,
+            },
+        })
+    except Exception as e:
+        logger.error(f"Error fetching backtest status: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+@backtest_bp.route("/api/results/<backtest_id>")
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def backtest_results(backtest_id):
+    """Get full results for a completed backtest."""
+    try:
+        run = get_backtest_run(backtest_id)
+        if not run:
+            return jsonify({"status": "error", "message": "Backtest not found"}), 404
+
+        if run.status != "completed":
+            return jsonify({
+                "status": "error",
+                "message": f"Backtest is {run.status}, not completed",
+            }), 400
+
+        # Build metrics dict from DB columns
+        metrics = {
+            "final_capital": float(run.final_capital or 0),
+            "total_return_pct": float(run.total_return_pct or 0),
+            "cagr": float(run.cagr or 0),
+            "sharpe_ratio": float(run.sharpe_ratio or 0),
+            "sortino_ratio": float(run.sortino_ratio or 0),
+            "max_drawdown_pct": float(run.max_drawdown_pct or 0),
+            "calmar_ratio": float(run.calmar_ratio or 0),
+            "win_rate": float(run.win_rate or 0),
+            "profit_factor": float(run.profit_factor or 0),
+            "total_trades": run.total_trades or 0,
+            "winning_trades": run.winning_trades or 0,
+            "losing_trades": run.losing_trades or 0,
+            "avg_win": float(run.avg_win or 0),
+            "avg_loss": float(run.avg_loss or 0),
+            "max_win": float(run.max_win or 0),
+            "max_loss": float(run.max_loss or 0),
+            "expectancy": float(run.expectancy or 0),
+            "avg_holding_bars": run.avg_holding_bars or 0,
+            "total_commission": float(run.total_commission or 0),
+            "total_slippage": float(run.total_slippage or 0),
+        }
+
+        # Parse stored JSON
+        equity_curve = json.loads(run.equity_curve_json) if run.equity_curve_json else []
+        monthly_returns = json.loads(run.monthly_returns_json) if run.monthly_returns_json else {}
+
+        # Get trades
+        trades = get_backtest_trades(backtest_id)
+        trades_list = [
+            {
+                "trade_num": t.trade_num,
+                "symbol": t.symbol,
+                "exchange": t.exchange,
+                "action": t.action,
+                "quantity": t.quantity,
+                "entry_price": float(t.entry_price or 0),
+                "exit_price": float(t.exit_price or 0),
+                "entry_time": t.entry_time,
+                "exit_time": t.exit_time,
+                "pnl": float(t.pnl or 0),
+                "pnl_pct": float(t.pnl_pct or 0),
+                "commission": float(t.commission or 0),
+                "slippage_cost": float(t.slippage_cost or 0),
+                "net_pnl": float(t.net_pnl or 0),
+                "bars_held": t.bars_held or 0,
+                "product": t.product,
+                "strategy_tag": t.strategy_tag,
+            }
+            for t in trades
+        ]
+
+        return jsonify({
+            "status": "success",
+            "data": {
+                "backtest_id": run.id,
+                "name": run.name,
+                "config": {
+                    "symbols": json.loads(run.symbols) if run.symbols else [],
+                    "start_date": run.start_date,
+                    "end_date": run.end_date,
+                    "interval": run.interval,
+                    "initial_capital": float(run.initial_capital or 0),
+                    "slippage_pct": float(run.slippage_pct or 0),
+                    "commission_per_order": float(run.commission_per_order or 0),
+                    "commission_pct": float(run.commission_pct or 0),
+                },
+                "metrics": metrics,
+                "equity_curve": equity_curve,
+                "monthly_returns": monthly_returns,
+                "trades": trades_list,
+                "duration_ms": run.duration_ms,
+                "created_at": str(run.created_at) if run.created_at else None,
+                "completed_at": str(run.completed_at) if run.completed_at else None,
+            },
+        })
+    except Exception as e:
+        logger.error(f"Error fetching backtest results: {e}")
+        traceback.print_exc()
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── List Backtests ───────────────────────────────────────────────
+
+@backtest_bp.route("/api/list")
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def list_backtests():
+    """List all backtests for the current user."""
+    try:
+        user_id = session.get("user")
+        limit = request.args.get("limit", 50, type=int)
+        runs = get_user_backtests(user_id, limit=limit)
+
+        data = []
+        for run in runs:
+            data.append({
+                "backtest_id": run.id,
+                "name": run.name,
+                "status": run.status,
+                "symbols": json.loads(run.symbols) if run.symbols else [],
+                "interval": run.interval,
+                "start_date": run.start_date,
+                "end_date": run.end_date,
+                "initial_capital": float(run.initial_capital or 0),
+                "total_return_pct": float(run.total_return_pct or 0) if run.total_return_pct else None,
+                "sharpe_ratio": float(run.sharpe_ratio or 0) if run.sharpe_ratio else None,
+                "max_drawdown_pct": float(run.max_drawdown_pct or 0) if run.max_drawdown_pct else None,
+                "total_trades": run.total_trades or 0,
+                "win_rate": float(run.win_rate or 0) if run.win_rate else None,
+                "duration_ms": run.duration_ms,
+                "created_at": str(run.created_at) if run.created_at else None,
+                "error_message": run.error_message,
+            })
+
+        return jsonify({"status": "success", "data": data})
+    except Exception as e:
+        logger.error(f"Error listing backtests: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── Cancel ───────────────────────────────────────────────────────
+
+@backtest_bp.route("/api/cancel/<backtest_id>", methods=["POST"])
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def cancel_backtest_route(backtest_id):
+    """Cancel a running backtest."""
+    try:
+        cancelled = cancel_backtest(backtest_id)
+        if cancelled:
+            return jsonify({"status": "success", "message": "Cancellation requested"})
+        return jsonify({
+            "status": "error",
+            "message": "Backtest not running or not found",
+        }), 404
+    except Exception as e:
+        logger.error(f"Error cancelling backtest: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── Delete ───────────────────────────────────────────────────────
+
+@backtest_bp.route("/api/delete/<backtest_id>", methods=["DELETE"])
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def delete_backtest_route(backtest_id):
+    """Delete a backtest run and all its trades."""
+    try:
+        # Verify ownership
+        run = get_backtest_run(backtest_id)
+        if not run:
+            return jsonify({"status": "error", "message": "Backtest not found"}), 404
+
+        if run.user_id != session.get("user"):
+            return jsonify({"status": "error", "message": "Unauthorized"}), 403
+
+        success = delete_backtest(backtest_id)
+        if success:
+            return jsonify({"status": "success", "message": "Backtest deleted"})
+        return jsonify({"status": "error", "message": "Failed to delete"}), 500
+    except Exception as e:
+        logger.error(f"Error deleting backtest: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── Export ───────────────────────────────────────────────────────
+
+@backtest_bp.route("/api/export/<backtest_id>")
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def export_backtest(backtest_id):
+    """Export backtest trades as CSV."""
+    try:
+        run = get_backtest_run(backtest_id)
+        if not run:
+            return jsonify({"status": "error", "message": "Backtest not found"}), 404
+
+        trades = get_backtest_trades(backtest_id)
+
+        # Build CSV
+        output = io.StringIO()
+        writer = csv.writer(output)
+        writer.writerow([
+            "Trade#", "Symbol", "Exchange", "Action", "Quantity",
+            "Entry Price", "Exit Price", "Entry Time", "Exit Time",
+            "P&L", "P&L%", "Commission", "Slippage", "Net P&L",
+            "Bars Held", "Product", "Strategy",
+        ])
+        for t in trades:
+            writer.writerow([
+                t.trade_num, t.symbol, t.exchange, t.action, t.quantity,
+                float(t.entry_price or 0), float(t.exit_price or 0),
+                t.entry_time, t.exit_time,
+                float(t.pnl or 0), float(t.pnl_pct or 0),
+                float(t.commission or 0), float(t.slippage_cost or 0),
+                float(t.net_pnl or 0), t.bars_held or 0,
+                t.product, t.strategy_tag,
+            ])
+
+        output.seek(0)
+        return Response(
+            output.getvalue(),
+            mimetype="text/csv",
+            headers={
+                "Content-Disposition": f"attachment; filename=backtest_{backtest_id}.csv"
+            },
+        )
+    except Exception as e:
+        logger.error(f"Error exporting backtest: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── Check Data Availability ─────────────────────────────────────
+
+@backtest_bp.route("/api/check-data", methods=["POST"])
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def check_data():
+    """Check if historical data is available for the requested configuration."""
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"status": "error", "message": "No JSON body"}), 400
+
+        symbols = data.get("symbols", [])
+        if isinstance(symbols, str):
+            symbols = [s.strip() for s in symbols.split(",") if s.strip()]
+
+        exchange = data.get("exchange", "NSE")
+        interval = data.get("interval", "D")
+        start_date = data.get("start_date", "")
+        end_date = data.get("end_date", "")
+
+        result = validate_data_availability(symbols, exchange, interval, start_date, end_date)
+        return jsonify({"status": "success", "data": result})
+    except Exception as e:
+        logger.error(f"Error checking data availability: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+
+# ─── Compare Backtests ────────────────────────────────────────────
+
+@backtest_bp.route("/api/compare", methods=["POST"])
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def compare_backtests():
+    """Get comparison data for multiple backtests."""
+    try:
+        data = request.get_json()
+        if not data:
+            return jsonify({"status": "error", "message": "No JSON body"}), 400
+
+        backtest_ids = data.get("backtest_ids", [])
+        if len(backtest_ids) < 2:
+            return jsonify({
+                "status": "error",
+                "message": "Need at least 2 backtest IDs to compare",
+            }), 400
+
+        if len(backtest_ids) > 5:
+            return jsonify({
+                "status": "error",
+                "message": "Maximum 5 backtests can be compared at once",
+            }), 400
+
+        results = []
+        for bt_id in backtest_ids:
+            run = get_backtest_run(bt_id)
+            if not run or run.status != "completed":
+                continue
+
+            equity_curve = json.loads(run.equity_curve_json) if run.equity_curve_json else []
+
+            results.append({
+                "backtest_id": run.id,
+                "name": run.name,
+                "config": {
+                    "symbols": json.loads(run.symbols) if run.symbols else [],
+                    "start_date": run.start_date,
+                    "end_date": run.end_date,
+                    "interval": run.interval,
+                    "initial_capital": float(run.initial_capital or 0),
+                },
+                "metrics": {
+                    "final_capital": float(run.final_capital or 0),
+                    "total_return_pct": float(run.total_return_pct or 0),
+                    "cagr": float(run.cagr or 0),
+                    "sharpe_ratio": float(run.sharpe_ratio or 0),
+                    "sortino_ratio": float(run.sortino_ratio or 0),
+                    "max_drawdown_pct": float(run.max_drawdown_pct or 0),
+                    "calmar_ratio": float(run.calmar_ratio or 0),
+                    "win_rate": float(run.win_rate or 0),
+                    "profit_factor": float(run.profit_factor or 0),
+                    "total_trades": run.total_trades or 0,
+                    "expectancy": float(run.expectancy or 0),
+                },
+                "equity_curve": equity_curve,
+            })
+
+        return jsonify({"status": "success", "data": results})
+    except Exception as e:
+        logger.error(f"Error comparing backtests: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500

--- a/database/backtest_db.py
+++ b/database/backtest_db.py
@@ -1,0 +1,215 @@
+# database/backtest_db.py
+"""
+Backtest Database Module
+
+Separate SQLite database for backtesting engine results.
+Stores backtest run configurations, metrics, trades, and equity curves.
+"""
+
+import os
+
+from dotenv import load_dotenv
+from sqlalchemy import (
+    DECIMAL,
+    Column,
+    DateTime,
+    ForeignKey,
+    Index,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
+from sqlalchemy.sql import func
+
+from utils.logging import get_logger
+
+# Initialize logger
+logger = get_logger(__name__)
+
+# Load environment variables
+load_dotenv()
+
+# Backtest database URL - separate database for isolation
+BACKTEST_DATABASE_URL = os.getenv("BACKTEST_DATABASE_URL", "sqlite:///db/backtest.db")
+
+# Create engine with NullPool for SQLite thread safety
+if BACKTEST_DATABASE_URL and "sqlite" in BACKTEST_DATABASE_URL:
+    engine = create_engine(
+        BACKTEST_DATABASE_URL,
+        poolclass=NullPool,
+        connect_args={"check_same_thread": False},
+    )
+else:
+    engine = create_engine(
+        BACKTEST_DATABASE_URL,
+        pool_size=10,
+        max_overflow=20,
+        pool_timeout=10,
+    )
+
+db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+class BacktestRun(Base):
+    """Backtest run configuration and results."""
+
+    __tablename__ = "backtest_runs"
+
+    id = Column(String(50), primary_key=True)  # BT-YYYYMMDD-HHMMSS-{uuid8}
+    user_id = Column(String(50), nullable=False, index=True)
+    name = Column(String(200), nullable=False)
+    strategy_id = Column(String(50), nullable=True)  # link to python_strategy
+    strategy_code = Column(Text, nullable=False)  # snapshot of code at run time
+
+    # Configuration
+    symbols = Column(Text, nullable=False)  # JSON array
+    start_date = Column(String(10), nullable=False)  # YYYY-MM-DD
+    end_date = Column(String(10), nullable=False)
+    interval = Column(String(10), nullable=False)  # 1m, 5m, 15m, 1h, D
+    initial_capital = Column(DECIMAL(15, 2), nullable=False)
+    slippage_pct = Column(DECIMAL(6, 4), nullable=False, default=0.05)
+    commission_per_order = Column(DECIMAL(10, 2), nullable=False, default=20.00)
+    commission_pct = Column(DECIMAL(6, 4), nullable=False, default=0.00)
+    data_source = Column(String(10), nullable=False, default="db")
+
+    # Status
+    status = Column(String(20), nullable=False, default="pending", index=True)
+    # pending / running / completed / failed / cancelled
+
+    # Results - populated after completion
+    final_capital = Column(DECIMAL(15, 2), nullable=True)
+    total_return_pct = Column(DECIMAL(10, 4), nullable=True)
+    cagr = Column(DECIMAL(10, 4), nullable=True)
+    sharpe_ratio = Column(DECIMAL(10, 4), nullable=True)
+    sortino_ratio = Column(DECIMAL(10, 4), nullable=True)
+    max_drawdown_pct = Column(DECIMAL(10, 4), nullable=True)
+    calmar_ratio = Column(DECIMAL(10, 4), nullable=True)
+    win_rate = Column(DECIMAL(10, 4), nullable=True)
+    profit_factor = Column(DECIMAL(10, 4), nullable=True)
+    total_trades = Column(Integer, default=0)
+    winning_trades = Column(Integer, default=0)
+    losing_trades = Column(Integer, default=0)
+    avg_win = Column(DECIMAL(15, 2), nullable=True)
+    avg_loss = Column(DECIMAL(15, 2), nullable=True)
+    max_win = Column(DECIMAL(15, 2), nullable=True)
+    max_loss = Column(DECIMAL(15, 2), nullable=True)
+    expectancy = Column(DECIMAL(15, 2), nullable=True)
+    avg_holding_bars = Column(Integer, nullable=True)
+    total_commission = Column(DECIMAL(15, 2), nullable=True)
+    total_slippage = Column(DECIMAL(15, 2), nullable=True)
+
+    # Serialized large data
+    equity_curve_json = Column(Text, nullable=True)
+    monthly_returns_json = Column(Text, nullable=True)
+    error_message = Column(Text, nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime, nullable=False, default=func.now())
+    started_at = Column(DateTime, nullable=True)
+    completed_at = Column(DateTime, nullable=True)
+    duration_ms = Column(Integer, nullable=True)
+
+    __table_args__ = (
+        Index("idx_backtest_user_status", "user_id", "status"),
+        Index("idx_backtest_created", "created_at"),
+    )
+
+
+class BacktestTrade(Base):
+    """Individual trade within a backtest run."""
+
+    __tablename__ = "backtest_trades"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    backtest_id = Column(
+        String(50),
+        ForeignKey("backtest_runs.id", ondelete="CASCADE"),
+        nullable=False,
+        index=True,
+    )
+    trade_num = Column(Integer, nullable=False)
+
+    symbol = Column(String(50), nullable=False)
+    exchange = Column(String(20), nullable=False)
+    action = Column(String(10), nullable=False)  # LONG / SHORT
+    quantity = Column(Integer, nullable=False)
+    entry_price = Column(DECIMAL(10, 2), nullable=False)
+    exit_price = Column(DECIMAL(10, 2), nullable=True)  # null if still open at end
+    entry_time = Column(String(30), nullable=True)  # ISO timestamp string
+    exit_time = Column(String(30), nullable=True)
+
+    pnl = Column(DECIMAL(15, 2), default=0)
+    pnl_pct = Column(DECIMAL(10, 4), default=0)
+    commission = Column(DECIMAL(10, 2), default=0)
+    slippage_cost = Column(DECIMAL(10, 2), default=0)
+    net_pnl = Column(DECIMAL(15, 2), default=0)
+
+    bars_held = Column(Integer, default=0)
+    product = Column(String(20), nullable=True)
+    strategy_tag = Column(String(100), nullable=True)
+
+    __table_args__ = (
+        Index("idx_bt_trade_backtest_num", "backtest_id", "trade_num"),
+    )
+
+
+def init_db():
+    """Initialize backtest database and tables."""
+    from database.db_init_helper import init_db_with_logging
+
+    init_db_with_logging(Base, engine, "Backtest DB", logger)
+
+
+def get_backtest_run(backtest_id):
+    """Get a backtest run by ID."""
+    try:
+        return BacktestRun.query.filter_by(id=backtest_id).first()
+    except Exception as e:
+        logger.exception(f"Error fetching backtest run {backtest_id}: {e}")
+        return None
+
+
+def get_user_backtests(user_id, limit=50):
+    """Get all backtests for a user, ordered by creation date descending."""
+    try:
+        return (
+            BacktestRun.query.filter_by(user_id=user_id)
+            .order_by(BacktestRun.created_at.desc())
+            .limit(limit)
+            .all()
+        )
+    except Exception as e:
+        logger.exception(f"Error fetching backtests for user {user_id}: {e}")
+        return []
+
+
+def get_backtest_trades(backtest_id):
+    """Get all trades for a backtest run."""
+    try:
+        return (
+            BacktestTrade.query.filter_by(backtest_id=backtest_id)
+            .order_by(BacktestTrade.trade_num)
+            .all()
+        )
+    except Exception as e:
+        logger.exception(f"Error fetching trades for backtest {backtest_id}: {e}")
+        return []
+
+
+def delete_backtest(backtest_id):
+    """Delete a backtest run and all its trades."""
+    try:
+        BacktestTrade.query.filter_by(backtest_id=backtest_id).delete()
+        BacktestRun.query.filter_by(id=backtest_id).delete()
+        db_session.commit()
+        return True
+    except Exception as e:
+        db_session.rollback()
+        logger.exception(f"Error deleting backtest {backtest_id}: {e}")
+        return False

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -234,7 +234,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -655,6 +654,7 @@
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
       "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^2.15.1"
       },
@@ -666,7 +666,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.0",
@@ -777,7 +778,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz",
       "integrity": "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -873,7 +873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -917,7 +916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1559,6 +1557,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
@@ -1571,12 +1570,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
       "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1586,6 +1587,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
       "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "peerDependencies": {
         "mapbox-gl": ">=0.32.1 <2.0.0"
       }
@@ -1594,25 +1596,29 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
       "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
@@ -1622,6 +1628,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1631,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
       "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -1650,13 +1658,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
@@ -1684,13 +1694,15 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.2.tgz",
       "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@plotly/d3-sankey": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
       "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-array": "1",
         "d3-collection": "1",
@@ -1702,6 +1714,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
       "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d3-array": "^1.2.1",
         "d3-collection": "^1.0.4",
@@ -1714,6 +1727,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
       "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
@@ -1747,6 +1761,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
       "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "binary-search-bounds": "^2.0.4",
@@ -1764,7 +1779,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
       "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -4399,7 +4415,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4518,6 +4533,7 @@
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.3.tgz",
       "integrity": "sha512-FT66TCxUec+3RsCCyO1kWP57/tiEWEqYfpIs5n44dup401Cne/E+xunahEWxMfP/HSUxfcRQqrjH5vEulLrNoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4533,6 +4549,7 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.3.tgz",
       "integrity": "sha512-1zNO/JUgDp0N+3EG5fG7+8EolE95OW1LD8ur0hRP0JK+lRyN0gAvJT7n1I9pu/NIqTa8x/zXxGRc1dcOdohYkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4548,6 +4565,7 @@
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.3.tgz",
       "integrity": "sha512-3vWLnF1CksLk7xTUH11IzOQJ6fOoj7zhuL8M3GTxcKruVkGat/vIm3Ye5b68sDVcE5nFDA2pYjjbL7Rfmn3/GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4563,6 +4581,7 @@
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.3.tgz",
       "integrity": "sha512-9Ias0L1GuZPIzO6sk8jraTEuLJye6n9LYNEdw69ZGOQ6C1IigjxkPW49zmn21aTv1z27vxdVLSS3r+78DB2QnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
@@ -4576,6 +4595,7 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.3.tgz",
       "integrity": "sha512-Tz1j4h70iFB5SebWWoVv/uL59x4aOngXU+d1xQDXzOCn/O6txnreGVGMcYU362c5F06yqZx38H9UFTQ553lK0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@types/geojson": "^7946.0.10",
@@ -4589,7 +4609,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4708,13 +4729,15 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
       "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -4804,13 +4827,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
       "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mapbox__vector-tile": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
       "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -4830,7 +4855,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/plotly.js": {
       "version": "3.0.9",
@@ -4848,7 +4874,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4858,7 +4883,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4882,6 +4906,7 @@
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -5204,13 +5229,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
       "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5232,6 +5259,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5272,13 +5300,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
       "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5288,6 +5318,7 @@
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
       "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.0"
       }
@@ -5296,13 +5327,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
       "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-rearrange": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
       "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -5424,25 +5457,29 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
       "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
       "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bitmap-sdf": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
       "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -5486,7 +5523,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5505,7 +5541,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -5557,6 +5594,7 @@
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "element-size": "^1.1.1"
       }
@@ -5629,7 +5667,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -5691,6 +5730,7 @@
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.3.8"
       }
@@ -5700,6 +5740,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5721,6 +5762,7 @@
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1"
       }
@@ -5735,6 +5777,7 @@
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
       "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1",
         "color-rgba": "^2.1.1",
@@ -5746,6 +5789,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5755,6 +5799,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
       "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.4.2",
         "color-space": "^2.0.0"
@@ -5765,6 +5810,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
       "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5774,6 +5820,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
       "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -5783,7 +5830,8 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
       "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -5830,6 +5878,7 @@
         "node >= 0.8"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -5860,13 +5909,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
       "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -5892,6 +5943,7 @@
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font-size-keywords": "^1.0.0",
         "css-font-stretch-keywords": "^1.0.1",
@@ -5908,31 +5960,36 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
       "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-stretch-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
       "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-style-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
       "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-weight-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
       "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-global-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
       "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-line-break": {
       "version": "2.1.0",
@@ -5963,7 +6020,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
       "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -6002,7 +6060,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -6168,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -6180,13 +6240,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -6233,6 +6295,7 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
       "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -6244,25 +6307,29 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
       "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-force/node_modules/d3-timer": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
       "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-geo": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
       "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-array": "1"
       }
@@ -6272,6 +6339,7 @@
       "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
       "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "commander": "2",
         "d3-array": "1",
@@ -6290,13 +6358,15 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-hierarchy": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
       "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -6314,20 +6384,21 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-quadtree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6337,6 +6408,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -6345,13 +6417,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-time-format": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
       "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-time": "1"
       }
@@ -6463,6 +6537,7 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
       "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6488,7 +6563,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
       "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -6595,6 +6671,7 @@
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abs-svg-path": "~0.1.1",
         "normalize-svg-path": "~0.1.0"
@@ -6605,6 +6682,7 @@
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
       "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6626,13 +6704,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
       "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -6644,7 +6724,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -6656,13 +6737,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
       "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/elementary-circuits-directed-graph": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
       "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "strongly-connected-components": "^1.0.1"
       }
@@ -6672,6 +6755,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -6774,6 +6858,7 @@
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -6789,6 +6874,7 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -6800,6 +6886,7 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -6813,6 +6900,7 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -6883,6 +6971,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -6904,6 +6993,7 @@
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -6919,6 +7009,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -6932,6 +7023,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6950,6 +7042,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6959,6 +7052,7 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -6969,6 +7063,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -7004,6 +7099,7 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -7013,6 +7109,7 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
       "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "isarray": "^2.0.1"
@@ -7031,6 +7128,7 @@
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
       "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-string-blank": "^1.0.1"
       }
@@ -7080,6 +7178,7 @@
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dtype": "^2.0.0"
       }
@@ -7108,6 +7207,7 @@
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font": "^1.0.0"
       }
@@ -7117,6 +7217,7 @@
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font": "^1.2.0"
       }
@@ -7163,6 +7264,7 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -7202,13 +7304,15 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
       "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -7258,6 +7362,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7269,19 +7374,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==",
-      "license": "Zlib"
+      "license": "Zlib",
+      "peer": true
     },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/gl-text": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.4.0.tgz",
       "integrity": "sha512-o47+XBqLCj1efmuNyCHt7/UEJmB9l66ql7pnobD6p+sgmBUdzfMZXIF0zD2+KRfpd99DJN+QXdvTFAGCKCVSmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -7307,6 +7415,7 @@
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
       "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",
@@ -7322,6 +7431,7 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
       "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^4.1.3",
         "kind-of": "^6.0.3",
@@ -7336,6 +7446,7 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-token-inject-block": "^1.0.0",
         "glsl-token-string": "^1.0.1",
@@ -7347,6 +7458,7 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "resolve": "^0.6.1",
         "xtend": "^2.1.2"
@@ -7356,12 +7468,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
       "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-resolve/node_modules/xtend": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
       "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -7370,13 +7484,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
       "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-defines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-tokenizer": "^2.0.0"
       }
@@ -7385,13 +7501,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
       "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-descope": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-token-assignments": "^2.0.0",
         "glsl-token-depth": "^1.1.0",
@@ -7403,37 +7521,43 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
       "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-properties": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
       "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-scope": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
       "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
       "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-whitespace-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
       "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "through2": "^0.6.3"
       }
@@ -7442,13 +7566,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer/node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -7460,13 +7586,15 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer/node_modules/through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -7477,6 +7605,7 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
       "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^2.2.1",
         "concat-stream": "^1.5.2",
@@ -7503,6 +7632,7 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-inject-defines": "^1.0.1",
         "glsl-token-defines": "^1.0.0",
@@ -7521,6 +7651,7 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
       "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@choojs/findup": "^0.2.0",
         "events": "^3.2.0",
@@ -7552,7 +7683,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7568,6 +7700,7 @@
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -7577,6 +7710,7 @@
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -7721,6 +7855,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -7746,7 +7881,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -7761,13 +7897,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ini": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
       "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -7798,13 +7936,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
       "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -7829,6 +7969,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       },
@@ -7841,6 +7982,7 @@
       "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
       "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7859,6 +8001,7 @@
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
       "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7867,7 +8010,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-4.0.0.tgz",
       "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7883,6 +8027,7 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7892,6 +8037,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7906,25 +8052,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
       "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-svg-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
       "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.2.tgz",
       "integrity": "sha512-mIcis6w+JiQf3P7t7mg/35GKB4T1FQsBOtMIvuKw4YErj5RjtbhcTd5/I30fmkmGMwvI0WlzSNN+27K0QCMkAw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -8402,7 +8552,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -8453,7 +8602,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8471,13 +8621,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8814,6 +8966,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8869,6 +9022,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "~1.3.0"
       }
@@ -8878,6 +9032,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8921,6 +9076,7 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
       "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -8961,43 +9117,50 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
       "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/earcut": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/geojson-vt": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/potpack": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -9006,7 +9169,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -9021,6 +9185,7 @@
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
       "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9090,6 +9255,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9099,6 +9265,7 @@
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mouse-event": "^1.0.0"
       }
@@ -9107,19 +9274,22 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
       "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
       "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -9135,7 +9305,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9158,13 +9329,15 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/needle": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -9182,6 +9355,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -9199,7 +9373,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -9211,7 +9386,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
       "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -9231,6 +9407,7 @@
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-finite": "^1.0.1"
       },
@@ -9262,6 +9439,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9274,7 +9452,8 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
       "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -9304,6 +9483,7 @@
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pick-by-alias": "^1.2.0"
       }
@@ -9312,13 +9492,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
       "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -9337,7 +9519,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9351,6 +9534,7 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
       "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -9363,13 +9547,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pick-by-alias": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
       "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9412,7 +9598,6 @@
       "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9507,13 +9692,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/polybooljs": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.2.tgz",
       "integrity": "sha512-ziHW/02J0XuNuUtmidBc6GXE8YohYydp3DWPWXYsd7O721TjcmN+k6ezjdwkDqep+gnWnFY+yqZHvzElra2oCg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -9533,7 +9720,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10006,13 +10192,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10035,6 +10223,7 @@
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
       "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -10045,7 +10234,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10077,7 +10267,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -10098,13 +10289,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -10113,7 +10306,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10122,7 +10314,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10134,7 +10325,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/react-plotly.js": {
       "version": "2.6.0",
@@ -10296,6 +10488,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10310,13 +10503,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -10350,13 +10545,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
       "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regl-error2d": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
       "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "color-normalize": "^1.5.0",
@@ -10372,6 +10569,7 @@
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.3.tgz",
       "integrity": "sha512-fkgzW+tTn4QUQLpFKsUIE0sgWdCmXAM3ctXcCgoGBZTSX5FE2A0M7aynz7nrZT5baaftLrk9te54B+MEq4QcSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-find-index": "^1.0.2",
@@ -10391,6 +10589,7 @@
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
       "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -10414,6 +10613,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -10423,6 +10623,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
       "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.4.2",
         "color-space": "^2.0.0"
@@ -10433,6 +10634,7 @@
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
       "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
@@ -10465,6 +10667,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -10485,6 +10688,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -10493,7 +10697,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -10543,7 +10748,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -10563,13 +10769,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sax": {
       "version": "1.4.4",
@@ -10616,7 +10824,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -10628,7 +10837,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
       "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -10680,6 +10890,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10705,6 +10916,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10732,6 +10944,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
       "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escodegen": "^2.1.0"
       }
@@ -10747,6 +10960,7 @@
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2"
       }
@@ -10756,6 +10970,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10764,19 +10979,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10785,13 +11003,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parenthesis": "^3.1.5"
       }
@@ -10812,7 +11032,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
       "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -10842,6 +11063,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
       "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "kdbush": "^3.0.0"
       }
@@ -10850,13 +11072,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
       "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10875,6 +11099,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10886,13 +11111,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/svg-path-bounds": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
       "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abs-svg-path": "^0.1.1",
         "is-svg-path": "^1.0.1",
@@ -10905,6 +11132,7 @@
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
       "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
@@ -10914,6 +11142,7 @@
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
       "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bitmap-sdf": "^1.0.0",
         "draw-svg-path": "^1.0.0",
@@ -10993,6 +11222,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -11008,7 +11238,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -11038,7 +11269,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
@@ -11073,13 +11305,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
       "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/to-px": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
       "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-unit": "^1.0.1"
       }
@@ -11101,6 +11335,7 @@
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "commander": "2"
       },
@@ -11114,7 +11349,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
@@ -11160,19 +11396,22 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typedarray-pool": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
       "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
@@ -11201,7 +11440,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -11237,7 +11477,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
       "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -11306,7 +11547,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11382,7 +11622,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11477,6 +11716,7 @@
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
       "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -11505,13 +11745,15 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-canvas-context": "^1.0.1"
       }
@@ -11555,6 +11797,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -11586,6 +11829,7 @@
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.4.tgz",
       "integrity": "sha512-VGRnLJS+xJmGDPodgJRnGIDwGu0s+Cr9V2HB3EzlDZ5n0qb8h5SJtGUEkjrphZYAglEiXZ6kiXdmk0H/h/uu/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.0"
       }
@@ -11594,7 +11838,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -11644,6 +11889,7 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -76,6 +76,12 @@ const PythonStrategyLogs = lazy(() => import('@/pages/python-strategy/PythonStra
 const SchedulePythonStrategy = lazy(() => import('@/pages/python-strategy/SchedulePythonStrategy'))
 const PythonStrategyGuide = lazy(() => import('@/pages/python-strategy/PythonStrategyGuide'))
 
+// Backtest pages
+const BacktestIndex = lazy(() => import('@/pages/backtest/BacktestIndex'))
+const NewBacktest = lazy(() => import('@/pages/backtest/NewBacktest'))
+const BacktestResults = lazy(() => import('@/pages/backtest/BacktestResults'))
+const CompareBacktests = lazy(() => import('@/pages/backtest/CompareBacktests'))
+
 // Chartink pages
 const ChartinkIndex = lazy(() => import('@/pages/chartink/ChartinkIndex'))
 const NewChartinkStrategy = lazy(() => import('@/pages/chartink/NewChartinkStrategy'))
@@ -177,6 +183,11 @@ function App() {
                 <Route path="/python/:strategyId/logs" element={<PythonStrategyLogs />} />
                 <Route path="/python/:strategyId/schedule" element={<SchedulePythonStrategy />} />
                 <Route path="/python/guide" element={<PythonStrategyGuide />} />
+                {/* Backtesting */}
+                <Route path="/backtest" element={<BacktestIndex />} />
+                <Route path="/backtest/new" element={<NewBacktest />} />
+                <Route path="/backtest/compare" element={<CompareBacktests />} />
+                <Route path="/backtest/:backtestId" element={<BacktestResults />} />
                 {/* Phase 6: Chartink Strategies */}
                 <Route path="/chartink" element={<ChartinkIndex />} />
                 <Route path="/chartink/new" element={<NewChartinkStrategy />} />

--- a/frontend/src/api/backtest.ts
+++ b/frontend/src/api/backtest.ts
@@ -1,0 +1,118 @@
+import type {
+  BacktestListItem,
+  BacktestResult,
+  BacktestRunRequest,
+  DataAvailability,
+} from '@/types/backtest'
+import { webClient } from './client'
+
+interface ApiResponse<T = void> {
+  status: string
+  message?: string
+  data?: T
+}
+
+export const backtestApi = {
+  /**
+   * Launch a new backtest run
+   */
+  run: async (request: BacktestRunRequest): Promise<{ backtest_id: string }> => {
+    const response = await webClient.post<
+      ApiResponse & { backtest_id: string }
+    >('/backtest/api/run', request)
+    return { backtest_id: response.data.backtest_id }
+  },
+
+  /**
+   * Get status of a backtest run
+   */
+  getStatus: async (backtestId: string) => {
+    const response = await webClient.get<ApiResponse<{
+      backtest_id: string
+      name: string
+      status: string
+      created_at: string | null
+      started_at: string | null
+      completed_at: string | null
+      duration_ms: number | null
+      error_message: string | null
+    }>>(`/backtest/api/status/${backtestId}`)
+    return response.data.data
+  },
+
+  /**
+   * Get full results for a completed backtest
+   */
+  getResults: async (backtestId: string): Promise<BacktestResult> => {
+    const response = await webClient.get<ApiResponse<BacktestResult>>(
+      `/backtest/api/results/${backtestId}`
+    )
+    return response.data.data!
+  },
+
+  /**
+   * List all backtests for the current user
+   */
+  list: async (limit = 50): Promise<BacktestListItem[]> => {
+    const response = await webClient.get<ApiResponse<BacktestListItem[]>>(
+      `/backtest/api/list?limit=${limit}`
+    )
+    return response.data.data || []
+  },
+
+  /**
+   * Cancel a running backtest
+   */
+  cancel: async (backtestId: string): Promise<void> => {
+    await webClient.post(`/backtest/api/cancel/${backtestId}`)
+  },
+
+  /**
+   * Delete a backtest run
+   */
+  delete: async (backtestId: string): Promise<void> => {
+    await webClient.delete(`/backtest/api/delete/${backtestId}`)
+  },
+
+  /**
+   * Export backtest trades as CSV (returns download URL)
+   */
+  getExportUrl: (backtestId: string): string => {
+    return `/backtest/api/export/${backtestId}`
+  },
+
+  /**
+   * Check data availability for requested configuration
+   */
+  checkData: async (params: {
+    symbols: string[]
+    exchange: string
+    interval: string
+    start_date: string
+    end_date: string
+  }): Promise<DataAvailability> => {
+    const response = await webClient.post<ApiResponse<DataAvailability>>(
+      '/backtest/api/check-data',
+      params
+    )
+    return response.data.data!
+  },
+
+  /**
+   * Compare multiple backtests
+   */
+  compare: async (backtestIds: string[]): Promise<BacktestResult[]> => {
+    const response = await webClient.post<ApiResponse<BacktestResult[]>>(
+      '/backtest/api/compare',
+      { backtest_ids: backtestIds }
+    )
+    return response.data.data || []
+  },
+
+  /**
+   * Create an EventSource for live backtest progress
+   */
+  createProgressStream: (backtestId: string): EventSource => {
+    return new EventSource(`/backtest/api/events/${backtestId}`)
+  },
+}

--- a/frontend/src/config/navigation.ts
+++ b/frontend/src/config/navigation.ts
@@ -1,4 +1,5 @@
 import {
+  Activity,
   BarChart3,
   Bell,
   BookOpen,
@@ -65,6 +66,7 @@ export const profileMenuItems: NavItem[] = [
   { href: '/holdings', label: 'Holdings', icon: ClipboardList },
   { href: '/flow', label: 'Flow Editor', icon: Workflow },
   { href: '/python', label: 'Python Strategies', icon: Code2 },
+  { href: '/backtest', label: 'Backtest', icon: Activity },
   { href: '/pnl-tracker', label: 'PnL Tracker', icon: BarChart3 },
   { href: '/historify', label: 'Historify', icon: Database },
   { href: '/search/token', label: 'Search', icon: Search },

--- a/frontend/src/pages/backtest/BacktestIndex.tsx
+++ b/frontend/src/pages/backtest/BacktestIndex.tsx
@@ -1,0 +1,298 @@
+import {
+  BarChart3,
+  Clock,
+  Download,
+  GitCompare,
+  Plus,
+  RefreshCw,
+  Trash2,
+  TrendingDown,
+} from 'lucide-react'
+import { useCallback, useEffect, useState } from 'react'
+import { useNavigate } from 'react-router-dom'
+
+import { backtestApi } from '@/api/backtest'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { BacktestListItem } from '@/types/backtest'
+import { STATUS_COLORS, STATUS_LABELS } from '@/types/backtest'
+import { showToast } from '@/utils/toast'
+
+export default function BacktestIndex() {
+  const navigate = useNavigate()
+  const [backtests, setBacktests] = useState<BacktestListItem[]>([])
+  const [loading, setLoading] = useState(true)
+  const [actionLoading, setActionLoading] = useState<string | null>(null)
+  const [selectedIds, setSelectedIds] = useState<string[]>([])
+
+  const fetchBacktests = useCallback(async (silent = false) => {
+    try {
+      if (!silent) setLoading(true)
+      const data = await backtestApi.list()
+      setBacktests(data)
+    } catch {
+      if (!silent) showToast.error('Failed to load backtests')
+    } finally {
+      if (!silent) setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchBacktests()
+  }, [fetchBacktests])
+
+  const handleDelete = async (id: string) => {
+    if (!confirm('Delete this backtest? This cannot be undone.')) return
+    setActionLoading(id)
+    try {
+      await backtestApi.delete(id)
+      showToast.success('Backtest deleted')
+      fetchBacktests(true)
+    } catch {
+      showToast.error('Failed to delete backtest')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  const handleCancel = async (id: string) => {
+    setActionLoading(id)
+    try {
+      await backtestApi.cancel(id)
+      showToast.success('Cancellation requested')
+      fetchBacktests(true)
+    } catch {
+      showToast.error('Failed to cancel backtest')
+    } finally {
+      setActionLoading(null)
+    }
+  }
+
+  const toggleSelect = (id: string) => {
+    setSelectedIds((prev) =>
+      prev.includes(id) ? prev.filter((x) => x !== id) : [...prev, id]
+    )
+  }
+
+  const handleCompare = () => {
+    if (selectedIds.length < 2) {
+      showToast.error('Select at least 2 backtests to compare')
+      return
+    }
+    navigate(`/backtest/compare?ids=${selectedIds.join(',')}`)
+  }
+
+  const formatDuration = (ms: number | null) => {
+    if (!ms) return '-'
+    if (ms < 1000) return `${ms}ms`
+    if (ms < 60000) return `${(ms / 1000).toFixed(1)}s`
+    return `${(ms / 60000).toFixed(1)}m`
+  }
+
+  const formatReturn = (pct: number | null) => {
+    if (pct === null || pct === undefined) return '-'
+    const isPositive = pct >= 0
+    return (
+      <span className={isPositive ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>
+        {isPositive ? '+' : ''}{pct.toFixed(2)}%
+      </span>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <BarChart3 className="h-6 w-6" />
+            Backtests
+          </h1>
+          <p className="text-muted-foreground text-sm mt-1">
+            Test your strategies on historical data
+          </p>
+        </div>
+        <div className="flex gap-2">
+          {selectedIds.length >= 2 && (
+            <Button variant="outline" onClick={handleCompare}>
+              <GitCompare className="h-4 w-4 mr-2" />
+              Compare ({selectedIds.length})
+            </Button>
+          )}
+          <Button variant="outline" size="icon" onClick={() => fetchBacktests()}>
+            <RefreshCw className="h-4 w-4" />
+          </Button>
+          <Button onClick={() => navigate('/backtest/new')}>
+            <Plus className="h-4 w-4 mr-2" />
+            New Backtest
+          </Button>
+        </div>
+      </div>
+
+      {/* Backtests Table */}
+      {backtests.length === 0 ? (
+        <Card>
+          <CardContent className="flex flex-col items-center justify-center py-16">
+            <BarChart3 className="h-12 w-12 text-muted-foreground mb-4" />
+            <h3 className="text-lg font-medium">No backtests yet</h3>
+            <p className="text-muted-foreground text-sm mt-1">
+              Create your first backtest to start testing strategies
+            </p>
+            <Button className="mt-4" onClick={() => navigate('/backtest/new')}>
+              <Plus className="h-4 w-4 mr-2" />
+              New Backtest
+            </Button>
+          </CardContent>
+        </Card>
+      ) : (
+        <Card>
+          <CardHeader>
+            <CardTitle>All Backtests</CardTitle>
+            <CardDescription>
+              Click on a backtest to view detailed results. Select multiple to compare.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead className="w-8" />
+                  <TableHead>Name</TableHead>
+                  <TableHead>Status</TableHead>
+                  <TableHead>Symbols</TableHead>
+                  <TableHead>Interval</TableHead>
+                  <TableHead>Period</TableHead>
+                  <TableHead className="text-right">Return</TableHead>
+                  <TableHead className="text-right">Sharpe</TableHead>
+                  <TableHead className="text-right">Max DD</TableHead>
+                  <TableHead className="text-right">Trades</TableHead>
+                  <TableHead className="text-right">Duration</TableHead>
+                  <TableHead className="w-20">Actions</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {backtests.map((bt) => (
+                  <TableRow
+                    key={bt.backtest_id}
+                    className="cursor-pointer hover:bg-muted/50"
+                    onClick={() => {
+                      if (bt.status === 'completed') {
+                        navigate(`/backtest/${bt.backtest_id}`)
+                      } else if (bt.status === 'running') {
+                        navigate(`/backtest/${bt.backtest_id}`)
+                      }
+                    }}
+                  >
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      {bt.status === 'completed' && (
+                        <input
+                          type="checkbox"
+                          checked={selectedIds.includes(bt.backtest_id)}
+                          onChange={() => toggleSelect(bt.backtest_id)}
+                          className="h-4 w-4 rounded border-gray-300"
+                        />
+                      )}
+                    </TableCell>
+                    <TableCell className="font-medium max-w-48 truncate">
+                      {bt.name}
+                    </TableCell>
+                    <TableCell>
+                      <Badge
+                        variant="secondary"
+                        className={`${STATUS_COLORS[bt.status] || 'bg-gray-500'} text-white text-xs`}
+                      >
+                        {STATUS_LABELS[bt.status] || bt.status}
+                      </Badge>
+                    </TableCell>
+                    <TableCell className="max-w-32 truncate">
+                      {bt.symbols.join(', ')}
+                    </TableCell>
+                    <TableCell>{bt.interval}</TableCell>
+                    <TableCell className="text-xs">
+                      {bt.start_date} to {bt.end_date}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {formatReturn(bt.total_return_pct)}
+                    </TableCell>
+                    <TableCell className="text-right font-mono">
+                      {bt.sharpe_ratio !== null ? bt.sharpe_ratio.toFixed(2) : '-'}
+                    </TableCell>
+                    <TableCell className="text-right font-mono text-red-600 dark:text-red-400">
+                      {bt.max_drawdown_pct !== null ? `-${bt.max_drawdown_pct.toFixed(2)}%` : '-'}
+                    </TableCell>
+                    <TableCell className="text-right">{bt.total_trades}</TableCell>
+                    <TableCell className="text-right text-xs text-muted-foreground">
+                      <Clock className="inline h-3 w-3 mr-1" />
+                      {formatDuration(bt.duration_ms)}
+                    </TableCell>
+                    <TableCell onClick={(e) => e.stopPropagation()}>
+                      <div className="flex gap-1">
+                        {bt.status === 'running' && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7"
+                            disabled={actionLoading === bt.backtest_id}
+                            onClick={() => handleCancel(bt.backtest_id)}
+                          >
+                            <TrendingDown className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                        {bt.status === 'completed' && (
+                          <a
+                            href={backtestApi.getExportUrl(bt.backtest_id)}
+                            onClick={(e) => e.stopPropagation()}
+                          >
+                            <Button variant="ghost" size="icon" className="h-7 w-7">
+                              <Download className="h-3.5 w-3.5" />
+                            </Button>
+                          </a>
+                        )}
+                        {bt.status !== 'running' && (
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="h-7 w-7 text-red-500"
+                            disabled={actionLoading === bt.backtest_id}
+                            onClick={() => handleDelete(bt.backtest_id)}
+                          >
+                            <Trash2 className="h-3.5 w-3.5" />
+                          </Button>
+                        )}
+                      </div>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </CardContent>
+        </Card>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/backtest/BacktestResults.tsx
+++ b/frontend/src/pages/backtest/BacktestResults.tsx
@@ -1,0 +1,622 @@
+import {
+  ArrowLeft,
+  BarChart3,
+  Clock,
+  Download,
+  Loader2,
+  TrendingDown,
+  TrendingUp,
+} from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useParams } from 'react-router-dom'
+
+import { backtestApi } from '@/api/backtest'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Progress } from '@/components/ui/progress'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import type { BacktestProgress, BacktestResult } from '@/types/backtest'
+
+// Equity chart component using lightweight-charts
+function EquityChart({ data }: { data: { timestamp: number; equity: number }[] }) {
+  const chartRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!chartRef.current || !data.length) return
+
+    let chart: ReturnType<typeof import('lightweight-charts').createChart> | null = null
+
+    const initChart = async () => {
+      const { createChart, LineSeries } = await import('lightweight-charts')
+
+      chart = createChart(chartRef.current!, {
+        width: chartRef.current!.clientWidth,
+        height: 350,
+        layout: {
+          background: { color: 'transparent' },
+          textColor: '#888',
+        },
+        grid: {
+          vertLines: { color: 'rgba(128,128,128,0.1)' },
+          horzLines: { color: 'rgba(128,128,128,0.1)' },
+        },
+        rightPriceScale: { borderColor: 'rgba(128,128,128,0.2)' },
+        timeScale: {
+          borderColor: 'rgba(128,128,128,0.2)',
+          timeVisible: true,
+        },
+      })
+
+      const series = chart.addSeries(LineSeries, {
+        color: '#2563eb',
+        lineWidth: 2,
+      })
+
+      const chartData = data.map((d) => ({
+        time: d.timestamp as import('lightweight-charts').UTCTimestamp,
+        value: d.equity,
+      }))
+
+      series.setData(chartData)
+      chart.timeScale().fitContent()
+
+      // Handle resize
+      const observer = new ResizeObserver(() => {
+        if (chartRef.current && chart) {
+          chart.applyOptions({ width: chartRef.current.clientWidth })
+        }
+      })
+      if (chartRef.current) observer.observe(chartRef.current)
+    }
+
+    initChart()
+
+    return () => {
+      if (chart) chart.remove()
+    }
+  }, [data])
+
+  return <div ref={chartRef} className="w-full" />
+}
+
+// Drawdown chart
+function DrawdownChart({ data }: { data: { timestamp: number; drawdown: number }[] }) {
+  const chartRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!chartRef.current || !data.length) return
+
+    let chart: ReturnType<typeof import('lightweight-charts').createChart> | null = null
+
+    const initChart = async () => {
+      const { createChart, AreaSeries } = await import('lightweight-charts')
+
+      chart = createChart(chartRef.current!, {
+        width: chartRef.current!.clientWidth,
+        height: 200,
+        layout: {
+          background: { color: 'transparent' },
+          textColor: '#888',
+        },
+        grid: {
+          vertLines: { color: 'rgba(128,128,128,0.1)' },
+          horzLines: { color: 'rgba(128,128,128,0.1)' },
+        },
+        rightPriceScale: { borderColor: 'rgba(128,128,128,0.2)' },
+        timeScale: {
+          borderColor: 'rgba(128,128,128,0.2)',
+          timeVisible: true,
+        },
+      })
+
+      const series = chart.addSeries(AreaSeries, {
+        topColor: 'rgba(239, 68, 68, 0.3)',
+        bottomColor: 'rgba(239, 68, 68, 0.05)',
+        lineColor: '#ef4444',
+        lineWidth: 1,
+      })
+
+      const chartData = data.map((d) => ({
+        time: d.timestamp as import('lightweight-charts').UTCTimestamp,
+        value: -(d.drawdown * 100),
+      }))
+
+      series.setData(chartData)
+      chart.timeScale().fitContent()
+
+      const observer = new ResizeObserver(() => {
+        if (chartRef.current && chart) {
+          chart.applyOptions({ width: chartRef.current.clientWidth })
+        }
+      })
+      if (chartRef.current) observer.observe(chartRef.current)
+    }
+
+    initChart()
+
+    return () => {
+      if (chart) chart.remove()
+    }
+  }, [data])
+
+  return <div ref={chartRef} className="w-full" />
+}
+
+function MetricCard({
+  label,
+  value,
+  suffix,
+  isPositive,
+}: {
+  label: string
+  value: string | number
+  suffix?: string
+  isPositive?: boolean | null
+}) {
+  let colorClass = ''
+  if (isPositive === true) colorClass = 'text-green-600 dark:text-green-400'
+  else if (isPositive === false) colorClass = 'text-red-600 dark:text-red-400'
+
+  return (
+    <div className="text-center p-3 rounded-lg bg-muted/50">
+      <p className="text-xs text-muted-foreground uppercase tracking-wider">{label}</p>
+      <p className={`text-lg font-bold mt-1 ${colorClass}`}>
+        {value}
+        {suffix && <span className="text-sm font-normal">{suffix}</span>}
+      </p>
+    </div>
+  )
+}
+
+export default function BacktestResults() {
+  const { backtestId } = useParams<{ backtestId: string }>()
+  const navigate = useNavigate()
+  const [result, setResult] = useState<BacktestResult | null>(null)
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  // For running backtests — show progress
+  const [isRunning, setIsRunning] = useState(false)
+  const [progress, setProgress] = useState<BacktestProgress | null>(null)
+  const eventSourceRef = useRef<EventSource | null>(null)
+
+  const fetchResults = useCallback(async () => {
+    if (!backtestId) return
+
+    try {
+      setLoading(true)
+
+      // First check status
+      const status = await backtestApi.getStatus(backtestId)
+
+      if (status?.status === 'running' || status?.status === 'pending') {
+        // Connect to SSE
+        setIsRunning(true)
+        setLoading(false)
+
+        const es = backtestApi.createProgressStream(backtestId)
+        eventSourceRef.current = es
+
+        es.onmessage = (event) => {
+          try {
+            const data: BacktestProgress = JSON.parse(event.data)
+            if (data.heartbeat) return
+            setProgress(data)
+
+            if (data.status === 'completed') {
+              es.close()
+              setIsRunning(false)
+              // Fetch results
+              backtestApi.getResults(backtestId).then((r) => {
+                setResult(r)
+              })
+            } else if (data.status === 'failed' || data.status === 'cancelled') {
+              es.close()
+              setIsRunning(false)
+              setError(data.message || `Backtest ${data.status}`)
+            }
+          } catch {
+            // Ignore parse errors
+          }
+        }
+
+        es.onerror = () => {
+          es.close()
+          setIsRunning(false)
+          setError('Lost connection to backtest')
+        }
+
+        return
+      }
+
+      if (status?.status === 'completed') {
+        const data = await backtestApi.getResults(backtestId)
+        setResult(data)
+      } else if (status?.status === 'failed') {
+        setError(status.error_message || 'Backtest failed')
+      } else if (status?.status === 'cancelled') {
+        setError('Backtest was cancelled')
+      } else {
+        setError('Backtest not found')
+      }
+    } catch {
+      setError('Failed to load backtest results')
+    } finally {
+      setLoading(false)
+    }
+  }, [backtestId])
+
+  useEffect(() => {
+    fetchResults()
+    return () => {
+      if (eventSourceRef.current) eventSourceRef.current.close()
+    }
+  }, [fetchResults])
+
+  if (loading) {
+    return (
+      <div className="container mx-auto p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <div className="grid grid-cols-4 gap-4">
+          {Array.from({ length: 8 }).map((_, i) => (
+            <Skeleton key={i} className="h-24" />
+          ))}
+        </div>
+        <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  // Running state
+  if (isRunning) {
+    return (
+      <div className="container mx-auto p-6 space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/backtest')}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <h1 className="text-2xl font-bold">Backtest Running...</h1>
+        </div>
+        <Card>
+          <CardContent className="py-8">
+            <div className="flex flex-col items-center space-y-4">
+              <Loader2 className="h-8 w-8 animate-spin text-blue-500" />
+              <p className="text-lg">{progress?.message || 'Starting...'}</p>
+              <div className="w-full max-w-md">
+                <Progress value={progress?.progress || 0} className="h-3" />
+              </div>
+              <p className="text-sm text-muted-foreground font-mono">
+                {progress?.progress || 0}%
+              </p>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  // Error state
+  if (error) {
+    return (
+      <div className="container mx-auto p-6 space-y-6">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/backtest')}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <h1 className="text-2xl font-bold">Backtest Error</h1>
+        </div>
+        <Card>
+          <CardContent className="py-8 text-center">
+            <TrendingDown className="h-12 w-12 text-red-500 mx-auto mb-4" />
+            <p className="text-lg text-red-600 dark:text-red-400">{error}</p>
+            <Button className="mt-4" onClick={() => navigate('/backtest')}>
+              Back to Backtests
+            </Button>
+          </CardContent>
+        </Card>
+      </div>
+    )
+  }
+
+  if (!result) return null
+
+  const m = result.metrics
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center justify-between">
+        <div className="flex items-center gap-4">
+          <Button variant="ghost" size="icon" onClick={() => navigate('/backtest')}>
+            <ArrowLeft className="h-4 w-4" />
+          </Button>
+          <div>
+            <h1 className="text-2xl font-bold">{result.name}</h1>
+            <p className="text-muted-foreground text-sm">
+              {result.config.symbols.join(', ')} | {result.config.interval} |{' '}
+              {result.config.start_date} to {result.config.end_date}
+            </p>
+          </div>
+        </div>
+        <div className="flex gap-2">
+          <a href={backtestApi.getExportUrl(result.backtest_id)}>
+            <Button variant="outline">
+              <Download className="h-4 w-4 mr-2" />
+              Export CSV
+            </Button>
+          </a>
+        </div>
+      </div>
+
+      {/* Key Metrics Grid */}
+      <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-5 gap-3">
+        <MetricCard
+          label="Total Return"
+          value={`${m.total_return_pct >= 0 ? '+' : ''}${m.total_return_pct.toFixed(2)}`}
+          suffix="%"
+          isPositive={m.total_return_pct >= 0}
+        />
+        <MetricCard
+          label="Final Capital"
+          value={m.final_capital.toLocaleString('en-IN', { maximumFractionDigits: 0 })}
+          suffix=""
+        />
+        <MetricCard
+          label="CAGR"
+          value={m.cagr.toFixed(2)}
+          suffix="%"
+          isPositive={m.cagr >= 0}
+        />
+        <MetricCard
+          label="Sharpe Ratio"
+          value={m.sharpe_ratio.toFixed(2)}
+          isPositive={m.sharpe_ratio > 0 ? true : m.sharpe_ratio < 0 ? false : null}
+        />
+        <MetricCard
+          label="Sortino Ratio"
+          value={m.sortino_ratio.toFixed(2)}
+          isPositive={m.sortino_ratio > 0 ? true : m.sortino_ratio < 0 ? false : null}
+        />
+        <MetricCard
+          label="Max Drawdown"
+          value={`-${m.max_drawdown_pct.toFixed(2)}`}
+          suffix="%"
+          isPositive={false}
+        />
+        <MetricCard
+          label="Calmar Ratio"
+          value={m.calmar_ratio.toFixed(2)}
+        />
+        <MetricCard
+          label="Win Rate"
+          value={m.win_rate.toFixed(1)}
+          suffix="%"
+          isPositive={m.win_rate >= 50}
+        />
+        <MetricCard
+          label="Profit Factor"
+          value={m.profit_factor.toFixed(2)}
+          isPositive={m.profit_factor > 1}
+        />
+        <MetricCard
+          label="Expectancy"
+          value={m.expectancy.toFixed(2)}
+          isPositive={m.expectancy > 0}
+        />
+      </div>
+
+      {/* Trade Summary Row */}
+      <div className="grid grid-cols-2 md:grid-cols-6 gap-3">
+        <MetricCard label="Total Trades" value={m.total_trades} />
+        <MetricCard label="Winners" value={m.winning_trades} isPositive={true} />
+        <MetricCard label="Losers" value={m.losing_trades} isPositive={false} />
+        <MetricCard label="Avg Win" value={m.avg_win.toFixed(2)} isPositive={true} />
+        <MetricCard label="Avg Loss" value={m.avg_loss.toFixed(2)} isPositive={false} />
+        <MetricCard label="Avg Bars Held" value={m.avg_holding_bars} />
+      </div>
+
+      {/* Charts & Trades Tabs */}
+      <Tabs defaultValue="charts" className="w-full">
+        <TabsList>
+          <TabsTrigger value="charts">
+            <BarChart3 className="h-4 w-4 mr-2" />
+            Charts
+          </TabsTrigger>
+          <TabsTrigger value="trades">
+            <TrendingUp className="h-4 w-4 mr-2" />
+            Trades ({m.total_trades})
+          </TabsTrigger>
+          <TabsTrigger value="monthly">
+            <Clock className="h-4 w-4 mr-2" />
+            Monthly Returns
+          </TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="charts" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Equity Curve</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <EquityChart data={result.equity_curve} />
+            </CardContent>
+          </Card>
+
+          <Card>
+            <CardHeader>
+              <CardTitle>Drawdown</CardTitle>
+            </CardHeader>
+            <CardContent>
+              <DrawdownChart data={result.equity_curve} />
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="trades">
+          <Card>
+            <CardHeader>
+              <CardTitle>Trade Log</CardTitle>
+              <CardDescription>
+                {m.total_trades} trades | Max Win: {m.max_win.toFixed(2)} | Max Loss: {m.max_loss.toFixed(2)}
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <div className="max-h-[500px] overflow-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>#</TableHead>
+                      <TableHead>Symbol</TableHead>
+                      <TableHead>Direction</TableHead>
+                      <TableHead>Qty</TableHead>
+                      <TableHead className="text-right">Entry</TableHead>
+                      <TableHead className="text-right">Exit</TableHead>
+                      <TableHead className="text-right">P&L</TableHead>
+                      <TableHead className="text-right">P&L%</TableHead>
+                      <TableHead className="text-right">Net P&L</TableHead>
+                      <TableHead className="text-right">Bars</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {result.trades.map((t) => (
+                      <TableRow key={t.trade_num}>
+                        <TableCell className="font-mono text-xs">{t.trade_num}</TableCell>
+                        <TableCell>{t.symbol}</TableCell>
+                        <TableCell>
+                          <Badge
+                            variant="secondary"
+                            className={
+                              t.action === 'LONG'
+                                ? 'bg-green-100 text-green-700 dark:bg-green-900 dark:text-green-300'
+                                : 'bg-red-100 text-red-700 dark:bg-red-900 dark:text-red-300'
+                            }
+                          >
+                            {t.action}
+                          </Badge>
+                        </TableCell>
+                        <TableCell>{t.quantity}</TableCell>
+                        <TableCell className="text-right font-mono">{t.entry_price.toFixed(2)}</TableCell>
+                        <TableCell className="text-right font-mono">{t.exit_price.toFixed(2)}</TableCell>
+                        <TableCell
+                          className={`text-right font-mono ${
+                            t.pnl >= 0
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}
+                        >
+                          {t.pnl >= 0 ? '+' : ''}{t.pnl.toFixed(2)}
+                        </TableCell>
+                        <TableCell
+                          className={`text-right font-mono ${
+                            t.pnl_pct >= 0
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}
+                        >
+                          {t.pnl_pct >= 0 ? '+' : ''}{t.pnl_pct.toFixed(2)}%
+                        </TableCell>
+                        <TableCell
+                          className={`text-right font-mono font-bold ${
+                            t.net_pnl >= 0
+                              ? 'text-green-600 dark:text-green-400'
+                              : 'text-red-600 dark:text-red-400'
+                          }`}
+                        >
+                          {t.net_pnl >= 0 ? '+' : ''}{t.net_pnl.toFixed(2)}
+                        </TableCell>
+                        <TableCell className="text-right">{t.bars_held}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+
+        <TabsContent value="monthly">
+          <Card>
+            <CardHeader>
+              <CardTitle>Monthly Returns</CardTitle>
+              <CardDescription>Monthly performance breakdown</CardDescription>
+            </CardHeader>
+            <CardContent>
+              {Object.keys(result.monthly_returns).length === 0 ? (
+                <p className="text-muted-foreground text-center py-8">
+                  Not enough data for monthly returns
+                </p>
+              ) : (
+                <div className="grid grid-cols-3 md:grid-cols-4 lg:grid-cols-6 gap-2">
+                  {Object.entries(result.monthly_returns)
+                    .sort(([a], [b]) => a.localeCompare(b))
+                    .map(([date, ret]) => (
+                      <div
+                        key={date}
+                        className={`p-3 rounded-lg text-center text-sm ${
+                          ret >= 0
+                            ? 'bg-green-50 dark:bg-green-950 text-green-700 dark:text-green-300'
+                            : 'bg-red-50 dark:bg-red-950 text-red-700 dark:text-red-300'
+                        }`}
+                      >
+                        <p className="text-xs text-muted-foreground">{date}</p>
+                        <p className="font-bold mt-1">
+                          {ret >= 0 ? '+' : ''}{ret.toFixed(2)}%
+                        </p>
+                      </div>
+                    ))}
+                </div>
+              )}
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+
+      {/* Costs Summary */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Cost Summary</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
+            <MetricCard
+              label="Total Commission"
+              value={m.total_commission.toFixed(2)}
+              isPositive={false}
+            />
+            <MetricCard
+              label="Total Slippage"
+              value={m.total_slippage.toFixed(2)}
+              isPositive={false}
+            />
+            <MetricCard
+              label="Max Win"
+              value={m.max_win.toFixed(2)}
+              isPositive={true}
+            />
+            <MetricCard
+              label="Max Loss"
+              value={m.max_loss.toFixed(2)}
+              isPositive={false}
+            />
+          </div>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/backtest/CompareBacktests.tsx
+++ b/frontend/src/pages/backtest/CompareBacktests.tsx
@@ -1,0 +1,295 @@
+import { ArrowLeft, BarChart3 } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { backtestApi } from '@/api/backtest'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Skeleton } from '@/components/ui/skeleton'
+import {
+  Table,
+  TableBody,
+  TableCell,
+  TableHead,
+  TableHeader,
+  TableRow,
+} from '@/components/ui/table'
+import type { BacktestResult } from '@/types/backtest'
+import { showToast } from '@/utils/toast'
+
+const COLORS = ['#2563eb', '#dc2626', '#16a34a', '#ca8a04', '#9333ea']
+
+function ComparisonChart({ results }: { results: BacktestResult[] }) {
+  const chartRef = useRef<HTMLDivElement>(null)
+
+  useEffect(() => {
+    if (!chartRef.current || results.length === 0) return
+
+    let chart: ReturnType<typeof import('lightweight-charts').createChart> | null = null
+
+    const initChart = async () => {
+      const { createChart, LineSeries } = await import('lightweight-charts')
+
+      chart = createChart(chartRef.current!, {
+        width: chartRef.current!.clientWidth,
+        height: 400,
+        layout: {
+          background: { color: 'transparent' },
+          textColor: '#888',
+        },
+        grid: {
+          vertLines: { color: 'rgba(128,128,128,0.1)' },
+          horzLines: { color: 'rgba(128,128,128,0.1)' },
+        },
+        rightPriceScale: { borderColor: 'rgba(128,128,128,0.2)' },
+        timeScale: {
+          borderColor: 'rgba(128,128,128,0.2)',
+          timeVisible: true,
+        },
+      })
+
+      results.forEach((r, i) => {
+        if (!r.equity_curve?.length) return
+
+        const series = chart!.addSeries(LineSeries, {
+          color: COLORS[i % COLORS.length],
+          lineWidth: 2,
+          title: r.name,
+        })
+
+        // Normalize to percentage return for fair comparison
+        const initial = r.equity_curve[0]?.equity || 1
+        const chartData = r.equity_curve.map((d) => ({
+          time: d.timestamp as import('lightweight-charts').UTCTimestamp,
+          value: ((d.equity - initial) / initial) * 100,
+        }))
+
+        series.setData(chartData)
+      })
+
+      chart.timeScale().fitContent()
+
+      const observer = new ResizeObserver(() => {
+        if (chartRef.current && chart) {
+          chart.applyOptions({ width: chartRef.current.clientWidth })
+        }
+      })
+      if (chartRef.current) observer.observe(chartRef.current)
+    }
+
+    initChart()
+
+    return () => {
+      if (chart) chart.remove()
+    }
+  }, [results])
+
+  return <div ref={chartRef} className="w-full" />
+}
+
+export default function CompareBacktests() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const [results, setResults] = useState<BacktestResult[]>([])
+  const [loading, setLoading] = useState(true)
+
+  const fetchComparison = useCallback(async () => {
+    const idsParam = searchParams.get('ids')
+    if (!idsParam) {
+      showToast.error('No backtest IDs provided')
+      navigate('/backtest')
+      return
+    }
+
+    const ids = idsParam.split(',').filter(Boolean)
+    if (ids.length < 2) {
+      showToast.error('Need at least 2 backtests to compare')
+      navigate('/backtest')
+      return
+    }
+
+    try {
+      setLoading(true)
+      const data = await backtestApi.compare(ids)
+      setResults(data)
+    } catch {
+      showToast.error('Failed to load comparison data')
+    } finally {
+      setLoading(false)
+    }
+  }, [searchParams, navigate])
+
+  useEffect(() => {
+    fetchComparison()
+  }, [fetchComparison])
+
+  if (loading) {
+    return (
+      <div className="container mx-auto p-6 space-y-4">
+        <Skeleton className="h-10 w-64" />
+        <Skeleton className="h-96 w-full" />
+      </div>
+    )
+  }
+
+  if (results.length < 2) {
+    return (
+      <div className="container mx-auto p-6">
+        <p className="text-muted-foreground">Not enough completed backtests to compare.</p>
+        <Button className="mt-4" onClick={() => navigate('/backtest')}>
+          Back to Backtests
+        </Button>
+      </div>
+    )
+  }
+
+  const metrics = [
+    { key: 'total_return_pct', label: 'Total Return %', suffix: '%', better: 'higher' as const },
+    { key: 'cagr', label: 'CAGR %', suffix: '%', better: 'higher' as const },
+    { key: 'sharpe_ratio', label: 'Sharpe Ratio', better: 'higher' as const },
+    { key: 'sortino_ratio', label: 'Sortino Ratio', better: 'higher' as const },
+    { key: 'max_drawdown_pct', label: 'Max Drawdown %', suffix: '%', better: 'lower' as const },
+    { key: 'calmar_ratio', label: 'Calmar Ratio', better: 'higher' as const },
+    { key: 'win_rate', label: 'Win Rate %', suffix: '%', better: 'higher' as const },
+    { key: 'profit_factor', label: 'Profit Factor', better: 'higher' as const },
+    { key: 'total_trades', label: 'Total Trades' },
+    { key: 'expectancy', label: 'Expectancy', better: 'higher' as const },
+    { key: 'total_commission', label: 'Total Commission', better: 'lower' as const },
+    { key: 'total_slippage', label: 'Total Slippage', better: 'lower' as const },
+  ]
+
+  // Find the best value for each metric
+  const bestValues: Record<string, number> = {}
+  for (const metric of metrics) {
+    if (!metric.better) continue
+    const values = results.map((r) => (r.metrics as unknown as Record<string, number>)[metric.key])
+    bestValues[metric.key] = metric.better === 'higher' ? Math.max(...values) : Math.min(...values)
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/backtest')}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold flex items-center gap-2">
+            <BarChart3 className="h-6 w-6" />
+            Compare Backtests
+          </h1>
+          <p className="text-muted-foreground text-sm">
+            Comparing {results.length} backtests
+          </p>
+        </div>
+      </div>
+
+      {/* Equity Curve Comparison */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Equity Curves (% Return)</CardTitle>
+          <CardDescription>
+            Normalized to percentage return for fair comparison
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <div className="flex gap-4 mb-4">
+            {results.map((r, i) => (
+              <div key={r.backtest_id} className="flex items-center gap-2">
+                <div
+                  className="w-3 h-3 rounded-full"
+                  style={{ backgroundColor: COLORS[i % COLORS.length] }}
+                />
+                <span className="text-sm">{r.name}</span>
+              </div>
+            ))}
+          </div>
+          <ComparisonChart results={results} />
+        </CardContent>
+      </Card>
+
+      {/* Metrics Comparison Table */}
+      <Card>
+        <CardHeader>
+          <CardTitle>Metrics Comparison</CardTitle>
+          <CardDescription>
+            Bold values indicate the best performer for each metric
+          </CardDescription>
+        </CardHeader>
+        <CardContent>
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Metric</TableHead>
+                {results.map((r, i) => (
+                  <TableHead key={r.backtest_id} className="text-right">
+                    <div className="flex items-center justify-end gap-2">
+                      <div
+                        className="w-2 h-2 rounded-full"
+                        style={{ backgroundColor: COLORS[i % COLORS.length] }}
+                      />
+                      {r.name}
+                    </div>
+                  </TableHead>
+                ))}
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {/* Config row */}
+              <TableRow>
+                <TableCell className="font-medium text-muted-foreground">Symbols</TableCell>
+                {results.map((r) => (
+                  <TableCell key={r.backtest_id} className="text-right text-xs">
+                    {r.config.symbols.join(', ')}
+                  </TableCell>
+                ))}
+              </TableRow>
+              <TableRow>
+                <TableCell className="font-medium text-muted-foreground">Period</TableCell>
+                {results.map((r) => (
+                  <TableCell key={r.backtest_id} className="text-right text-xs">
+                    {r.config.start_date} to {r.config.end_date}
+                  </TableCell>
+                ))}
+              </TableRow>
+              <TableRow>
+                <TableCell className="font-medium text-muted-foreground">Capital</TableCell>
+                {results.map((r) => (
+                  <TableCell key={r.backtest_id} className="text-right font-mono">
+                    {r.config.initial_capital.toLocaleString()}
+                  </TableCell>
+                ))}
+              </TableRow>
+
+              {/* Metric rows */}
+              {metrics.map((metric) => (
+                <TableRow key={metric.key}>
+                  <TableCell className="font-medium">{metric.label}</TableCell>
+                  {results.map((r) => {
+                    const val = (r.metrics as unknown as Record<string, number>)[metric.key]
+                    const isBest = metric.better && val === bestValues[metric.key]
+                    return (
+                      <TableCell
+                        key={r.backtest_id}
+                        className={`text-right font-mono ${isBest ? 'font-bold text-blue-600 dark:text-blue-400' : ''}`}
+                      >
+                        {typeof val === 'number' ? val.toFixed(2) : val}
+                        {metric.suffix || ''}
+                      </TableCell>
+                    )
+                  })}
+                </TableRow>
+              ))}
+            </TableBody>
+          </Table>
+        </CardContent>
+      </Card>
+    </div>
+  )
+}

--- a/frontend/src/pages/backtest/NewBacktest.tsx
+++ b/frontend/src/pages/backtest/NewBacktest.tsx
@@ -1,0 +1,479 @@
+import {
+  ArrowLeft,
+  CheckCircle,
+  Play,
+  XCircle,
+} from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useNavigate, useSearchParams } from 'react-router-dom'
+
+import { backtestApi } from '@/api/backtest'
+import { Button } from '@/components/ui/button'
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from '@/components/ui/card'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { Progress } from '@/components/ui/progress'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { PythonEditor } from '@/components/ui/python-editor'
+import type { BacktestProgress } from '@/types/backtest'
+import { EXCHANGE_OPTIONS, INTERVAL_OPTIONS } from '@/types/backtest'
+import { showToast } from '@/utils/toast'
+
+const DEFAULT_STRATEGY = `from openalgo import api
+
+# Initialize client
+client = api(api_key="your_api_key", host="http://127.0.0.1:5000")
+
+# Strategy parameters
+symbol = "SBIN"
+exchange = "NSE"
+
+while True:
+    # Get historical data
+    df = client.history(symbol=symbol, exchange=exchange, interval="D")
+
+    if len(df) < 20:
+        import time
+        time.sleep(5)
+        continue
+
+    # Calculate 10-period and 20-period EMAs
+    df["ema_10"] = df["close"].ewm(span=10).mean()
+    df["ema_20"] = df["close"].ewm(span=20).mean()
+
+    # Get current position
+    pos = client.openposition(strategy="ema_crossover", symbol=symbol, exchange=exchange)
+    current_qty = int(pos.get("quantity", "0"))
+
+    # EMA crossover logic
+    if df["ema_10"].iloc[-1] > df["ema_20"].iloc[-1] and df["ema_10"].iloc[-2] <= df["ema_20"].iloc[-2]:
+        # Bullish crossover — go long
+        client.placesmartorder(
+            strategy="ema_crossover",
+            symbol=symbol,
+            action="BUY",
+            exchange=exchange,
+            price_type="MARKET",
+            product="MIS",
+            quantity=1,
+            position_size=1,
+        )
+
+    elif df["ema_10"].iloc[-1] < df["ema_20"].iloc[-1] and df["ema_10"].iloc[-2] >= df["ema_20"].iloc[-2]:
+        # Bearish crossover — go short or close
+        client.placesmartorder(
+            strategy="ema_crossover",
+            symbol=symbol,
+            action="SELL",
+            exchange=exchange,
+            price_type="MARKET",
+            product="MIS",
+            quantity=1,
+            position_size=0,
+        )
+
+    import time
+    time.sleep(5)
+`
+
+export default function NewBacktest() {
+  const navigate = useNavigate()
+  const [searchParams] = useSearchParams()
+  const eventSourceRef = useRef<EventSource | null>(null)
+
+  // Form state
+  const [name, setName] = useState('')
+  const [strategyCode, setStrategyCode] = useState(DEFAULT_STRATEGY)
+  const [symbols, setSymbols] = useState('SBIN')
+  const [exchange, setExchange] = useState('NSE')
+  const [interval, setInterval] = useState('D')
+  const [startDate, setStartDate] = useState('2024-01-01')
+  const [endDate, setEndDate] = useState('2024-12-31')
+  const [initialCapital, setInitialCapital] = useState('100000')
+  const [slippagePct, setSlippagePct] = useState('0.05')
+  const [commissionPerOrder, setCommissionPerOrder] = useState('20')
+  const [commissionPct] = useState('0')
+
+  // Running state
+  const [isRunning, setIsRunning] = useState(false)
+  const [backtestId, setBacktestId] = useState<string | null>(null)
+  const [progress, setProgress] = useState<BacktestProgress | null>(null)
+  const [dataCheck, setDataCheck] = useState<{
+    checked: boolean
+    available: boolean
+    message: string
+  }>({ checked: false, available: false, message: '' })
+
+  // Load strategy code from URL params (e.g., from python strategy page)
+  useEffect(() => {
+    const code = searchParams.get('code')
+    const stratName = searchParams.get('name')
+    if (code) setStrategyCode(decodeURIComponent(code))
+    if (stratName) setName(decodeURIComponent(stratName))
+  }, [searchParams])
+
+  // Cleanup SSE on unmount
+  useEffect(() => {
+    return () => {
+      if (eventSourceRef.current) {
+        eventSourceRef.current.close()
+      }
+    }
+  }, [])
+
+  const checkDataAvailability = useCallback(async () => {
+    const symbolList = symbols.split(',').map((s) => s.trim()).filter(Boolean)
+    if (symbolList.length === 0) {
+      setDataCheck({ checked: true, available: false, message: 'No symbols specified' })
+      return
+    }
+
+    try {
+      const result = await backtestApi.checkData({
+        symbols: symbolList,
+        exchange,
+        interval,
+        start_date: startDate,
+        end_date: endDate,
+      })
+
+      const unavailable = symbolList.filter(
+        (s) => !result.details[s]?.has_data
+      )
+
+      if (result.available) {
+        setDataCheck({
+          checked: true,
+          available: true,
+          message: `Data available for all ${symbolList.length} symbol(s)`,
+        })
+      } else {
+        setDataCheck({
+          checked: true,
+          available: false,
+          message: `No data for: ${unavailable.join(', ')}. Please fetch data in Historify first.`,
+        })
+      }
+    } catch {
+      setDataCheck({
+        checked: true,
+        available: false,
+        message: 'Failed to check data availability',
+      })
+    }
+  }, [symbols, exchange, interval, startDate, endDate])
+
+  const handleRun = async () => {
+    if (!strategyCode.trim()) {
+      showToast.error('Strategy code cannot be empty')
+      return
+    }
+
+    const symbolList = symbols.split(',').map((s) => s.trim()).filter(Boolean)
+    if (symbolList.length === 0) {
+      showToast.error('At least one symbol is required')
+      return
+    }
+
+    setIsRunning(true)
+    setProgress(null)
+
+    try {
+      const result = await backtestApi.run({
+        name: name || `Backtest ${new Date().toLocaleDateString()}`,
+        strategy_code: strategyCode,
+        symbols: symbolList,
+        exchange,
+        start_date: startDate,
+        end_date: endDate,
+        interval,
+        initial_capital: Number(initialCapital),
+        slippage_pct: Number(slippagePct),
+        commission_per_order: Number(commissionPerOrder),
+        commission_pct: Number(commissionPct),
+      })
+
+      setBacktestId(result.backtest_id)
+
+      // Connect to SSE for progress
+      const es = backtestApi.createProgressStream(result.backtest_id)
+      eventSourceRef.current = es
+
+      es.onmessage = (event) => {
+        try {
+          const data: BacktestProgress = JSON.parse(event.data)
+          if (data.heartbeat) return
+
+          setProgress(data)
+
+          if (data.status === 'completed') {
+            es.close()
+            eventSourceRef.current = null
+            showToast.success('Backtest completed')
+            setTimeout(() => {
+              navigate(`/backtest/${result.backtest_id}`)
+            }, 500)
+          } else if (data.status === 'failed') {
+            es.close()
+            eventSourceRef.current = null
+            setIsRunning(false)
+            showToast.error(data.message || 'Backtest failed')
+          } else if (data.status === 'cancelled') {
+            es.close()
+            eventSourceRef.current = null
+            setIsRunning(false)
+            showToast.error('Backtest cancelled')
+          }
+        } catch {
+          // Ignore parse errors
+        }
+      }
+
+      es.onerror = () => {
+        es.close()
+        eventSourceRef.current = null
+        setIsRunning(false)
+      }
+    } catch {
+      setIsRunning(false)
+      showToast.error('Failed to start backtest')
+    }
+  }
+
+  const handleCancel = async () => {
+    if (backtestId) {
+      try {
+        await backtestApi.cancel(backtestId)
+        showToast.success('Cancellation requested')
+      } catch {
+        showToast.error('Failed to cancel')
+      }
+    }
+  }
+
+  return (
+    <div className="container mx-auto p-6 space-y-6">
+      {/* Header */}
+      <div className="flex items-center gap-4">
+        <Button variant="ghost" size="icon" onClick={() => navigate('/backtest')}>
+          <ArrowLeft className="h-4 w-4" />
+        </Button>
+        <div>
+          <h1 className="text-2xl font-bold">New Backtest</h1>
+          <p className="text-muted-foreground text-sm">
+            Configure and run a backtest on historical data
+          </p>
+        </div>
+      </div>
+
+      <div className="grid grid-cols-1 lg:grid-cols-3 gap-6">
+        {/* Left: Strategy Code Editor */}
+        <div className="lg:col-span-2 space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Strategy Code</CardTitle>
+              <CardDescription>
+                Paste your live trading strategy code. It will run as-is with the
+                openalgo API mocked for backtesting.
+              </CardDescription>
+            </CardHeader>
+            <CardContent>
+              <PythonEditor
+                value={strategyCode}
+                onChange={setStrategyCode}
+                height="500px"
+              />
+            </CardContent>
+          </Card>
+
+          {/* Progress Card */}
+          {isRunning && progress && (
+            <Card>
+              <CardContent className="py-4">
+                <div className="space-y-2">
+                  <div className="flex justify-between text-sm">
+                    <span>{progress.message}</span>
+                    <span className="font-mono">{progress.progress}%</span>
+                  </div>
+                  <Progress value={progress.progress} className="h-2" />
+                </div>
+              </CardContent>
+            </Card>
+          )}
+        </div>
+
+        {/* Right: Configuration */}
+        <div className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle>Configuration</CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <div>
+                <Label htmlFor="name">Backtest Name</Label>
+                <Input
+                  id="name"
+                  value={name}
+                  onChange={(e) => setName(e.target.value)}
+                  placeholder="My EMA Strategy"
+                />
+              </div>
+
+              <div>
+                <Label htmlFor="symbols">Symbols (comma-separated)</Label>
+                <Input
+                  id="symbols"
+                  value={symbols}
+                  onChange={(e) => setSymbols(e.target.value)}
+                  placeholder="SBIN, RELIANCE, TCS"
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label>Exchange</Label>
+                  <Select value={exchange} onValueChange={setExchange}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {EXCHANGE_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+
+                <div>
+                  <Label>Interval</Label>
+                  <Select value={interval} onValueChange={setInterval}>
+                    <SelectTrigger>
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {INTERVAL_OPTIONS.map((opt) => (
+                        <SelectItem key={opt.value} value={opt.value}>
+                          {opt.label}
+                        </SelectItem>
+                      ))}
+                    </SelectContent>
+                  </Select>
+                </div>
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label htmlFor="start_date">Start Date</Label>
+                  <Input
+                    id="start_date"
+                    type="date"
+                    value={startDate}
+                    onChange={(e) => setStartDate(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="end_date">End Date</Label>
+                  <Input
+                    id="end_date"
+                    type="date"
+                    value={endDate}
+                    onChange={(e) => setEndDate(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              <div>
+                <Label htmlFor="capital">Initial Capital</Label>
+                <Input
+                  id="capital"
+                  type="number"
+                  value={initialCapital}
+                  onChange={(e) => setInitialCapital(e.target.value)}
+                />
+              </div>
+
+              <div className="grid grid-cols-2 gap-3">
+                <div>
+                  <Label htmlFor="slippage">Slippage %</Label>
+                  <Input
+                    id="slippage"
+                    type="number"
+                    step="0.01"
+                    value={slippagePct}
+                    onChange={(e) => setSlippagePct(e.target.value)}
+                  />
+                </div>
+                <div>
+                  <Label htmlFor="commission">Commission/Order</Label>
+                  <Input
+                    id="commission"
+                    type="number"
+                    step="1"
+                    value={commissionPerOrder}
+                    onChange={(e) => setCommissionPerOrder(e.target.value)}
+                  />
+                </div>
+              </div>
+
+              {/* Data Availability Check */}
+              <div className="pt-2 border-t">
+                <Button
+                  variant="outline"
+                  className="w-full"
+                  onClick={checkDataAvailability}
+                  disabled={isRunning}
+                >
+                  Check Data Availability
+                </Button>
+                {dataCheck.checked && (
+                  <div className="mt-2 flex items-start gap-2 text-sm">
+                    {dataCheck.available ? (
+                      <CheckCircle className="h-4 w-4 text-green-500 mt-0.5 shrink-0" />
+                    ) : (
+                      <XCircle className="h-4 w-4 text-red-500 mt-0.5 shrink-0" />
+                    )}
+                    <span className={dataCheck.available ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400'}>
+                      {dataCheck.message}
+                    </span>
+                  </div>
+                )}
+              </div>
+
+              {/* Run / Cancel */}
+              <div className="pt-2">
+                {isRunning ? (
+                  <Button
+                    variant="destructive"
+                    className="w-full"
+                    onClick={handleCancel}
+                  >
+                    Cancel Backtest
+                  </Button>
+                ) : (
+                  <Button className="w-full" onClick={handleRun}>
+                    <Play className="h-4 w-4 mr-2" />
+                    Run Backtest
+                  </Button>
+                )}
+              </div>
+            </CardContent>
+          </Card>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/frontend/src/types/backtest.ts
+++ b/frontend/src/types/backtest.ts
@@ -1,0 +1,162 @@
+// Backtest Types
+
+export interface BacktestConfig {
+  symbols: string[]
+  exchange: string
+  start_date: string
+  end_date: string
+  interval: string
+  initial_capital: number
+  slippage_pct: number
+  commission_per_order: number
+  commission_pct: number
+}
+
+export interface BacktestMetrics {
+  final_capital: number
+  total_return_pct: number
+  cagr: number
+  sharpe_ratio: number
+  sortino_ratio: number
+  max_drawdown_pct: number
+  calmar_ratio: number
+  win_rate: number
+  profit_factor: number
+  total_trades: number
+  winning_trades: number
+  losing_trades: number
+  avg_win: number
+  avg_loss: number
+  max_win: number
+  max_loss: number
+  expectancy: number
+  avg_holding_bars: number
+  total_commission: number
+  total_slippage: number
+}
+
+export interface BacktestTrade {
+  trade_num: number
+  symbol: string
+  exchange: string
+  action: 'LONG' | 'SHORT'
+  quantity: number
+  entry_price: number
+  exit_price: number
+  entry_time: string
+  exit_time: string
+  pnl: number
+  pnl_pct: number
+  commission: number
+  slippage_cost: number
+  net_pnl: number
+  bars_held: number
+  product: string
+  strategy_tag: string
+}
+
+export interface EquityPoint {
+  timestamp: number
+  equity: number
+  drawdown: number
+}
+
+export interface BacktestListItem {
+  backtest_id: string
+  name: string
+  status: 'pending' | 'running' | 'completed' | 'failed' | 'cancelled'
+  symbols: string[]
+  interval: string
+  start_date: string
+  end_date: string
+  initial_capital: number
+  total_return_pct: number | null
+  sharpe_ratio: number | null
+  max_drawdown_pct: number | null
+  total_trades: number
+  win_rate: number | null
+  duration_ms: number | null
+  created_at: string | null
+  error_message: string | null
+}
+
+export interface BacktestResult {
+  backtest_id: string
+  name: string
+  config: BacktestConfig
+  metrics: BacktestMetrics
+  equity_curve: EquityPoint[]
+  monthly_returns: Record<string, number>
+  trades: BacktestTrade[]
+  duration_ms: number | null
+  created_at: string | null
+  completed_at: string | null
+}
+
+export interface BacktestRunRequest {
+  name?: string
+  strategy_id?: string
+  strategy_code: string
+  symbols: string[] | string
+  exchange?: string
+  start_date: string
+  end_date: string
+  interval: string
+  initial_capital?: number
+  slippage_pct?: number
+  commission_per_order?: number
+  commission_pct?: number
+  data_source?: string
+}
+
+export interface BacktestProgress {
+  backtest_id: string
+  progress: number
+  message: string
+  status?: string
+  heartbeat?: boolean
+}
+
+export interface DataAvailability {
+  available: boolean
+  details: Record<string, {
+    has_data: boolean
+    record_count: number
+    first_timestamp?: number
+    last_timestamp?: number
+  }>
+}
+
+export const INTERVAL_OPTIONS = [
+  { value: '1m', label: '1 Minute' },
+  { value: '5m', label: '5 Minutes' },
+  { value: '15m', label: '15 Minutes' },
+  { value: '30m', label: '30 Minutes' },
+  { value: '1h', label: '1 Hour' },
+  { value: 'D', label: 'Daily' },
+] as const
+
+export const EXCHANGE_OPTIONS = [
+  { value: 'NSE', label: 'NSE' },
+  { value: 'BSE', label: 'BSE' },
+  { value: 'NFO', label: 'NFO' },
+  { value: 'BFO', label: 'BFO' },
+  { value: 'MCX', label: 'MCX' },
+  { value: 'CDS', label: 'CDS' },
+] as const
+
+export const STATUS_COLORS: Record<string, string> = {
+  completed: 'bg-green-500',
+  running: 'bg-blue-500',
+  pending: 'bg-yellow-500',
+  failed: 'bg-red-500',
+  cancelled: 'bg-gray-500',
+}
+
+export const STATUS_LABELS: Record<string, string> = {
+  completed: 'Completed',
+  running: 'Running',
+  pending: 'Pending',
+  failed: 'Failed',
+  cancelled: 'Cancelled',
+}

--- a/services/backtest_client.py
+++ b/services/backtest_client.py
@@ -1,0 +1,581 @@
+# services/backtest_client.py
+"""
+BacktestClient — Drop-in replacement for openalgo.api
+
+Mirrors the openalgo SDK interface exactly so that strategies written for
+live trading work in backtest mode with zero code changes.
+
+The engine swaps `api()` with this client. All order execution is simulated
+on historical OHLCV bars. Look-ahead bias is prevented by only exposing
+data up to the current bar via history().
+"""
+
+import pandas as pd
+
+
+class BacktestClient:
+    """
+    SDK-compatible mock client for backtesting.
+
+    All public methods match the openalgo Python SDK signatures.
+    """
+
+    def __init__(self, config):
+        self.initial_capital = float(config["initial_capital"])
+        self.capital = float(config["initial_capital"])
+        self.slippage_pct = float(config.get("slippage_pct", 0.05))
+        self.commission_per_order = float(config.get("commission_per_order", 20.0))
+        self.commission_pct = float(config.get("commission_pct", 0.0))
+
+        # Data store — populated by engine before run
+        self.data = {}  # {symbol:exchange -> DataFrame}
+        self.current_bar_index = {}  # {symbol:exchange -> int}
+        self.current_timestamp = None
+
+        # State
+        self.positions = {}  # {symbol:exchange -> {qty, avg_price, product}}
+        self.orders = []  # all orders placed
+        self.trades = []  # completed round-trip trades
+        self.open_entries = {}  # {symbol:exchange -> entry info}
+        self.pending_orders = []  # LIMIT/SL/SL-M waiting
+        self.equity_curve = []  # [{timestamp, equity, drawdown}]
+        self.peak_equity = float(config["initial_capital"])
+        self._order_counter = 0
+        self._trade_counter = 0
+
+    # ─── SDK-Compatible Methods ──────────────────────────────────────
+
+    def history(self, symbol="", exchange="", interval="", start_date="",
+                end_date="", source="db"):
+        """
+        Returns historical data UP TO current bar only.
+        This prevents look-ahead bias — the single most critical requirement.
+        """
+        key = f"{symbol}:{exchange}"
+        if key not in self.data:
+            return pd.DataFrame()
+        df = self.data[key]
+        # CRITICAL: Default to -1 (no data visible) if bar index not set.
+        # Using len(df)-1 would expose ALL future data — a look-ahead bias leak.
+        current_idx = self.current_bar_index.get(key, -1)
+        if current_idx < 0:
+            return pd.DataFrame()
+        return df.iloc[: current_idx + 1].copy()
+
+    def quotes(self, symbol="", exchange=""):
+        """Returns current bar's data as a quote snapshot."""
+        bar = self._get_current_bar(symbol, exchange)
+        if bar is None:
+            return {"status": "error", "message": "No data available"}
+        prev_close = self._get_prev_close(symbol, exchange)
+        return {
+            "status": "success",
+            "data": {
+                "ltp": float(bar["close"]),
+                "open": float(bar["open"]),
+                "high": float(bar["high"]),
+                "low": float(bar["low"]),
+                "close": float(bar["close"]),
+                "volume": int(bar.get("volume", 0)),
+                "bid": float(bar["close"]),
+                "ask": float(bar["close"]),
+                "prev_close": float(prev_close) if prev_close is not None else float(bar["open"]),
+                "oi": int(bar.get("oi", 0)),
+            },
+        }
+
+    def multiquotes(self, symbols=None):
+        """Returns quotes for multiple symbols."""
+        if symbols is None:
+            symbols = []
+        results = {}
+        for sym in symbols:
+            q = self.quotes(sym.get("symbol", ""), sym.get("exchange", ""))
+            if q["status"] == "success":
+                results[f"{sym['symbol']}:{sym['exchange']}"] = q["data"]
+        return {"status": "success", "data": results}
+
+    def placeorder(self, strategy="", symbol="", action="", exchange="",
+                   price_type="MARKET", product="MIS", quantity=1,
+                   price=0, trigger_price=0, **kwargs):
+        """Simulate order execution."""
+        bar = self._get_current_bar(symbol, exchange)
+        if bar is None:
+            return {"status": "error", "message": f"No data for {symbol}:{exchange}"}
+
+        quantity = int(quantity)
+        if quantity <= 0:
+            return {"status": "error", "message": "Quantity must be positive"}
+
+        self._order_counter += 1
+        order_id = f"BT-{self._order_counter:06d}"
+
+        if price_type == "MARKET":
+            exec_price = self._apply_slippage(float(bar["close"]), action)
+            self._execute_fill(
+                symbol, exchange, action, quantity,
+                exec_price, product, strategy, bar,
+            )
+            self.orders.append({
+                "orderid": order_id, "symbol": symbol, "exchange": exchange,
+                "action": action, "quantity": quantity, "price": exec_price,
+                "price_type": "MARKET", "product": product, "strategy": strategy,
+                "status": "complete", "timestamp": self.current_timestamp,
+            })
+            return {"orderid": order_id, "status": "success"}
+
+        if price_type in ("LIMIT", "SL", "SL-M"):
+            self.pending_orders.append({
+                "order_id": order_id,
+                "symbol": symbol,
+                "exchange": exchange,
+                "action": action,
+                "quantity": quantity,
+                "price_type": price_type,
+                "price": float(price),
+                "trigger_price": float(trigger_price),
+                "product": product,
+                "strategy": strategy,
+                "placed_bar": self.current_bar_index.get(f"{symbol}:{exchange}", 0),
+            })
+            self.orders.append({
+                "orderid": order_id, "symbol": symbol, "exchange": exchange,
+                "action": action, "quantity": quantity, "price": float(price),
+                "price_type": price_type, "product": product, "strategy": strategy,
+                "status": "open", "timestamp": self.current_timestamp,
+            })
+            return {"orderid": order_id, "status": "success"}
+
+        return {"status": "error", "message": f"Unknown price_type: {price_type}"}
+
+    def placesmartorder(self, strategy="", symbol="", action="", exchange="",
+                        price_type="MARKET", product="MIS", quantity=1,
+                        position_size=0, **kwargs):
+        """Position-aware order placement."""
+        key = f"{symbol}:{exchange}"
+        current_qty = self.positions.get(key, {}).get("qty", 0)
+        target = int(position_size)
+
+        if action == "BUY":
+            needed = target - current_qty
+        else:  # SELL
+            needed = current_qty - target
+
+        if needed > 0:
+            actual_action = "BUY" if action == "BUY" else "SELL"
+            return self.placeorder(
+                strategy=strategy, symbol=symbol, action=actual_action,
+                exchange=exchange, price_type=price_type, product=product,
+                quantity=abs(needed), **kwargs,
+            )
+        elif needed < 0:
+            actual_action = "SELL" if action == "BUY" else "BUY"
+            return self.placeorder(
+                strategy=strategy, symbol=symbol, action=actual_action,
+                exchange=exchange, price_type=price_type, product=product,
+                quantity=abs(needed), **kwargs,
+            )
+
+        return {"status": "success", "message": "No action needed"}
+
+    def cancelorder(self, order_id="", **kwargs):
+        """Cancel a pending order by ID."""
+        before = len(self.pending_orders)
+        self.pending_orders = [
+            o for o in self.pending_orders if o["order_id"] != order_id
+        ]
+        # Update order status in orders list
+        for o in self.orders:
+            if o.get("orderid") == order_id and o.get("status") == "open":
+                o["status"] = "cancelled"
+        if len(self.pending_orders) < before:
+            return {"status": "success"}
+        return {"status": "error", "message": "Order not found"}
+
+    def cancelallorder(self, strategy="", **kwargs):
+        """Cancel all pending orders, optionally filtered by strategy."""
+        if strategy:
+            self.pending_orders = [
+                o for o in self.pending_orders if o.get("strategy") != strategy
+            ]
+        else:
+            self.pending_orders.clear()
+        for o in self.orders:
+            if o.get("status") == "open":
+                if not strategy or o.get("strategy") == strategy:
+                    o["status"] = "cancelled"
+        return {"status": "success"}
+
+    def closeposition(self, strategy="", **kwargs):
+        """Close all open positions."""
+        for key, pos in list(self.positions.items()):
+            if pos["qty"] != 0:
+                symbol, exchange = key.split(":")
+                action = "SELL" if pos["qty"] > 0 else "BUY"
+                self.placeorder(
+                    strategy=strategy, symbol=symbol, action=action,
+                    exchange=exchange, price_type="MARKET",
+                    product=pos.get("product", "MIS"),
+                    quantity=abs(pos["qty"]),
+                )
+        return {"status": "success"}
+
+    def positionbook(self):
+        """Return current open positions."""
+        positions = []
+        for key, pos in self.positions.items():
+            if pos["qty"] != 0:
+                symbol, exchange = key.split(":")
+                bar = self._get_current_bar(symbol, exchange)
+                ltp = float(bar["close"]) if bar is not None else pos["avg_price"]
+                if pos["qty"] > 0:
+                    pnl = (ltp - pos["avg_price"]) * pos["qty"]
+                else:
+                    pnl = (pos["avg_price"] - ltp) * abs(pos["qty"])
+                positions.append({
+                    "symbol": symbol, "exchange": exchange,
+                    "product": pos.get("product", "MIS"),
+                    "quantity": str(pos["qty"]),
+                    "average_price": str(round(pos["avg_price"], 2)),
+                    "ltp": str(round(ltp, 2)),
+                    "pnl": str(round(pnl, 2)),
+                })
+        return {"status": "success", "data": positions}
+
+    def orderbook(self):
+        """Return all orders."""
+        return {"status": "success", "data": self.orders}
+
+    def tradebook(self):
+        """Return all executed trades."""
+        return {
+            "status": "success",
+            "data": [
+                {
+                    "symbol": t["symbol"],
+                    "exchange": t["exchange"],
+                    "action": t["action"],
+                    "quantity": t["quantity"],
+                    "price": t["entry_price"],
+                    "strategy": t.get("strategy_tag", ""),
+                }
+                for t in self.trades
+            ],
+        }
+
+    def funds(self):
+        """Return fund balances."""
+        unrealized = self._total_unrealized()
+        realized = self.capital - self.initial_capital
+        return {
+            "status": "success",
+            "data": {
+                "availablecash": str(round(self.capital, 2)),
+                "collateral": "0",
+                "m2mrealized": str(round(realized, 2)),
+                "m2munrealized": str(round(unrealized, 2)),
+            },
+        }
+
+    def openposition(self, strategy="", symbol="", exchange="", product="MIS"):
+        """Check if a position exists for a symbol."""
+        key = f"{symbol}:{exchange}"
+        pos = self.positions.get(key, {})
+        qty = pos.get("qty", 0)
+        return {"status": "success", "quantity": str(qty)}
+
+    def holdings(self):
+        """No holdings in backtest mode."""
+        return {"status": "success", "data": []}
+
+    def orderstatus(self, order_id="", strategy=""):
+        """Get status of a specific order."""
+        for o in self.orders:
+            if o.get("orderid") == order_id:
+                return {"status": "success", "data": o}
+        return {"status": "error", "message": "Order not found"}
+
+    def search(self, query="", exchange=""):
+        """Stub — not applicable in backtest."""
+        return {"status": "success", "data": []}
+
+    def intervals(self):
+        """Return supported intervals."""
+        return {
+            "status": "success",
+            "data": {
+                "minutes": ["1m", "3m", "5m", "10m", "15m", "30m"],
+                "hours": ["1h"],
+                "days": ["D"],
+            },
+        }
+
+    # ─── Internal Methods ────────────────────────────────────────────
+
+    def _get_current_bar(self, symbol, exchange):
+        """Get the current bar for a symbol."""
+        key = f"{symbol}:{exchange}"
+        if key not in self.data:
+            return None
+        idx = self.current_bar_index.get(key, 0)
+        df = self.data[key]
+        if idx >= len(df):
+            return None
+        return df.iloc[idx]
+
+    def _get_prev_close(self, symbol, exchange):
+        """Get previous bar's close price."""
+        key = f"{symbol}:{exchange}"
+        idx = self.current_bar_index.get(key, 0)
+        if idx <= 0:
+            return None
+        return float(self.data[key].iloc[idx - 1]["close"])
+
+    def _apply_slippage(self, price, action):
+        """Apply slippage percentage to execution price."""
+        pct = self.slippage_pct / 100.0
+        if action == "BUY":
+            return round(price * (1 + pct), 2)
+        return round(price * (1 - pct), 2)
+
+    def _calculate_commission(self, trade_value):
+        """Calculate commission for a trade."""
+        if self.commission_pct > 0:
+            return round(trade_value * self.commission_pct / 100.0, 2)
+        return self.commission_per_order
+
+    def _execute_fill(self, symbol, exchange, action, qty, exec_price,
+                      product, strategy, bar):
+        """
+        Execute a fill: update positions, deduct commission, record trade.
+        Handles: new position, add to position, partial close, full close, reversal.
+        """
+        key = f"{symbol}:{exchange}"
+        trade_value = qty * exec_price
+        slippage_cost = abs(exec_price - float(bar["close"])) * qty
+
+        # Get or create position
+        pos = self.positions.get(key, {"qty": 0, "avg_price": 0.0, "product": product})
+        old_qty = pos["qty"]
+
+        if action == "BUY":
+            new_qty = old_qty + qty
+        else:
+            new_qty = old_qty - qty
+
+        # Case 1: New position (was flat)
+        if old_qty == 0:
+            commission = self._calculate_commission(trade_value)
+            self.capital -= commission
+            pos["avg_price"] = exec_price
+            pos["qty"] = new_qty
+            pos["product"] = product
+            self.open_entries[key] = {
+                "entry_price": exec_price,
+                "entry_time": self.current_timestamp,
+                "entry_bar": self.current_bar_index.get(key, 0),
+                "qty": abs(new_qty),
+                "action": action,
+                "strategy": strategy,
+            }
+
+        # Case 2: Adding to existing position (same direction)
+        elif (old_qty > 0 and action == "BUY") or (old_qty < 0 and action == "SELL"):
+            commission = self._calculate_commission(trade_value)
+            self.capital -= commission
+            total_cost = abs(old_qty) * pos["avg_price"] + qty * exec_price
+            pos["qty"] = new_qty
+            if abs(new_qty) > 0:
+                pos["avg_price"] = round(total_cost / abs(new_qty), 2)
+
+        # Case 3: Reducing, closing, or reversing
+        else:
+            close_qty = min(abs(old_qty), qty)
+            excess_qty = qty - close_qty  # >0 only for reversals
+
+            # Commission for the CLOSE portion only (proportional to close_qty)
+            close_value = close_qty * exec_price
+            close_commission = self._calculate_commission(close_value)
+            close_slippage = abs(exec_price - float(bar["close"])) * close_qty
+
+            # Deduct close commission
+            self.capital -= close_commission
+
+            # P&L for closed portion
+            if old_qty > 0:
+                pnl = (exec_price - pos["avg_price"]) * close_qty
+            else:
+                pnl = (pos["avg_price"] - exec_price) * close_qty
+
+            self.capital += pnl
+
+            # Record completed trade
+            entry = self.open_entries.get(key, {})
+            self._trade_counter += 1
+            entry_bar = entry.get("entry_bar", 0)
+            current_bar = self.current_bar_index.get(key, 0)
+
+            self.trades.append({
+                "trade_num": self._trade_counter,
+                "symbol": symbol,
+                "exchange": exchange,
+                "action": "LONG" if old_qty > 0 else "SHORT",
+                "quantity": close_qty,
+                "entry_price": round(pos["avg_price"], 2),
+                "exit_price": round(exec_price, 2),
+                "entry_time": entry.get("entry_time"),
+                "exit_time": self.current_timestamp,
+                "pnl": round(pnl, 2),
+                "pnl_pct": round(
+                    pnl / (pos["avg_price"] * close_qty) * 100, 4
+                ) if pos["avg_price"] > 0 and close_qty > 0 else 0.0,
+                "commission": round(close_commission, 2),
+                "slippage_cost": round(close_slippage, 2),
+                "net_pnl": round(pnl - close_commission, 2),
+                "bars_held": max(current_bar - entry_bar, 0),
+                "product": product,
+                "strategy_tag": strategy,
+            })
+
+            pos["qty"] = new_qty
+
+            if new_qty == 0:
+                # Fully closed
+                pos["avg_price"] = 0.0
+                self.open_entries.pop(key, None)
+            elif (old_qty > 0 and new_qty < 0) or (old_qty < 0 and new_qty > 0):
+                # Reversed — open new entry for excess, charge separate commission
+                reversal_value = excess_qty * exec_price
+                reversal_commission = self._calculate_commission(reversal_value)
+                self.capital -= reversal_commission
+
+                pos["avg_price"] = exec_price
+                self.open_entries[key] = {
+                    "entry_price": exec_price,
+                    "entry_time": self.current_timestamp,
+                    "entry_bar": self.current_bar_index.get(key, 0),
+                    "qty": abs(new_qty),
+                    "action": action,
+                    "strategy": strategy,
+                }
+            # else: partial close — keep existing avg_price
+
+        self.positions[key] = pos
+
+    def process_pending_orders(self):
+        """
+        Check all pending SL/LIMIT orders against current bar's OHLC.
+        Called by the engine at the start of each bar.
+        """
+        remaining = []
+        for order in self.pending_orders:
+            key = f"{order['symbol']}:{order['exchange']}"
+            bar = self._get_current_bar(order["symbol"], order["exchange"])
+            if bar is None:
+                remaining.append(order)
+                continue
+
+            triggered = False
+            exec_price = 0.0
+            bar_high = float(bar["high"])
+            bar_low = float(bar["low"])
+            bar_close = float(bar["close"])
+
+            if order["price_type"] == "LIMIT":
+                if order["action"] == "BUY" and bar_low <= order["price"]:
+                    exec_price = order["price"]
+                    triggered = True
+                elif order["action"] == "SELL" and bar_high >= order["price"]:
+                    exec_price = order["price"]
+                    triggered = True
+
+            elif order["price_type"] == "SL":
+                if order["action"] == "BUY" and bar_high >= order["trigger_price"]:
+                    exec_price = min(order["price"], bar_high)
+                    triggered = True
+                elif order["action"] == "SELL" and bar_low <= order["trigger_price"]:
+                    exec_price = max(order["price"], bar_low)
+                    triggered = True
+
+            elif order["price_type"] == "SL-M":
+                if order["action"] == "BUY" and bar_high >= order["trigger_price"]:
+                    exec_price = self._apply_slippage(bar_close, "BUY")
+                    triggered = True
+                elif order["action"] == "SELL" and bar_low <= order["trigger_price"]:
+                    exec_price = self._apply_slippage(bar_close, "SELL")
+                    triggered = True
+
+            if triggered:
+                self._execute_fill(
+                    order["symbol"], order["exchange"], order["action"],
+                    order["quantity"], exec_price, order["product"],
+                    order["strategy"], bar,
+                )
+                # Update order status
+                for o in self.orders:
+                    if o.get("orderid") == order["order_id"] and o.get("status") == "open":
+                        o["status"] = "complete"
+                        o["price"] = exec_price
+            else:
+                remaining.append(order)
+
+        self.pending_orders = remaining
+
+    def record_equity(self, timestamp):
+        """Snapshot equity for curve generation."""
+        unrealized = self._total_unrealized()
+        equity = self.capital + unrealized
+        self.peak_equity = max(self.peak_equity, equity)
+        drawdown = 0.0
+        if self.peak_equity > 0:
+            drawdown = (self.peak_equity - equity) / self.peak_equity
+        self.equity_curve.append({
+            "timestamp": int(timestamp) if not isinstance(timestamp, int) else timestamp,
+            "equity": round(equity, 2),
+            "drawdown": round(drawdown, 6),
+        })
+
+    def close_all_positions_at_end(self):
+        """Force-close all open positions at last bar price."""
+        for key, pos in list(self.positions.items()):
+            if pos["qty"] != 0:
+                symbol, exchange = key.split(":")
+                bar = self._get_current_bar(symbol, exchange)
+                if bar is not None:
+                    action = "SELL" if pos["qty"] > 0 else "BUY"
+                    exec_price = self._apply_slippage(float(bar["close"]), action)
+                    self._execute_fill(
+                        symbol, exchange, action, abs(pos["qty"]),
+                        exec_price, pos.get("product", "MIS"),
+                        "_backtest_close", bar,
+                    )
+
+    def advance_to(self, timestamp):
+        """Advance all symbol cursors to the given timestamp."""
+        self.current_timestamp = timestamp
+        for key, df in self.data.items():
+            if "timestamp" in df.columns:
+                ts_values = df["timestamp"].values
+            else:
+                ts_values = df.index.values
+            # Find the latest bar at or before this timestamp
+            mask = ts_values <= timestamp
+            if mask.any():
+                self.current_bar_index[key] = int(mask.sum()) - 1
+            else:
+                self.current_bar_index[key] = -1
+
+    def _total_unrealized(self):
+        """Calculate total unrealized P&L across all positions."""
+        total = 0.0
+        for key, pos in self.positions.items():
+            if pos["qty"] != 0:
+                symbol, exchange = key.split(":")
+                bar = self._get_current_bar(symbol, exchange)
+                if bar is not None:
+                    ltp = float(bar["close"])
+                    if pos["qty"] > 0:
+                        total += (ltp - pos["avg_price"]) * pos["qty"]
+                    else:
+                        total += (pos["avg_price"] - ltp) * abs(pos["qty"])
+        return total

--- a/services/backtest_engine.py
+++ b/services/backtest_engine.py
@@ -1,0 +1,521 @@
+# services/backtest_engine.py
+"""
+Backtest Engine — Bar-by-bar replay orchestrator.
+
+Loads data from Historify DuckDB, builds a unified timestamp timeline,
+patches the strategy code, and replays bar-by-bar. Emits progress via
+callback, computes metrics on completion.
+
+Supports cancellation via threading.Event.
+"""
+
+import json
+import time as _time
+import uuid
+from datetime import datetime, timezone
+from threading import Event
+
+import pandas as pd
+
+from database.backtest_db import BacktestRun, BacktestTrade, db_session
+from database.historify_db import get_data_range, get_ohlcv
+from services.backtest_client import BacktestClient
+from services.backtest_metrics import calculate_metrics
+from services.backtest_patcher import StrategyPatcher
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def generate_backtest_id():
+    """Generate a unique backtest ID: BT-YYYYMMDD-HHMMSS-{uuid8}."""
+    now = datetime.now(timezone.utc)
+    short_uuid = uuid.uuid4().hex[:8]
+    return f"BT-{now.strftime('%Y%m%d-%H%M%S')}-{short_uuid}"
+
+
+def validate_data_availability(symbols, exchange, interval, start_date, end_date):
+    """
+    Check if data exists in Historify for the requested configuration.
+
+    Args:
+        symbols: list of symbol strings
+        exchange: exchange code
+        interval: bar interval string
+        start_date: YYYY-MM-DD string
+        end_date: YYYY-MM-DD string
+
+    Returns:
+        dict: {available: bool, details: {symbol: {has_data, record_count, ...}}}
+    """
+    # Determine storage interval for data_range check
+    storage_interval = _storage_interval_for(interval)
+
+    details = {}
+    all_available = True
+
+    for sym in symbols:
+        range_info = get_data_range(sym, exchange, storage_interval)
+        if range_info and range_info.get("record_count", 0) > 0:
+            details[sym] = {
+                "has_data": True,
+                "record_count": range_info["record_count"],
+                "first_timestamp": range_info["first_timestamp"],
+                "last_timestamp": range_info["last_timestamp"],
+            }
+        else:
+            details[sym] = {"has_data": False, "record_count": 0}
+            all_available = False
+
+    return {"available": all_available, "details": details}
+
+
+def _storage_interval_for(interval):
+    """Map requested interval to Historify storage interval for catalog lookup."""
+    intraday = {"1m", "3m", "5m", "10m", "15m", "30m", "1h"}
+    if interval in intraday:
+        return "1m"
+    return "D"
+
+
+class BacktestEngine:
+    """
+    Orchestrates a single backtest run: data loading, strategy patching,
+    bar-by-bar replay, metric computation, and result persistence.
+    """
+
+    def __init__(self, config, progress_callback=None, cancel_event=None):
+        """
+        Args:
+            config: dict with keys:
+                backtest_id, user_id, name, strategy_id, strategy_code,
+                symbols (list), exchange, start_date, end_date, interval,
+                initial_capital, slippage_pct, commission_per_order,
+                commission_pct, data_source
+            progress_callback: callable(backtest_id, pct, message) for progress updates
+            cancel_event: threading.Event to signal cancellation
+        """
+        self.config = config
+        self.backtest_id = config["backtest_id"]
+        self.progress_callback = progress_callback or (lambda *a, **kw: None)
+        self.cancel_event = cancel_event or Event()
+
+    def run(self):
+        """
+        Execute the full backtest pipeline.
+
+        Returns:
+            dict: {status, metrics, trades_count, duration_ms, error}
+        """
+        start_time = _time.time()
+
+        try:
+            self._update_status("running")
+            self._emit_progress(0, "Loading historical data...")
+
+            # Step 1: Load data from Historify
+            data_frames = self._load_data()
+            if not data_frames:
+                return self._fail("No data available for the requested configuration")
+
+            if self._is_cancelled():
+                return self._cancel()
+
+            self._emit_progress(10, "Building timeline...")
+
+            # Step 2: Build unified timestamp timeline
+            timeline = self._build_timeline(data_frames)
+            if not timeline:
+                return self._fail("Could not build timeline — no overlapping data")
+
+            if self._is_cancelled():
+                return self._cancel()
+
+            self._emit_progress(15, "Patching strategy...")
+
+            # Step 3: Create BacktestClient and inject data
+            client = BacktestClient(self.config)
+            for key, df in data_frames.items():
+                client.data[key] = df
+
+            # Step 4: Patch strategy code
+            patcher = StrategyPatcher()
+            try:
+                iteration_fn = patcher.patch(self.config["strategy_code"], client)
+            except ValueError as e:
+                return self._fail(f"Strategy error: {e}")
+
+            if self._is_cancelled():
+                return self._cancel()
+
+            self._emit_progress(20, "Running backtest...")
+
+            # Step 5: Bar-by-bar replay
+            total_bars = len(timeline)
+            progress_interval = max(total_bars // 100, 1)  # Update every ~1%
+
+            for i, timestamp in enumerate(timeline):
+                if self._is_cancelled():
+                    return self._cancel()
+
+                # Advance client to this bar
+                client.advance_to(timestamp)
+
+                # Process pending orders BEFORE strategy iteration
+                client.process_pending_orders()
+
+                # Execute strategy iteration
+                try:
+                    iteration_fn()
+                except Exception as e:
+                    # Strategy errors are non-fatal — log and continue
+                    logger.debug(f"Strategy iteration error at bar {i}: {e}")
+
+                # Record equity AFTER iteration
+                client.record_equity(timestamp)
+
+                # Emit progress periodically
+                if i % progress_interval == 0 or i == total_bars - 1:
+                    pct = 20 + int((i / max(total_bars - 1, 1)) * 70)  # 20-90%
+                    self._emit_progress(
+                        pct,
+                        f"Processing bar {i + 1}/{total_bars}",
+                    )
+
+            self._emit_progress(90, "Closing positions...")
+
+            # Step 6: Close all open positions at end
+            client.close_all_positions_at_end()
+            # Record final equity after closing ONLY if positions were actually closed
+            # (which changes capital). Use a distinct timestamp to avoid duplicates.
+            if timeline and any(
+                pos["qty"] != 0 for pos in client.positions.values()
+            ) is False:
+                # Positions were closed — update the last equity point in-place
+                # instead of appending a duplicate timestamp
+                if client.equity_curve:
+                    last = client.equity_curve[-1]
+                    unrealized = client._total_unrealized()
+                    equity = client.capital + unrealized
+                    client.peak_equity = max(client.peak_equity, equity)
+                    dd = 0.0
+                    if client.peak_equity > 0:
+                        dd = (client.peak_equity - equity) / client.peak_equity
+                    last["equity"] = round(equity, 2)
+                    last["drawdown"] = round(dd, 6)
+
+            if self._is_cancelled():
+                return self._cancel()
+
+            self._emit_progress(92, "Computing metrics...")
+
+            # Step 7: Compute metrics
+            metrics = calculate_metrics(
+                trades=client.trades,
+                equity_curve=client.equity_curve,
+                initial_capital=float(self.config["initial_capital"]),
+                interval=self.config["interval"],
+            )
+
+            self._emit_progress(95, "Saving results...")
+
+            # Step 8: Persist results
+            duration_ms = int((_time.time() - start_time) * 1000)
+            self._save_results(client, metrics, duration_ms)
+
+            self._emit_progress(100, "Backtest complete")
+            self._update_status("completed")
+
+            return {
+                "status": "completed",
+                "backtest_id": self.backtest_id,
+                "metrics": metrics,
+                "trades_count": len(client.trades),
+                "duration_ms": duration_ms,
+            }
+
+        except Exception as e:
+            logger.exception(f"Backtest {self.backtest_id} failed: {e}")
+            return self._fail(str(e))
+
+    # ─── Data Loading ─────────────────────────────────────────────
+
+    def _load_data(self):
+        """Load OHLCV data for all symbols from Historify."""
+        symbols = self.config.get("symbols", [])
+        if isinstance(symbols, str):
+            symbols = json.loads(symbols)
+
+        exchange = self.config.get("exchange", "NSE")
+        interval = self.config["interval"]
+        start_date = self.config["start_date"]
+        end_date = self.config["end_date"]
+
+        # Convert dates to timestamps
+        start_ts = self._date_to_timestamp(start_date)
+        end_ts = self._date_to_timestamp(end_date, end_of_day=True)
+
+        data_frames = {}
+
+        for sym in symbols:
+            try:
+                df = get_ohlcv(
+                    symbol=sym,
+                    exchange=exchange,
+                    interval=interval,
+                    start_timestamp=start_ts,
+                    end_timestamp=end_ts,
+                )
+                if df is not None and not df.empty:
+                    key = f"{sym}:{exchange}"
+                    data_frames[key] = df
+                    logger.debug(
+                        f"Loaded {len(df)} bars for {key} "
+                        f"({interval}, {start_date} to {end_date})"
+                    )
+                else:
+                    logger.warning(f"No data for {sym}:{exchange} ({interval})")
+            except Exception as e:
+                logger.error(f"Error loading data for {sym}:{exchange}: {e}")
+
+        return data_frames
+
+    def _build_timeline(self, data_frames):
+        """
+        Build a unified, sorted timeline of unique timestamps across all symbols.
+        This ensures multi-symbol strategies see consistent bar timing.
+        """
+        all_timestamps = set()
+        for key, df in data_frames.items():
+            if "timestamp" in df.columns:
+                all_timestamps.update(df["timestamp"].tolist())
+
+        if not all_timestamps:
+            return []
+
+        return sorted(all_timestamps)
+
+    def _date_to_timestamp(self, date_str, end_of_day=False):
+        """Convert YYYY-MM-DD string to epoch timestamp."""
+        dt = datetime.strptime(date_str, "%Y-%m-%d")
+        if end_of_day:
+            dt = dt.replace(hour=23, minute=59, second=59)
+        # Use UTC for consistency
+        dt = dt.replace(tzinfo=timezone.utc)
+        return int(dt.timestamp())
+
+    # ─── Persistence ──────────────────────────────────────────────
+
+    def _save_results(self, client, metrics, duration_ms):
+        """Save backtest results (metrics + trades) to the database."""
+        try:
+            # Update the BacktestRun record with results
+            run = BacktestRun.query.filter_by(id=self.backtest_id).first()
+            if not run:
+                logger.error(f"BacktestRun {self.backtest_id} not found for result save")
+                return
+
+            # Metrics
+            run.final_capital = metrics.get("final_capital")
+            run.total_return_pct = metrics.get("total_return_pct")
+            run.cagr = metrics.get("cagr")
+            run.sharpe_ratio = metrics.get("sharpe_ratio")
+            run.sortino_ratio = metrics.get("sortino_ratio")
+            run.max_drawdown_pct = metrics.get("max_drawdown_pct")
+            run.calmar_ratio = metrics.get("calmar_ratio")
+            run.win_rate = metrics.get("win_rate")
+            run.profit_factor = metrics.get("profit_factor")
+            run.total_trades = metrics.get("total_trades", 0)
+            run.winning_trades = metrics.get("winning_trades", 0)
+            run.losing_trades = metrics.get("losing_trades", 0)
+            run.avg_win = metrics.get("avg_win")
+            run.avg_loss = metrics.get("avg_loss")
+            run.max_win = metrics.get("max_win")
+            run.max_loss = metrics.get("max_loss")
+            run.expectancy = metrics.get("expectancy")
+            run.avg_holding_bars = metrics.get("avg_holding_bars")
+            run.total_commission = metrics.get("total_commission")
+            run.total_slippage = metrics.get("total_slippage")
+
+            # Serialize large data
+            # Limit equity curve to max 5000 points for storage
+            equity_curve = client.equity_curve
+            if len(equity_curve) > 5000:
+                step = len(equity_curve) // 5000
+                equity_curve = equity_curve[::step]
+                # Always include the last point
+                if equity_curve[-1] != client.equity_curve[-1]:
+                    equity_curve.append(client.equity_curve[-1])
+
+            run.equity_curve_json = json.dumps(equity_curve)
+            run.monthly_returns_json = json.dumps(
+                metrics.get("monthly_returns", {})
+            )
+
+            run.status = "completed"
+            run.completed_at = datetime.now(timezone.utc)
+            run.duration_ms = duration_ms
+
+            # Save trades
+            for t in client.trades:
+                trade = BacktestTrade(
+                    backtest_id=self.backtest_id,
+                    trade_num=t["trade_num"],
+                    symbol=t["symbol"],
+                    exchange=t["exchange"],
+                    action=t["action"],
+                    quantity=t["quantity"],
+                    entry_price=t["entry_price"],
+                    exit_price=t["exit_price"],
+                    entry_time=str(t.get("entry_time", "")),
+                    exit_time=str(t.get("exit_time", "")),
+                    pnl=t.get("pnl", 0),
+                    pnl_pct=t.get("pnl_pct", 0),
+                    commission=t.get("commission", 0),
+                    slippage_cost=t.get("slippage_cost", 0),
+                    net_pnl=t.get("net_pnl", 0),
+                    bars_held=t.get("bars_held", 0),
+                    product=t.get("product"),
+                    strategy_tag=t.get("strategy_tag"),
+                )
+                db_session.add(trade)
+
+            db_session.commit()
+            logger.info(
+                f"Backtest {self.backtest_id} saved: "
+                f"{len(client.trades)} trades, "
+                f"return={metrics.get('total_return_pct', 0):.2f}%"
+            )
+
+        except Exception as e:
+            db_session.rollback()
+            logger.exception(f"Error saving backtest results: {e}")
+
+    # ─── Status & Progress ────────────────────────────────────────
+
+    def _update_status(self, status, error_message=None):
+        """Update backtest run status in the database."""
+        try:
+            run = BacktestRun.query.filter_by(id=self.backtest_id).first()
+            if run:
+                run.status = status
+                if status == "running":
+                    run.started_at = datetime.now(timezone.utc)
+                if error_message:
+                    run.error_message = error_message
+                db_session.commit()
+        except Exception as e:
+            db_session.rollback()
+            logger.error(f"Error updating backtest status: {e}")
+
+    def _emit_progress(self, pct, message):
+        """Emit progress update via callback."""
+        try:
+            self.progress_callback(self.backtest_id, pct, message)
+        except Exception:
+            pass  # Progress is best-effort
+
+    def _is_cancelled(self):
+        """Check if cancellation has been requested."""
+        return self.cancel_event.is_set()
+
+    def _cancel(self):
+        """Handle cancellation."""
+        self._update_status("cancelled")
+        self._emit_progress(0, "Backtest cancelled")
+        return {"status": "cancelled", "backtest_id": self.backtest_id}
+
+    def _fail(self, error_message):
+        """Handle failure."""
+        self._update_status("failed", error_message)
+        self._emit_progress(0, f"Failed: {error_message}")
+        return {
+            "status": "failed",
+            "backtest_id": self.backtest_id,
+            "error": error_message,
+        }
+
+
+# ─── Module-level runner (used by blueprint) ─────────────────────
+
+# Active backtest runs — {backtest_id: cancel_event}
+_active_runs = {}
+
+
+def start_backtest(config, progress_callback=None):
+    """
+    Create a BacktestRun record and launch the engine.
+
+    Args:
+        config: dict with all backtest configuration
+        progress_callback: callable(backtest_id, pct, message)
+
+    Returns:
+        dict: {backtest_id, status}
+    """
+    backtest_id = config.get("backtest_id") or generate_backtest_id()
+    config["backtest_id"] = backtest_id
+
+    # Create DB record
+    try:
+        symbols = config.get("symbols", [])
+        if isinstance(symbols, list):
+            symbols_json = json.dumps(symbols)
+        else:
+            symbols_json = symbols
+
+        run = BacktestRun(
+            id=backtest_id,
+            user_id=config.get("user_id", "default"),
+            name=config.get("name", f"Backtest {backtest_id}"),
+            strategy_id=config.get("strategy_id"),
+            strategy_code=config.get("strategy_code", ""),
+            symbols=symbols_json,
+            start_date=config["start_date"],
+            end_date=config["end_date"],
+            interval=config["interval"],
+            initial_capital=config.get("initial_capital", 100000),
+            slippage_pct=config.get("slippage_pct", 0.05),
+            commission_per_order=config.get("commission_per_order", 20.0),
+            commission_pct=config.get("commission_pct", 0.0),
+            data_source=config.get("data_source", "db"),
+            status="pending",
+        )
+        db_session.add(run)
+        db_session.commit()
+    except Exception as e:
+        db_session.rollback()
+        logger.exception(f"Error creating backtest run: {e}")
+        return {"status": "error", "error": str(e)}
+
+    # Create cancel event
+    cancel_event = Event()
+    _active_runs[backtest_id] = cancel_event
+
+    # Run engine
+    engine = BacktestEngine(config, progress_callback, cancel_event)
+    try:
+        result = engine.run()
+    finally:
+        _active_runs.pop(backtest_id, None)
+        # Clean up scoped_session to prevent stale sessions in thread pool reuse
+        try:
+            db_session.remove()
+        except Exception:
+            pass
+
+    return result
+
+
+def cancel_backtest(backtest_id):
+    """Request cancellation of a running backtest."""
+    cancel_event = _active_runs.get(backtest_id)
+    if cancel_event:
+        cancel_event.set()
+        return True
+    return False
+
+
+def get_active_backtests():
+    """Return list of currently running backtest IDs."""
+    return list(_active_runs.keys())

--- a/services/backtest_metrics.py
+++ b/services/backtest_metrics.py
@@ -1,0 +1,274 @@
+# services/backtest_metrics.py
+"""
+Backtest Performance Metrics Calculator
+
+Calculates all standard quantitative trading metrics from backtest results:
+Sharpe, Sortino, Max Drawdown, CAGR, Win Rate, Profit Factor, etc.
+
+Handles edge cases: zero trades, flat equity, single bar, inf values.
+"""
+
+import numpy as np
+import pandas as pd
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def calculate_metrics(trades, equity_curve, initial_capital, interval):
+    """
+    Calculate all performance metrics from backtest results.
+
+    Args:
+        trades: list of trade dicts from BacktestClient
+        equity_curve: list of {timestamp, equity, drawdown} dicts
+        initial_capital: starting capital (float)
+        interval: bar interval string ('1m', '5m', '15m', '30m', '1h', 'D')
+
+    Returns:
+        dict with all computed metrics
+    """
+    if not equity_curve or len(equity_curve) < 2:
+        return _empty_metrics(initial_capital)
+
+    try:
+        equity_values = [e["equity"] for e in equity_curve]
+        equity = pd.Series(equity_values, dtype=float)
+        returns = equity.pct_change().dropna()
+
+        # Replace inf/nan in returns
+        returns = returns.replace([np.inf, -np.inf], 0.0).fillna(0.0)
+
+        # Annualization factor
+        bars_per_year = _get_bars_per_year(interval)
+
+        metrics = {}
+
+        # ── Return Metrics ──
+        final_equity = float(equity.iloc[-1])
+        metrics["final_capital"] = round(final_equity, 2)
+        if initial_capital > 0:
+            metrics["total_return_pct"] = round(
+                (final_equity - initial_capital) / initial_capital * 100, 4
+            )
+        else:
+            metrics["total_return_pct"] = 0.0
+
+        # CAGR
+        total_bars = len(equity)
+        if total_bars > 1 and final_equity > 0 and initial_capital > 0 and bars_per_year > 0:
+            years = total_bars / bars_per_year
+            if years > 0:
+                ratio = final_equity / initial_capital
+                if ratio > 0:
+                    metrics["cagr"] = round(
+                        (ratio ** (1.0 / years) - 1) * 100, 4
+                    )
+                else:
+                    metrics["cagr"] = -100.0
+            else:
+                metrics["cagr"] = 0.0
+        else:
+            metrics["cagr"] = 0.0
+
+        # ── Risk Metrics ──
+        std = float(returns.std())
+        mean = float(returns.mean())
+
+        if len(returns) > 1 and std > 0:
+            metrics["sharpe_ratio"] = round(
+                mean / std * np.sqrt(bars_per_year), 4
+            )
+        else:
+            metrics["sharpe_ratio"] = 0.0
+
+        # Sortino — only downside deviation
+        downside = returns[returns < 0]
+        if len(downside) > 1:
+            down_std = float(downside.std())
+            if down_std > 0:
+                metrics["sortino_ratio"] = round(
+                    mean / down_std * np.sqrt(bars_per_year), 4
+                )
+            else:
+                metrics["sortino_ratio"] = 0.0
+        else:
+            metrics["sortino_ratio"] = 0.0
+
+        # Max drawdown
+        dd_values = [e.get("drawdown", 0) for e in equity_curve]
+        max_dd = max(dd_values) if dd_values else 0.0
+        metrics["max_drawdown_pct"] = round(max_dd * 100, 4)
+
+        # Calmar — use signed CAGR (not abs) so losing strategies show negative Calmar
+        if metrics["max_drawdown_pct"] > 0:
+            metrics["calmar_ratio"] = round(
+                metrics["cagr"] / metrics["max_drawdown_pct"], 4
+            )
+        else:
+            metrics["calmar_ratio"] = 0.0
+
+        # ── Trade Metrics ──
+        _compute_trade_metrics(metrics, trades)
+
+        # ── Monthly Returns ──
+        metrics["monthly_returns"] = _compute_monthly_returns(equity_curve)
+
+        return metrics
+
+    except Exception as e:
+        logger.exception(f"Error calculating metrics: {e}")
+        return _empty_metrics(initial_capital)
+
+
+def _compute_trade_metrics(metrics, trades):
+    """Compute trade-level statistics."""
+    if not trades:
+        metrics.update({
+            "total_trades": 0, "winning_trades": 0, "losing_trades": 0,
+            "win_rate": 0.0, "profit_factor": 0.0,
+            "avg_win": 0.0, "avg_loss": 0.0,
+            "max_win": 0.0, "max_loss": 0.0,
+            "expectancy": 0.0, "avg_holding_bars": 0,
+            "total_commission": 0.0, "total_slippage": 0.0,
+        })
+        return
+
+    wins = [t for t in trades if t.get("net_pnl", 0) > 0]
+    losses = [t for t in trades if t.get("net_pnl", 0) <= 0]
+
+    metrics["total_trades"] = len(trades)
+    metrics["winning_trades"] = len(wins)
+    metrics["losing_trades"] = len(losses)
+
+    if len(trades) > 0:
+        metrics["win_rate"] = round(len(wins) / len(trades) * 100, 4)
+    else:
+        metrics["win_rate"] = 0.0
+
+    gross_profit = sum(t.get("net_pnl", 0) for t in wins)
+    gross_loss = abs(sum(t.get("net_pnl", 0) for t in losses))
+
+    if gross_loss > 0:
+        pf = gross_profit / gross_loss
+        # Cap profit factor at 999.99 to avoid serialization issues
+        metrics["profit_factor"] = round(min(pf, 999.99), 4)
+    elif gross_profit > 0:
+        metrics["profit_factor"] = 999.99  # effectively infinite
+    else:
+        metrics["profit_factor"] = 0.0
+
+    # Win/loss averages
+    if wins:
+        win_pnls = [t.get("net_pnl", 0) for t in wins]
+        metrics["avg_win"] = round(float(np.mean(win_pnls)), 2)
+        metrics["max_win"] = round(float(max(win_pnls)), 2)
+    else:
+        metrics["avg_win"] = 0.0
+        metrics["max_win"] = 0.0
+
+    if losses:
+        loss_pnls = [t.get("net_pnl", 0) for t in losses]
+        metrics["avg_loss"] = round(float(np.mean(loss_pnls)), 2)
+        metrics["max_loss"] = round(float(min(loss_pnls)), 2)
+    else:
+        metrics["avg_loss"] = 0.0
+        metrics["max_loss"] = 0.0
+
+    # Expectancy
+    wr = metrics["win_rate"] / 100.0
+    metrics["expectancy"] = round(
+        wr * metrics["avg_win"] + (1.0 - wr) * metrics["avg_loss"], 2
+    )
+
+    # Average holding bars
+    bars_held = [t.get("bars_held", 0) for t in trades if t.get("bars_held", 0) > 0]
+    if bars_held:
+        metrics["avg_holding_bars"] = round(float(np.mean(bars_held)))
+    else:
+        metrics["avg_holding_bars"] = 0
+
+    # Totals
+    metrics["total_commission"] = round(
+        sum(t.get("commission", 0) for t in trades), 2
+    )
+    metrics["total_slippage"] = round(
+        sum(t.get("slippage_cost", 0) for t in trades), 2
+    )
+
+
+def _compute_monthly_returns(equity_curve):
+    """Compute monthly returns for calendar heatmap."""
+    try:
+        if len(equity_curve) < 2:
+            return {}
+
+        timestamps = [e["timestamp"] for e in equity_curve]
+        equities = [e["equity"] for e in equity_curve]
+
+        equity_ts = pd.Series(
+            equities,
+            index=pd.to_datetime(timestamps, unit="s"),
+            dtype=float,
+        )
+
+        # Resample to monthly, take last value
+        monthly = equity_ts.resample("ME").last().dropna()
+        if len(monthly) < 2:
+            return {}
+
+        monthly_returns = monthly.pct_change().dropna() * 100.0
+
+        return {
+            str(k.date()): round(float(v), 2)
+            for k, v in monthly_returns.items()
+            if not np.isnan(v) and not np.isinf(v)
+        }
+    except Exception as e:
+        logger.debug(f"Could not compute monthly returns: {e}")
+        return {}
+
+
+def _get_bars_per_year(interval):
+    """Get the number of bars per year for annualization."""
+    mapping = {
+        "1m": 252 * 375,
+        "3m": 252 * 125,
+        "5m": 252 * 75,
+        "10m": 252 * 37,
+        "15m": 252 * 25,
+        "30m": 252 * 12,
+        "1h": 252 * 6,
+        "D": 252,
+        "W": 52,
+        "M": 12,
+    }
+    return mapping.get(interval, 252)
+
+
+def _empty_metrics(initial_capital=0):
+    """Return empty metrics when no data is available."""
+    return {
+        "final_capital": round(float(initial_capital), 2),
+        "total_return_pct": 0.0,
+        "cagr": 0.0,
+        "sharpe_ratio": 0.0,
+        "sortino_ratio": 0.0,
+        "max_drawdown_pct": 0.0,
+        "calmar_ratio": 0.0,
+        "total_trades": 0,
+        "winning_trades": 0,
+        "losing_trades": 0,
+        "win_rate": 0.0,
+        "profit_factor": 0.0,
+        "avg_win": 0.0,
+        "avg_loss": 0.0,
+        "max_win": 0.0,
+        "max_loss": 0.0,
+        "expectancy": 0.0,
+        "avg_holding_bars": 0,
+        "total_commission": 0.0,
+        "total_slippage": 0.0,
+        "monthly_returns": {},
+    }

--- a/services/backtest_patcher.py
+++ b/services/backtest_patcher.py
@@ -1,0 +1,278 @@
+# services/backtest_patcher.py
+"""
+Strategy Patcher — Transforms live strategy code for backtest execution.
+
+Approach: Regex-based transformation + namespace injection.
+- Intercepts `from openalgo import api` and `api()` constructor
+- Replaces `time.sleep()` with a signal to advance to next bar
+- Extracts while-True loop body as a single-iteration function
+- Provides a safe, sandboxed execution namespace
+
+AST-based approach can be added later for robustness.
+"""
+
+import re
+import types
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+class BarComplete(Exception):
+    """Raised when strategy calls time.sleep() — signals engine to advance."""
+    pass
+
+
+class StrategyPatcher:
+    """
+    Transform a live trading strategy into a backtest-compatible iteration function.
+    """
+
+    def patch(self, source_code, client):
+        """
+        Patch strategy source code and return a callable that executes one iteration.
+
+        Args:
+            source_code: Python source code of the strategy
+            client: BacktestClient instance to inject
+
+        Returns:
+            callable: A function that runs one iteration of the strategy logic
+
+        Raises:
+            ValueError: If no strategy entry point can be found
+        """
+        # Step 1: Remove openalgo imports (we inject our own)
+        code = self._remove_openalgo_imports(source_code)
+
+        # Step 2: Replace api() constructor calls with client reference
+        code = self._replace_api_constructor(code)
+
+        # Step 3: Try to extract while-True loop body as iteration function
+        has_while_loop = self._has_while_true(code)
+        if has_while_loop:
+            code = self._extract_loop_body(code)
+
+        # Step 4: Remove time.sleep calls (they'd be inside extracted function)
+        code = self._remove_sleep_calls(code)
+
+        # Step 5: Build safe namespace
+        namespace = self._build_namespace(client)
+
+        # Step 6: Execute the patched code to define functions
+        try:
+            compiled = compile(code, "<backtest_strategy>", "exec")
+            exec(compiled, namespace)
+        except Exception as e:
+            raise ValueError(f"Failed to compile strategy code: {e}") from e
+
+        # Step 7: Find and return the iteration function
+        return self._find_entry_point(namespace, has_while_loop, code, client)
+
+    def _remove_openalgo_imports(self, code):
+        """Remove openalgo import statements."""
+        code = re.sub(
+            r"^\s*from\s+openalgo\s+import\s+api\s*$",
+            "# [backtest] openalgo import intercepted",
+            code,
+            flags=re.MULTILINE,
+        )
+        code = re.sub(
+            r"^\s*import\s+openalgo\s*$",
+            "# [backtest] openalgo import intercepted",
+            code,
+            flags=re.MULTILINE,
+        )
+        return code
+
+    def _replace_api_constructor(self, code):
+        """Replace api(...) constructor calls with _backtest_client reference."""
+        # Match: client = api(api_key=..., host=...)
+        # or: client = api(...)
+        code = re.sub(
+            r"(\w+)\s*=\s*api\s*\([^)]*\)",
+            r"\1 = _backtest_client",
+            code,
+        )
+        return code
+
+    def _has_while_true(self, code):
+        """Check if the code contains a while True loop."""
+        return bool(re.search(r"while\s+(True|1)\s*:", code))
+
+    def _extract_loop_body(self, code):
+        """
+        Extract the body of `while True:` into `def _backtest_iteration():`.
+
+        This handles the common strategy pattern:
+            while True:
+                ... strategy logic ...
+                time.sleep(N)
+        """
+        lines = code.split("\n")
+        result = []
+        in_while_loop = False
+        while_indent = 0
+        found_loop = False
+
+        for i, line in enumerate(lines):
+            stripped = line.lstrip()
+            indent = len(line) - len(stripped)
+
+            if not in_while_loop:
+                if re.match(r"while\s+(True|1)\s*:", stripped) and not found_loop:
+                    in_while_loop = True
+                    while_indent = indent
+                    found_loop = True
+                    result.append(" " * indent + "def _backtest_iteration():")
+                    continue
+                result.append(line)
+            else:
+                # Check if we've exited the while block
+                if stripped and indent <= while_indent:
+                    in_while_loop = False
+                    result.append(line)
+                else:
+                    result.append(line)
+
+        return "\n".join(result)
+
+    def _remove_sleep_calls(self, code):
+        """Remove time.sleep() calls from the code."""
+        code = re.sub(
+            r"^\s*time\.sleep\s*\([^)]*\)\s*$",
+            "",
+            code,
+            flags=re.MULTILINE,
+        )
+        return code
+
+    # Modules blocked from import inside strategy code (network, subprocess, etc.)
+    BLOCKED_MODULES = frozenset({
+        "requests", "urllib", "urllib2", "httplib", "http.client",
+        "socket", "socketserver", "xmlrpc", "ftplib", "smtplib",
+        "subprocess", "shutil", "signal", "ctypes", "multiprocessing",
+        "threading", "asyncio", "aiohttp", "websocket", "paramiko",
+        "boto3", "botocore", "google", "azure",
+    })
+
+    def _build_namespace(self, client):
+        """Build a safe execution namespace with injected dependencies."""
+        import builtins
+        import datetime
+        import json
+        import math
+
+        import numpy as np
+        import pandas as pd
+
+        # Create a safe os module (allow getenv, block filesystem writes)
+        safe_os = types.ModuleType("os")
+        import os as real_os
+        safe_os.getenv = real_os.getenv
+        safe_os.environ = real_os.environ
+        safe_os.path = real_os.path
+        safe_os.getcwd = real_os.getcwd
+
+        # Create a safe time module (sleep is a no-op)
+        safe_time = types.ModuleType("time")
+        safe_time.sleep = lambda *args, **kwargs: None  # no-op in backtest
+        safe_time.time = lambda: client.current_timestamp or 0
+        safe_time.monotonic = lambda: client.current_timestamp or 0
+
+        # Restricted __import__ that blocks dangerous modules
+        blocked = self.BLOCKED_MODULES
+        original_import = builtins.__import__
+
+        def _restricted_import(name, *args, **kwargs):
+            top_level = name.split(".")[0]
+            if top_level in blocked:
+                raise ImportError(
+                    f"Module '{name}' is blocked in backtest sandbox for security."
+                )
+            return original_import(name, *args, **kwargs)
+
+        # Build restricted builtins (copy all then override __import__)
+        restricted_builtins = dict(vars(builtins))
+        restricted_builtins["__import__"] = _restricted_import
+
+        namespace = {
+            "__builtins__": restricted_builtins,
+            # Injected client
+            "_backtest_client": client,
+            "api": lambda *args, **kwargs: client,
+            # Standard library
+            "pd": pd,
+            "pandas": pd,
+            "np": np,
+            "numpy": np,
+            "os": safe_os,
+            "time": safe_time,
+            "datetime": datetime,
+            "json": json,
+            "math": math,
+            # Convenience
+            "print": self._safe_print,
+        }
+
+        return namespace
+
+    def _safe_print(self, *args, **kwargs):
+        """Capture print statements (silently in backtest mode)."""
+        pass
+
+    def _find_entry_point(self, namespace, has_while_loop, code, client):
+        """
+        Find the callable entry point in the patched namespace.
+        Priority:
+        1. _backtest_iteration (extracted from while loop)
+        2. Named functions: main, run, strategy, execute, ema_strategy, etc.
+        3. If __name__ == "__main__" block functions
+        """
+        # Priority 1: extracted iteration function
+        if "_backtest_iteration" in namespace and callable(namespace["_backtest_iteration"]):
+            return namespace["_backtest_iteration"]
+
+        # Priority 2: common entry point names
+        common_names = [
+            "main", "run", "strategy", "execute",
+            "ema_strategy", "run_strategy", "start_strategy",
+            "trading_strategy", "algo",
+        ]
+        for name in common_names:
+            if name in namespace and callable(namespace[name]):
+                return namespace[name]
+
+        # Priority 3: scan for any function called in __name__ == __main__ block
+        main_match = re.search(
+            r'if\s+__name__\s*==\s*["\']__main__["\']\s*:\s*\n\s+(\w+)\s*\(',
+            code,
+        )
+        if main_match:
+            func_name = main_match.group(1)
+            if func_name in namespace and callable(namespace[func_name]):
+                return namespace[func_name]
+
+        # Priority 4: find any user-defined function (excluding dunder methods)
+        user_funcs = [
+            (name, obj) for name, obj in namespace.items()
+            if callable(obj)
+            and not name.startswith("_")
+            and name not in ("api", "print")
+            and isinstance(obj, types.FunctionType)
+        ]
+        if len(user_funcs) == 1:
+            return user_funcs[0][1]
+
+        # If no while loop was found and no functions, the code might be
+        # a simple script — wrap the entire code as a function
+        if not has_while_loop:
+            def _script_iteration():
+                pass  # Already executed during compile/exec
+            return _script_iteration
+
+        raise ValueError(
+            "Could not find strategy entry point. "
+            "Strategy must have a while True loop, or a main()/run()/strategy() function."
+        )

--- a/test/test_backtest_audit.py
+++ b/test/test_backtest_audit.py
@@ -1,0 +1,739 @@
+#!/usr/bin/env python
+"""
+ADVERSARIAL AUDIT — Full backtest engine audit.
+Phases 1-7, 10 of the 10-phase audit protocol.
+"""
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+import pandas as pd
+import pytest
+from services.backtest_client import BacktestClient
+from services.backtest_metrics import calculate_metrics, _get_bars_per_year, _empty_metrics
+from services.backtest_patcher import StrategyPatcher
+
+
+def make_client(capital=100000, slippage=0.05, commission=20.0, comm_pct=0.0):
+    return BacktestClient({
+        "initial_capital": capital,
+        "slippage_pct": slippage,
+        "commission_per_order": commission,
+        "commission_pct": comm_pct,
+    })
+
+
+def make_data(closes, symbol="SBIN", exchange="NSE"):
+    """Create simple OHLCV data from a list of close prices."""
+    n = len(closes)
+    df = pd.DataFrame({
+        "timestamp": list(range(1000, 1000 + n)),
+        "open": closes,
+        "high": [c + 2 for c in closes],
+        "low": [c - 2 for c in closes],
+        "close": closes,
+        "volume": [10000] * n,
+        "oi": [0] * n,
+    })
+    return df
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 1 — LOOK-AHEAD BIAS
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase1LookAheadBias:
+
+    def test_history_only_returns_up_to_current_bar(self):
+        """Prove history() never exposes future data."""
+        c = make_client()
+        c.data["S:E"] = make_data([100, 110, 120, 130, 140])
+        for idx in range(5):
+            c.current_bar_index["S:E"] = idx
+            df = c.history(symbol="S", exchange="E")
+            assert len(df) == idx + 1, f"At bar {idx}, got {len(df)} rows"
+            assert df.iloc[-1]["close"] == [100,110,120,130,140][idx]
+
+    def test_no_internal_method_reads_future(self):
+        """Verify _get_current_bar never reads beyond index."""
+        c = make_client()
+        data = make_data([100, 200, 300])
+        c.data["S:E"] = data
+        c.current_bar_index["S:E"] = 0
+        bar = c._get_current_bar("S", "E")
+        assert bar["close"] == 100  # Not 200 or 300
+
+    def test_cheating_strategy_does_not_get_perfect_returns(self):
+        """
+        Strategy that tries to buy when next bar is higher.
+        Since history() only shows up to current bar, it CANNOT
+        know tomorrow's close. If it tries df.iloc[-1] that's today.
+        """
+        c = make_client(commission=0, slippage=0)
+        prices = [100, 105, 95, 110, 90, 120, 80]
+        c.data["S:E"] = make_data(prices)
+
+        # Simulate: at each bar, strategy can only see history up to current
+        for i in range(len(prices)):
+            c.current_bar_index["S:E"] = i
+            c.current_timestamp = 1000 + i
+            df = c.history(symbol="S", exchange="E")
+            # Try to "cheat" by reading the last row — it's TODAY, not tomorrow
+            last_close = df.iloc[-1]["close"]
+            assert last_close == prices[i], "History leaked future data!"
+
+    def test_deliberate_future_access_fails(self):
+        """If someone tries to access data[current_idx+1], it should fail or return wrong data."""
+        c = make_client()
+        data = make_data([100, 200, 300])
+        c.data["S:E"] = data
+        c.current_bar_index["S:E"] = 0
+
+        # history() returns only 1 bar
+        df = c.history(symbol="S", exchange="E")
+        assert len(df) == 1
+        # Accessing iloc[1] should raise IndexError
+        with pytest.raises(IndexError):
+            _ = df.iloc[1]
+
+    def test_advance_to_never_overshoots(self):
+        """advance_to should set index to bar AT or BEFORE timestamp."""
+        c = make_client()
+        c.data["S:E"] = make_data([100, 200, 300])
+        # Advance to timestamp 1001 (bar index 1)
+        c.advance_to(1001)
+        assert c.current_bar_index["S:E"] == 1
+        # Advance to timestamp 1000 (bar index 0)
+        c.advance_to(1000)
+        assert c.current_bar_index["S:E"] == 0
+        # Advance to timestamp 999 (before data — should be -1)
+        c.advance_to(999)
+        assert c.current_bar_index["S:E"] == -1
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 2 — ORDER EXECUTION EDGE CASES
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase2OrderExecution:
+
+    def _setup(self, capital=100000, slippage=0, commission=0):
+        c = make_client(capital=capital, slippage=slippage, commission=commission)
+        c.data["S:E"] = make_data([100, 105, 95, 110])
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+        return c
+
+    def test_case1_partial_close(self):
+        """Buy 100, Sell 40, Sell 60 — verify trades and capital."""
+        c = self._setup(commission=20)
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=100, price_type="MARKET")
+        # commission = 20 deducted
+        assert c.positions["S:E"]["qty"] == 100
+
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=40, price_type="MARKET")
+        assert c.positions["S:E"]["qty"] == 60
+        assert len(c.trades) == 1  # First partial close logged
+
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=60, price_type="MARKET")
+        assert c.positions["S:E"]["qty"] == 0
+        assert len(c.trades) == 2  # Second close logged
+
+        # Both trades should have commission
+        assert c.trades[0]["commission"] > 0
+        assert c.trades[1]["commission"] > 0
+
+    def test_case2_reversal(self):
+        """Buy 100, Sell 200 — should close long + open short."""
+        c = self._setup()
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=100, price_type="MARKET")
+        assert c.positions["S:E"]["qty"] == 100
+
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=200, price_type="MARKET")
+        assert c.positions["S:E"]["qty"] == -100  # Short 100
+        assert len(c.trades) == 1  # Close of the long recorded
+
+        # Verify the trade action is LONG (was a long position closed)
+        assert c.trades[0]["action"] == "LONG"
+        assert c.trades[0]["quantity"] == 100
+
+    def test_case3_same_bar_sl_and_limit(self):
+        """Both SL and LIMIT could trigger on same bar — verify deterministic."""
+        c = self._setup()
+        # Buy 100 first
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=100, price_type="MARKET")
+
+        # Place SL-SELL at trigger=98 and LIMIT-SELL at 104
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=100,
+                     price_type="SL", trigger_price=98, price=97, product="MIS")
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=100,
+                     price_type="LIMIT", price=104, product="MIS")
+
+        # Move to bar 1: high=107, low=103 — LIMIT triggers (high>=104), SL doesn't (low>98)
+        c.current_bar_index["S:E"] = 1
+        c.current_timestamp = 1001
+        c.process_pending_orders()
+
+        # Only LIMIT should have triggered
+        filled = [o for o in c.orders if o["status"] == "complete" and o["price_type"] != "MARKET"]
+        assert len(filled) == 1
+
+    def test_case4_commission_exceeds_profit(self):
+        """Small winning trade where commission > pnl."""
+        c = make_client(capital=100000, slippage=0, commission=50)
+        c.data["S:E"] = make_data([100, 100.10])  # tiny gain
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=1, price_type="MARKET")
+        # Move to bar 1
+        c.current_bar_index["S:E"] = 1
+        c.current_timestamp = 1001
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=1, price_type="MARKET")
+
+        assert len(c.trades) == 1
+        t = c.trades[0]
+        # PnL = 0.10, Commission on entry=50, commission on exit=50
+        # net_pnl = pnl - commission_on_exit = 0.10 - 50 = -49.90
+        assert t["net_pnl"] < 0, f"Net PnL should be negative: {t['net_pnl']}"
+
+    def test_case5_slippage_direction(self):
+        """BUY increases price, SELL decreases price."""
+        c = make_client(slippage=1.0, commission=0)  # 1% slippage
+        c.data["S:E"] = make_data([100])
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+
+        buy_price = c._apply_slippage(100.0, "BUY")
+        sell_price = c._apply_slippage(100.0, "SELL")
+
+        assert buy_price > 100.0, f"BUY slippage should increase price: {buy_price}"
+        assert sell_price < 100.0, f"SELL slippage should decrease price: {sell_price}"
+        assert buy_price == 101.0
+        assert sell_price == 99.0
+
+    def test_case6_multi_symbol_timeline(self):
+        """Two symbols with overlapping bars — timeline union correctness."""
+        c = make_client()
+        c.data["A:E"] = pd.DataFrame({
+            "timestamp": [100, 200, 300],
+            "open": [10,11,12], "high": [12,13,14], "low": [9,10,11],
+            "close": [11,12,13], "volume": [1000]*3, "oi": [0]*3,
+        })
+        c.data["B:E"] = pd.DataFrame({
+            "timestamp": [150, 200, 250, 300],
+            "open": [20,21,22,23], "high": [22,23,24,25], "low": [19,20,21,22],
+            "close": [21,22,23,24], "volume": [1000]*4, "oi": [0]*4,
+        })
+
+        # Build timeline like engine does
+        all_ts = set()
+        for key, df in c.data.items():
+            all_ts.update(df["timestamp"].tolist())
+        timeline = sorted(all_ts)
+
+        assert timeline == [100, 150, 200, 250, 300]
+
+        # At timestamp 150, A should be at bar 0, B at bar 0
+        c.advance_to(150)
+        assert c.current_bar_index["A:E"] == 0  # ts 100 <= 150
+        assert c.current_bar_index["B:E"] == 0  # ts 150 <= 150
+
+    def test_case7_no_trades_no_nan(self):
+        """Zero trades — metrics must not NaN."""
+        equity = [
+            {"timestamp": 1000, "equity": 100000, "drawdown": 0},
+            {"timestamp": 1001, "equity": 100000, "drawdown": 0},
+            {"timestamp": 1002, "equity": 100000, "drawdown": 0},
+        ]
+        metrics = calculate_metrics([], equity, 100000, "D")
+        for k, v in metrics.items():
+            if k == "monthly_returns":
+                continue
+            if isinstance(v, float):
+                assert not np.isnan(v), f"Metric {k} is NaN"
+                assert not np.isinf(v), f"Metric {k} is inf"
+
+    def test_case8_flat_equity_sharpe_zero(self):
+        """Zero equity change — Sharpe = 0, not NaN."""
+        equity = [
+            {"timestamp": i, "equity": 100000, "drawdown": 0}
+            for i in range(100)
+        ]
+        metrics = calculate_metrics([], equity, 100000, "D")
+        assert metrics["sharpe_ratio"] == 0.0
+        assert not np.isnan(metrics["sharpe_ratio"])
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 3 — METRIC VERIFICATION AGAINST NUMPY GROUND TRUTH
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase3MetricGroundTruth:
+
+    def _make_equity_curve(self, equities):
+        peak = equities[0]
+        curve = []
+        for i, eq in enumerate(equities):
+            peak = max(peak, eq)
+            dd = (peak - eq) / peak if peak > 0 else 0
+            curve.append({"timestamp": 1000 + i, "equity": eq, "drawdown": dd})
+        return curve
+
+    def test_cagr_independent(self):
+        """Verify CAGR against independent numpy calculation."""
+        equities = [100000, 102000, 98000, 105000, 110000, 108000, 115000]
+        curve = self._make_equity_curve(equities)
+        metrics = calculate_metrics([], curve, 100000, "D")
+
+        # Independent CAGR
+        n_bars = len(equities)
+        bars_per_year = 252
+        years = n_bars / bars_per_year
+        ratio = equities[-1] / equities[0]
+        expected_cagr = (ratio ** (1.0 / years) - 1) * 100
+
+        assert abs(metrics["cagr"] - round(expected_cagr, 4)) < 1e-3, \
+            f"CAGR mismatch: {metrics['cagr']} vs {expected_cagr}"
+
+    def test_sharpe_independent(self):
+        """Verify Sharpe against independent numpy calculation."""
+        equities = [100000, 102000, 98000, 105000, 110000, 108000, 115000]
+        curve = self._make_equity_curve(equities)
+        metrics = calculate_metrics([], curve, 100000, "D")
+
+        # Independent Sharpe
+        eq = pd.Series(equities, dtype=float)
+        rets = eq.pct_change().dropna().replace([np.inf, -np.inf], 0).fillna(0)
+        expected_sharpe = float(rets.mean() / rets.std() * np.sqrt(252))
+
+        assert abs(metrics["sharpe_ratio"] - round(expected_sharpe, 4)) < 1e-3, \
+            f"Sharpe mismatch: {metrics['sharpe_ratio']} vs {expected_sharpe}"
+
+    def test_sortino_independent(self):
+        """Verify Sortino against independent numpy calculation."""
+        equities = [100000, 102000, 98000, 105000, 110000, 108000, 115000]
+        curve = self._make_equity_curve(equities)
+        metrics = calculate_metrics([], curve, 100000, "D")
+
+        eq = pd.Series(equities, dtype=float)
+        rets = eq.pct_change().dropna().replace([np.inf, -np.inf], 0).fillna(0)
+        downside = rets[rets < 0]
+        if len(downside) > 1 and downside.std() > 0:
+            expected_sortino = float(rets.mean() / downside.std() * np.sqrt(252))
+        else:
+            expected_sortino = 0.0
+
+        assert abs(metrics["sortino_ratio"] - round(expected_sortino, 4)) < 1e-3, \
+            f"Sortino mismatch: {metrics['sortino_ratio']} vs {expected_sortino}"
+
+    def test_max_drawdown_independent(self):
+        """Verify max drawdown against independent calculation."""
+        equities = [100000, 110000, 95000, 105000, 90000, 120000]
+        curve = self._make_equity_curve(equities)
+        metrics = calculate_metrics([], curve, 100000, "D")
+
+        # Independent max DD
+        peak = equities[0]
+        max_dd = 0
+        for eq in equities:
+            peak = max(peak, eq)
+            dd = (peak - eq) / peak
+            max_dd = max(max_dd, dd)
+
+        assert abs(metrics["max_drawdown_pct"] - round(max_dd * 100, 4)) < 1e-3, \
+            f"Max DD mismatch: {metrics['max_drawdown_pct']} vs {max_dd * 100}"
+
+    def test_profit_factor_independent(self):
+        """Verify profit factor against independent calculation."""
+        trades = [
+            {"net_pnl": 500, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+            {"net_pnl": -200, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+            {"net_pnl": 800, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+            {"net_pnl": -100, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+        ]
+        equities = [100000, 100500, 100300, 101100, 101000]
+        curve = self._make_equity_curve(equities)
+        metrics = calculate_metrics(trades, curve, 100000, "D")
+
+        gross_profit = 500 + 800
+        gross_loss = 200 + 100
+        expected_pf = gross_profit / gross_loss
+
+        assert abs(metrics["profit_factor"] - round(expected_pf, 4)) < 1e-3, \
+            f"PF mismatch: {metrics['profit_factor']} vs {expected_pf}"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 5 — STRATEGY PATCHER BREAK TESTS
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase5Patcher:
+
+    def _patch(self, code):
+        p = StrategyPatcher()
+        client = make_client()
+        client.data["S:E"] = make_data([100, 110, 120])
+        client.current_bar_index["S:E"] = 0
+        return p.patch(code, client)
+
+    def test_nested_while_loops(self):
+        """Nested while loops — should extract outer only."""
+        code = """
+from openalgo import api
+client = api(api_key="x")
+while True:
+    for i in range(3):
+        while i < 2:
+            break
+    import time
+    time.sleep(5)
+"""
+        fn = self._patch(code)
+        assert callable(fn)
+
+    def test_try_except_inside_loop(self):
+        code = """
+from openalgo import api
+client = api(api_key="x")
+while True:
+    try:
+        x = 1 / 0
+    except ZeroDivisionError:
+        pass
+    import time
+    time.sleep(1)
+"""
+        fn = self._patch(code)
+        assert callable(fn)
+        fn()  # Should not crash
+
+    def test_no_while_loop_with_function(self):
+        """Strategy with main() but no while loop."""
+        code = """
+from openalgo import api
+client = api(api_key="x")
+def main():
+    pass
+"""
+        fn = self._patch(code)
+        assert callable(fn)
+
+    def test_no_entry_point_script(self):
+        """Simple script with no function — should return no-op."""
+        code = """
+x = 42
+y = x + 1
+"""
+        fn = self._patch(code)
+        assert callable(fn)
+
+    def test_async_def_should_not_crash(self):
+        """async def should compile but not be callable in normal way."""
+        code = """
+async def strategy():
+    pass
+"""
+        # Should not raise during patching
+        fn = self._patch(code)
+        assert callable(fn)
+
+    def test_import_requests_blocked(self):
+        """Strategy importing requests — should fail because blocked in sandbox."""
+        code = """
+import requests
+"""
+        with pytest.raises(ValueError, match="blocked in backtest sandbox"):
+            self._patch(code)
+
+    def test_safe_os_no_write(self):
+        """os module should allow getenv but not have system, remove, etc."""
+        p = StrategyPatcher()
+        client = make_client()
+        ns = p._build_namespace(client)
+        safe_os = ns["os"]
+        assert hasattr(safe_os, "getenv")
+        assert not hasattr(safe_os, "system")
+        assert not hasattr(safe_os, "remove")
+        assert not hasattr(safe_os, "unlink")
+        assert not hasattr(safe_os, "rmdir")
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 6 — CAPITAL CONSISTENCY INVARIANT
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase6CapitalConsistency:
+
+    def test_capital_plus_unrealized_equals_equity(self):
+        """At every bar: capital + unrealized == equity (within rounding)."""
+        c = make_client(capital=100000, slippage=0, commission=0)
+        prices = [100, 105, 95, 110, 90, 120]
+        c.data["S:E"] = make_data(prices)
+
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=10, price_type="MARKET")
+
+        for i in range(len(prices)):
+            c.current_bar_index["S:E"] = i
+            c.current_timestamp = 1000 + i
+            c.record_equity(1000 + i)
+
+            unrealized = c._total_unrealized()
+            expected_equity = c.capital + unrealized
+            actual_equity = c.equity_curve[-1]["equity"]
+
+            assert abs(expected_equity - actual_equity) < 0.02, \
+                f"Bar {i}: capital({c.capital}) + unrealized({unrealized}) = {expected_equity} != equity({actual_equity})"
+
+    def test_final_capital_accounting(self):
+        """After all trades: initial + sum(pnl) - sum(commission) == final capital."""
+        c = make_client(capital=100000, slippage=0, commission=20)
+        prices = [100, 110, 95, 105, 115]
+        c.data["S:E"] = make_data(prices)
+
+        # Buy, sell, buy, sell
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=10, price_type="MARKET")
+
+        c.current_bar_index["S:E"] = 1
+        c.current_timestamp = 1001
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=10, price_type="MARKET")
+
+        c.current_bar_index["S:E"] = 2
+        c.current_timestamp = 1002
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=10, price_type="MARKET")
+
+        c.current_bar_index["S:E"] = 3
+        c.current_timestamp = 1003
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=10, price_type="MARKET")
+
+        # Verify: no open positions
+        assert c.positions["S:E"]["qty"] == 0
+
+        total_pnl = sum(t["pnl"] for t in c.trades)
+        total_commission = sum(20 for _ in range(4))  # 4 orders, each 20
+        expected_capital = 100000 + total_pnl - total_commission
+        assert abs(c.capital - expected_capital) < 0.02, \
+            f"Capital accounting mismatch: {c.capital} vs {expected_capital}"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 7 — FINANCIAL INVARIANTS
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase7FinancialInvariants:
+
+    def test_max_drawdown_never_negative(self):
+        equities = [100000, 110000, 95000, 105000, 90000, 120000]
+        peak = equities[0]
+        for eq in equities:
+            peak = max(peak, eq)
+            dd = (peak - eq) / peak
+            assert dd >= 0, f"Drawdown negative: {dd}"
+
+    def test_peak_equity_monotonic(self):
+        """peak_equity should be monotonically non-decreasing."""
+        c = make_client()
+        c.data["S:E"] = make_data([100, 110, 95, 120, 80])
+
+        peaks = []
+        for i in range(5):
+            c.current_bar_index["S:E"] = i
+            c.current_timestamp = 1000 + i
+            c.record_equity(1000 + i)
+            peaks.append(c.peak_equity)
+
+        for i in range(1, len(peaks)):
+            assert peaks[i] >= peaks[i-1], f"Peak decreased at {i}: {peaks[i]} < {peaks[i-1]}"
+
+    def test_equity_never_nan(self):
+        c = make_client()
+        c.data["S:E"] = make_data([100, 0.01, 100, 50])  # edge: near-zero price
+
+        for i in range(4):
+            c.current_bar_index["S:E"] = i
+            c.current_timestamp = 1000 + i
+            c.record_equity(1000 + i)
+
+        for pt in c.equity_curve:
+            assert not np.isnan(pt["equity"]), f"Equity NaN at {pt['timestamp']}"
+            assert not np.isinf(pt["equity"]), f"Equity Inf at {pt['timestamp']}"
+
+    def test_profit_factor_infinite_only_no_losses(self):
+        trades = [
+            {"net_pnl": 100, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+            {"net_pnl": 200, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+        ]
+        curve = [
+            {"timestamp": 1000, "equity": 100000, "drawdown": 0},
+            {"timestamp": 1001, "equity": 100100, "drawdown": 0},
+            {"timestamp": 1002, "equity": 100300, "drawdown": 0},
+        ]
+        metrics = calculate_metrics(trades, curve, 100000, "D")
+        assert metrics["profit_factor"] == 999.99  # capped infinite
+
+    def test_win_rate_between_0_and_100(self):
+        trades = [
+            {"net_pnl": 100, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+            {"net_pnl": -50, "bars_held": 1, "commission": 0, "slippage_cost": 0},
+        ]
+        curve = [
+            {"timestamp": 1000, "equity": 100000, "drawdown": 0},
+            {"timestamp": 1001, "equity": 100100, "drawdown": 0},
+            {"timestamp": 1002, "equity": 100050, "drawdown": 0},
+        ]
+        metrics = calculate_metrics(trades, curve, 100000, "D")
+        assert 0 <= metrics["win_rate"] <= 100
+
+
+# ═══════════════════════════════════════════════════════════════════
+# PHASE 10 — FAILURE INJECTION
+# ═══════════════════════════════════════════════════════════════════
+
+class TestPhase10FailureInjection:
+
+    def test_strategy_division_by_zero(self):
+        """Strategy with div/0 should not crash engine — iteration is non-fatal."""
+        c = make_client()
+        c.data["S:E"] = make_data([100, 110])
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+
+        p = StrategyPatcher()
+        code = """
+def strategy():
+    x = 1 / 0
+"""
+        fn = p.patch(code, c)
+        # Engine catches exceptions from iteration_fn
+        try:
+            fn()
+            assert False, "Should have raised"
+        except ZeroDivisionError:
+            pass  # Expected — engine wraps this in try/except
+
+    def test_negative_capital_start(self):
+        """Negative initial capital should still produce metrics, not crash."""
+        c = make_client(capital=-50000)
+        c.data["S:E"] = make_data([100, 110])
+        for i in range(2):
+            c.current_bar_index["S:E"] = i
+            c.current_timestamp = 1000 + i
+            c.record_equity(1000 + i)
+        # Should not crash
+        assert len(c.equity_curve) == 2
+
+    def test_empty_metrics_returns_valid(self):
+        m = _empty_metrics(0)
+        assert m["final_capital"] == 0.0
+        assert m["sharpe_ratio"] == 0.0
+        assert isinstance(m["monthly_returns"], dict)
+
+    def test_commission_pct_mode(self):
+        """Test percentage-based commission instead of per-order."""
+        c = make_client(capital=100000, slippage=0, commission=0, comm_pct=0.1)
+        c.data["S:E"] = make_data([100])
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=100, price_type="MARKET")
+        # trade_value = 100 * 100 = 10000
+        # commission = 10000 * 0.1% = 10
+        expected_commission = 10.0
+        expected_capital = 100000 - expected_commission
+        assert abs(c.capital - expected_capital) < 0.01, f"Capital: {c.capital} != {expected_capital}"
+
+
+# ═══════════════════════════════════════════════════════════════════
+# ADDITIONAL VULNERABILITY PROBES
+# ═══════════════════════════════════════════════════════════════════
+
+class TestAdditionalVulnerabilities:
+
+    def test_FIXED_reversal_double_commission(self):
+        """
+        FIXED: On reversal (Buy 100, Sell 200), commission is now charged
+        separately for the close portion AND the new open portion.
+        """
+        c = make_client(capital=100000, slippage=0, commission=20)
+        c.data["S:E"] = make_data([100])
+        c.current_bar_index["S:E"] = 0
+        c.current_timestamp = 1000
+
+        c.placeorder(symbol="S", exchange="E", action="BUY", quantity=100, price_type="MARKET")
+        initial = c.capital  # 100000 - 20 = 99980
+        assert initial == 99980
+
+        c.placeorder(symbol="S", exchange="E", action="SELL", quantity=200, price_type="MARKET")
+        # Close commission (20) + open commission (20) = 40
+        assert c.capital == initial - 40  # 2 commissions for reversal
+
+    def test_FIXED_history_default_index_returns_empty(self):
+        """
+        FIXED: If current_bar_index is NOT set for a symbol, history() now
+        defaults to -1 and returns empty DataFrame (no look-ahead leak).
+        """
+        c = make_client()
+        c.data["S:E"] = make_data([100, 200, 300, 400, 500])
+        # NOTE: current_bar_index NOT set for S:E
+        df = c.history(symbol="S", exchange="E")
+        assert len(df) == 0  # No data exposed — safe default
+
+    def test_BUG_api_constructor_positional_args(self):
+        """
+        Patcher uses `api\\s*\\([^)]*\\)` but if strategy calls api() with
+        no arguments or positional args like api("key", "host"), the regex
+        still matches. What about api = api(...)?
+        """
+        p = StrategyPatcher()
+        code = 'client = api("mykey", "localhost")'
+        patched = p._replace_api_constructor(code)
+        assert "_backtest_client" in patched
+
+    def test_FIXED_calmar_uses_signed_cagr(self):
+        """
+        FIXED: Calmar ratio now uses signed CAGR, so losing strategies
+        show negative Calmar ratio.
+        """
+        equities = [100000, 95000, 90000, 85000]  # Losing strategy
+        peak = equities[0]
+        curve = []
+        for i, eq in enumerate(equities):
+            peak = max(peak, eq)
+            dd = (peak - eq) / peak if peak > 0 else 0
+            curve.append({"timestamp": 1000+i, "equity": eq, "drawdown": dd})
+
+        metrics = calculate_metrics([], curve, 100000, "D")
+        assert metrics["cagr"] < 0, "CAGR should be negative"
+        assert metrics["calmar_ratio"] < 0, "Calmar should be negative for losing strategies"
+
+    def test_BUG_duplicate_equity_point_on_last_bar(self):
+        """
+        Engine calls record_equity() in the loop (line 175) AND again
+        after close_all_positions (line 191) with the same timestamp.
+        This creates a DUPLICATE equity point at the last timestamp.
+        """
+        c = make_client()
+        c.record_equity(1000)
+        c.record_equity(1000)  # Same timestamp
+        assert len(c.equity_curve) == 2  # Duplicate exists
+        assert c.equity_curve[0]["timestamp"] == c.equity_curve[1]["timestamp"]
+
+    def test_FIXED_scoped_session_cleanup_after_run(self):
+        """
+        FIXED: start_backtest() now calls db_session.remove() in its finally
+        block, ensuring thread-local sessions are cleaned up after each run
+        even when threads are reused in the ThreadPoolExecutor.
+        """
+        import inspect
+        from services.backtest_engine import start_backtest
+        source = inspect.getsource(start_backtest)
+        assert "db_session.remove()" in source, \
+            "start_backtest must call db_session.remove() after run"
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--tb=short"])

--- a/test/test_backtest_client.py
+++ b/test/test_backtest_client.py
@@ -1,0 +1,245 @@
+# test/test_backtest_client.py
+"""Tests for BacktestClient — the SDK-compatible mock client."""
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pandas as pd
+import pytest
+
+from services.backtest_client import BacktestClient
+
+
+@pytest.fixture
+def config():
+    return {
+        "initial_capital": 100000,
+        "slippage_pct": 0.05,
+        "commission_per_order": 20.0,
+        "commission_pct": 0.0,
+    }
+
+
+@pytest.fixture
+def client(config):
+    return BacktestClient(config)
+
+
+@pytest.fixture
+def sample_data():
+    """Create sample OHLCV DataFrame."""
+    return pd.DataFrame({
+        "timestamp": [1704067200, 1704153600, 1704240000, 1704326400, 1704412800],
+        "open": [100.0, 102.0, 101.0, 105.0, 103.0],
+        "high": [103.0, 104.0, 106.0, 107.0, 108.0],
+        "low": [99.0, 100.0, 100.0, 103.0, 101.0],
+        "close": [102.0, 101.0, 105.0, 103.0, 107.0],
+        "volume": [10000, 12000, 11000, 13000, 9000],
+        "oi": [0, 0, 0, 0, 0],
+    })
+
+
+@pytest.fixture
+def loaded_client(client, sample_data):
+    """Client with data loaded and positioned at bar 2."""
+    client.data["SBIN:NSE"] = sample_data
+    client.current_bar_index["SBIN:NSE"] = 2
+    client.current_timestamp = 1704240000
+    return client
+
+
+class TestClientInit:
+    def test_initial_capital(self, client, config):
+        assert client.capital == 100000
+        assert client.initial_capital == 100000
+
+    def test_empty_state(self, client):
+        assert len(client.positions) == 0
+        assert len(client.trades) == 0
+        assert len(client.orders) == 0
+        assert len(client.equity_curve) == 0
+
+
+class TestHistory:
+    def test_history_returns_data_up_to_current_bar(self, loaded_client):
+        df = loaded_client.history(symbol="SBIN", exchange="NSE")
+        # At bar index 2, should get bars 0, 1, 2 (3 bars)
+        assert len(df) == 3
+
+    def test_history_prevents_lookahead(self, loaded_client):
+        df = loaded_client.history(symbol="SBIN", exchange="NSE")
+        # Should not include future bars
+        assert df.iloc[-1]["close"] == 105.0  # bar 2 close
+
+    def test_history_missing_symbol(self, loaded_client):
+        df = loaded_client.history(symbol="UNKNOWN", exchange="NSE")
+        assert df.empty
+
+
+class TestQuotes:
+    def test_quotes_returns_current_bar(self, loaded_client):
+        q = loaded_client.quotes(symbol="SBIN", exchange="NSE")
+        assert q["status"] == "success"
+        assert q["data"]["ltp"] == 105.0  # bar 2 close
+
+    def test_quotes_missing_symbol(self, loaded_client):
+        q = loaded_client.quotes(symbol="UNKNOWN", exchange="NSE")
+        assert q["status"] == "error"
+
+
+class TestPlaceOrder:
+    def test_market_buy(self, loaded_client):
+        result = loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        assert result["status"] == "success"
+        assert "orderid" in result
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 10
+
+    def test_market_sell(self, loaded_client):
+        # First buy
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        # Then sell
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="SELL",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 0
+        assert len(loaded_client.trades) == 1
+
+    def test_limit_order_queued(self, loaded_client):
+        result = loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="LIMIT", quantity=10, price=100.0, product="MIS",
+        )
+        assert result["status"] == "success"
+        assert len(loaded_client.pending_orders) == 1
+
+    def test_zero_quantity_rejected(self, loaded_client):
+        result = loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=0, product="MIS",
+        )
+        assert result["status"] == "error"
+
+
+class TestPositionManagement:
+    def test_add_to_position(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=5, product="MIS",
+        )
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 15
+
+    def test_partial_close(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="SELL",
+            price_type="MARKET", quantity=5, product="MIS",
+        )
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 5
+        assert len(loaded_client.trades) == 1
+
+    def test_reversal(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="SELL",
+            price_type="MARKET", quantity=15, product="MIS",
+        )
+        # Should be short 5
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == -5
+
+
+class TestPendingOrders:
+    def test_limit_buy_triggers(self, loaded_client, sample_data):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="LIMIT", quantity=10, price=100.0, product="MIS",
+        )
+        # Advance to bar 3 where low=103, so limit at 100 won't trigger
+        loaded_client.current_bar_index["SBIN:NSE"] = 3
+        loaded_client.process_pending_orders()
+        assert len(loaded_client.pending_orders) == 1  # still pending
+
+    def test_cancel_order(self, loaded_client):
+        result = loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="LIMIT", quantity=10, price=100.0, product="MIS",
+        )
+        loaded_client.cancelorder(order_id=result["orderid"])
+        assert len(loaded_client.pending_orders) == 0
+
+
+class TestEquity:
+    def test_record_equity(self, loaded_client):
+        loaded_client.record_equity(1704240000)
+        assert len(loaded_client.equity_curve) == 1
+        assert loaded_client.equity_curve[0]["equity"] == 100000  # no positions
+
+    def test_equity_with_position(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        loaded_client.record_equity(1704240000)
+        assert len(loaded_client.equity_curve) == 1
+        # Capital reduced by commission, but position adds unrealized P&L
+
+
+class TestSmartOrder:
+    def test_smart_buy_from_flat(self, loaded_client):
+        loaded_client.placesmartorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", product="MIS",
+            quantity=1, position_size=10,
+        )
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 10
+
+    def test_smart_no_action_needed(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        result = loaded_client.placesmartorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", product="MIS",
+            quantity=1, position_size=10,
+        )
+        assert result["message"] == "No action needed"
+
+
+class TestCloseAll:
+    def test_close_all_positions(self, loaded_client):
+        loaded_client.placeorder(
+            symbol="SBIN", exchange="NSE", action="BUY",
+            price_type="MARKET", quantity=10, product="MIS",
+        )
+        loaded_client.close_all_positions_at_end()
+        assert loaded_client.positions["SBIN:NSE"]["qty"] == 0
+        assert len(loaded_client.trades) == 1
+
+
+class TestFunds:
+    def test_funds_initial(self, loaded_client):
+        f = loaded_client.funds()
+        assert f["status"] == "success"
+        assert float(f["data"]["availablecash"]) == 100000
+
+    def test_positionbook_empty(self, loaded_client):
+        pb = loaded_client.positionbook()
+        assert pb["status"] == "success"
+        assert len(pb["data"]) == 0

--- a/test/test_backtest_engine.py
+++ b/test/test_backtest_engine.py
@@ -1,0 +1,123 @@
+# test/test_backtest_engine.py
+"""Tests for the backtest engine orchestrator."""
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import pytest
+from unittest.mock import MagicMock, patch
+from threading import Event
+
+from services.backtest_engine import (
+    BacktestEngine,
+    generate_backtest_id,
+    validate_data_availability,
+    _storage_interval_for,
+)
+
+
+class TestGenerateBacktestId:
+    def test_format(self):
+        bt_id = generate_backtest_id()
+        assert bt_id.startswith("BT-")
+        parts = bt_id.split("-")
+        # BT-YYYYMMDD-HHMMSS-uuid8
+        assert len(parts) == 4
+
+    def test_unique(self):
+        ids = {generate_backtest_id() for _ in range(100)}
+        assert len(ids) == 100
+
+
+class TestStorageInterval:
+    def test_intraday_maps_to_1m(self):
+        for iv in ["1m", "5m", "15m", "30m", "1h"]:
+            assert _storage_interval_for(iv) == "1m"
+
+    def test_daily_maps_to_d(self):
+        assert _storage_interval_for("D") == "D"
+
+    def test_unknown_maps_to_d(self):
+        assert _storage_interval_for("W") == "D"
+
+
+class TestValidateDataAvailability:
+    @patch("services.backtest_engine.get_data_range")
+    def test_all_available(self, mock_range):
+        mock_range.return_value = {
+            "first_timestamp": 1704067200,
+            "last_timestamp": 1735689600,
+            "record_count": 100000,
+        }
+        result = validate_data_availability(
+            ["SBIN", "TCS"], "NSE", "5m", "2024-01-01", "2024-12-31"
+        )
+        assert result["available"] is True
+        assert result["details"]["SBIN"]["has_data"] is True
+        assert result["details"]["TCS"]["has_data"] is True
+
+    @patch("services.backtest_engine.get_data_range")
+    def test_some_missing(self, mock_range):
+        def side_effect(sym, exc, iv):
+            if sym == "SBIN":
+                return {"first_timestamp": 1, "last_timestamp": 2, "record_count": 100}
+            return None
+
+        mock_range.side_effect = side_effect
+        result = validate_data_availability(
+            ["SBIN", "UNKNOWN"], "NSE", "D", "2024-01-01", "2024-12-31"
+        )
+        assert result["available"] is False
+        assert result["details"]["SBIN"]["has_data"] is True
+        assert result["details"]["UNKNOWN"]["has_data"] is False
+
+
+class TestBacktestEngine:
+    @pytest.fixture
+    def base_config(self):
+        return {
+            "backtest_id": "BT-TEST-001",
+            "user_id": "test_user",
+            "name": "Test Backtest",
+            "strategy_id": None,
+            "strategy_code": "# empty strategy\npass",
+            "symbols": ["SBIN"],
+            "exchange": "NSE",
+            "start_date": "2024-01-01",
+            "end_date": "2024-03-31",
+            "interval": "D",
+            "initial_capital": 100000,
+            "slippage_pct": 0.05,
+            "commission_per_order": 20.0,
+            "commission_pct": 0.0,
+            "data_source": "db",
+        }
+
+    def test_cancellation_works(self, base_config):
+        cancel = Event()
+        cancel.set()  # Pre-cancel
+        engine = BacktestEngine(base_config, cancel_event=cancel)
+
+        with patch.object(engine, "_update_status"):
+            with patch.object(engine, "_emit_progress"):
+                with patch.object(engine, "_load_data", return_value={"SBIN:NSE": MagicMock()}):
+                    result = engine.run()
+                    assert result["status"] == "cancelled"
+
+    def test_empty_data_fails(self, base_config):
+        engine = BacktestEngine(base_config)
+
+        with patch.object(engine, "_update_status"):
+            with patch.object(engine, "_emit_progress"):
+                with patch.object(engine, "_load_data", return_value={}):
+                    result = engine.run()
+                    assert result["status"] == "failed"
+                    assert "No data" in result["error"]
+
+    def test_date_to_timestamp(self, base_config):
+        engine = BacktestEngine(base_config)
+        ts = engine._date_to_timestamp("2024-01-01")
+        assert ts == 1704067200  # 2024-01-01 00:00:00 UTC
+
+        ts_eod = engine._date_to_timestamp("2024-01-01", end_of_day=True)
+        assert ts_eod > ts

--- a/test/test_backtest_metrics.py
+++ b/test/test_backtest_metrics.py
@@ -1,0 +1,134 @@
+# test/test_backtest_metrics.py
+"""Tests for backtest performance metrics calculator."""
+
+import sys, os
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import numpy as np
+import pytest
+
+from services.backtest_metrics import (
+    _compute_monthly_returns,
+    _compute_trade_metrics,
+    _empty_metrics,
+    _get_bars_per_year,
+    calculate_metrics,
+)
+
+
+@pytest.fixture
+def sample_equity_curve():
+    """Equity curve with known drawdown pattern."""
+    return [
+        {"timestamp": 1704067200, "equity": 100000, "drawdown": 0.0},
+        {"timestamp": 1704153600, "equity": 101000, "drawdown": 0.0},
+        {"timestamp": 1704240000, "equity": 99000, "drawdown": 0.0198},
+        {"timestamp": 1704326400, "equity": 102000, "drawdown": 0.0},
+        {"timestamp": 1704412800, "equity": 103000, "drawdown": 0.0},
+        {"timestamp": 1704499200, "equity": 100500, "drawdown": 0.0243},
+        {"timestamp": 1704585600, "equity": 105000, "drawdown": 0.0},
+    ]
+
+
+@pytest.fixture
+def sample_trades():
+    """Mix of winning and losing trades."""
+    return [
+        {"trade_num": 1, "net_pnl": 500, "bars_held": 3, "commission": 20, "slippage_cost": 5},
+        {"trade_num": 2, "net_pnl": -200, "bars_held": 2, "commission": 20, "slippage_cost": 3},
+        {"trade_num": 3, "net_pnl": 800, "bars_held": 5, "commission": 20, "slippage_cost": 8},
+        {"trade_num": 4, "net_pnl": -100, "bars_held": 1, "commission": 20, "slippage_cost": 2},
+        {"trade_num": 5, "net_pnl": 300, "bars_held": 4, "commission": 20, "slippage_cost": 4},
+    ]
+
+
+class TestCalculateMetrics:
+    def test_basic_metrics(self, sample_trades, sample_equity_curve):
+        metrics = calculate_metrics(sample_trades, sample_equity_curve, 100000, "D")
+        assert metrics["final_capital"] == 105000
+        assert metrics["total_return_pct"] == 5.0
+        assert metrics["total_trades"] == 5
+        assert metrics["winning_trades"] == 3
+        assert metrics["losing_trades"] == 2
+
+    def test_empty_equity_curve(self):
+        metrics = calculate_metrics([], [], 100000, "D")
+        assert metrics["final_capital"] == 100000
+        assert metrics["total_return_pct"] == 0.0
+        assert metrics["total_trades"] == 0
+
+    def test_single_bar_returns_empty(self):
+        curve = [{"timestamp": 1, "equity": 100000, "drawdown": 0.0}]
+        metrics = calculate_metrics([], curve, 100000, "D")
+        assert metrics["total_return_pct"] == 0.0
+
+    def test_no_trades(self, sample_equity_curve):
+        metrics = calculate_metrics([], sample_equity_curve, 100000, "D")
+        assert metrics["total_trades"] == 0
+        assert metrics["win_rate"] == 0.0
+        assert metrics["profit_factor"] == 0.0
+
+
+class TestTradeMetrics:
+    def test_win_rate(self, sample_trades):
+        metrics = {}
+        _compute_trade_metrics(metrics, sample_trades)
+        assert metrics["win_rate"] == 60.0  # 3 out of 5
+
+    def test_profit_factor(self, sample_trades):
+        metrics = {}
+        _compute_trade_metrics(metrics, sample_trades)
+        # Gross profit = 500 + 800 + 300 = 1600
+        # Gross loss = |-200| + |-100| = 300
+        # PF = 1600 / 300 = 5.333
+        assert round(metrics["profit_factor"], 2) == 5.33
+
+    def test_all_winners(self):
+        trades = [
+            {"trade_num": 1, "net_pnl": 100, "bars_held": 1, "commission": 10, "slippage_cost": 0},
+            {"trade_num": 2, "net_pnl": 200, "bars_held": 2, "commission": 10, "slippage_cost": 0},
+        ]
+        metrics = {}
+        _compute_trade_metrics(metrics, trades)
+        assert metrics["win_rate"] == 100.0
+        assert metrics["profit_factor"] == 999.99  # capped infinite
+
+    def test_no_trades(self):
+        metrics = {}
+        _compute_trade_metrics(metrics, [])
+        assert metrics["total_trades"] == 0
+        assert metrics["win_rate"] == 0.0
+        assert metrics["expectancy"] == 0.0
+
+    def test_avg_holding_bars(self, sample_trades):
+        metrics = {}
+        _compute_trade_metrics(metrics, sample_trades)
+        # (3 + 2 + 5 + 1 + 4) / 5 = 3
+        assert metrics["avg_holding_bars"] == 3
+
+
+class TestBarsPerYear:
+    def test_daily(self):
+        assert _get_bars_per_year("D") == 252
+
+    def test_5min(self):
+        assert _get_bars_per_year("5m") == 252 * 75
+
+    def test_1min(self):
+        assert _get_bars_per_year("1m") == 252 * 375
+
+    def test_unknown_defaults_to_daily(self):
+        assert _get_bars_per_year("unknown") == 252
+
+
+class TestEmptyMetrics:
+    def test_has_all_keys(self):
+        m = _empty_metrics(100000)
+        assert "final_capital" in m
+        assert "sharpe_ratio" in m
+        assert "monthly_returns" in m
+        assert m["final_capital"] == 100000
+
+    def test_zero_default(self):
+        m = _empty_metrics()
+        assert m["final_capital"] == 0.0

--- a/upgrade/migrate_backtest.py
+++ b/upgrade/migrate_backtest.py
@@ -1,0 +1,134 @@
+#!/usr/bin/env python
+"""
+Backtest Engine Migration Script for OpenAlgo
+
+This migration creates the backtest database and tables:
+- backtest_runs: Stores backtest configurations and results
+- backtest_trades: Stores individual trades from backtest runs
+
+Usage:
+    cd upgrade
+    uv run migrate_backtest.py           # Apply migration
+    uv run migrate_backtest.py --status  # Check status
+
+Migration: 020
+Created: 2025-03-01
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.pool import NullPool
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Migration metadata
+MIGRATION_NAME = "backtest_engine_setup"
+MIGRATION_VERSION = "020"
+
+
+def get_backtest_db_url():
+    """Get the backtest database URL from environment."""
+    load_dotenv()
+    return os.getenv("BACKTEST_DATABASE_URL", "sqlite:///db/backtest.db")
+
+
+def check_status():
+    """Check current migration status."""
+    db_url = get_backtest_db_url()
+
+    # Check if the database file exists
+    if "sqlite" in db_url:
+        db_path = db_url.replace("sqlite:///", "")
+        if not Path(db_path).exists():
+            print(f"Database file does not exist: {db_path}")
+            print("Status: NOT APPLIED (database not created)")
+            return
+
+    engine = create_engine(db_url, poolclass=NullPool)
+    inspector = inspect(engine)
+    tables = inspector.get_table_names()
+
+    print(f"Database: {db_url}")
+    print(f"Tables found: {tables}")
+
+    required_tables = ["backtest_runs", "backtest_trades"]
+    missing = [t for t in required_tables if t not in tables]
+
+    if missing:
+        print(f"Missing tables: {missing}")
+        print("Status: PARTIALLY APPLIED or NOT APPLIED")
+    else:
+        # Check columns on backtest_runs
+        columns = [c["name"] for c in inspector.get_columns("backtest_runs")]
+        print(f"backtest_runs columns: {len(columns)}")
+        print("Status: APPLIED")
+
+    engine.dispose()
+
+
+def apply_migration():
+    """Apply the backtest migration."""
+    db_url = get_backtest_db_url()
+
+    # Ensure db directory exists
+    if "sqlite" in db_url:
+        db_path = db_url.replace("sqlite:///", "")
+        db_dir = os.path.dirname(db_path)
+        if db_dir:
+            os.makedirs(db_dir, exist_ok=True)
+
+    print(f"Applying migration {MIGRATION_VERSION}: {MIGRATION_NAME}")
+    print(f"Database: {db_url}")
+
+    engine = create_engine(
+        db_url,
+        poolclass=NullPool,
+        connect_args={"check_same_thread": False} if "sqlite" in db_url else {},
+    )
+
+    # Import and create all tables using the ORM models
+    try:
+        from database.backtest_db import Base
+        Base.metadata.create_all(engine)
+        print("Tables created successfully:")
+        inspector = inspect(engine)
+        for table in inspector.get_table_names():
+            columns = inspector.get_columns(table)
+            print(f"  - {table}: {len(columns)} columns")
+        print(f"Migration {MIGRATION_VERSION} applied successfully!")
+    except Exception as e:
+        print(f"Error applying migration: {e}")
+        raise
+    finally:
+        engine.dispose()
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=f"Migration {MIGRATION_VERSION}: {MIGRATION_NAME}"
+    )
+    parser.add_argument(
+        "--status",
+        action="store_true",
+        help="Check migration status without applying changes",
+    )
+    args = parser.parse_args()
+
+    if args.status:
+        check_status()
+    else:
+        apply_migration()
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
- Bar-by-bar replay engine with look-ahead bias prevention
- SDK-compatible BacktestClient (drop-in replacement for openalgo.api)
- Strategy patcher: transforms live strategies for backtest with sandbox
- Performance metrics: Sharpe, Sortino, CAGR, Max DD, Calmar, Profit Factor
- SSE progress streaming, ThreadPoolExecutor (max 3 concurrent)
- React frontend: New Backtest, Results, Compare pages
- 90 tests covering adversarial audit (look-ahead, execution, metrics)
- Migration script for backtest database tables

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a built-in backtesting engine that replays historical bars and runs existing openalgo strategies without code changes. Includes performance metrics, live progress, and a React UI to create, view, and compare results.

- **New Features**
  - Bar-by-bar replay with strict look-ahead prevention.
  - SDK-compatible BacktestClient as a drop-in for openalgo.api.
  - Strategy patcher and sandbox to run live strategies in backtest.
  - Performance metrics: Sharpe, Sortino, CAGR, Max drawdown, Calmar, Profit Factor.
  - SSE progress streaming; max 3 concurrent runs via ThreadPoolExecutor.
  - React pages: Backtest, Results, Compare; 90 tests covering execution, bias checks, and metrics.

- **Migration**
  - Run upgrade/migrate_backtest.py to create backtest_runs and backtest_trades tables.
  - Optionally set BACKTEST_DATABASE_URL (defaults to sqlite:///db/backtest.db).
  - Restart the app to load the backtest blueprint and initialize tables.

<sup>Written for commit cf0c4474fc1d6f01b8f962ac3027e24475016127. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

