### PR TITLE
Standardize database environment variable naming to HISTORIFY_DATABASE_URL

### DIFF
--- a/database/historify_db.py
+++ b/database/historify_db.py
@@ -24,7 +24,7 @@ logger = get_logger(__name__)
 load_dotenv()
 
 # Database path - in /db folder like other OpenAlgo databases
-HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_PATH", "db/historify.duckdb")
+HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_URL", "db/historify.duckdb")
 
 
 def get_db_path() -> str:

--- a/install/install-multi.sh
+++ b/install/install-multi.sh
@@ -338,7 +338,7 @@ for ((i=1; i<=INSTANCES; i++)); do
     sudo sed -i "s|a25d94718479b170c16278e321ea6c989358bf499a658fd20c90033cef8ce772|$API_KEY_PEPPER|g" "$ENV_FILE"
 
     # 8. Update database paths (unique per instance - ALL 5 databases)
-    sudo sed -i "s|DATABASE_URL = '.*'|DATABASE_URL = '$DB_PATH'|g" "$ENV_FILE"
+    sudo sed -i "s|^DATABASE_URL = '.*'|DATABASE_URL = '$DB_PATH'|g" "$ENV_FILE"
     sudo sed -i "s|LATENCY_DATABASE_URL = '.*'|LATENCY_DATABASE_URL = '$LATENCY_DB'|g" "$ENV_FILE"
     sudo sed -i "s|LOGS_DATABASE_URL = '.*'|LOGS_DATABASE_URL = '$LOGS_DB'|g" "$ENV_FILE"
     sudo sed -i "s|SANDBOX_DATABASE_URL = '.*'|SANDBOX_DATABASE_URL = '$SANDBOX_DB'|g" "$ENV_FILE"

--- a/upgrade/migrate_historify.py
+++ b/upgrade/migrate_historify.py
@@ -40,7 +40,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 load_dotenv(os.path.join(parent_dir, ".env"))
 
 # Database path
-HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_PATH", "db/historify.duckdb")
+HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_URL", "db/historify.duckdb")
 
 
 def get_db_path():

--- a/upgrade/migrate_historify_scheduler.py
+++ b/upgrade/migrate_historify_scheduler.py
@@ -39,7 +39,7 @@ parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 load_dotenv(os.path.join(parent_dir, ".env"))
 
 # Database path
-HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_PATH", "db/historify.duckdb")
+HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_URL", "db/historify.duckdb")
 
 
 def get_db_path():


### PR DESCRIPTION
## Summary
This PR standardizes the environment variable naming convention for the Historify database configuration across the codebase. The variable `HISTORIFY_DATABASE_PATH` has been renamed to `HISTORIFY_DATABASE_URL` to maintain consistency with other database configuration variables in the project.

## Key Changes
- **database/historify_db.py**: Updated environment variable from `HISTORIFY_DATABASE_PATH` to `HISTORIFY_DATABASE_URL`
- **upgrade/migrate_historify.py**: Updated environment variable from `HISTORIFY_DATABASE_PATH` to `HISTORIFY_DATABASE_URL`
- **upgrade/migrate_historify_scheduler.py**: Updated environment variable from `HISTORIFY_DATABASE_PATH` to `HISTORIFY_DATABASE_URL`
- **install/install-multi.sh**: Fixed regex pattern for `DATABASE_URL` substitution by adding `^` anchor to match only lines starting with the variable name, preventing unintended replacements

## Implementation Details
- The naming change aligns with the existing convention used for other databases in the system (`LATENCY_DATABASE_URL`, `LOGS_DATABASE_URL`, `SANDBOX_DATABASE_URL`)
- The regex fix in the installation script ensures more precise string replacement during multi-instance setup, reducing the risk of accidental substitutions in comments or other content
- All three Python modules that reference the Historify database path have been updated consistently

https://claude.ai/code/session_01QYVMFBdiHGDF6evewd9JLi