### PR TITLE
Fix: Add null check for request.json in market_holidays, symbol, and intervals endpoints

### DIFF
--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -27,8 +27,18 @@ class Intervals(Resource):
     def post(self):
         """Get supported intervals for the broker"""
         try:
+            # Check if request body is valid JSON
+            data = request.json
+            if data is None:
+                return make_response(
+                    jsonify(
+                        {"status": "error", "message": "Request body is missing or invalid JSON"}
+                    ),
+                    400,
+                )
+
             # Validate request data
-            intervals_data = intervals_schema.load(request.json)
+            intervals_data = intervals_schema.load(data)
 
             api_key = intervals_data["apikey"]
 

--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -28,7 +28,7 @@ class Intervals(Resource):
         """Get supported intervals for the broker"""
         try:
             # Check if request body is valid JSON
-            data = request.json
+            data = request.get_json(silent=True)
             if data is None:
                 return make_response(
                     jsonify(

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -26,8 +26,18 @@ class MarketHolidays(Resource):
     def post(self):
         """Get market holidays for a specific year"""
         try:
+            # Check if request body is valid JSON
+            data = request.json
+            if data is None:
+                return make_response(
+                    jsonify(
+                        {"status": "error", "message": "Request body is missing or invalid JSON"}
+                    ),
+                    400,
+                )
+
             # Validate request data
-            holidays_data = holidays_schema.load(request.json)
+            holidays_data = holidays_schema.load(data)
 
             # Extract parameters
             year = holidays_data.get("year")

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -27,7 +27,7 @@ class MarketHolidays(Resource):
         """Get market holidays for a specific year"""
         try:
             # Check if request body is valid JSON
-            data = request.json
+            data = request.get_json(silent=True)
             if data is None:
                 return make_response(
                     jsonify(

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -27,7 +27,7 @@ class Symbol(Resource):
         """Get symbol information for a given symbol and exchange"""
         try:
             # Check if request body is valid JSON
-            data = request.json
+            data = request.get_json(silent=True)
             if data is None:
                 return make_response(
                     jsonify(

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -26,8 +26,18 @@ class Symbol(Resource):
     def post(self):
         """Get symbol information for a given symbol and exchange"""
         try:
+            # Check if request body is valid JSON
+            data = request.json
+            if data is None:
+                return make_response(
+                    jsonify(
+                        {"status": "error", "message": "Request body is missing or invalid JSON"}
+                    ),
+                    400,
+                )
+
             # Validate request data
-            symbol_data = symbol_schema.load(request.json)
+            symbol_data = symbol_schema.load(data)
 
             # Extract parameters
             api_key = symbol_data.pop("apikey", None)


### PR DESCRIPTION
## Summary
- Added null check for `request.json` in `market_holidays.py`, `symbol.py`, and `intervals.py` endpoints
- When request body is missing or invalid JSON, endpoints now return a structured `400 Bad Request` response
- Follows the existing pattern in `option_greeks.py`

## Changes
- `restx_api/market_holidays.py`: Added null check before schema validation
- `restx_api/symbol.py`: Added null check before schema validation
- `restx_api/intervals.py`: Added null check before schema validation

## Test plan
- [x] Send POST request with no body -> should return 400 with error message
- [x] Send POST request with valid JSON -> should work as before
- [x] Send POST request with invalid JSON -> should return 400 with error message

Fixes #1015

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Use request.get_json(silent=True) and add null checks in market_holidays, symbol, and intervals so missing or invalid JSON returns a consistent 400 Bad Request instead of a 500 or crash; fixes #1015.

<sup>Written for commit 526a07d2c555e27cd524ab71775d221b142723a5. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

