### PR TITLE
fix: clipboard copy fails on HTTP (non-HTTPS) deployments

### DIFF
--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -4,6 +4,7 @@
 import { useCallback, useState } from 'react'
 import { useParams } from 'react-router-dom'
 import { useQuery } from '@tanstack/react-query'
+import { copyToClipboard as copyText } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { X, Trash2, Settings2, Info, Copy, Eye, EyeOff, Loader2 } from 'lucide-react'
 import { useFlowWorkflowStore } from '@/stores/flowWorkflowStore'
@@ -164,7 +165,7 @@ export function ConfigPanel() {
 
   const handleDelete = useCallback(() => { if (selectedNodeId) deleteNode(selectedNodeId) }, [selectedNodeId, deleteNode])
   const handleClose = useCallback(() => { selectNode(null) }, [selectNode])
-  const copyToClipboard = (text: string, label: string) => { navigator.clipboard.writeText(text); showToast.success(`${label} copied`) }
+  const copyToClipboard = async (text: string, label: string) => { await copyText(text); showToast.success(`${label} copied`) }
 
   if (!selectedNode) {
     return (

--- a/frontend/src/pages/ApiKey.tsx
+++ b/frontend/src/pages/ApiKey.tsx
@@ -27,6 +27,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
 import { useAuthStore } from '@/stores/authStore'
+import { copyToClipboard } from '@/utils/clipboard'
 
 async function fetchCSRFToken(): Promise<string> {
   const response = await fetch('/auth/csrf-token', {
@@ -86,7 +87,7 @@ export default function ApiKey() {
   const handleCopyApiKey = async () => {
     if (apiKey) {
       try {
-        await navigator.clipboard.writeText(apiKey)
+        await copyToClipboard(apiKey)
         showToast.success('API key copied to clipboard', 'clipboard')
       } catch {
         showToast.error('Failed to copy API key', 'clipboard')

--- a/frontend/src/pages/GoCharting.tsx
+++ b/frontend/src/pages/GoCharting.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, BookOpen, Copy, ExternalLink, Info, RefreshCw } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { copyToClipboard as copyText } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -181,7 +182,7 @@ export default function GoCharting() {
 
   const copyToClipboard = async (text: string, label: string) => {
     try {
-      await navigator.clipboard.writeText(text)
+      await copyText(text)
       showToast.success(`${label} copied to clipboard`, 'clipboard')
     } catch {
       showToast.error('Copy failed - please copy manually', 'system')

--- a/frontend/src/pages/Playground.tsx
+++ b/frontend/src/pages/Playground.tsx
@@ -25,6 +25,7 @@ import {
 } from "lucide-react";
 import { useCallback, useEffect, useState } from "react";
 import { Link, useNavigate } from "react-router-dom";
+import { copyToClipboard } from "@/utils/clipboard";
 import { showToast } from "@/utils/toast";
 import { authApi } from "@/api/auth";
 import { Badge } from "@/components/ui/badge";
@@ -512,16 +513,16 @@ export default function Playground() {
     }
   };
 
-  const copyResponse = () => {
+  const copyResponse = async () => {
     if (responseData) {
-      navigator.clipboard.writeText(responseData);
+      await copyToClipboard(responseData);
       showToast.success("Response copied!", 'clipboard');
     }
   };
 
-  const copyApiKey = () => {
+  const copyApiKey = async () => {
     if (apiKey) {
-      navigator.clipboard.writeText(apiKey);
+      await copyToClipboard(apiKey);
       showToast.success("API key copied!", 'clipboard');
     }
   };
@@ -549,7 +550,7 @@ export default function Playground() {
     }
   };
 
-  const copyCurl = () => {
+  const copyCurl = async () => {
     if (!url) return;
 
     let curlUrl = url;
@@ -579,7 +580,7 @@ export default function Playground() {
       curl += ` \\\n  -d '${requestBody.replace(/'/g, "'\\''")}'`;
     }
 
-    navigator.clipboard.writeText(curl);
+    await copyToClipboard(curl);
     showToast.success("Copied as cURL", 'clipboard');
   };
 

--- a/frontend/src/pages/Profile.tsx
+++ b/frontend/src/pages/Profile.tsx
@@ -28,6 +28,7 @@ import {
 } from 'lucide-react'
 import { useCallback, useEffect, useState } from 'react'
 import { Link } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast, toast } from '@/utils/toast'
 import { webClient } from '@/api/client'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -725,15 +726,13 @@ export default function ProfilePage() {
     showToast.success('Theme reset to default', 'system')
   }
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        showToast.success('Copied to clipboard', 'clipboard')
-      })
-      .catch(() => {
-        showToast.error('Failed to copy', 'clipboard')
-      })
+  const copyText = async (text: string) => {
+    try {
+      await copyToClipboard(text)
+      showToast.success('Copied to clipboard', 'clipboard')
+    } catch {
+      showToast.error('Failed to copy', 'clipboard')
+    }
   }
 
   const strength = getPasswordStrength()
@@ -2198,7 +2197,7 @@ export default function ProfilePage() {
                       <Button
                         size="icon"
                         variant="outline"
-                        onClick={() => copyToClipboard(profileData.totp_secret!)}
+                        onClick={() => copyText(profileData.totp_secret!)}
                       >
                         <Copy className="h-4 w-4" />
                       </Button>

--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -1,6 +1,7 @@
 import { ArrowUpDown, ChevronLeft, ChevronRight, Copy, Search as SearchIcon } from 'lucide-react'
 import { useEffect, useMemo, useState } from 'react'
 import { Link, useSearchParams } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -110,15 +111,13 @@ export default function Search() {
     }
   }
 
-  const copyToClipboard = (text: string) => {
-    navigator.clipboard
-      .writeText(text)
-      .then(() => {
-        showToast.success('Symbol copied to clipboard', 'clipboard')
-      })
-      .catch(() => {
-        showToast.error('Failed to copy symbol', 'clipboard')
-      })
+  const copyText = async (text: string) => {
+    try {
+      await copyToClipboard(text)
+      showToast.success('Symbol copied to clipboard', 'clipboard')
+    } catch {
+      showToast.error('Failed to copy symbol', 'clipboard')
+    }
   }
 
   const handleSort = (key: SortKey) => {
@@ -248,7 +247,7 @@ export default function Search() {
                             variant="ghost"
                             size="icon"
                             className="h-6 w-6 opacity-60 hover:opacity-100"
-                            onClick={() => copyToClipboard(row.symbol)}
+                            onClick={() => copyText(row.symbol)}
                             title="Copy symbol"
                           >
                             <Copy className="h-3 w-3" />

--- a/frontend/src/pages/TradingView.tsx
+++ b/frontend/src/pages/TradingView.tsx
@@ -1,5 +1,6 @@
 import { AlertTriangle, BookOpen, Copy, ExternalLink, RefreshCw } from 'lucide-react'
 import { useCallback, useEffect, useRef, useState } from 'react'
+import { copyToClipboard as copyText } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { Alert, AlertDescription } from '@/components/ui/alert'
 import { Button } from '@/components/ui/button'
@@ -200,7 +201,7 @@ export default function TradingView() {
 
   const copyToClipboard = async (text: string, label: string) => {
     try {
-      await navigator.clipboard.writeText(text)
+      await copyText(text)
       showToast.success(`${label} copied to clipboard`, 'clipboard')
     } catch {
       showToast.error('Copy failed - please copy manually', 'clipboard')

--- a/frontend/src/pages/chartink/ChartinkIndex.tsx
+++ b/frontend/src/pages/chartink/ChartinkIndex.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { chartinkApi } from '@/api/chartink'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -72,7 +73,7 @@ export default function ChartinkIndex() {
   const copyWebhookUrl = async (webhookId: string) => {
     const url = getWebhookUrl(webhookId)
     try {
-      await navigator.clipboard.writeText(url)
+      await copyToClipboard(url)
       setCopiedId(webhookId)
       showToast.success('Webhook URL copied to clipboard', 'clipboard')
       setTimeout(() => setCopiedId(null), 2000)

--- a/frontend/src/pages/chartink/ViewChartinkStrategy.tsx
+++ b/frontend/src/pages/chartink/ViewChartinkStrategy.tsx
@@ -12,6 +12,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { chartinkApi } from '@/api/chartink'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -90,7 +91,7 @@ export default function ViewChartinkStrategy() {
 
   const copyToClipboard = async (text: string, field: string) => {
     try {
-      await navigator.clipboard.writeText(text)
+      await copyToClipboard(text)
       setCopiedField(field)
       showToast.success('Copied to clipboard', 'clipboard')
       setTimeout(() => setCopiedField(null), 2000)

--- a/frontend/src/pages/flow/FlowIndex.tsx
+++ b/frontend/src/pages/flow/FlowIndex.tsx
@@ -4,6 +4,7 @@
 import { useState } from 'react'
 import { useQuery, useMutation, useQueryClient } from '@tanstack/react-query'
 import { useNavigate } from 'react-router-dom'
+import { copyToClipboard as copyText } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import {
   AlertCircle,
@@ -167,8 +168,8 @@ function WorkflowCard({ workflow }: { workflow: WorkflowListItem }) {
     },
   })
 
-  const copyToClipboard = (text: string, label: string) => {
-    navigator.clipboard.writeText(text)
+  const copyToClipboard = async (text: string, label: string) => {
+    await copyText(text)
     showToast.success(`${label} copied to clipboard`, 'clipboard')
   }
 

--- a/frontend/src/pages/python-strategy/NewPythonStrategy.tsx
+++ b/frontend/src/pages/python-strategy/NewPythonStrategy.tsx
@@ -1,6 +1,7 @@
 import { ArrowLeft, Clock, FileCode, Info, Upload } from 'lucide-react'
 import { useRef, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { pythonStrategyApi } from '@/api/python-strategy'
 import { Alert, AlertDescription } from '@/components/ui/alert'
@@ -362,7 +363,7 @@ export default function NewPythonStrategy() {
                 size="sm"
                 className="mt-4"
                 onClick={() => {
-                  navigator.clipboard.writeText(EXAMPLE_STRATEGY)
+                  copyToClipboard(EXAMPLE_STRATEGY)
                   showToast.success('Copied to clipboard', 'clipboard')
                 }}
               >

--- a/frontend/src/pages/python-strategy/PythonStrategyGuide.tsx
+++ b/frontend/src/pages/python-strategy/PythonStrategyGuide.tsx
@@ -18,6 +18,7 @@ import {
   Terminal,
 } from 'lucide-react'
 import { Link } from 'react-router-dom'
+import { copyToClipboard as copyText } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
 import { Badge } from '@/components/ui/badge'
@@ -134,8 +135,8 @@ if __name__ == "__main__":
     main()
 `
 
-const copyToClipboard = (text: string) => {
-  navigator.clipboard.writeText(text)
+const copyToClipboard = async (text: string) => {
+  await copyText(text)
   showToast.success('Copied to clipboard', 'clipboard')
 }
 

--- a/frontend/src/pages/strategy/StrategyIndex.tsx
+++ b/frontend/src/pages/strategy/StrategyIndex.tsx
@@ -14,6 +14,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { strategyApi } from '@/api/strategy'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -74,7 +75,7 @@ export default function StrategyIndex() {
   const copyWebhookUrl = async (webhookId: string) => {
     const url = getWebhookUrl(webhookId)
     try {
-      await navigator.clipboard.writeText(url)
+      await copyToClipboard(url)
       setCopiedId(webhookId)
       showToast.success('Webhook URL copied to clipboard', 'clipboard')
       setTimeout(() => setCopiedId(null), 2000)

--- a/frontend/src/pages/strategy/ViewStrategy.tsx
+++ b/frontend/src/pages/strategy/ViewStrategy.tsx
@@ -16,6 +16,7 @@ import {
 } from 'lucide-react'
 import { useEffect, useState } from 'react'
 import { Link, useNavigate, useParams } from 'react-router-dom'
+import { copyToClipboard } from '@/utils/clipboard'
 import { showToast } from '@/utils/toast'
 import { strategyApi } from '@/api/strategy'
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert'
@@ -96,7 +97,7 @@ export default function ViewStrategy() {
 
   const copyToClipboard = async (text: string, field: string) => {
     try {
-      await navigator.clipboard.writeText(text)
+      await copyToClipboard(text)
       setCopiedField(field)
       showToast.success('Copied to clipboard', 'clipboard')
       setTimeout(() => setCopiedField(null), 2000)

--- a/frontend/src/utils/clipboard.ts
+++ b/frontend/src/utils/clipboard.ts
@@ -1,0 +1,21 @@
+/**
+ * Copy text to clipboard with fallback for non-HTTPS contexts.
+ *
+ * navigator.clipboard.writeText() requires a secure context (HTTPS).
+ * Many OpenAlgo deployments use plain HTTP (local or IP-based), so
+ * this helper falls back to the legacy execCommand('copy') approach.
+ */
+export async function copyToClipboard(text: string): Promise<void> {
+  if (navigator.clipboard && window.isSecureContext) {
+    await navigator.clipboard.writeText(text)
+  } else {
+    const textarea = document.createElement('textarea')
+    textarea.value = text
+    textarea.style.position = 'fixed'
+    textarea.style.left = '-9999px'
+    document.body.appendChild(textarea)
+    textarea.select()
+    document.execCommand('copy')
+    document.body.removeChild(textarea)
+  }
+}


### PR DESCRIPTION
## Summary
- `navigator.clipboard.writeText()` requires a secure context (HTTPS) and silently fails on HTTP deployments
- Added a shared clipboard utility (`frontend/src/utils/clipboard.ts`) with a `document.execCommand('copy')` fallback for non-secure contexts
- Updated all 14 files across the frontend that used `navigator.clipboard.writeText` directly to use the shared utility

## Files Changed
- **New**: `frontend/src/utils/clipboard.ts` — shared utility with HTTPS detection and fallback
- **Updated**: ApiKey, TradingView, GoCharting, Playground, Profile, Search, ChartinkIndex, ViewChartinkStrategy, StrategyIndex, ViewStrategy, PythonStrategyGuide, NewPythonStrategy, FlowIndex, ConfigPanel

## How It Works
```typescript
export async function copyToClipboard(text: string): Promise<void> {
  if (navigator.clipboard && window.isSecureContext) {
    await navigator.clipboard.writeText(text)
  } else {
    // Fallback for HTTP contexts
    const textarea = document.createElement('textarea')
    textarea.value = text
    textarea.style.position = 'fixed'
    textarea.style.left = '-9999px'
    document.body.appendChild(textarea)
    textarea.select()
    document.execCommand('copy')
    document.body.removeChild(textarea)
  }
}
```

## Test plan
- [ ] Verify copy buttons work on HTTPS deployment
- [ ] Verify copy buttons work on HTTP deployment (e.g., `http://localhost:5000`)
- [ ] Test copy on API Key page, Search results, Profile page, Strategy pages, and Playground

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes clipboard copy on non-HTTPS deployments by adding a shared utility with a secure-context check and fallback. Copy buttons now work consistently on HTTP and HTTPS.

- **Bug Fixes**
  - Added frontend/src/utils/clipboard.ts with a document.execCommand('copy') fallback when not in a secure context.
  - Replaced direct navigator.clipboard.writeText calls across 14 files to use the utility.
  - Updated ApiKey, Search, Profile, Strategy, Chartink, Playground, TradingView, GoCharting, Flow views to use the shared helper.

<sup>Written for commit bb52c0375999ca97026cf5d5afca1cf0ef76f8c9. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

