### PR TITLE
fix: correct Fyers reformat_symbol_detail day/year swap (DDMMMYY)

### DIFF
--- a/broker/fyers/database/master_contract_db.py
+++ b/broker/fyers/database/master_contract_db.py
@@ -207,9 +207,11 @@ def download_csv_fyers_data(output_path: str) -> tuple[bool, list[str], str | No
 
 def reformat_symbol_detail(s):
     parts = s.split()  # Split the string into parts
-    # Reorder and format the parts to match the desired output
-    # Assuming the format is consistent and always "Name DD Mon YY FUT"
-    return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
+    # Reorder and format the parts to match the OpenAlgo standard symbol format
+    # Input format: "Name DD Mon YY Strike" (e.g., "NIFTY 02 Mar 26 30600")
+    # Output format: Name + DD + MMM + YY + Strike (e.g., "NIFTY02MAR2630600")
+    # This matches the DDMMMYY convention used by all other brokers
+    return f"{parts[0]}{parts[1]}{parts[2].upper()}{parts[3]}{parts[4]}"
 
 
 def process_fyers_nse_csv(path):


### PR DESCRIPTION
## Fix: Correct Fyers `reformat_symbol_detail` day/year swap (DDMMMYY)

### Problem

The `reformat_symbol_detail()` function in `broker/fyers/database/master_contract_db.py` was swapping the **day** and **year** fields when constructing the OpenAlgo standard symbol format from Fyers' "Symbol Details" column.

Fyers provides symbol details in the format:

```
"NIFTY 02 Mar 26 30600"
 parts[0] parts[1] parts[2] parts[3] parts[4]
 Name     DD       Mon      YY       Strike
```

The old code assembled them as:

```python
f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
#  Name     YY       MMM        DD       Strike  → YYMMMDD (wrong)
```

This produced incorrect symbols like `NIFTY26MAR0230600` instead of the correct `NIFTY02MAR2630600`.

### Fix

Corrected the field ordering to match the **DDMMMYY** convention used by all other brokers:

```python
f"{parts[0]}{parts[1]}{parts[2].upper()}{parts[3]}{parts[4]}"
#  Name     DD       MMM        YY       Strike  → DDMMMYY (correct)
```

### Impact

This fix affects all derivative symbol mapping for the Fyers broker across **NFO**, **BFO**, **CDS**, and **MCX** segments. Without this fix, Fyers symbols don't match the OpenAlgo standard format, causing failures in:

- Option chain lookups
- Order placement for derivatives
- Symbol search and mapping between OpenAlgo ↔ Fyers

### File Changed

- `broker/fyers/database/master_contract_db.py` — `reformat_symbol_detail()` function (line ~213)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fyers symbol reformatting by correcting a day/year swap in reformat_symbol_detail. Symbols now use DDMMMYY, matching the OpenAlgo standard and restoring correct derivative mappings.

- **Bug Fixes**
  - Reordered fields to Name + DD + MMM + YY + Strike (e.g., NIFTY02MAR2630600).
  - Restores correct mapping across NFO, BFO, CDS, and MCX; fixes option chain lookups and order placement.

<sup>Written for commit 4c7e3baf03829479029e9624a17a70e10bc12b42. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

