### PR TITLE
test: add pytest conftest.py with reusable fixtures and security test data

### DIFF
--- a/test/conftest.py
+++ b/test/conftest.py
@@ -1,0 +1,198 @@
+"""Shared pytest fixtures for OpenAlgo test suite.
+
+Provides reusable test infrastructure including environment setup,
+order data factories, mock broker modules, and security edge-case
+fixtures.  All test files in the ``test/`` directory automatically
+have access to these fixtures via pytest's conftest discovery.
+"""
+
+import os
+import sys
+from unittest.mock import MagicMock
+
+import pytest
+
+# ---------------------------------------------------------------------------
+# Ensure the project root is on sys.path so that ``import database``,
+# ``import utils``, etc. resolve correctly when running ``pytest`` from
+# the repository root.
+# ---------------------------------------------------------------------------
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+if PROJECT_ROOT not in sys.path:
+    sys.path.insert(0, PROJECT_ROOT)
+
+
+# ── Environment Variables ─────────────────────────────────────────────────
+@pytest.fixture(autouse=True)
+def mock_env_vars(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Set required environment variables for testing.
+
+    This fixture runs automatically for every test so that modules
+    which read ``os.getenv(...)`` at import time always find a value.
+    All values are safe, non-production test defaults.
+    """
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+    monkeypatch.setenv("BROKER_API_KEY", "test_api_key")
+    monkeypatch.setenv("BROKER_API_SECRET", "test_api_secret")
+    monkeypatch.setenv("API_KEY_PEPPER", "a" * 64)
+    monkeypatch.setenv("APP_KEY", "test_app_key_for_session_security")
+    monkeypatch.setenv("HOST_SERVER", "http://127.0.0.1:5000")
+    monkeypatch.setenv("REDIRECT_URL", "http://127.0.0.1:5000/callback")
+    monkeypatch.setenv("FLASK_ENV", "testing")
+
+
+# ── Order Data Factories ─────────────────────────────────────────────────
+@pytest.fixture
+def valid_order_data() -> dict[str, str]:
+    """Return a valid order payload with all mandatory fields.
+
+    Returns a fresh copy each time so tests can mutate the dict
+    without affecting other tests.
+
+    Returns:
+        Dictionary containing all required order fields with valid
+        values suitable for unit testing.
+    """
+    return {
+        "apikey": "test_api_key",
+        "strategy": "TestStrategy",
+        "symbol": "RELIANCE-EQ",
+        "exchange": "NSE",
+        "action": "BUY",
+        "product": "MIS",
+        "pricetype": "MARKET",
+        "quantity": "10",
+        "price": "0",
+        "trigger_price": "0",
+        "disclosed_quantity": "0",
+    }
+
+
+@pytest.fixture
+def valid_smart_order_data(valid_order_data: dict[str, str]) -> dict[str, str]:
+    """Return a valid smart order payload including ``position_size``.
+
+    Extends ``valid_order_data`` with the extra field required by the
+    smart order endpoint.
+
+    Returns:
+        Dictionary containing all required smart order fields.
+    """
+    return {**valid_order_data, "position_size": "10"}
+
+
+@pytest.fixture
+def valid_cancel_order_data() -> dict[str, str]:
+    """Return a valid cancel order payload.
+
+    Returns:
+        Dictionary containing all required cancel order fields.
+    """
+    return {
+        "apikey": "test_api_key",
+        "strategy": "TestStrategy",
+        "orderid": "123456789",
+    }
+
+
+# ── Mock Broker Module ────────────────────────────────────────────────────
+@pytest.fixture
+def mock_broker_module() -> MagicMock:
+    """Return a mock broker API module with sensible default return values.
+
+    The mock pre-configures return values for the standard broker API
+    functions (``place_order_api``, ``get_order_book``, ``cancel_order``,
+    etc.) so that service-layer tests can run without a real broker
+    connection.
+
+    Returns:
+        A ``MagicMock`` instance simulating a broker order API module.
+    """
+    module = MagicMock()
+    module.place_order_api.return_value = (
+        MagicMock(status=200),
+        {"status": "success", "data": {"order_id": "12345"}},
+        "12345",
+    )
+    module.get_order_book.return_value = {"status": "success", "data": []}
+    module.get_trade_book.return_value = {"status": "success", "data": []}
+    module.get_positions.return_value = {"status": True, "data": []}
+    module.get_holdings.return_value = {"status": True, "data": []}
+    module.cancel_order.return_value = (
+        {"status": "success", "orderid": "12345"},
+        200,
+    )
+    module.modify_order.return_value = (
+        {"status": "success", "orderid": "12345"},
+        200,
+    )
+    module.close_all_positions.return_value = (
+        {"status": "success", "message": "All positions closed"},
+        200,
+    )
+    module.cancel_all_orders_api.return_value = (
+        {"status": "success", "message": "All orders cancelled"},
+        200,
+    )
+    return module
+
+
+# ── Security Edge-Case Fixtures ───────────────────────────────────────────
+@pytest.fixture
+def malicious_order_data() -> dict[str, str]:
+    """Return order data with SQL injection and XSS payloads.
+
+    Used to verify that input handling is safe against common
+    injection attacks.  Tests consuming this fixture should assert
+    that the application rejects or sanitises the data rather than
+    processing it.
+
+    Returns:
+        Dictionary with attack payloads in key fields.
+    """
+    return {
+        "apikey": "test_api_key",
+        "strategy": "Test",
+        "symbol": "'; DROP TABLE orders;--",
+        "exchange": "<script>alert('xss')</script>",
+        "action": "BUY",
+        "product": "MIS",
+        "pricetype": "MARKET",
+        "quantity": "10",
+        "price": "0",
+        "trigger_price": "0",
+        "disclosed_quantity": "0",
+    }
+
+
+@pytest.fixture
+def empty_auth_data() -> dict[str, str]:
+    """Return order data with empty/blank authentication fields.
+
+    Used to verify that empty API keys and missing strategy names
+    are rejected before reaching the broker layer.
+
+    Returns:
+        Dictionary with empty strings for auth-sensitive fields.
+    """
+    return {
+        "apikey": "",
+        "strategy": "",
+        "symbol": "",
+        "exchange": "",
+        "action": "",
+        "quantity": "",
+    }
+
+
+@pytest.fixture
+def oversized_order_data(valid_order_data: dict[str, str]) -> dict[str, str]:
+    """Return order data with an absurdly large quantity.
+
+    Used to verify that unreasonable order sizes are caught before
+    being sent to the broker.
+
+    Returns:
+        Dictionary with a very large quantity value.
+    """
+    return {**valid_order_data, "quantity": "99999999999"}

--- a/test/test_conftest_smoke.py
+++ b/test/test_conftest_smoke.py
@@ -1,0 +1,92 @@
+"""Smoke tests for conftest.py fixtures.
+
+Verifies that all shared fixtures load correctly and return the
+expected data shapes.  These tests serve as a safety net—if a change
+to conftest.py breaks a fixture, this test file will catch it before
+downstream test files are affected.
+"""
+
+
+def test_valid_order_data_has_required_fields(valid_order_data: dict) -> None:
+    """valid_order_data fixture must include all mandatory order fields."""
+    required = ["apikey", "strategy", "symbol", "exchange", "action", "quantity"]
+    for field in required:
+        assert field in valid_order_data, f"Missing required field: {field}"
+
+
+def test_valid_order_data_values_are_sane(valid_order_data: dict) -> None:
+    """valid_order_data fixture values should be non-empty strings."""
+    for key, value in valid_order_data.items():
+        assert isinstance(value, str), f"{key} should be a string"
+
+
+def test_valid_smart_order_data_extends_order(
+    valid_smart_order_data: dict,
+    valid_order_data: dict,
+) -> None:
+    """valid_smart_order_data must contain all order fields plus position_size."""
+    for field in valid_order_data:
+        assert field in valid_smart_order_data, f"Missing field: {field}"
+    assert "position_size" in valid_smart_order_data
+
+
+def test_valid_cancel_order_data_has_required_fields(
+    valid_cancel_order_data: dict,
+) -> None:
+    """valid_cancel_order_data must include apikey, strategy, and orderid."""
+    required = ["apikey", "strategy", "orderid"]
+    for field in required:
+        assert field in valid_cancel_order_data, f"Missing required field: {field}"
+
+
+def test_mock_broker_module_has_order_apis(mock_broker_module) -> None:
+    """mock_broker_module must expose standard broker API methods."""
+    required_methods = [
+        "place_order_api",
+        "get_order_book",
+        "get_trade_book",
+        "get_positions",
+        "get_holdings",
+        "cancel_order",
+        "modify_order",
+        "close_all_positions",
+        "cancel_all_orders_api",
+    ]
+    for method in required_methods:
+        assert hasattr(mock_broker_module, method), f"Missing method: {method}"
+
+
+def test_mock_broker_place_order_returns_tuple(mock_broker_module) -> None:
+    """place_order_api mock should return a 3-element tuple."""
+    result = mock_broker_module.place_order_api("data", "auth")
+    assert len(result) == 3, "place_order_api should return (response, body, order_id)"
+
+
+def test_malicious_order_data_contains_payloads(malicious_order_data: dict) -> None:
+    """malicious_order_data must contain injection payloads in key fields."""
+    assert "DROP TABLE" in malicious_order_data["symbol"]
+    assert "<script>" in malicious_order_data["exchange"]
+
+
+def test_empty_auth_data_has_blank_fields(empty_auth_data: dict) -> None:
+    """empty_auth_data must have empty strings for auth fields."""
+    assert empty_auth_data["apikey"] == ""
+    assert empty_auth_data["strategy"] == ""
+
+
+def test_oversized_order_data_has_large_quantity(oversized_order_data: dict) -> None:
+    """oversized_order_data must have an unreasonably large quantity."""
+    qty = int(oversized_order_data["quantity"])
+    assert qty > 1_000_000_000, "Quantity should be absurdly large"
+
+
+def test_fixtures_return_independent_copies(
+    valid_order_data: dict,
+) -> None:
+    """Each call to valid_order_data must return an independent dict."""
+    valid_order_data["symbol"] = "MUTATED"
+    # The fixture is a function-scoped factory, so the mutation should
+    # not affect other tests.  This test just verifies the mutation
+    # itself succeeded (independence is verified by other tests seeing
+    # the original value).
+    assert valid_order_data["symbol"] == "MUTATED"


### PR DESCRIPTION
**TL;DR:** While working on test coverage for OpenAlgo, I noticed there's no shared [conftest.py](cci:7://file:///d:/sem4/openalgo/test/conftest.py:0:0-0:0) — every test file reinvents its own env setup and mock data. This PR adds one central place for fixtures so future tests can just plug in and go. I also added some security-focused fixtures (SQL injection, empty auth, XSS) because I figured if we're building test infra, might as well bake in security testing from day one. 🛡️
## Description
Adds [test/conftest.py](cci:7://file:///d:/sem4/openalgo/test/conftest.py:0:0-0:0) with 8 reusable pytest fixtures and [test/test_conftest_smoke.py](cci:7://file:///d:/sem4/openalgo/test/test_conftest_smoke.py:0:0-0:0) with 10 smoke tests to verify everything works. This is foundational test infrastructure — it doesn't test application logic directly, but makes it significantly easier to write tests that do.
## Related Issues
Closes #992
## Changes Made
**New files:**
- **[test/conftest.py](cci:7://file:///d:/sem4/openalgo/test/conftest.py:0:0-0:0)** (196 lines) — 8 fixtures:
  - [mock_env_vars](cci:1://file:///d:/sem4/openalgo/test/conftest.py:25:0-40:46) (autouse) — sets `DATABASE_URL`, `BROKER_API_KEY`, etc. for every test
  - [valid_order_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:44:0-67:5) — valid order payload matching `REQUIRED_ORDER_FIELDS` from [utils/constants.py](cci:7://file:///d:/sem4/openalgo/utils/constants.py:0:0-0:0)
  - [valid_smart_order_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:70:0-80:54) — extends above with `position_size`
  - [valid_cancel_order_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:83:0-94:5) — cancel order payload with `orderid`
  - [mock_broker_module](cci:1://file:///d:/sem4/openalgo/test/conftest.py:98:0-136:17) — pre-configured `MagicMock` with all 9 standard broker API methods
  - [malicious_order_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:140:0-164:5) — SQL injection + XSS payloads for security testing
  - [empty_auth_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:167:0-184:5) — empty strings for auth bypass testing
  - [oversized_order_data](cci:1://file:///d:/sem4/openalgo/test/conftest.py:187:0-197:58) — absurdly large quantity for boundary testing
- **[test/test_conftest_smoke.py](cci:7://file:///d:/sem4/openalgo/test/test_conftest_smoke.py:0:0-0:0)** (94 lines) — 10 tests making sure all fixtures load correctly and return expected shapes
## Testing
$ pytest test/test_conftest_smoke.py -v 10 passed in 0.04s

$ pytest test/test_conftest_smoke.py test/test_log_location.py test/test_navigation_update.py test/test_python_editor.py test/test_rate_limits_simple.py test/test_logout_csrf.py -v 17 passed in 15.89s

- Zero existing tests broken by the new [conftest.py](cci:7://file:///d:/sem4/openalgo/test/conftest.py:0:0-0:0)
- Ruff clean — zero violations
- No real credentials anywhere — all test values are obviously fake
## Screenshots
N/A — test infrastructure, no UI changes.
## Checklist
- [x] Code follows PEP 8 guidelines
- [x] Added docstrings to all functions
- [x] Tested locally and verified working
- [x] No breaking changes to existing code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a shared pytest conftest.py with reusable fixtures to standardize test setup and include security edge-case data. Also adds smoke tests to verify fixture behavior so writing future tests is faster and consistent.

- **New Features**
  - Autouse env vars fixture for consistent test setup.
  - Order data factories (valid, smart, cancel) plus oversized quantity.
  - Mock broker module with standard API methods and sensible defaults.
  - Security fixtures for SQLi/XSS and empty auth; smoke tests validate shapes and keep existing tests passing.

<sup>Written for commit dc1f24ec3e61bdd1945c478959862689b2761162. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

