### PR TITLE
fix: replace bare except and silent exception handlers

### DIFF
--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -60,6 +60,6 @@ class MarginCalculator(Resource):
                 log_executor.submit(
                     async_log_order, "margin", data if "data" in locals() else {}, error_response
                 )
-            except:
-                pass
+            except Exception as e:
+                logger.exception(f"Failed to log margin order: {e}")
             return make_response(jsonify(error_response), 500)

--- a/services/gex_service.py
+++ b/services/gex_service.py
@@ -99,8 +99,8 @@ def get_gex_data(
                             greeks = greeks_resp.get("greeks", {})
                             ce_gamma = greeks.get("gamma", 0) or 0
                             ce_gex = ce_gamma * ce_oi * current_lotsize
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning(f"Failed to calculate greeks for CE {ce.get('symbol')}: {e}")
 
             # Process PE
             if pe and pe.get("symbol"):
@@ -122,8 +122,8 @@ def get_gex_data(
                             greeks = greeks_resp.get("greeks", {})
                             pe_gamma = greeks.get("gamma", 0) or 0
                             pe_gex = pe_gamma * pe_oi * current_lotsize
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.warning(f"Failed to calculate greeks for PE {pe.get('symbol')}: {e}")
 
             net_gex = ce_gex - pe_gex
 


### PR DESCRIPTION
## Summary
Fixes #1013

### Changes

**restx_api/margin.py:**
- Replaced bare `except:` with `except Exception as e:` 
- Added proper logging: `logger.exception(f"Failed to log margin order: {e}")`

**services/gex_service.py:**
- Replaced silent `except Exception: pass` with proper warning logs
- Now logs: `logger.warning(f"Failed to calculate greeks for CE/PE {symbol}: {e}")`

### Why This Matters
- Bare `except:` catches ALL exceptions including SystemExit, KeyboardInterrupt, and GeneratorExit which should normally propagate
- Silent exception handling hides errors that would help debug issues in production
- Proper exception handling with logging improves observability and debugging

### Testing
- Verified syntax is correct
- All exception handlers now properly catch `Exception` (not BaseException)
- All exception handlers now log meaningful error messages

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced bare and silent exception handlers with explicit Exception handling and logging in the margin API and GEX service, addressing #1013. Improves error visibility and prevents swallowing interrupts and other critical errors.

- **Bug Fixes**
  - restx_api/margin.py: replace bare except with "except Exception as e" and log failures when logging margin orders.
  - services/gex_service.py: replace "except Exception: pass" with warnings for CE/PE greeks calculation, including symbol.

<sup>Written for commit b6fcae39c6232f5def9ec91c4430e8cfb09eb9c8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

