### PR TITLE
Add skeleton loaders for stats cards during loading state

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -234,7 +234,6 @@
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.28.5.tgz",
       "integrity": "sha512-e7jT4DxYvIDLk1ZHmU/m/mB19rex9sv0c2ftBtjSBv+kVM/902eh0fINUzD7UwLLNR+jU585GxUJ8/EBfAM5fw==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.27.1",
         "@babel/generator": "^7.28.5",
@@ -655,6 +654,7 @@
       "resolved": "https://registry.npmjs.org/@choojs/findup/-/findup-0.2.1.tgz",
       "integrity": "sha512-YstAqNb0MCN8PjdLCDfRsBcGVRN41f3vgLvaI0IrIcBp4AqILRSS0DeWNGkicC+f/zRIPJLc+9RURVSepwvfBw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "commander": "^2.15.1"
       },
@@ -666,7 +666,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@codemirror/autocomplete": {
       "version": "6.20.0",
@@ -777,7 +778,6 @@
       "resolved": "https://registry.npmjs.org/@codemirror/view/-/view-6.39.11.tgz",
       "integrity": "sha512-bWdeR8gWM87l4DB/kYSF9A+dVackzDb/V56Tq7QVrQ7rn86W0rgZFtlL3g3pem6AeGcb9NQNoy3ao4WpW4h5tQ==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@codemirror/state": "^6.5.0",
         "crelt": "^1.0.6",
@@ -873,7 +873,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       },
@@ -917,7 +916,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=18"
       }
@@ -1559,6 +1557,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-rewind/-/geojson-rewind-0.5.2.tgz",
       "integrity": "sha512-tJaT+RbYGJYStt7wI3cq4Nl4SXxG8W7JDG5DMJu97V25RnbNg3QtQtf+KD+VLjNpWKYsRvXDNmNrBgEETr1ifA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "get-stream": "^6.0.1",
         "minimist": "^1.2.6"
@@ -1571,12 +1570,14 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/geojson-types/-/geojson-types-1.0.2.tgz",
       "integrity": "sha512-e9EBqHHv3EORHrSfbR9DqecPNn+AmuAoQxV6aL8Xu30bJMJR1o8PZLZzpk1Wq7/NfCbuhmakHTPYRhoqLsXRnw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/jsonlint-lines-primitives": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/@mapbox/jsonlint-lines-primitives/-/jsonlint-lines-primitives-2.0.2.tgz",
       "integrity": "sha512-rY0o9A5ECsTQRVhv7tL/OyDpGAoUB4tTvLiW1DSzQGq4bvTPhNw1VpSNjDJc5GFZ2XuyOtSWSVN05qOtcD71qQ==",
+      "peer": true,
       "engines": {
         "node": ">= 0.6"
       }
@@ -1586,6 +1587,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/mapbox-gl-supported/-/mapbox-gl-supported-1.5.0.tgz",
       "integrity": "sha512-/PT1P6DNf7vjEEiPkVIRJkvibbqWtqnyGaBz3nfRdcxclNSnSdaLU5tfAgcD7I8Yt5i+L19s406YLl1koLnLbg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "peerDependencies": {
         "mapbox-gl": ">=0.32.1 <2.0.0"
       }
@@ -1594,25 +1596,29 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/@mapbox/point-geometry/-/point-geometry-0.1.0.tgz",
       "integrity": "sha512-6j56HdLTwWGO0fJPlrZtdU/B13q8Uwmo18Ck2GnGgN9PCFyKTZ3UbXeEdRFh18i9XQ92eH2VdtpJHpBD3aripQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@mapbox/tiny-sdf": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-1.2.5.tgz",
       "integrity": "sha512-cD8A/zJlm6fdJOk6DqPUV8mcpyJkRz2x2R+/fYcWDYG3oWbG7/L7Yl/WqQ1VZCjnL9OTIMAn6c+BC5Eru4sQEw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@mapbox/unitbezier": {
       "version": "0.0.0",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.0.tgz",
       "integrity": "sha512-HPnRdYO0WjFjRTSwO3frz1wKaU649OBFPX3Zo/2WZvuRi6zMiRGui8SnPQiQABgqCf8YikDe5t3HViTVw1WUzA==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@mapbox/vector-tile": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/@mapbox/vector-tile/-/vector-tile-1.3.1.tgz",
       "integrity": "sha512-MCEddb8u44/xfQ3oD+Srl/tNcQoqTw3goGk2oLsrFxOTc3dUp+kAnby3PvAeeBYSMSjSPD1nd1AJA6W49WnoUw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "~0.1.0"
       }
@@ -1622,6 +1628,7 @@
       "resolved": "https://registry.npmjs.org/@mapbox/whoots-js/-/whoots-js-3.1.0.tgz",
       "integrity": "sha512-Es6WcD0nO5l+2BOQS4uLfNPYQaNDfbot3X1XUoloz+x0mPDS3eeORZJl06HXjwBG1fOGwCRnzK88LMdxKRrd6Q==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": ">=6.0.0"
       }
@@ -1631,6 +1638,7 @@
       "resolved": "https://registry.npmjs.org/@maplibre/maplibre-gl-style-spec/-/maplibre-gl-style-spec-20.4.0.tgz",
       "integrity": "sha512-AzBy3095fTFPjDjmWpR2w6HVRAZJ6hQZUCwk5Plz6EyfnfuQW1odeW5i2Ai47Y6TBA2hQnC+azscjBSALpaWgw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@mapbox/jsonlint-lines-primitives": "~2.0.2",
         "@mapbox/unitbezier": "^0.0.1",
@@ -1650,13 +1658,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/@maplibre/maplibre-gl-style-spec/node_modules/tinyqueue": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/@marijn/find-cluster-break": {
       "version": "1.0.2",
@@ -1684,13 +1694,15 @@
       "version": "3.8.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3/-/d3-3.8.2.tgz",
       "integrity": "sha512-wvsNmh1GYjyJfyEBPKJLTMzgf2c2bEbSIL50lmqVUi+o1NHaLPi1Lb4v7VxXXJn043BhNyrxUrWI85Q+zmjOVA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/@plotly/d3-sankey": {
       "version": "0.7.2",
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey/-/d3-sankey-0.7.2.tgz",
       "integrity": "sha512-2jdVos1N3mMp3QW0k2q1ph7Gd6j5PY1YihBrwpkFnKqO+cqtZq3AdEYUeSGXMeLsBDQYiqTVcihYfk8vr5tqhw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-array": "1",
         "d3-collection": "1",
@@ -1702,6 +1714,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/d3-sankey-circular/-/d3-sankey-circular-0.33.1.tgz",
       "integrity": "sha512-FgBV1HEvCr3DV7RHhDsPXyryknucxtfnLwPtCKKxdolKyTFYoLX/ibEfX39iFYIL7DYbVeRtP43dbFcrHNE+KQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d3-array": "^1.2.1",
         "d3-collection": "^1.0.4",
@@ -1714,6 +1727,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/mapbox-gl/-/mapbox-gl-1.13.4.tgz",
       "integrity": "sha512-sR3/Pe5LqT/fhYgp4rT4aSFf1rTsxMbGiH6Hojc7PH36ny5Bn17iVFUjpzycafETURuFbLZUfjODO8LvSI+5zQ==",
       "license": "SEE LICENSE IN LICENSE.txt",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/geojson-types": "^1.0.2",
@@ -1747,6 +1761,7 @@
       "resolved": "https://registry.npmjs.org/@plotly/point-cluster/-/point-cluster-3.1.9.tgz",
       "integrity": "sha512-MwaI6g9scKf68Orpr1pHZ597pYx9uP8UEFXLPbsCmuw3a84obwz6pnMXGc90VhgDNeNiLEdlmuK7CPo+5PIxXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "binary-search-bounds": "^2.0.4",
@@ -1764,7 +1779,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/@plotly/regl/-/regl-2.1.2.tgz",
       "integrity": "sha512-Mdk+vUACbQvjd0m/1JJjOOafmkp/EpmHjISsopEz5Av44CBq7rPC05HHNbYGKVyNUF2zmEoBS/TT0pd0SPFFyw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@radix-ui/number": {
       "version": "1.1.1",
@@ -4399,7 +4415,6 @@
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.90.20.tgz",
       "integrity": "sha512-vXBxa+qeyveVO7OA0jX1z+DeyCA4JKnThKv411jd5SORpBKgkcVnYKCiBgECvADvniBX7tobwBmg01qq9JmMJw==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@tanstack/query-core": "5.90.20"
       },
@@ -4518,6 +4533,7 @@
       "resolved": "https://registry.npmjs.org/@turf/area/-/area-7.3.3.tgz",
       "integrity": "sha512-FT66TCxUec+3RsCCyO1kWP57/tiEWEqYfpIs5n44dup401Cne/E+xunahEWxMfP/HSUxfcRQqrjH5vEulLrNoA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4533,6 +4549,7 @@
       "resolved": "https://registry.npmjs.org/@turf/bbox/-/bbox-7.3.3.tgz",
       "integrity": "sha512-1zNO/JUgDp0N+3EG5fG7+8EolE95OW1LD8ur0hRP0JK+lRyN0gAvJT7n1I9pu/NIqTa8x/zXxGRc1dcOdohYkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4548,6 +4565,7 @@
       "resolved": "https://registry.npmjs.org/@turf/centroid/-/centroid-7.3.3.tgz",
       "integrity": "sha512-3vWLnF1CksLk7xTUH11IzOQJ6fOoj7zhuL8M3GTxcKruVkGat/vIm3Ye5b68sDVcE5nFDA2pYjjbL7Rfmn3/GQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@turf/meta": "7.3.3",
@@ -4563,6 +4581,7 @@
       "resolved": "https://registry.npmjs.org/@turf/helpers/-/helpers-7.3.3.tgz",
       "integrity": "sha512-9Ias0L1GuZPIzO6sk8jraTEuLJye6n9LYNEdw69ZGOQ6C1IigjxkPW49zmn21aTv1z27vxdVLSS3r+78DB2QnQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "^7946.0.10",
         "tslib": "^2.8.1"
@@ -4576,6 +4595,7 @@
       "resolved": "https://registry.npmjs.org/@turf/meta/-/meta-7.3.3.tgz",
       "integrity": "sha512-Tz1j4h70iFB5SebWWoVv/uL59x4aOngXU+d1xQDXzOCn/O6txnreGVGMcYU362c5F06yqZx38H9UFTQ553lK0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@turf/helpers": "7.3.3",
         "@types/geojson": "^7946.0.10",
@@ -4589,7 +4609,8 @@
       "version": "5.0.4",
       "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
       "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
@@ -4708,13 +4729,15 @@
       "version": "7946.0.16",
       "resolved": "https://registry.npmjs.org/@types/geojson/-/geojson-7946.0.16.tgz",
       "integrity": "sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/geojson-vt": {
       "version": "3.2.5",
       "resolved": "https://registry.npmjs.org/@types/geojson-vt/-/geojson-vt-3.2.5.tgz",
       "integrity": "sha512-qDO7wqtprzlpe8FfQ//ClPV9xiuoh2nkIgiouIptON9w5jvD/fA4szvP9GBlDVdJ5dldAl0kX/sy3URbWwLx0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -4804,13 +4827,15 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__point-geometry/-/mapbox__point-geometry-0.1.4.tgz",
       "integrity": "sha512-mUWlSxAmYLfwnRBmgYV86tgYmMIICX4kza8YnE/eIlywGe2XoOxlpVnXWwir92xRLjwyarqwpu2EJKD2pk0IUA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/mapbox__vector-tile": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/@types/mapbox__vector-tile/-/mapbox__vector-tile-1.3.4.tgz",
       "integrity": "sha512-bpd8dRn9pr6xKvuEBQup8pwQfD4VUyqO/2deGjfpe6AwC8YRlyEipvefyRJUSiCJTZuCb8Pl1ciVV5ekqJ96Bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*",
         "@types/mapbox__point-geometry": "*",
@@ -4830,7 +4855,8 @@
       "version": "3.0.5",
       "resolved": "https://registry.npmjs.org/@types/pbf/-/pbf-3.0.5.tgz",
       "integrity": "sha512-j3pOPiEcWZ34R6a6mN07mUkM4o4Lwf6hPNt8eilOeZhTFbxFXmKhvXl9Y28jotFPaI1bpPDJsbCprUoNke6OrA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/@types/plotly.js": {
       "version": "3.0.9",
@@ -4848,7 +4874,6 @@
       "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.9.tgz",
       "integrity": "sha512-Lpo8kgb/igvMIPeNV2rsYKTgaORYdO1XGVZ4Qz3akwOj0ySGYMPlQWa8BaLn0G63D1aSaAQ5ldR06wCpChQCjA==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -4858,7 +4883,6 @@
       "resolved": "https://registry.npmjs.org/@types/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-jp2L/eY6fn+KgVVQAOqYItbF0VY/YApe5Mz2F0aykSO8gx31bYCZyvSeYxCHKvzHG5eZjc+zyaS5BrBWya2+kQ==",
       "devOptional": true,
-      "peer": true,
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
@@ -4882,6 +4906,7 @@
       "resolved": "https://registry.npmjs.org/@types/supercluster/-/supercluster-7.1.3.tgz",
       "integrity": "sha512-Z0pOY34GDFl3Q6hUFYf3HkTwKEE02e7QgtJppBt+beEAxnyOpJua+voGFvxINBHa06GwLFFym7gRPY2SiKIfIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@types/geojson": "*"
       }
@@ -5204,13 +5229,15 @@
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/abs-svg-path/-/abs-svg-path-0.1.1.tgz",
       "integrity": "sha512-d8XPSGjfyzlXC3Xx891DJRyZfqk5JU0BJrDQcsWomFIV1/BIzPW5HDH5iDdWpqWaav0YVIEzT1RHTwWr0FFshA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/acorn": {
       "version": "7.4.1",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-7.4.1.tgz",
       "integrity": "sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==",
       "license": "MIT",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5232,6 +5259,7 @@
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
       "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
       "dev": true,
+      "peer": true,
       "engines": {
         "node": ">=8"
       }
@@ -5272,13 +5300,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-bounds/-/array-bounds-1.0.1.tgz",
       "integrity": "sha512-8wdW3ZGk6UjMPJx/glyEt0sLzzwAE1bhToPsO1W2pbpR2gULyxe3BjSiuJFheP50T/GgODVPz2fuMUmIywt8cQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-find-index": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-find-index/-/array-find-index-1.0.2.tgz",
       "integrity": "sha512-M1HQyIXcBGtVywBt8WVdim+lrNaK7VHp99Qt5pSNziXznKHViIBbXWtfRTpEFpF/c4FdfxNAsCCwPp5phBYJtw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -5288,6 +5318,7 @@
       "resolved": "https://registry.npmjs.org/array-normalize/-/array-normalize-1.1.4.tgz",
       "integrity": "sha512-fCp0wKFLjvSPmCn4F5Tiw4M3lpMZoHlCjfcs7nNzuj3vqQQ1/a8cgB9DXcpDSn18c+coLnaW7rqfcYCvKbyJXg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.0"
       }
@@ -5296,13 +5327,15 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/array-range/-/array-range-1.0.1.tgz",
       "integrity": "sha512-shdaI1zT3CVNL2hnx9c0JMc0ZogGaxDs5e85akgHWKYa0yVbIyp06Ind3dVkTj/uuFrzaHBOyqFzo+VV6aXgtA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/array-rearrange": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/array-rearrange/-/array-rearrange-2.2.2.tgz",
       "integrity": "sha512-UfobP5N12Qm4Qu4fwLDIi2v6+wZsSf6snYSxAMeKhrh37YGnNWZPRmVEKc/2wfms53TLQnzfpG8wCx2Y/6NG1w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/assertion-error": {
       "version": "2.0.1",
@@ -5424,25 +5457,29 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/binary-search-bounds/-/binary-search-bounds-2.0.5.tgz",
       "integrity": "sha512-H0ea4Fd3lS1+sTEB2TgcLoK21lLhwEJzlQv3IN47pJS976Gx4zoWe0ak3q+uYh60ppQxg9F16Ri4tS1sfD4+jA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bit-twiddle": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/bit-twiddle/-/bit-twiddle-1.0.2.tgz",
       "integrity": "sha512-B9UhK0DKFZhoTFcfvAzhqsjStvGJp9vYWf3+6SNTtdSQnvIgfkHbgHrg/e4+TH71N2GDu8tpmCVoyfrL1d7ntA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bitmap-sdf": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/bitmap-sdf/-/bitmap-sdf-1.0.4.tgz",
       "integrity": "sha512-1G3U4n5JE6RAiALMxu0p1XmeZkTeCwGKykzsLTCqVzfSDaN6S7fKnkIkfejogz+iwqBWc0UYAIKnKHNN7pSfDg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/bl": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/bl/-/bl-2.2.1.tgz",
       "integrity": "sha512-6Pesp1w0DEX1N550i/uGV/TqucVL4AM/pgThFSN/Qq9si1/DF9aIHs1BxD8V/QU0HoeHO6cQRTAuYnLPKq1e4g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "^2.3.5",
         "safe-buffer": "^5.1.1"
@@ -5486,7 +5523,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -5505,7 +5541,8 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/buffer-from/-/buffer-from-1.1.2.tgz",
       "integrity": "sha512-E+XQCRwSbaaiChtv6k6Dwgc+bx+Bs6vuKJHHl5kox/BaKbhiXzqQOwK4cO22yElGp2OCmjwVhT3HmxgyPGnJfQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
@@ -5557,6 +5594,7 @@
       "resolved": "https://registry.npmjs.org/canvas-fit/-/canvas-fit-1.5.0.tgz",
       "integrity": "sha512-onIcjRpz69/Hx5bB5HGbYKUF2uC6QT6Gp+pfpGm3A7mPfcluSLV5v4Zu+oflDUwLdUw0rLIBhUbi0v8hM4FJQQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "element-size": "^1.1.1"
       }
@@ -5629,7 +5667,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/clamp/-/clamp-1.0.1.tgz",
       "integrity": "sha512-kgMuFyE78OC6Dyu3Dy7vcx4uy97EIbVxJB/B0eJ3bUNAkwdNcxYzgKltnyADiYwsR7SEqkkUPsEUT//OVS6XMA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/class-variance-authority": {
       "version": "0.7.1",
@@ -5691,6 +5730,7 @@
       "resolved": "https://registry.npmjs.org/color-alpha/-/color-alpha-1.0.4.tgz",
       "integrity": "sha512-lr8/t5NPozTSqli+duAN+x+no/2WaKTeWvxhHGN+aXT6AJ8vPlzLa7UriyjWak0pSC2jHol9JgjBYnnHsGha9A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.3.8"
       }
@@ -5700,6 +5740,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5721,6 +5762,7 @@
       "resolved": "https://registry.npmjs.org/color-id/-/color-id-1.1.0.tgz",
       "integrity": "sha512-2iRtAn6dC/6/G7bBIo0uupVrIne1NsQJvJxZOBCzQOfk7jRq97feaDZ3RdzuHakRXXnHGNwglto3pqtRx1sX0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1"
       }
@@ -5735,6 +5777,7 @@
       "resolved": "https://registry.npmjs.org/color-normalize/-/color-normalize-1.5.0.tgz",
       "integrity": "sha512-rUT/HDXMr6RFffrR53oX3HGWkDOP9goSAQGBkUaAYKjOE2JxozccdGyufageWDlInRAjm/jYPrf/Y38oa+7obw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "clamp": "^1.0.1",
         "color-rgba": "^2.1.1",
@@ -5746,6 +5789,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5755,6 +5799,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
       "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.4.2",
         "color-space": "^2.0.0"
@@ -5765,6 +5810,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-2.0.0.tgz",
       "integrity": "sha512-g2Z+QnWsdHLppAbrpcFWo629kLOnOPtpxYV69GCqm92gqSgyXbzlfyN3MXs0412fPBkFmiuS+rXposgBgBa6Kg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -5774,6 +5820,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-3.0.0.tgz",
       "integrity": "sha512-PPwZYkEY3M2THEHHV6Y95sGUie77S7X8v+h1r6LSAPF3/LL2xJ8duUXSrkic31Nzc4odPwHgUbiX/XuTYzQHQg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^2.0.0",
         "color-space": "^2.0.0"
@@ -5783,7 +5830,8 @@
       "version": "2.3.2",
       "resolved": "https://registry.npmjs.org/color-space/-/color-space-2.3.2.tgz",
       "integrity": "sha512-BcKnbOEsOarCwyoLstcoEztwT0IJxqqQkNwDuA3a65sICvvHL2yoeV13psoDFh5IuiOMnIOKdQDwB4Mk3BypiA==",
-      "license": "Unlicense"
+      "license": "Unlicense",
+      "peer": true
     },
     "node_modules/colord": {
       "version": "2.9.3",
@@ -5830,6 +5878,7 @@
         "node >= 0.8"
       ],
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "buffer-from": "^1.0.0",
         "inherits": "^2.0.3",
@@ -5860,13 +5909,15 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.3.tgz",
       "integrity": "sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/country-regex": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/country-regex/-/country-regex-1.1.0.tgz",
       "integrity": "sha512-iSPlClZP8vX7MC3/u6s3lrDuoQyhQukh5LyABJ3hvfzbQ3Yyayd4fp04zjLnfi267B/B2FkumcWWgrbban7sSA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/crelt": {
       "version": "1.0.6",
@@ -5892,6 +5943,7 @@
       "resolved": "https://registry.npmjs.org/css-font/-/css-font-1.2.0.tgz",
       "integrity": "sha512-V4U4Wps4dPDACJ4WpgofJ2RT5Yqwe1lEH6wlOOaIxMi0gTjdIijsc5FmxQlZ7ZZyKQkkutqqvULOp07l9c7ssA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font-size-keywords": "^1.0.0",
         "css-font-stretch-keywords": "^1.0.1",
@@ -5908,31 +5960,36 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-size-keywords/-/css-font-size-keywords-1.0.0.tgz",
       "integrity": "sha512-Q+svMDbMlelgCfH/RVDKtTDaf5021O486ZThQPIpahnIjUkMUslC+WuOQSWTgGSrNCH08Y7tYNEmmy0hkfMI8Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-stretch-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-stretch-keywords/-/css-font-stretch-keywords-1.0.1.tgz",
       "integrity": "sha512-KmugPO2BNqoyp9zmBIUGwt58UQSfyk1X5DbOlkb2pckDXFSAfjsD5wenb88fNrD6fvS+vu90a/tsPpb9vb0SLg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-style-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-font-style-keywords/-/css-font-style-keywords-1.0.1.tgz",
       "integrity": "sha512-0Fn0aTpcDktnR1RzaBYorIxQily85M2KXRpzmxQPgh8pxUN9Fcn00I8u9I3grNr1QXVgCl9T5Imx0ZwKU973Vg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-font-weight-keywords": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-font-weight-keywords/-/css-font-weight-keywords-1.0.0.tgz",
       "integrity": "sha512-5So8/NH+oDD+EzsnF4iaG4ZFHQ3vaViePkL1ZbZ5iC/KrsCY+WHq/lvOgrtmuOQ9pBBZ1ADGpaf+A4lj1Z9eYA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-global-keywords": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/css-global-keywords/-/css-global-keywords-1.0.1.tgz",
       "integrity": "sha512-X1xgQhkZ9n94WDwntqst5D/FKkmiU0GlJSFZSV3kLvyJ1WC5VeyoXDOuleUD+SIuH9C7W05is++0Woh0CGfKjQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-line-break": {
       "version": "2.1.0",
@@ -5963,7 +6020,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/css-system-font-keywords/-/css-system-font-keywords-1.0.0.tgz",
       "integrity": "sha512-1umTtVd/fXS25ftfjB71eASCrYhilmEsvDEI6wG/QplnmlfmVM5HkZ/ZX46DT5K3eblFPgLUHt5BRCb0YXkSFA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/css-tree": {
       "version": "3.1.0",
@@ -6002,7 +6060,8 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/csscolorparser/-/csscolorparser-1.0.3.tgz",
       "integrity": "sha512-umPSgYwZkdFoUrH5hIq5kf0wPSXiro51nPw0j2K/c83KflkPSTBGMz6NJvMB+07VlL0y7VPo6QJcDjcgKTTm3w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/cssesc": {
       "version": "3.0.0",
@@ -6168,6 +6227,7 @@
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.2.tgz",
       "integrity": "sha512-MOqHvMWF9/9MX6nza0KgvFH4HpMU0EF5uUDXqX/BtxtU8NfB0QzRtJ8Oe/6SuS4kbhyzVJwjd97EA4PKrzJ8bw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "es5-ext": "^0.10.64",
         "type": "^2.7.2"
@@ -6180,13 +6240,15 @@
       "version": "1.2.4",
       "resolved": "https://registry.npmjs.org/d3-array/-/d3-array-1.2.4.tgz",
       "integrity": "sha512-KHW6M86R+FUPYGb3R5XiYjXPq7VzwxZ22buHhAEVG5ztoEcZZMLov530mmccaqA1GghZArjQV46fuc8kUqhhHw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-collection": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-collection/-/d3-collection-1.0.7.tgz",
       "integrity": "sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-color": {
       "version": "3.1.0",
@@ -6233,6 +6295,7 @@
       "resolved": "https://registry.npmjs.org/d3-force/-/d3-force-1.2.1.tgz",
       "integrity": "sha512-HHvehyaiUlVo5CxBJ0yF/xny4xoaxFxDnBXNvNcfW9adORGZfyNF1dj6DGLKyk4Yh3brP/1h3rnDzdIAwL08zg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-collection": "1",
         "d3-dispatch": "1",
@@ -6244,25 +6307,29 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/d3-dispatch/-/d3-dispatch-1.0.6.tgz",
       "integrity": "sha512-fVjoElzjhCEy+Hbn8KygnmMS7Or0a9sI2UzGwoB7cCtvI1XpVN9GpoYlnb3xt2YV66oXYb1fLJ8GMvP4hdU1RA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-force/node_modules/d3-timer": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/d3-timer/-/d3-timer-1.0.10.tgz",
       "integrity": "sha512-B1JDm0XDaQC+uvo4DT79H0XmBskgS3l6Ve+1SBCfxgmtIb1AVrPIoqd+nPSv+loMX8szQ0sVUhGngL7D5QPiXw==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-format": {
       "version": "1.4.5",
       "resolved": "https://registry.npmjs.org/d3-format/-/d3-format-1.4.5.tgz",
       "integrity": "sha512-J0piedu6Z8iB6TbIGfZgDzfXxUFN3qQRMofy2oPdXzQibYGqPB/9iMcxr/TGalU+2RsyDO+U4f33id8tbnSRMQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-geo": {
       "version": "1.12.1",
       "resolved": "https://registry.npmjs.org/d3-geo/-/d3-geo-1.12.1.tgz",
       "integrity": "sha512-XG4d1c/UJSEX9NfU02KwBL6BYPj8YKHxgBEw5om2ZnTRSbIcego6dhHwcxuSR3clxh0EpE38os1DVPOmnYtTPg==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-array": "1"
       }
@@ -6272,6 +6339,7 @@
       "resolved": "https://registry.npmjs.org/d3-geo-projection/-/d3-geo-projection-2.9.0.tgz",
       "integrity": "sha512-ZULvK/zBn87of5rWAfFMc9mJOipeSo57O+BBitsKIXmU4rTVAnX1kSsJkE0R+TxY8pGNoM1nbyRRE7GYHhdOEQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "commander": "2",
         "d3-array": "1",
@@ -6290,13 +6358,15 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/d3-hierarchy": {
       "version": "1.1.9",
       "resolved": "https://registry.npmjs.org/d3-hierarchy/-/d3-hierarchy-1.1.9.tgz",
       "integrity": "sha512-j8tPxlqh1srJHAtxfvOUwKNYJkQuBFdM1+JAUfq6xqH5eAqf93L7oG1NVqDa4CpFZNvnNKtCYEUC8KY9yEn9lQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-interpolate": {
       "version": "3.0.1",
@@ -6314,20 +6384,21 @@
       "version": "1.0.9",
       "resolved": "https://registry.npmjs.org/d3-path/-/d3-path-1.0.9.tgz",
       "integrity": "sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-quadtree": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/d3-quadtree/-/d3-quadtree-1.0.7.tgz",
       "integrity": "sha512-RKPAeXnkC59IDGD0Wu5mANy0Q2V28L+fNe65pOCXVdVuTJS3WPKaJlFHer32Rbh9gIo9qMuJXio8ra4+YmIymA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
       "license": "ISC",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -6337,6 +6408,7 @@
       "resolved": "https://registry.npmjs.org/d3-shape/-/d3-shape-1.3.7.tgz",
       "integrity": "sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-path": "1"
       }
@@ -6345,13 +6417,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/d3-time/-/d3-time-1.1.0.tgz",
       "integrity": "sha512-Xh0isrZ5rPYYdqhAVk8VLnMEidhz5aP7htAADH6MfzgmmicPkTo8LhkLxci61/lCB7n7UmE3bN0leRt+qvkLxA==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/d3-time-format": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/d3-time-format/-/d3-time-format-2.3.0.tgz",
       "integrity": "sha512-guv6b2H37s2Uq/GefleCDtbe0XZAuy7Wa49VGkPVPMfLL9qObgBST3lEHJBMUp8S7NdLQAGIvr2KXk8Hc98iKQ==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "d3-time": "1"
       }
@@ -6463,6 +6537,7 @@
       "resolved": "https://registry.npmjs.org/defined/-/defined-1.0.1.tgz",
       "integrity": "sha512-hsBd2qSVCRE+5PmNdHt1uzyrFu5d3RwmFDKzyNZMFq/EwDNJF7Ee5+D5oEKF0hU6LhtoUF1macFvOe4AskQC1Q==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -6488,7 +6563,8 @@
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-kerning/-/detect-kerning-2.1.2.tgz",
       "integrity": "sha512-I3JIbrnKPAntNLl1I6TpSQQdQ4AutYzv/sKMFKbepawV/hlH0GmYKhUoOEMd4xqaUHT+Bm0f4127lh5qs1m1tw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -6595,6 +6671,7 @@
       "resolved": "https://registry.npmjs.org/draw-svg-path/-/draw-svg-path-1.0.0.tgz",
       "integrity": "sha512-P8j3IHxcgRMcY6sDzr0QvJDLzBnJJqpTG33UZ2Pvp8rw0apCHhJCWqYprqrXjrgHnJ6tuhP1iTJSAodPDHxwkg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abs-svg-path": "~0.1.1",
         "normalize-svg-path": "~0.1.0"
@@ -6605,6 +6682,7 @@
       "resolved": "https://registry.npmjs.org/dtype/-/dtype-2.0.0.tgz",
       "integrity": "sha512-s2YVcLKdFGS0hpFqJaTwscsyt0E8nNFdmo73Ocd81xNPj4URI4rj6D60A+vFMIw7BXWlb4yRkEwfBqcZzPGiZg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.8.0"
       }
@@ -6626,13 +6704,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/dup/-/dup-1.0.0.tgz",
       "integrity": "sha512-Bz5jxMMC0wgp23Zm15ip1x8IhYRqJvF3nFC0UInJUDkN1z4uNPk9jTnfCUJXbOGiQ1JbXLQsiV41Fb+HXcj5BA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/duplexify": {
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/duplexify/-/duplexify-3.7.1.tgz",
       "integrity": "sha512-07z8uv2wMyS51kKhD1KsdXJg5WQ6t93RneqRxUHnskXVtlYYkLqM0gqStQZ3pj073g687jPCHrqNfCzawLYh5g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "end-of-stream": "^1.0.0",
         "inherits": "^2.0.1",
@@ -6644,7 +6724,8 @@
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
       "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.5.267",
@@ -6656,13 +6737,15 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/element-size/-/element-size-1.1.1.tgz",
       "integrity": "sha512-eaN+GMOq/Q+BIWy0ybsgpcYImjGIdNLyjLFJU4XsLHXYQao5jCNb36GyN6C2qwmDDYSfIBmKpPpr4VnBdLCsPQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/elementary-circuits-directed-graph": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/elementary-circuits-directed-graph/-/elementary-circuits-directed-graph-1.3.1.tgz",
       "integrity": "sha512-ZEiB5qkn2adYmpXGnJKkxT8uJHlW/mxmBpmeqawEHzPxh9HkLD4/1mFYX5l0On+f6rcPIt8/EWlRU2Vo3fX6dQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "strongly-connected-components": "^1.0.1"
       }
@@ -6672,6 +6755,7 @@
       "resolved": "https://registry.npmjs.org/end-of-stream/-/end-of-stream-1.4.5.tgz",
       "integrity": "sha512-ooEGc6HP26xXq/N+GCGOT0JKCLDGrq2bQUZrQ7gyrJiZANJ/8YDTxTpQBXGMn+WbIQXNVpyWymm7KYVICQnyOg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "^1.4.0"
       }
@@ -6774,6 +6858,7 @@
       "integrity": "sha512-p2snDhiLaXe6dahss1LddxqEm+SkuDvV8dnIQG0MWjyHpcMNfXKPE+/Cc0y+PhxJX3A4xGNeFCj5oc0BUh6deg==",
       "hasInstallScript": true,
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "es6-iterator": "^2.0.3",
         "es6-symbol": "^3.1.3",
@@ -6789,6 +6874,7 @@
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha512-zw4SRzoUkd+cl+ZoE15A9o1oQd920Bb0iOJMQkQhl3jNc03YqVjAhG7scf9C5KWRU/R13Orf588uCC6525o02g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.35",
@@ -6800,6 +6886,7 @@
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.4.tgz",
       "integrity": "sha512-U9bFFjX8tFiATgtkJ1zg25+KviIXpgRvRHS8sau3GfhVzThRQrOeksPeT0BWW2MNZs1OEWJ1DPXOQMn0KKRkvg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.2",
         "ext": "^1.7.0"
@@ -6813,6 +6900,7 @@
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.3.tgz",
       "integrity": "sha512-p5um32HOTO1kP+w7PRnB+5lQ43Z6muuMuIMffvDN8ZB4GcnjLBV6zGStpbASIMk4DCAvEaamhe2zhyCb/QXXsA==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "^0.10.46",
@@ -6883,6 +6971,7 @@
       "resolved": "https://registry.npmjs.org/escodegen/-/escodegen-2.1.0.tgz",
       "integrity": "sha512-2NlIDTwUWJN0mRPQOdtQBzbUHvdGY2P1VXSyU83Q3xKxM7WHX2Ql8dKq782Q9TgQUNOLEzEYu9bzLNj1q88I5w==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "dependencies": {
         "esprima": "^4.0.1",
         "estraverse": "^5.2.0",
@@ -6904,6 +6993,7 @@
       "resolved": "https://registry.npmjs.org/esniff/-/esniff-2.0.1.tgz",
       "integrity": "sha512-kTUIGKQ/mDPFoJ0oVfcmyJn4iBDRptjNVIzwIFR7tqWXdVI9xfA2RMwY/gbSpJG3lkdWNEjLap/NqVHZiJsdfg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "d": "^1.0.1",
         "es5-ext": "^0.10.62",
@@ -6919,6 +7009,7 @@
       "resolved": "https://registry.npmjs.org/esprima/-/esprima-4.0.1.tgz",
       "integrity": "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "bin": {
         "esparse": "bin/esparse.js",
         "esvalidate": "bin/esvalidate.js"
@@ -6932,6 +7023,7 @@
       "resolved": "https://registry.npmjs.org/estraverse/-/estraverse-5.3.0.tgz",
       "integrity": "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=4.0"
       }
@@ -6950,6 +7042,7 @@
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
       "integrity": "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g==",
       "license": "BSD-2-Clause",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -6959,6 +7052,7 @@
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha512-D9rRn9y7kLPnJ+hMq7S/nhvoKwwvVJahBi2BPmx3bvbsEdK3W9ii8cBSGjP+72/LnM4n6fo3+dkCX5FeTQruXA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "d": "1",
         "es5-ext": "~0.10.14"
@@ -6969,6 +7063,7 @@
       "resolved": "https://registry.npmjs.org/events/-/events-3.3.0.tgz",
       "integrity": "sha512-mQw+2fkQbALzQ7V0MY0IqdnXNOeTtP4r0lN9z7AAawCXgqea7bDii20AYrIBrFd/Hx0M2Ocz6S111CaFkUcb0Q==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.8.x"
       }
@@ -7004,6 +7099,7 @@
       "resolved": "https://registry.npmjs.org/ext/-/ext-1.7.0.tgz",
       "integrity": "sha512-6hxeJYaL110a9b5TEJSj0gojyHQAmA2ch5Os+ySCiA1QGdS697XWY1pzsrSjqA9LDEEgdB/KypIlR59RcLuHYw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "type": "^2.7.2"
       }
@@ -7013,6 +7109,7 @@
       "resolved": "https://registry.npmjs.org/falafel/-/falafel-2.2.5.tgz",
       "integrity": "sha512-HuC1qF9iTnHDnML9YZAdCDQwT0yKl/U55K4XSUXqGAA2GLoafFgWRqdAbhWJxXaYD4pyoVxAJ8wH670jMpI9DQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "acorn": "^7.1.1",
         "isarray": "^2.0.1"
@@ -7031,6 +7128,7 @@
       "resolved": "https://registry.npmjs.org/fast-isnumeric/-/fast-isnumeric-1.1.4.tgz",
       "integrity": "sha512-1mM8qOr2LYz8zGaUdmiqRDiuue00Dxjgcb1NQR7TnhLVh6sQyngP9xvLo7Sl7LZpP/sk5eb+bcyWXw530NTBZw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-string-blank": "^1.0.1"
       }
@@ -7080,6 +7178,7 @@
       "resolved": "https://registry.npmjs.org/flatten-vertex-data/-/flatten-vertex-data-1.0.2.tgz",
       "integrity": "sha512-BvCBFK2NZqerFTdMDgqfHBwxYWnxeCkwONsw6PvBMcUXqo8U/KDWwmXhqx1x2kLIg7DqIsJfOaJFOmlua3Lxuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "dtype": "^2.0.0"
       }
@@ -7108,6 +7207,7 @@
       "resolved": "https://registry.npmjs.org/font-atlas/-/font-atlas-2.1.0.tgz",
       "integrity": "sha512-kP3AmvX+HJpW4w3d+PiPR2X6E1yvsBXt2yhuCw+yReO9F1WYhvZwx3c95DGZGwg9xYzDGrgJYa885xmVA+28Cg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font": "^1.0.0"
       }
@@ -7117,6 +7217,7 @@
       "resolved": "https://registry.npmjs.org/font-measure/-/font-measure-1.2.2.tgz",
       "integrity": "sha512-mRLEpdrWzKe9hbfaF3Qpr06TAjquuBVP5cHy4b3hyeNdjc9i0PO6HniGsX5vjL5OWv7+Bd++NiooNpT/s8BvIA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "css-font": "^1.2.0"
       }
@@ -7163,6 +7264,7 @@
       "resolved": "https://registry.npmjs.org/from2/-/from2-2.3.0.tgz",
       "integrity": "sha512-OMcX/4IC/uqEPVgGeyfN22LJk6AZrMkRZHxcHBMBvHScDGgwTm2GT2Wkgtocyd3JfZffjj2kYUDXXII0Fk9W0g==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "inherits": "^2.0.1",
         "readable-stream": "^2.0.0"
@@ -7202,13 +7304,15 @@
       "version": "3.2.1",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-3.2.1.tgz",
       "integrity": "sha512-EvGQQi/zPrDA6zr6BnJD/YhwAkBP8nnJ9emh3EnHQKVMfg/MRVtPbMYdgVy/IaEmn4UfagD2a6fafPDL5hbtwg==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/get-canvas-context": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/get-canvas-context/-/get-canvas-context-1.0.2.tgz",
       "integrity": "sha512-LnpfLf/TNzr9zVOGiIY6aKCz8EKuXmlYNV7CM2pUjBa/B+c2I15tS7KLySep75+FuerJdmArvJLcsAXWEy2H0A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/get-intrinsic": {
       "version": "1.3.0",
@@ -7258,6 +7362,7 @@
       "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
       "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -7269,19 +7374,22 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gl-mat4/-/gl-mat4-1.2.0.tgz",
       "integrity": "sha512-sT5C0pwB1/e9G9AvAoLsoaJtbMGjfd/jfxo8jMCKqYYEnjZuFvqV5rehqar0538EmssjdDeiEWnKyBSTw7quoA==",
-      "license": "Zlib"
+      "license": "Zlib",
+      "peer": true
     },
     "node_modules/gl-matrix": {
       "version": "3.4.4",
       "resolved": "https://registry.npmjs.org/gl-matrix/-/gl-matrix-3.4.4.tgz",
       "integrity": "sha512-latSnyDNt/8zYUB6VIJ6PCh2jBjJX6gnDsoCZ7LyW7GkqrD51EWwa9qCoGixj8YqBtETQK/xY7OmpTF8xz1DdQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/gl-text": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/gl-text/-/gl-text-1.4.0.tgz",
       "integrity": "sha512-o47+XBqLCj1efmuNyCHt7/UEJmB9l66ql7pnobD6p+sgmBUdzfMZXIF0zD2+KRfpd99DJN+QXdvTFAGCKCVSmQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.2",
         "color-normalize": "^1.5.0",
@@ -7307,6 +7415,7 @@
       "resolved": "https://registry.npmjs.org/gl-util/-/gl-util-3.1.3.tgz",
       "integrity": "sha512-dvRTggw5MSkJnCbh74jZzSoTOGnVYK+Bt+Ckqm39CVcl6+zSsxqWk4lr5NKhkqXHL6qvZAU9h17ZF8mIskY9mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1",
         "is-firefox": "^1.0.3",
@@ -7322,6 +7431,7 @@
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-4.0.0.tgz",
       "integrity": "sha512-w0Uf9Y9/nyHinEk5vMJKRie+wa4kR5hmDbEhGGds/kG1PwGLLHKRoNMeJOyCQjjBkANlnScqgzcFwGHgmgLkVA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ini": "^4.1.3",
         "kind-of": "^6.0.3",
@@ -7336,6 +7446,7 @@
       "resolved": "https://registry.npmjs.org/glsl-inject-defines/-/glsl-inject-defines-1.0.3.tgz",
       "integrity": "sha512-W49jIhuDtF6w+7wCMcClk27a2hq8znvHtlGnrYkSWEr8tHe9eA2dcnohlcAmxLYBSpSSdzOkRdyPTrx9fw49+A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-token-inject-block": "^1.0.0",
         "glsl-token-string": "^1.0.1",
@@ -7347,6 +7458,7 @@
       "resolved": "https://registry.npmjs.org/glsl-resolve/-/glsl-resolve-0.0.1.tgz",
       "integrity": "sha512-xxFNsfnhZTK9NBhzJjSBGX6IOqYpvBHxxmo+4vapiljyGNCY0Bekzn0firQkQrazK59c1hYxMDxYS8MDlhw4gA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "resolve": "^0.6.1",
         "xtend": "^2.1.2"
@@ -7356,12 +7468,14 @@
       "version": "0.6.3",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-0.6.3.tgz",
       "integrity": "sha512-UHBY3viPlJKf85YijDUcikKX6tmF4SokIDp518ZDVT92JNDcG5uKIthaT/owt3Sar0lwtOafsQuwrg22/v2Dwg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-resolve/node_modules/xtend": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-2.2.0.tgz",
       "integrity": "sha512-SLt5uylT+4aoXxXuwtQp5ZnMMzhDb1Xkg4pEqc00WUJCQifPfV9Ub1VrNhp9kXkrjZD2I2Hl8WnjP37jzZLPZw==",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }
@@ -7370,13 +7484,15 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-assignments/-/glsl-token-assignments-2.0.2.tgz",
       "integrity": "sha512-OwXrxixCyHzzA0U2g4btSNAyB2Dx8XrztY5aVUCjRSh4/D0WoJn8Qdps7Xub3sz6zE73W3szLrmWtQ7QMpeHEQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-defines": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-defines/-/glsl-token-defines-1.0.0.tgz",
       "integrity": "sha512-Vb5QMVeLjmOwvvOJuPNg3vnRlffscq2/qvIuTpMzuO/7s5kT+63iL6Dfo2FYLWbzuiycWpbC0/KV0biqFwHxaQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-tokenizer": "^2.0.0"
       }
@@ -7385,13 +7501,15 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-depth/-/glsl-token-depth-1.1.2.tgz",
       "integrity": "sha512-eQnIBLc7vFf8axF9aoi/xW37LSWd2hCQr/3sZui8aBJnksq9C7zMeUYHVJWMhFzXrBU7fgIqni4EhXVW4/krpg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-descope": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/glsl-token-descope/-/glsl-token-descope-1.0.2.tgz",
       "integrity": "sha512-kS2PTWkvi/YOeicVjXGgX5j7+8N7e56srNDEHDTVZ1dcESmbmpmgrnpjPcjxJjMxh56mSXYoFdZqb90gXkGjQw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-token-assignments": "^2.0.0",
         "glsl-token-depth": "^1.1.0",
@@ -7403,37 +7521,43 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/glsl-token-inject-block/-/glsl-token-inject-block-1.1.0.tgz",
       "integrity": "sha512-q/m+ukdUBuHCOtLhSr0uFb/qYQr4/oKrPSdIK2C4TD+qLaJvqM9wfXIF/OOBjuSA3pUoYHurVRNao6LTVVUPWA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-properties": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-properties/-/glsl-token-properties-1.0.1.tgz",
       "integrity": "sha512-dSeW1cOIzbuUoYH0y+nxzwK9S9O3wsjttkq5ij9ZGw0OS41BirKJzzH48VLm8qLg+au6b0sINxGC0IrGwtQUcA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-scope": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/glsl-token-scope/-/glsl-token-scope-1.1.2.tgz",
       "integrity": "sha512-YKyOMk1B/tz9BwYUdfDoHvMIYTGtVv2vbDSLh94PT4+f87z21FVdou1KNKgF+nECBTo0fJ20dpm0B1vZB1Q03A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-string": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/glsl-token-string/-/glsl-token-string-1.0.1.tgz",
       "integrity": "sha512-1mtQ47Uxd47wrovl+T6RshKGkRRCYWhnELmkEcUAPALWGTFe2XZpH3r45XAwL2B6v+l0KNsCnoaZCSnhzKEksg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-token-whitespace-trim": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/glsl-token-whitespace-trim/-/glsl-token-whitespace-trim-1.0.0.tgz",
       "integrity": "sha512-ZJtsPut/aDaUdLUNtmBYhaCmhIjpKNg7IgZSfX5wFReMc2vnj8zok+gB/3Quqs0TsBSX/fGnqUUYZDqyuc2xLQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/glsl-tokenizer/-/glsl-tokenizer-2.1.5.tgz",
       "integrity": "sha512-XSZEJ/i4dmz3Pmbnpsy3cKh7cotvFlBiZnDOwnj/05EwNp2XrhQ4XKJxT7/pDt4kp4YcpRSKz8eTV7S+mwV6MA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "through2": "^0.6.3"
       }
@@ -7442,13 +7566,15 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-0.0.1.tgz",
       "integrity": "sha512-D2S+3GLxWH+uhrNEcoh/fnmYeP8E8/zHl644d/jdA0g2uyXvy3sb0qxotE+ne0LtccHknQzWwZEzhak7oJ0COQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer/node_modules/readable-stream": {
       "version": "1.0.34",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-1.0.34.tgz",
       "integrity": "sha512-ok1qVCJuRkNmvebYikljxJA/UEsKwLl2nI1OmaqAu4/UE+h0wKCHok4XkL/gvi39OacXvw59RJUOFUkDib2rHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.1",
@@ -7460,13 +7586,15 @@
       "version": "0.10.31",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-0.10.31.tgz",
       "integrity": "sha512-ev2QzSzWPYmy9GuqfIVildA4OdcGLeFZQrq5ys6RtiuF+RQQiZWr8TZNyAcuVXyQRYfEO+MsoB/1BuQVhOJuoQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/glsl-tokenizer/node_modules/through2": {
       "version": "0.6.5",
       "resolved": "https://registry.npmjs.org/through2/-/through2-0.6.5.tgz",
       "integrity": "sha512-RkK/CCESdTKQZHdmKICijdKKsCRVHs5KsLZ6pACAmF/1GPUQhonHSXWNERctxEp7RmvjdNbZTL5z9V7nSCXKcg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": ">=1.0.33-1 <1.1.0-0",
         "xtend": ">=4.0.0 <4.1.0-0"
@@ -7477,6 +7605,7 @@
       "resolved": "https://registry.npmjs.org/glslify/-/glslify-7.1.1.tgz",
       "integrity": "sha512-bud98CJ6kGZcP9Yxcsi7Iz647wuDz3oN+IZsjCRi5X1PI7t/xPKeL0mOwXJjo+CRZMqvq0CkSJiywCcY7kVYog==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bl": "^2.2.1",
         "concat-stream": "^1.5.2",
@@ -7503,6 +7632,7 @@
       "resolved": "https://registry.npmjs.org/glslify-bundle/-/glslify-bundle-5.1.1.tgz",
       "integrity": "sha512-plaAOQPv62M1r3OsWf2UbjN0hUYAB7Aph5bfH58VxJZJhloRNbxOL9tl/7H71K7OLJoSJ2ZqWOKk3ttQ6wy24A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "glsl-inject-defines": "^1.0.1",
         "glsl-token-defines": "^1.0.0",
@@ -7521,6 +7651,7 @@
       "resolved": "https://registry.npmjs.org/glslify-deps/-/glslify-deps-1.3.2.tgz",
       "integrity": "sha512-7S7IkHWygJRjcawveXQjRXLO2FTjijPDYC7QfZyAQanY+yGLCFHYnPtsGT9bdyHiwPTw/5a1m1M9hamT2aBpag==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "@choojs/findup": "^0.2.0",
         "events": "^3.2.0",
@@ -7552,7 +7683,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/grid-index/-/grid-index-1.1.0.tgz",
       "integrity": "sha512-HZRwumpOGUrHyxO5bqKZL0B0GlUpwtCAzZ42sgxUPniu33R1LSFH5yrIcBCHjkctCAh3mtWKcKd9J4vDDdeVHA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/has-flag": {
       "version": "4.0.0",
@@ -7568,6 +7700,7 @@
       "resolved": "https://registry.npmjs.org/has-hover/-/has-hover-1.0.1.tgz",
       "integrity": "sha512-0G6w7LnlcpyDzpeGUTuT0CEw05+QlMuGVk1IHNAlHrGJITGodjZu3x8BNDUMfKJSZXNB2ZAclqc1bvrd+uUpfg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -7577,6 +7710,7 @@
       "resolved": "https://registry.npmjs.org/has-passive-events/-/has-passive-events-1.0.0.tgz",
       "integrity": "sha512-2vSj6IeIsgvsRMyeQ0JaCX5Q3lX4zMn5HpoVc7MEhQ6pv8Iq9rsXjsp+E5ZwaT7T0xhMT0KmU8gtt1EFVdbJiw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-browser": "^2.0.1"
       }
@@ -7721,6 +7855,7 @@
       "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.4.24.tgz",
       "integrity": "sha512-v3MXnZAcvnywkTUEZomIActle7RXXeedOR31wwl7VlyoXO4Qi9arvSenNQWne1TcRwhCL1HwLI21bEqdpj8/rA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safer-buffer": ">= 2.1.2 < 3"
       },
@@ -7746,7 +7881,8 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/indent-string": {
       "version": "4.0.0",
@@ -7761,13 +7897,15 @@
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
       "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ini": {
       "version": "4.1.3",
       "resolved": "https://registry.npmjs.org/ini/-/ini-4.1.3.tgz",
       "integrity": "sha512-X7rqawQBvfdjS10YU1y1YVreA3SsLrW9dX2CewP2EbBJM4ypVNLDkO5y04gejPwKIY9lR+7r9gn3rFPt/kmWFg==",
       "license": "ISC",
+      "peer": true,
       "engines": {
         "node": "^14.17.0 || ^16.13.0 || >=18.0.0"
       }
@@ -7798,13 +7936,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-browser/-/is-browser-2.1.0.tgz",
       "integrity": "sha512-F5rTJxDQ2sW81fcfOR1GnCXT6sVJC104fCyfj+mjpwNEwaPYSn5fte5jiHmBg3DHsIoL/l8Kvw5VN5SsTRcRFQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-core-module": {
       "version": "2.16.1",
       "resolved": "https://registry.npmjs.org/is-core-module/-/is-core-module-2.16.1.tgz",
       "integrity": "sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "hasown": "^2.0.2"
       },
@@ -7829,6 +7969,7 @@
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.1.0.tgz",
       "integrity": "sha512-cdyMtqX/BOqqNBBiKlIVkytNHm49MtMlYyn1zxzvJKWmFMlGzm+ry5BBfYyeY9YmNKbRSo/o7OX9w9ale0wg3w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       },
@@ -7841,6 +7982,7 @@
       "resolved": "https://registry.npmjs.org/is-firefox/-/is-firefox-1.0.3.tgz",
       "integrity": "sha512-6Q9ITjvWIm0Xdqv+5U12wgOKEM2KoBw4Y926m0OFkvlCxnbG94HKAsVz8w3fWcfAS5YA2fJORXX1dLrkprCCxA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7859,6 +8001,7 @@
       "resolved": "https://registry.npmjs.org/is-iexplorer/-/is-iexplorer-1.0.0.tgz",
       "integrity": "sha512-YeLzceuwg3K6O0MLM3UyUUjKAlyULetwryFp1mHy1I5PfArK0AEqlfa+MR4gkJjcbuJXoDJCvXbyqZVf5CR2Sg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7867,7 +8010,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/is-mobile/-/is-mobile-4.0.0.tgz",
       "integrity": "sha512-mlcHZA84t1qLSuWkt2v0I2l61PYdyQDt4aG1mLIXF5FDMm4+haBCxCPYSr/uwqQNRk1MiTizn0ypEuRAOLRAew==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-number": {
       "version": "7.0.0",
@@ -7883,6 +8027,7 @@
       "resolved": "https://registry.npmjs.org/is-obj/-/is-obj-1.0.1.tgz",
       "integrity": "sha512-l4RyHgRqGN4Y3+9JHVrNqO+tN0rV5My76uW5/nuO4K1b6vw5G8d/cmFjP9tRfEsdhZNt0IFdZuK/c2Vr4Nb+Qg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7892,6 +8037,7 @@
       "resolved": "https://registry.npmjs.org/is-plain-obj/-/is-plain-obj-1.1.0.tgz",
       "integrity": "sha512-yvkRyxmFKEOQ4pNXCmJG5AEQNlXJS5LaONXo5/cLdTZdWvsZ1ioJEonLGAosKlMWE8lwUy/bJzMjcw8az73+Fg==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -7906,25 +8052,29 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-string-blank/-/is-string-blank-1.0.1.tgz",
       "integrity": "sha512-9H+ZBCVs3L9OYqv8nuUAzpcT9OTgMD1yAWrG7ihlnibdkbtB850heAmYWxHuXc4CHy4lKeK69tN+ny1K7gBIrw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/is-svg-path": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-svg-path/-/is-svg-path-1.0.2.tgz",
       "integrity": "sha512-Lj4vePmqpPR1ZnRctHv8ltSh1OrSxHkhUkd7wi+VQdcdP15/KvQFyk7LhNuM7ZW0EVbJz8kZLVmL9quLrfq4Kg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isarray": {
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-2.0.5.tgz",
       "integrity": "sha512-xHjhDr3cNBK0BzdUJSPXZntQUx/mwMS5Rw4A7lPJ90XGAO6ISP/ePDNuo0vhqOZU+UD5JoodwCAAoZQd3FeAKw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/isexe": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/isexe/-/isexe-3.1.2.tgz",
       "integrity": "sha512-mIcis6w+JiQf3P7t7mg/35GKB4T1FQsBOtMIvuKw4YErj5RjtbhcTd5/I30fmkmGMwvI0WlzSNN+27K0QCMkAw==",
       "license": "BlueOak-1.0.0",
+      "peer": true,
       "engines": {
         "node": ">=20"
       }
@@ -8402,7 +8552,6 @@
       "integrity": "sha512-mjzqwWRD9Y1J1KUi7W97Gja1bwOOM5Ug0EZ6UDK3xS7j7mndrkwozHtSblfomlzyB4NepioNt+B2sOSzczVgtQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@acemir/cssom": "^0.9.28",
         "@asamuzakjp/dom-selector": "^6.7.6",
@@ -8453,7 +8602,8 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/json-stringify-pretty-compact/-/json-stringify-pretty-compact-4.0.0.tgz",
       "integrity": "sha512-3CNZ2DnrpByG9Nqj6Xo8vqbjT4F6N+tb4Gb28ESAZjYZ5yqvmc56J+/kuIwkaAMOyblTQhUW7PxMkUb8Q36N3Q==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/json5": {
       "version": "2.2.3",
@@ -8471,13 +8621,15 @@
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-4.0.2.tgz",
       "integrity": "sha512-WbCVYJ27Sz8zi9Q7Q0xHC+05iwkm3Znipc2XTlrnJbsHMYktW4hPhXUE8Ys1engBrvffoSCqbil1JQAa7clRpA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/kind-of": {
       "version": "6.0.3",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-6.0.3.tgz",
       "integrity": "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -8814,6 +8966,7 @@
       "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
       "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
       "dev": true,
+      "peer": true,
       "bin": {
         "lz-string": "bin/bin.js"
       }
@@ -8869,6 +9022,7 @@
       "resolved": "https://registry.npmjs.org/map-limit/-/map-limit-0.0.1.tgz",
       "integrity": "sha512-pJpcfLPnIF/Sk3taPW21G/RQsEEirGaFpCW3oXRwH9dnFHPHNGjNyvh++rdmC2fNqEaTw2MhYJraoJWAHx8kEg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "once": "~1.3.0"
       }
@@ -8878,6 +9032,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.3.3.tgz",
       "integrity": "sha512-6vaNInhu+CHxtONf3zw3vq4SP2DOQhjBvIa3rNcG0+P7eKWlYH6Peu7rHizSloRU2EwMz6GraLieis9Ac9+p1w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -8921,6 +9076,7 @@
       "resolved": "https://registry.npmjs.org/maplibre-gl/-/maplibre-gl-4.7.1.tgz",
       "integrity": "sha512-lgL7XpIwsgICiL82ITplfS7IGwrB1OJIw/pCvprDp2dhmSSEBgmPzYRvwYYYvJGJD7fxUv1Tvpih4nZ6VrLuaA==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "@mapbox/geojson-rewind": "^0.5.2",
         "@mapbox/jsonlint-lines-primitives": "^2.0.2",
@@ -8961,43 +9117,50 @@
       "version": "2.0.7",
       "resolved": "https://registry.npmjs.org/@mapbox/tiny-sdf/-/tiny-sdf-2.0.7.tgz",
       "integrity": "sha512-25gQLQMcpivjOSA40g3gO6qgiFPDpWRoMfd+G/GoppPIeP6JDaMMkMrEJnMZhKyyS6iKwVt5YKu02vCUyJM3Ug==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/@mapbox/unitbezier": {
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/@mapbox/unitbezier/-/unitbezier-0.0.1.tgz",
       "integrity": "sha512-nMkuDXFv60aBr9soUG5q+GvZYL+2KZHVvsqFCzqnkGEf46U2fvmytHaEVc1/YZbiLn8X+eR3QzX1+dwDO1lxlw==",
-      "license": "BSD-2-Clause"
+      "license": "BSD-2-Clause",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/earcut": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-3.0.2.tgz",
       "integrity": "sha512-X7hshQbLyMJ/3RPhyObLARM2sNxxmRALLKx1+NVFFnQ9gKzmCrxm9+uLIAdBcvc8FNLpctqlQ2V6AE92Ol9UDQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/geojson-vt": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/geojson-vt/-/geojson-vt-4.0.2.tgz",
       "integrity": "sha512-AV9ROqlNqoZEIJGfm1ncNjEXfkz2hdFlZf0qkVfmkwdKa8vj7H16YUOT81rJw1rdFhyEDlN2Tds91p/glzbl5A==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/potpack": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-2.1.0.tgz",
       "integrity": "sha512-pcaShQc1Shq0y+E7GqJqvZj8DTthWV1KeHGdi0Z6IAin2Oi3JnLCOfwnCo84qc+HAp52wT9nK9H7FAJp5a44GQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/quickselect": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-3.0.0.tgz",
       "integrity": "sha512-XdjUArbK4Bm5fLLvlm5KpTFOiOThgfWWI4axAZDWg4E/0mKdZyI9tNEfds27qCi1ze/vwTR16kvmmGhRra3c2g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/maplibre-gl/node_modules/supercluster": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-8.0.1.tgz",
       "integrity": "sha512-IiOea5kJ9iqzD2t7QJq/cREyLHTtSmUT6gQsweojg9WH2sYJqZK9SswTu6jrscO6D1G5v5vYZ9ru/eq85lXeZQ==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "kdbush": "^4.0.2"
       }
@@ -9006,7 +9169,8 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-3.0.0.tgz",
       "integrity": "sha512-gRa9gwYU3ECmQYv3lslts5hxuIa90veaEcxDYuu3QGOIAEM2mOZkVHp48ANJuu1CURtRdHKUBY5Lm1tHV+sD4g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/math-intrinsics": {
       "version": "1.1.0",
@@ -9021,6 +9185,7 @@
       "resolved": "https://registry.npmjs.org/math-log2/-/math-log2-1.0.1.tgz",
       "integrity": "sha512-9W0yGtkaMAkf74XGYVy4Dqw3YUMnTNB2eeiw9aQbUl4A3KmuCEHTt2DgAB07ENzOYAjsYSAYufkAq0Zd+jU7zA==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -9090,6 +9255,7 @@
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
       "integrity": "sha512-2yyAR8qBkN3YuheJanUpWC5U3bb5osDywNB8RzDVlDwDHbocAJveqqj1u8+SVD7jkWT4yvsHCpWqqWqAxb0zCA==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -9099,6 +9265,7 @@
       "resolved": "https://registry.npmjs.org/mouse-change/-/mouse-change-1.4.0.tgz",
       "integrity": "sha512-vpN0s+zLL2ykyyUDh+fayu9Xkor5v/zRD9jhSqjRS1cJTGS0+oakVZzNm5n19JvvEj0you+MXlYTpNxUDQUjkQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "mouse-event": "^1.0.0"
       }
@@ -9107,19 +9274,22 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/mouse-event/-/mouse-event-1.0.5.tgz",
       "integrity": "sha512-ItUxtL2IkeSKSp9cyaX2JLUuKk2uMoxBg4bbOWVd29+CskYJR9BGsUqtXenNzKbnDshvupjUewDIYVrOB6NmGw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mouse-event-offset": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/mouse-event-offset/-/mouse-event-offset-3.0.2.tgz",
       "integrity": "sha512-s9sqOs5B1Ykox3Xo8b3Ss2IQju4UwlW6LSR+Q5FXWpprJ5fzMLefIIItr3PH8RwzfGy6gxs/4GAmiNuZScE25w==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/mouse-wheel": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/mouse-wheel/-/mouse-wheel-1.2.0.tgz",
       "integrity": "sha512-+OfYBiUOCTWcTECES49neZwL5AoGkXE+lFjIvzwNCnYRlso+EnfvovcBxGoyQ0yQt806eSPjS675K0EwWknXmw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "right-now": "^1.0.0",
         "signum": "^1.0.0",
@@ -9135,7 +9305,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/murmurhash-js/-/murmurhash-js-1.0.0.tgz",
       "integrity": "sha512-TvmkNhkv8yct0SVBSy+o8wYzXjE4Zz3PCesbfs8HiCXXdcTuocApFv11UWlNFWKYsP2okqrhb7JNlSm9InBhIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nanoid": {
       "version": "3.3.11",
@@ -9158,13 +9329,15 @@
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/native-promise-only/-/native-promise-only-0.8.1.tgz",
       "integrity": "sha512-zkVhZUA3y8mbz652WrL5x0fB0ehrBkulWT3TomAQ9iDtyXZvzKeEA6GPxAItBYeNYl5yngKRX612qHOhvMkDeg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/needle": {
       "version": "2.9.1",
       "resolved": "https://registry.npmjs.org/needle/-/needle-2.9.1.tgz",
       "integrity": "sha512-6R9fqJ5Zcmf+uYaFgdIHmLwNldn5HbK8L5ybn7Uz+ylX/rnOsSp1AHcvQSrCaFN+qNM1wpymHqD7mVasEOlHGQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "^3.2.6",
         "iconv-lite": "^0.4.4",
@@ -9182,6 +9355,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-3.2.7.tgz",
       "integrity": "sha512-CFjzYYAi4ThfiQvizrFQevTTXHtnCqWfe7x1AhgEscTz6ZbLbfoLRLPugTQyBth6f8ZERVUSyWHFD/7Wu4t1XQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "^2.1.1"
       }
@@ -9199,7 +9373,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/next-tick/-/next-tick-1.1.0.tgz",
       "integrity": "sha512-CXdUiJembsNjuToQvxayPZF9Vqht7hewsvy2sOWafLvi2awflj9mOC6bHIg50orX8IJvWKY9wYQ/zB2kogPslQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/node-releases": {
       "version": "2.0.27",
@@ -9211,7 +9386,8 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-0.1.0.tgz",
       "integrity": "sha512-1/kmYej2iedi5+ROxkRESL/pI02pkg0OBnaR4hJkSIX6+ORzepwbuUXfrdZaPjysTsJInj0Rj5NuX027+dMBvA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/nth-check": {
       "version": "2.1.1",
@@ -9231,6 +9407,7 @@
       "resolved": "https://registry.npmjs.org/number-is-integer/-/number-is-integer-1.0.1.tgz",
       "integrity": "sha512-Dq3iuiFBkrbmuQjGFFF3zckXNCQoSD37/SdSbgcBailUx6knDvDwb5CympBgcoWHy36sfS12u74MHYkXyHq6bg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-finite": "^1.0.1"
       },
@@ -9262,6 +9439,7 @@
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha512-lNaJgI+2Q5URQBkccEKHTQOPaXdUxnZZElQTZY0MFUAuaEqe1E+Nyvgdz/aIyNi6Z9MzO5dv1H8n58/GELp3+w==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "wrappy": "1"
       }
@@ -9274,7 +9452,8 @@
       "version": "3.1.8",
       "resolved": "https://registry.npmjs.org/parenthesis/-/parenthesis-3.1.8.tgz",
       "integrity": "sha512-KF/U8tk54BgQewkJPvB4s/US3VQY68BRDpH638+7O/n58TpnwiwnOtGIOsT2/i+M78s61BBpeC83STB88d8sqw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-entities": {
       "version": "4.0.2",
@@ -9304,6 +9483,7 @@
       "resolved": "https://registry.npmjs.org/parse-rect/-/parse-rect-1.2.0.tgz",
       "integrity": "sha512-4QZ6KYbnE6RTwg9E0HpLchUM9EZt6DnDxajFZZDSV4p/12ZJEvPO702DZpGvRYEPo00yKDys7jASi+/w7aO8LA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "pick-by-alias": "^1.2.0"
       }
@@ -9312,13 +9492,15 @@
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/parse-svg-path/-/parse-svg-path-0.1.2.tgz",
       "integrity": "sha512-JyPSBnkTJ0AI8GGJLfMXvKq42cj5c006fnLz6fXy6zfoVjJizi8BNTpu8on8ziI1cKy9d9DGNuY17Ce7wuejpQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse-unit": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/parse-unit/-/parse-unit-1.0.1.tgz",
       "integrity": "sha512-hrqldJHokR3Qj88EIlV/kAyAi/G5R2+R56TBANxNMy0uPlYcttx0jnMW6Yx5KsKPSbC3KddM/7qQm3+0wEXKxg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/parse5": {
       "version": "8.0.0",
@@ -9337,7 +9519,8 @@
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
       "integrity": "sha512-LDJzPVEEEPR+y48z93A0Ed0yXb8pAByGWo/k5YYdYgpY2/2EsOsksJrq7lOHxryrVOn1ejG6oAp8ahvOIQD8sw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pathe": {
       "version": "2.0.3",
@@ -9351,6 +9534,7 @@
       "resolved": "https://registry.npmjs.org/pbf/-/pbf-3.3.0.tgz",
       "integrity": "sha512-XDF38WCH3z5OV/OVa8GKUNtLAyneuzbCisx7QUCF8Q6Nutx0WnJrQe5O+kOtBlLfRNUws98Y58Lblp+NJG5T4Q==",
       "license": "BSD-3-Clause",
+      "peer": true,
       "dependencies": {
         "ieee754": "^1.1.12",
         "resolve-protobuf-schema": "^2.1.0"
@@ -9363,13 +9547,15 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/pick-by-alias": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/pick-by-alias/-/pick-by-alias-1.2.0.tgz",
       "integrity": "sha512-ESj2+eBxhGrcA1azgHs7lARG5+5iLakc/6nlfbpjcLl00HuuUOIuORhYXN4D1HfvMSKuVtFQjAlnwi1JHEeDIw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -9412,7 +9598,6 @@
       "integrity": "sha512-aaoB1RWrdNi3//rOeKuMiS65UCcgOVljU46At6eFcOFPFHWtd2weHRRow6z/n+Lec0Lvu0k9ZPKJSjPugikirw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "playwright-core": "cli.js"
       },
@@ -9507,13 +9692,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/point-in-polygon/-/point-in-polygon-1.1.0.tgz",
       "integrity": "sha512-3ojrFwjnnw8Q9242TzgXuTD+eKiutbzyslcq1ydfu82Db2y+Ogbmyrkpv0Hgj31qwT3lbS9+QAAO/pIQM35XRw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/polybooljs": {
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/polybooljs/-/polybooljs-1.2.2.tgz",
       "integrity": "sha512-ziHW/02J0XuNuUtmidBc6GXE8YohYydp3DWPWXYsd7O721TjcmN+k6ezjdwkDqep+gnWnFY+yqZHvzElra2oCg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/postcss": {
       "version": "8.5.6",
@@ -9533,7 +9720,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.11",
         "picocolors": "^1.1.1",
@@ -10006,13 +10192,15 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/potpack/-/potpack-1.0.2.tgz",
       "integrity": "sha512-choctRBIV9EMT9WGAZHn3V7t0Z2pMQyl0EZE6pFc/6ml3ssw7Dlf/oAOvFwjm1HVsqfQN8GfeFyJ+d8tRzqueQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/pretty-format": {
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
       "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "ansi-regex": "^5.0.1",
         "ansi-styles": "^5.0.0",
@@ -10035,6 +10223,7 @@
       "resolved": "https://registry.npmjs.org/probe-image-size/-/probe-image-size-7.2.3.tgz",
       "integrity": "sha512-HubhG4Rb2UH8YtV4ba0Vp5bQ7L78RTONYu/ujmCu5nBI8wGv24s4E9xSKBi0N1MowRpxk76pFCpJtW0KPzOK0w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "lodash.merge": "^4.6.2",
         "needle": "^2.5.2",
@@ -10045,7 +10234,8 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/process-nextick-args/-/process-nextick-args-2.0.1.tgz",
       "integrity": "sha512-3ouUOpQhtgrbOa17J7+uxOTpITYWaGP7/AhoR3+A+/1e9skrzelGi/dXzEYyvbxubEF6Wn2ypscTKiKJFFn1ag==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/prop-types": {
       "version": "15.8.1",
@@ -10077,7 +10267,8 @@
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/protocol-buffers-schema/-/protocol-buffers-schema-3.6.0.tgz",
       "integrity": "sha512-TdDRD+/QNdrCGCE7v8340QyuXd4kIWIgapsE2+n/SaGiSSbomYl4TjHlvIoCWRpE7wFt02EpB35VVA2ImcBVqw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
@@ -10098,13 +10289,15 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/quickselect/-/quickselect-2.0.0.tgz",
       "integrity": "sha512-RKJ22hX8mHe3Y6wH/N3wCM6BWtjaxIyyUIkpHOvfFnxdI4yD4tBXEBKSbriGujF6jnSVkJrffuo6vxACiSSxIw==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/raf": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/raf/-/raf-3.4.1.tgz",
       "integrity": "sha512-Sq4CW4QhwOHE8ucn6J34MqtZCeWFP2aQSmrlroYgqAV1PjStIhJXxYuTgUIfkEk7zTLjmIjLmU5q+fbD1NnOJA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "performance-now": "^2.1.0"
       }
@@ -10113,7 +10306,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10122,7 +10314,6 @@
       "version": "19.2.3",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -10134,7 +10325,8 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
       "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
-      "dev": true
+      "dev": true,
+      "peer": true
     },
     "node_modules/react-plotly.js": {
       "version": "2.6.0",
@@ -10296,6 +10488,7 @@
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.8.tgz",
       "integrity": "sha512-8p0AUk4XODgIewSi0l8Epjs+EVnWiK7NoDIEGU0HhE7+ZyY8D1IMY7odu5lRrFXGg71L15KG8QrPmum45RTtdA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "core-util-is": "~1.0.0",
         "inherits": "~2.0.3",
@@ -10310,13 +10503,15 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/isarray/-/isarray-1.0.0.tgz",
       "integrity": "sha512-VLghIWNM6ELQzo7zwmcg0NmTVyWKYjvIeM83yjp0wRDTmUnrM678fQbcKBo6n2CJEF0szoG//ytg+TKla89ALQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/readable-stream/node_modules/safe-buffer": {
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/redent": {
       "version": "3.0.0",
@@ -10350,13 +10545,15 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/regl/-/regl-2.1.1.tgz",
       "integrity": "sha512-+IOGrxl3FZ8ZM9ixCWQZzFRiRn7Rzn9bu3iFHwg/yz4tlOUQgbO4PHLgG+1ZT60zcIV8tief6Qrmyl8qcoJP0g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/regl-error2d": {
       "version": "2.0.12",
       "resolved": "https://registry.npmjs.org/regl-error2d/-/regl-error2d-2.0.12.tgz",
       "integrity": "sha512-r7BUprZoPO9AbyqM5qlJesrSRkl+hZnVKWKsVp7YhOl/3RIpi4UDGASGJY0puQ96u5fBYw/OlqV24IGcgJ0McA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "color-normalize": "^1.5.0",
@@ -10372,6 +10569,7 @@
       "resolved": "https://registry.npmjs.org/regl-line2d/-/regl-line2d-3.1.3.tgz",
       "integrity": "sha512-fkgzW+tTn4QUQLpFKsUIE0sgWdCmXAM3ctXcCgoGBZTSX5FE2A0M7aynz7nrZT5baaftLrk9te54B+MEq4QcSA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-find-index": "^1.0.2",
@@ -10391,6 +10589,7 @@
       "resolved": "https://registry.npmjs.org/regl-scatter2d/-/regl-scatter2d-3.3.1.tgz",
       "integrity": "sha512-seOmMIVwaCwemSYz/y4WE0dbSO9svNFSqtTh5RE57I7PjGo3tcUYKtH0MTSoshcAsreoqN8HoCtnn8wfHXXfKQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@plotly/point-cluster": "^3.1.9",
         "array-range": "^1.0.1",
@@ -10414,6 +10613,7 @@
       "resolved": "https://registry.npmjs.org/color-parse/-/color-parse-1.4.3.tgz",
       "integrity": "sha512-BADfVl/FHkQkyo8sRBwMYBqemqsgnu7JZAwUgvBvuwwuNUZAhSvLTbsEErS5bQXzOjDR0dWzJ4vXN2Q+QoPx0A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-name": "^1.0.0"
       }
@@ -10423,6 +10623,7 @@
       "resolved": "https://registry.npmjs.org/color-rgba/-/color-rgba-2.4.0.tgz",
       "integrity": "sha512-Nti4qbzr/z2LbUWySr7H9dk3Rl7gZt7ihHAxlgT4Ho90EXWkjtkL1avTleu9yeGuqrt/chxTB6GKK8nZZ6V0+Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "color-parse": "^1.4.2",
         "color-space": "^2.0.0"
@@ -10433,6 +10634,7 @@
       "resolved": "https://registry.npmjs.org/regl-splom/-/regl-splom-1.0.14.tgz",
       "integrity": "sha512-OiLqjmPRYbd7kDlHC6/zDf6L8lxgDC65BhC8JirhP4ykrK4x22ZyS+BnY8EUinXKDeMgmpRwCvUmk7BK4Nweuw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "array-bounds": "^1.0.1",
         "array-range": "^1.0.1",
@@ -10465,6 +10667,7 @@
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.22.11.tgz",
       "integrity": "sha512-RfqAvLnMl313r7c9oclB1HhUEAezcpLjz95wFH4LVuhk9JF/r22qmVP9AMmOU4vMX7Q8pN8jwNg/CSpdFnMjTQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "is-core-module": "^2.16.1",
         "path-parse": "^1.0.7",
@@ -10485,6 +10688,7 @@
       "resolved": "https://registry.npmjs.org/resolve-protobuf-schema/-/resolve-protobuf-schema-2.1.0.tgz",
       "integrity": "sha512-kI5ffTiZWmJaS/huM8wZfEMer1eRd7oJQhDuxeCLe3t7N7mX3z94CN0xPxBQxFYQTSNz9T0i+v6inKqSdK8xrQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "protocol-buffers-schema": "^3.3.1"
       }
@@ -10493,7 +10697,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/right-now/-/right-now-1.0.0.tgz",
       "integrity": "sha512-DA8+YS+sMIVpbsuKgy+Z67L9Lxb1p05mNxRpDPNksPDEFir4vmBlUtuN9jkTGn9YMMdlBuK7XQgFiz6ws+yhSg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/rollup": {
       "version": "4.59.0",
@@ -10543,7 +10748,8 @@
       "version": "1.3.3",
       "resolved": "https://registry.npmjs.org/rw/-/rw-1.3.3.tgz",
       "integrity": "sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==",
-      "license": "BSD-3-Clause"
+      "license": "BSD-3-Clause",
+      "peer": true
     },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
@@ -10563,13 +10769,15 @@
           "url": "https://feross.org/support"
         }
       ],
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/safer-buffer": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
       "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/sax": {
       "version": "1.4.4",
@@ -10616,7 +10824,8 @@
       "version": "0.0.1",
       "resolved": "https://registry.npmjs.org/shallow-copy/-/shallow-copy-0.0.1.tgz",
       "integrity": "sha512-b6i4ZpVuUxB9h5gfCxPiusKYkqTMOjEbBs4wMaFbkfia4yFv92UKZ6Df8WXcKbn08JNL/abvg3FnMAOfakDvUw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/siginfo": {
       "version": "2.0.0",
@@ -10628,7 +10837,8 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/signum/-/signum-1.0.0.tgz",
       "integrity": "sha512-yodFGwcyt59XRh7w5W3jPcIQb3Bwi21suEfT7MAWnBX3iCdklJpgDgvGT9o04UonglZN5SNMfJFkHIR/jO8GHw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/slash": {
       "version": "3.0.0",
@@ -10680,6 +10890,7 @@
       "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
       "license": "BSD-3-Clause",
       "optional": true,
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -10705,6 +10916,7 @@
       "version": "0.0.9",
       "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.9.tgz",
       "integrity": "sha512-vjUc6sfgtgY0dxCdnc40mK6Oftjo9+2K8H/NG81TMhgL392FtiPA9tn9RLyTxXmTLPJPjF3VyzFp6bsWFLisMQ==",
+      "peer": true,
       "engines": {
         "node": "*"
       }
@@ -10732,6 +10944,7 @@
       "resolved": "https://registry.npmjs.org/static-eval/-/static-eval-2.1.1.tgz",
       "integrity": "sha512-MgWpQ/ZjGieSVB3eOJVs4OA2LT/q1vx98KPCTTQPzq/aLr0YUXTsgryTXr4SLfR0ZfUUCiedM9n/ABeDIyy4mA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "escodegen": "^2.1.0"
       }
@@ -10747,6 +10960,7 @@
       "resolved": "https://registry.npmjs.org/stream-parser/-/stream-parser-0.3.1.tgz",
       "integrity": "sha512-bJ/HgKq41nlKvlhccD5kaCr/P+Hu0wPNKPJOH7en+YrJu/9EgqUF+88w5Jb6KNcjOFMhfX4B2asfeAtIGuHObQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "debug": "2"
       }
@@ -10756,6 +10970,7 @@
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
       "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "ms": "2.0.0"
       }
@@ -10764,19 +10979,22 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
       "integrity": "sha512-Tpp60P6IUJDTuOq/5Z8cdskzJujfwqfOTkrwIwj7IRISpnkJnT6SyJ4PCPnGMoFjC9ddhal5KVIYtAt97ix05A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/stream-shift": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/stream-shift/-/stream-shift-1.0.3.tgz",
       "integrity": "sha512-76ORR0DO1o1hlKwTbi/DM3EXWGf3ZJYO8cXX5RJwnul2DEg2oyoZyjLNoQM8WsvZiFKCRfC1O0J7iCvie3RZmQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string_decoder": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.1.1.tgz",
       "integrity": "sha512-n/ShnvDi6FHbbVfviro+WojiFzv+s8MPMHBczVePfUpDJLwoLT0ht1l4YwBCbi8pJAveEEdnkHyPyTP/mzRfwg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "safe-buffer": "~5.1.0"
       }
@@ -10785,13 +11003,15 @@
       "version": "5.1.2",
       "resolved": "https://registry.npmjs.org/safe-buffer/-/safe-buffer-5.1.2.tgz",
       "integrity": "sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/string-split-by": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/string-split-by/-/string-split-by-1.0.0.tgz",
       "integrity": "sha512-KaJKY+hfpzNyet/emP81PJA9hTVSfxNLS9SFTWxdCnnW1/zOOwiV248+EfoX7IQFcBaOp4G5YE6xTJMF+pLg6A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parenthesis": "^3.1.5"
       }
@@ -10812,7 +11032,8 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strongly-connected-components/-/strongly-connected-components-1.0.1.tgz",
       "integrity": "sha512-i0TFx4wPcO0FwX+4RkLJi1MxmcTv90jNZgxMu9XRnMXMeFUY1VJlIoXpZunPUvUUqbCT1pg5PEkFqqpcaElNaA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/style-mod": {
       "version": "4.1.3",
@@ -10842,6 +11063,7 @@
       "resolved": "https://registry.npmjs.org/supercluster/-/supercluster-7.1.5.tgz",
       "integrity": "sha512-EulshI3pGUM66o6ZdH3ReiFcvHpM3vAigyK+vcxdjpJyEbIIrtbmBdY23mGgnI24uXiGFvrGq9Gkum/8U7vJWg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "kdbush": "^3.0.0"
       }
@@ -10850,13 +11072,15 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/kdbush/-/kdbush-3.0.0.tgz",
       "integrity": "sha512-hRkd6/XW4HTsA9vjVpY9tuXJYLSlelnkTmVFu4M9/7MIYQtFcHpbugAU7UbOfjOiVSVYl2fqgBuJ32JUmRo5Ew==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/superscript-text": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/superscript-text/-/superscript-text-1.0.0.tgz",
       "integrity": "sha512-gwu8l5MtRZ6koO0icVTlmN5pm7Dhh1+Xpe9O4x6ObMAsW+3jPbW14d1DsBq1F4wiI+WOFjXF35pslgec/G8yCQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/supports-color": {
       "version": "7.2.0",
@@ -10875,6 +11099,7 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -10886,13 +11111,15 @@
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/svg-arc-to-cubic-bezier/-/svg-arc-to-cubic-bezier-3.2.0.tgz",
       "integrity": "sha512-djbJ/vZKZO+gPoSDThGNpKDO+o+bAeA4XQKovvkNCqnIS2t+S4qnLAGQhyyrulhCFRl1WWzAp0wUDV8PpTVU3g==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/svg-path-bounds": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/svg-path-bounds/-/svg-path-bounds-1.0.2.tgz",
       "integrity": "sha512-H4/uAgLWrppIC0kHsb2/dWUYSmb4GE5UqH06uqWBcg6LBjX2fu0A8+JrO2/FJPZiSsNOKZAhyFFgsLTdYUvSqQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "abs-svg-path": "^0.1.1",
         "is-svg-path": "^1.0.1",
@@ -10905,6 +11132,7 @@
       "resolved": "https://registry.npmjs.org/normalize-svg-path/-/normalize-svg-path-1.1.0.tgz",
       "integrity": "sha512-r9KHKG2UUeB5LoTouwDzBy2VxXlHsiM6fyLQvnJa0S5hrhzqElH/CH7TUGhT1fVvIYBIKf3OpY4YJ4CK+iaqHg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "svg-arc-to-cubic-bezier": "^3.0.0"
       }
@@ -10914,6 +11142,7 @@
       "resolved": "https://registry.npmjs.org/svg-path-sdf/-/svg-path-sdf-1.1.3.tgz",
       "integrity": "sha512-vJJjVq/R5lSr2KLfVXVAStktfcfa1pNFjFOgyJnzZFXlO/fDZ5DmM8FpnSKKzLPfEYTVeXuVBTHF296TpxuJVg==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bitmap-sdf": "^1.0.0",
         "draw-svg-path": "^1.0.0",
@@ -10993,6 +11222,7 @@
       "resolved": "https://registry.npmjs.org/through2/-/through2-2.0.5.tgz",
       "integrity": "sha512-/mrRod8xqpA+IHSLyGCQ2s8SPHiCDEeQJSep1jqLYeEUClOFG2Qsh+4FU6G9VeqpZnGW/Su8LQGc4YKni5rYSQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "readable-stream": "~2.3.6",
         "xtend": "~4.0.1"
@@ -11008,7 +11238,8 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/tinycolor2/-/tinycolor2-1.6.0.tgz",
       "integrity": "sha512-XPaBkWQJdsf3pLKJV9p4qN/S+fm2Oj8AIPo1BTUhg5oxkvm9+SVEGFdhyOz7tTdUTfvxMiAs4sp6/eZO2Ew+pw==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tinyexec": {
       "version": "1.0.2",
@@ -11038,7 +11269,8 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/tinyqueue/-/tinyqueue-2.0.3.tgz",
       "integrity": "sha512-ppJZNDuKGgxzkHihX8v9v9G5f+18gzaTfrukGrq6ueg0lmH4nqVnA2IPG0AEH3jKEk2GRJCUhDoqpoiw3PHLBA==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/tinyrainbow": {
       "version": "3.0.3",
@@ -11073,13 +11305,15 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/to-float32/-/to-float32-1.1.0.tgz",
       "integrity": "sha512-keDnAusn/vc+R3iEiSDw8TOF7gPiTLdK1ArvWtYbJQiVfmRg6i/CAvbKq3uIS0vWroAC7ZecN3DjQKw3aSklUg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/to-px": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/to-px/-/to-px-1.0.1.tgz",
       "integrity": "sha512-2y3LjBeIZYL19e5gczp14/uRWFDtDUErJPVN3VU9a7SJO+RjGRtYR47aMN2bZgGlxvW4ZcEz2ddUPVHXcMfuXw==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "parse-unit": "^1.0.1"
       }
@@ -11101,6 +11335,7 @@
       "resolved": "https://registry.npmjs.org/topojson-client/-/topojson-client-3.1.0.tgz",
       "integrity": "sha512-605uxS6bcYxGXw9qi62XyrV6Q3xwbndjachmNxu8HWTtVPxZfEJN9fd/SZS1Q54Sn2y0TMyMxFj/cJINqGHrKw==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "commander": "2"
       },
@@ -11114,7 +11349,8 @@
       "version": "2.20.3",
       "resolved": "https://registry.npmjs.org/commander/-/commander-2.20.3.tgz",
       "integrity": "sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/tough-cookie": {
       "version": "6.0.0",
@@ -11160,19 +11396,22 @@
       "version": "2.7.3",
       "resolved": "https://registry.npmjs.org/type/-/type-2.7.3.tgz",
       "integrity": "sha512-8j+1QmAbPvLZow5Qpi6NCaN8FB60p/6x8/vfNqOk/hC+HuvFZhL4+WfekuhQLiqFZXOgQdrs3B+XxEmCc6b3FQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/typedarray": {
       "version": "0.0.6",
       "resolved": "https://registry.npmjs.org/typedarray/-/typedarray-0.0.6.tgz",
       "integrity": "sha512-/aCDEGatGvZ2BIk+HmLf4ifCJFwvKFNb9/JeZPMulfgFracn9QFcAf5GO8B/mweUjSoblS5In0cWhqpfs/5PQA==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/typedarray-pool": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/typedarray-pool/-/typedarray-pool-1.2.0.tgz",
       "integrity": "sha512-YTSQbzX43yvtpfRtIDAYygoYtgT+Rpjuxy9iOpczrjpXLgGoyG7aS5USJXV2d3nn8uHTeb9rXDvzS27zUg5KYQ==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "bit-twiddle": "^1.0.0",
         "dup": "^1.0.0"
@@ -11201,7 +11440,8 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/unquote/-/unquote-1.1.1.tgz",
       "integrity": "sha512-vRCqFv6UhXpWxZPyGDh/F3ZpNv8/qo7w6iufLpQg9aKnQ71qM4B5KiI7Mia9COcjEhrO9LueHpMYjYzsWH3OIg==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/update-browserslist-db": {
       "version": "1.2.3",
@@ -11237,7 +11477,8 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/update-diff/-/update-diff-1.1.0.tgz",
       "integrity": "sha512-rCiBPiHxZwT4+sBhEbChzpO5hYHjm91kScWgdHf4Qeafs6Ba7MBl+d9GlGv72bcTZQO0sLmtQS1pHSWoCLtN/A==",
-      "license": "MIT"
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/use-callback-ref": {
       "version": "1.3.3",
@@ -11306,7 +11547,6 @@
       "version": "7.3.1",
       "resolved": "https://registry.npmjs.org/vite/-/vite-7.3.1.tgz",
       "integrity": "sha512-w+N7Hifpc3gRjZ63vYBXA56dvvRlNWRczTdmCBBa+CotUzAPf5b7YMdMR/8CQoeYE5LX3W4wj6RYTgonm1b9DA==",
-      "peer": true,
       "dependencies": {
         "esbuild": "^0.27.0",
         "fdir": "^6.5.0",
@@ -11382,7 +11622,6 @@
       "integrity": "sha512-hOQuK7h0FGKgBAas7v0mSAsnvrIgAvWmRFjmzpJ7SwFHH3g1k2u37JtYwOwmEKhK6ZO3v9ggDBBm0La1LCK4uQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@vitest/expect": "4.0.18",
         "@vitest/mocker": "4.0.18",
@@ -11477,6 +11716,7 @@
       "resolved": "https://registry.npmjs.org/vt-pbf/-/vt-pbf-3.1.3.tgz",
       "integrity": "sha512-2LzDFzt0mZKZ9IpVF2r69G9bXaP2Q2sArJCmcCgvfTdCCZzSyz4aCLoQyUilu37Ll56tCblIZrXFIjNUpGIlmA==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "@mapbox/point-geometry": "0.1.0",
         "@mapbox/vector-tile": "^1.3.1",
@@ -11505,13 +11745,15 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/weak-map/-/weak-map-1.0.8.tgz",
       "integrity": "sha512-lNR9aAefbGPpHO7AEnY0hCFjz1eTkWCXYvkTRrTHs9qv8zJp+SkVYpzfLIFXQQiG3tVvbNFQgVg2bQS8YGgxyw==",
-      "license": "Apache-2.0"
+      "license": "Apache-2.0",
+      "peer": true
     },
     "node_modules/webgl-context": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/webgl-context/-/webgl-context-2.2.0.tgz",
       "integrity": "sha512-q/fGIivtqTT7PEoF07axFIlHNk/XCPaYpq64btnepopSWvKNFkoORlQYgqDigBIuGA1ExnFd/GnSUnBNEPQY7Q==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "get-canvas-context": "^1.0.1"
       }
@@ -11555,6 +11797,7 @@
       "resolved": "https://registry.npmjs.org/which/-/which-4.0.0.tgz",
       "integrity": "sha512-GlaYyEb07DPxYCKhKzplCWBJtvxZcZMrL+4UkrTSJHHPyZU4mYYTv3qaOe77H7EODLSSopAUFAc6W8U4yqvscg==",
       "license": "ISC",
+      "peer": true,
       "dependencies": {
         "isexe": "^3.1.1"
       },
@@ -11586,6 +11829,7 @@
       "resolved": "https://registry.npmjs.org/world-calendars/-/world-calendars-1.0.4.tgz",
       "integrity": "sha512-VGRnLJS+xJmGDPodgJRnGIDwGu0s+Cr9V2HB3EzlDZ5n0qb8h5SJtGUEkjrphZYAglEiXZ6kiXdmk0H/h/uu/w==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "object-assign": "^4.1.0"
       }
@@ -11594,7 +11838,8 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
       "integrity": "sha512-l4Sp/DRseor9wL6EvV2+TuQn63dMkPjZ/sp9XkghTEbV9KlPS1xUsZ3u7/IQO4wxtcFB4bgpQPRcR3QCvezPcQ==",
-      "license": "ISC"
+      "license": "ISC",
+      "peer": true
     },
     "node_modules/ws": {
       "version": "8.18.3",
@@ -11644,6 +11889,7 @@
       "resolved": "https://registry.npmjs.org/xtend/-/xtend-4.0.2.tgz",
       "integrity": "sha512-LKYU1iAXJXUgAXn9URjiu+MWhyUXHsvfp7mcuYm9dSUKK0/CjtrUwFAxD82/mCWbtLsGjFIad0wIsod4zrTAEQ==",
       "license": "MIT",
+      "peer": true,
       "engines": {
         "node": ">=0.4"
       }

--- a/frontend/src/components/error-boundary/ErrorBoundary.tsx
+++ b/frontend/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import ErrorFallback from "./ErrorFallback";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+/**
+ * ErrorBoundary catches rendering errors in its child component tree
+ * and displays a fallback UI instead of crashing the entire app.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: undefined };
+
+  // Triggered when a child component throws an error
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  // Useful for logging errors to monitoring tools (Sentry, etc.)
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info);
+  }
+
+  // Reset error state when user clicks "Try Again"
+  resetError = () => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <ErrorFallback error={this.state.error} resetError={this.resetError} />
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/error-boundary/ErrorFallback.tsx
+++ b/frontend/src/components/error-boundary/ErrorFallback.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface ErrorFallbackProps {
+  error?: Error;
+  resetError: () => void;
+}
+
+export default function ErrorFallback({ error, resetError }: ErrorFallbackProps) {
+  return (
+    <div className="flex min-h-[300px] flex-col items-center justify-center rounded-lg border bg-background p-8 text-center shadow-sm">
+      <h2 className="text-xl font-semibold text-foreground">
+        Something went wrong
+      </h2>
+
+      <p className="mt-2 text-sm text-muted-foreground">
+        Please try refreshing the page or retry the action.
+      </p>
+
+      {error && (
+        <p className="mt-2 text-xs text-destructive">
+          {error.message}
+        </p>
+      )}
+
+      <button
+        onClick={resetError}
+        className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/empty-state.tsx
+++ b/frontend/src/components/ui/empty-state.tsx
@@ -1,0 +1,24 @@
+import React from "react";
+
+interface EmptyStateProps {
+  icon: React.ElementType;
+  title: string;
+  description: string;
+  action?: React.ReactNode;
+}
+
+export function EmptyState({
+  icon: Icon,
+  title,
+  description,
+  action,
+}: EmptyStateProps) {
+  return (
+    <div className="flex flex-col items-center justify-center py-12 text-center">
+      <Icon className="h-12 w-12 text-muted-foreground/50 mb-4" />
+      <h3 className="text-lg font-medium">{title}</h3>
+      <p className="text-sm text-muted-foreground mt-1">{description}</p>
+      {action && <div className="mt-4">{action}</div>}
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { onModeChange } from '@/stores/themeStore'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 interface MarginData {
   availablecash: string
@@ -270,6 +271,7 @@ export default function Dashboard() {
   }
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6 md:space-y-12">
       {/* Dashboard Header */}
       <div className="flex flex-col lg:flex-row lg:items-start gap-4">
@@ -470,5 +472,6 @@ export default function Dashboard() {
         </div>
       </div>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -7,13 +7,19 @@ import {
   RefreshCw,
   TrendingDown,
   TrendingUp,
-} from 'lucide-react'
-import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { tradingApi } from '@/api/trading'
-import { Alert, AlertDescription } from '@/components/ui/alert'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { tradingApi } from "@/api/trading";
+import { Alert, AlertDescription } from "@/components/ui/alert";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Table,
   TableBody,
@@ -22,143 +28,151 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { useLivePrice, calculateLiveStats } from '@/hooks/useLivePrice'
-import { usePageVisibility } from '@/hooks/usePageVisibility'
-import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
-import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
-import type { Holding, HoldingsStats } from '@/types/trading'
-import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
+} from "@/components/ui/table";
+import { useLivePrice, calculateLiveStats } from "@/hooks/useLivePrice";
+import { usePageVisibility } from "@/hooks/usePageVisibility";
+import { cn, makeFormatCurrency, sanitizeCSV } from "@/lib/utils";
+import { useAuthStore } from "@/stores/authStore";
+import { onModeChange } from "@/stores/themeStore";
+import type { Holding, HoldingsStats } from "@/types/trading";
+import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { EmptyState } from "@/components/ui/empty-state";
 
 function formatPercent(value: number): string {
-  return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
+  return `${value >= 0 ? "+" : ""}${value.toFixed(2)}%`;
 }
 
 export default function Holdings() {
-  const { apiKey, user } = useAuthStore()
-  const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
-  const [holdings, setHoldings] = useState<Holding[]>([])
-  const [stats, setStats] = useState<HoldingsStats | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [showStaleWarning, setShowStaleWarning] = useState(false)
+  const { apiKey, user } = useAuthStore();
+  const formatCurrency = useMemo(
+    () => makeFormatCurrency(user?.broker),
+    [user?.broker],
+  );
+  const [holdings, setHoldings] = useState<Holding[]>([]);
+  const [stats, setStats] = useState<HoldingsStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showStaleWarning, setShowStaleWarning] = useState(false);
 
   // Page visibility tracking for resource optimization
-  const { isVisible, wasHidden, timeSinceHidden } = usePageVisibility()
-  const lastFetchRef = useRef<number>(Date.now())
+  const { isVisible, wasHidden, timeSinceHidden } = usePageVisibility();
+  const lastFetchRef = useRef<number>(Date.now());
 
   // Centralized real-time price hook with WebSocket + MultiQuotes fallback
   // Automatically pauses when tab is hidden
-  const { data: enhancedHoldings, isLive, isPaused } = useLivePrice(holdings, {
+  const {
+    data: enhancedHoldings,
+    isLive,
+    isPaused,
+  } = useLivePrice(holdings, {
     enabled: holdings.length > 0,
     useMultiQuotesFallback: true,
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,
     pauseWhenHidden: true,
-  })
+  });
 
   // Calculate enhanced stats based on real-time data
   const enhancedStats = useMemo(() => {
-    if (!stats) return stats
+    if (!stats) return stats;
 
     // Check if any holding has live data
     const hasAnyLiveData = enhancedHoldings.some(
-      (h) => (h as Holding & { _dataSource?: string })._dataSource !== 'rest'
-    )
+      (h) => (h as Holding & { _dataSource?: string })._dataSource !== "rest",
+    );
 
     // If no live data, return original REST stats
-    if (!hasAnyLiveData) return stats
+    if (!hasAnyLiveData) return stats;
 
     // Recalculate stats with real-time data
-    return calculateLiveStats(enhancedHoldings, stats)
-  }, [stats, enhancedHoldings])
+    return calculateLiveStats(enhancedHoldings, stats);
+  }, [stats, enhancedHoldings]);
 
   const fetchHoldings = useCallback(
     async (showRefresh = false) => {
       if (!apiKey) {
-        setIsLoading(false)
-        return
+        setIsLoading(false);
+        return;
       }
 
-      if (showRefresh) setIsRefreshing(true)
+      if (showRefresh) setIsRefreshing(true);
 
       try {
-        const response = await tradingApi.getHoldings(apiKey)
-        if (response.status === 'success' && response.data) {
-          setHoldings(response.data.holdings || [])
-          setStats(response.data.statistics)
-          setError(null)
+        const response = await tradingApi.getHoldings(apiKey);
+        if (response.status === "success" && response.data) {
+          setHoldings(response.data.holdings || []);
+          setStats(response.data.statistics);
+          setError(null);
         } else {
-          setError(response.message || 'Failed to fetch holdings')
+          setError(response.message || "Failed to fetch holdings");
         }
       } catch {
-        setError('Failed to fetch holdings')
+        setError("Failed to fetch holdings");
       } finally {
-        setIsLoading(false)
-        setIsRefreshing(false)
+        setIsLoading(false);
+        setIsRefreshing(false);
       }
     },
-    [apiKey]
-  )
+    [apiKey],
+  );
 
   // Initial fetch and visibility-aware polling
   // Pauses polling when tab is hidden to save resources
   useEffect(() => {
     // Don't poll when tab is hidden
-    if (!isVisible) return
+    if (!isVisible) return;
 
-    fetchHoldings()
-    lastFetchRef.current = Date.now()
+    fetchHoldings();
+    lastFetchRef.current = Date.now();
 
     // Reduce polling interval when live (WebSocket connected AND market open)
-    const intervalMs = isLive ? 30000 : 10000
+    const intervalMs = isLive ? 30000 : 10000;
     const interval = setInterval(() => {
-      fetchHoldings()
-      lastFetchRef.current = Date.now()
-    }, intervalMs)
+      fetchHoldings();
+      lastFetchRef.current = Date.now();
+    }, intervalMs);
 
-    return () => clearInterval(interval)
-  }, [fetchHoldings, isLive, isVisible])
+    return () => clearInterval(interval);
+  }, [fetchHoldings, isLive, isVisible]);
 
   // Refresh data when tab becomes visible after being hidden
   useEffect(() => {
-    if (!wasHidden || !isVisible) return
+    if (!wasHidden || !isVisible) return;
 
-    const timeSinceLastFetch = Date.now() - lastFetchRef.current
+    const timeSinceLastFetch = Date.now() - lastFetchRef.current;
 
     // If hidden for more than 30 seconds, show stale warning and refresh
     if (timeSinceHidden > 30000 || timeSinceLastFetch > 30000) {
-      setShowStaleWarning(true)
-      fetchHoldings()
-      lastFetchRef.current = Date.now()
+      setShowStaleWarning(true);
+      fetchHoldings();
+      lastFetchRef.current = Date.now();
 
       // Hide the warning after 5 seconds
-      const timeout = setTimeout(() => setShowStaleWarning(false), 5000)
-      return () => clearTimeout(timeout)
+      const timeout = setTimeout(() => setShowStaleWarning(false), 5000);
+      return () => clearTimeout(timeout);
     }
-  }, [wasHidden, isVisible, timeSinceHidden, fetchHoldings])
+  }, [wasHidden, isVisible, timeSinceHidden, fetchHoldings]);
 
   // Listen for mode changes (live/analyze) and refresh data
   useEffect(() => {
     const unsubscribe = onModeChange(() => {
-      fetchHoldings()
-    })
-    return () => unsubscribe()
-  }, [fetchHoldings])
+      fetchHoldings();
+    });
+    return () => unsubscribe();
+  }, [fetchHoldings]);
 
   const exportToCSV = () => {
     const headers = [
-      'Symbol',
-      'Exchange',
-      'Quantity',
-      'Avg Price',
-      'LTP',
-      'Product',
-      'P&L',
-      'P&L %',
-    ]
+      "Symbol",
+      "Exchange",
+      "Quantity",
+      "Avg Price",
+      "LTP",
+      "Product",
+      "P&L",
+      "P&L %",
+    ];
     const rows = enhancedHoldings.map((h) => [
       sanitizeCSV(h.symbol),
       sanitizeCSV(h.exchange),
@@ -168,243 +182,285 @@ export default function Holdings() {
       sanitizeCSV(h.product),
       sanitizeCSV(h.pnl),
       sanitizeCSV(h.pnlpercent),
-    ])
+    ]);
 
-    const csv = [headers, ...rows].map((row) => row.join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `holdings_${new Date().toISOString().split('T')[0]}.csv`
-    a.click()
+    const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `holdings_${new Date().toISOString().split("T")[0]}.csv`;
+    a.click();
     // Revoke the object URL to free memory
-    URL.revokeObjectURL(url)
-  }
+    URL.revokeObjectURL(url);
+  };
 
-  const isProfit = (value: number) => value >= 0
+  const isProfit = (value: number) => value >= 0;
 
   return (
     <ErrorBoundary>
-    <div className="space-y-6">
-      {/* Stale Data Warning */}
-      {showStaleWarning && (
-        <Alert variant="default" className="bg-amber-500/10 border-amber-500/30">
-          <AlertTriangle className="h-4 w-4 text-amber-600" />
-          <AlertDescription className="text-amber-700 dark:text-amber-400">
-            Data is being refreshed after tab was inactive...
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold tracking-tight">Investor Summary</h1>
-            {isPaused ? (
-              <Badge
-                variant="outline"
-                className="bg-amber-500/10 text-amber-600 border-amber-500/30 gap-1"
-              >
-                <Pause className="h-3 w-3" />
-                Paused
-              </Badge>
-            ) : isLive ? (
-              <Badge
-                variant="outline"
-                className="bg-emerald-500/10 text-emerald-600 border-emerald-500/30 gap-1"
-              >
-                <Radio className="h-3 w-3 animate-pulse" />
-                Live
-              </Badge>
-            ) : null}
-          </div>
-          <p className="text-muted-foreground">View your holdings portfolio</p>
-        </div>
-        <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchHoldings(true)}
-            disabled={isRefreshing}
+      <div className="space-y-6">
+        {/* Stale Data Warning */}
+        {showStaleWarning && (
+          <Alert
+            variant="default"
+            className="bg-amber-500/10 border-amber-500/30"
           >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
-        </div>
-      </div>
+            <AlertTriangle className="h-4 w-4 text-amber-600" />
+            <AlertDescription className="text-amber-700 dark:text-amber-400">
+              Data is being refreshed after tab was inactive...
+            </AlertDescription>
+          </Alert>
+        )}
 
-      {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Total Holding Value</CardDescription>
-            <CardTitle className="text-2xl text-primary">
-              {enhancedStats ? formatCurrency(enhancedStats.totalholdingvalue) : '---'}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Total Investment Value</CardDescription>
-            <CardTitle className="text-2xl">
-              {enhancedStats ? formatCurrency(enhancedStats.totalinvvalue) : '---'}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Total Profit and Loss</CardDescription>
-            <CardTitle
-              className={cn(
-                'text-2xl',
-                enhancedStats && isProfit(enhancedStats.totalprofitandloss)
-                  ? 'text-green-600'
-                  : 'text-red-600'
-              )}
-            >
-              {enhancedStats ? (
-                <div className="flex items-center gap-1">
-                  {isProfit(enhancedStats.totalprofitandloss) ? (
-                    <TrendingUp className="h-5 w-5" />
-                  ) : (
-                    <TrendingDown className="h-5 w-5" />
-                  )}
-                  {formatCurrency(enhancedStats.totalprofitandloss)}
-                </div>
-              ) : (
-                '---'
-              )}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Total PnL Percentage</CardDescription>
-            <CardTitle
-              className={cn(
-                'text-2xl',
-                enhancedStats && isProfit(enhancedStats.totalpnlpercentage)
-                  ? 'text-green-600'
-                  : 'text-red-600'
-              )}
-            >
-              {enhancedStats ? formatPercent(enhancedStats.totalpnlpercentage) : '---'}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-      </div>
-
-      {/* Holdings Table */}
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin" />
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-bold tracking-tight">
+                Investor Summary
+              </h1>
+              {isPaused ? (
+                <Badge
+                  variant="outline"
+                  className="bg-amber-500/10 text-amber-600 border-amber-500/30 gap-1"
+                >
+                  <Pause className="h-3 w-3" />
+                  Paused
+                </Badge>
+              ) : isLive ? (
+                <Badge
+                  variant="outline"
+                  className="bg-emerald-500/10 text-emerald-600 border-emerald-500/30 gap-1"
+                >
+                  <Radio className="h-3 w-3 animate-pulse" />
+                  Live
+                </Badge>
+              ) : null}
             </div>
-          ) : error ? (
-            <div className="text-center py-12 text-muted-foreground">{error}</div>
-          ) : holdings.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">No holdings found</div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead>Trading Symbol</TableHead>
-                    <TableHead>Exchange</TableHead>
-                    <TableHead className="text-right">Quantity</TableHead>
-                    <TableHead className="text-right">Avg Price</TableHead>
-                    <TableHead className="text-right">LTP</TableHead>
-                    <TableHead>Product</TableHead>
-                    <TableHead className="text-right">Profit and Loss</TableHead>
-                    <TableHead className="text-right">PnL %</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {enhancedHoldings.map((holding, index) => (
-                    <TableRow key={`${holding.symbol}-${holding.exchange}-${index}`}>
-                      <TableCell className="font-medium">{holding.symbol}</TableCell>
-                      <TableCell>
-                        <Badge variant="outline">{holding.exchange}</Badge>
-                      </TableCell>
-                      <TableCell className="text-right font-mono">{holding.quantity}</TableCell>
-                      <TableCell className="text-right font-mono">
-                        {holding.average_price !== undefined
-                          ? formatCurrency(holding.average_price)
-                          : '-'}
-                      </TableCell>
-                      <TableCell className="text-right font-mono">
-                        {holding.ltp !== undefined ? formatCurrency(holding.ltp) : '-'}
-                      </TableCell>
-                      <TableCell>
-                        <Badge variant="secondary">{holding.product}</Badge>
-                      </TableCell>
-                      <TableCell
-                        className={cn(
-                          'text-right font-medium',
-                          isProfit(holding.pnl) ? 'text-green-600' : 'text-red-600'
-                        )}
+            <p className="text-muted-foreground">
+              View your holdings portfolio
+            </p>
+          </div>
+          <div className="flex items-center gap-2">
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchHoldings(true)}
+              disabled={isRefreshing}
+            >
+              <RefreshCw
+                className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+              />
+              Refresh
+            </Button>
+            <Button variant="outline" size="sm" onClick={exportToCSV}>
+              <Download className="h-4 w-4 mr-2" />
+              Export
+            </Button>
+          </div>
+        </div>
+
+        {/* Stats Cards */}
+        <div className="grid gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total Holding Value</CardDescription>
+              <CardTitle className="text-2xl text-primary">
+                {enhancedStats
+                  ? formatCurrency(enhancedStats.totalholdingvalue)
+                  : "---"}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total Investment Value</CardDescription>
+              <CardTitle className="text-2xl">
+                {enhancedStats
+                  ? formatCurrency(enhancedStats.totalinvvalue)
+                  : "---"}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total Profit and Loss</CardDescription>
+              <CardTitle
+                className={cn(
+                  "text-2xl",
+                  enhancedStats && isProfit(enhancedStats.totalprofitandloss)
+                    ? "text-green-600"
+                    : "text-red-600",
+                )}
+              >
+                {enhancedStats ? (
+                  <div className="flex items-center gap-1">
+                    {isProfit(enhancedStats.totalprofitandloss) ? (
+                      <TrendingUp className="h-5 w-5" />
+                    ) : (
+                      <TrendingDown className="h-5 w-5" />
+                    )}
+                    {formatCurrency(enhancedStats.totalprofitandloss)}
+                  </div>
+                ) : (
+                  "---"
+                )}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total PnL Percentage</CardDescription>
+              <CardTitle
+                className={cn(
+                  "text-2xl",
+                  enhancedStats && isProfit(enhancedStats.totalpnlpercentage)
+                    ? "text-green-600"
+                    : "text-red-600",
+                )}
+              >
+                {enhancedStats
+                  ? formatPercent(enhancedStats.totalpnlpercentage)
+                  : "---"}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        {/* Holdings Table */}
+        <Card>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin" />
+              </div>
+            ) : error ? (
+              <div className="text-center py-12 text-muted-foreground">
+                {error}
+              </div>
+            ) : holdings.length === 0 ? (
+              <EmptyState
+                icon={AlertTriangle}
+                title="No holdings found"
+                description="Your portfolio is currently empty."
+              />
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Trading Symbol</TableHead>
+                      <TableHead>Exchange</TableHead>
+                      <TableHead className="text-right">Quantity</TableHead>
+                      <TableHead className="text-right">Avg Price</TableHead>
+                      <TableHead className="text-right">LTP</TableHead>
+                      <TableHead>Product</TableHead>
+                      <TableHead className="text-right">
+                        Profit and Loss
+                      </TableHead>
+                      <TableHead className="text-right">PnL %</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {enhancedHoldings.map((holding, index) => (
+                      <TableRow
+                        key={`${holding.symbol}-${holding.exchange}-${index}`}
                       >
-                        <div className="flex items-center justify-end gap-1">
-                          {isProfit(holding.pnl) ? (
-                            <TrendingUp className="h-4 w-4" />
-                          ) : (
-                            <TrendingDown className="h-4 w-4" />
+                        <TableCell className="font-medium">
+                          {holding.symbol}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="outline">{holding.exchange}</Badge>
+                        </TableCell>
+                        <TableCell className="text-right font-mono">
+                          {holding.quantity}
+                        </TableCell>
+                        <TableCell className="text-right font-mono">
+                          {holding.average_price !== undefined
+                            ? formatCurrency(holding.average_price)
+                            : "-"}
+                        </TableCell>
+                        <TableCell className="text-right font-mono">
+                          {holding.ltp !== undefined
+                            ? formatCurrency(holding.ltp)
+                            : "-"}
+                        </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">{holding.product}</Badge>
+                        </TableCell>
+                        <TableCell
+                          className={cn(
+                            "text-right font-medium",
+                            isProfit(holding.pnl)
+                              ? "text-green-600"
+                              : "text-red-600",
                           )}
-                          {formatCurrency(holding.pnl)}
-                        </div>
+                        >
+                          <div className="flex items-center justify-end gap-1">
+                            {isProfit(holding.pnl) ? (
+                              <TrendingUp className="h-4 w-4" />
+                            ) : (
+                              <TrendingDown className="h-4 w-4" />
+                            )}
+                            {formatCurrency(holding.pnl)}
+                          </div>
+                        </TableCell>
+                        <TableCell
+                          className={cn(
+                            "text-right",
+                            isProfit(holding.pnlpercent)
+                              ? "text-green-600"
+                              : "text-red-600",
+                          )}
+                        >
+                          {formatPercent(holding.pnlpercent)}
+                        </TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                  <TableFooter>
+                    <TableRow className="bg-muted/50">
+                      <TableCell
+                        colSpan={6}
+                        className="text-right text-muted-foreground"
+                      >
+                        Total P&L:
                       </TableCell>
                       <TableCell
                         className={cn(
-                          'text-right',
-                          isProfit(holding.pnlpercent) ? 'text-green-600' : 'text-red-600'
+                          "text-right font-bold",
+                          enhancedStats &&
+                            isProfit(enhancedStats.totalprofitandloss)
+                            ? "text-green-600"
+                            : "text-red-600",
                         )}
                       >
-                        {formatPercent(holding.pnlpercent)}
+                        {enhancedStats
+                          ? `${enhancedStats.totalprofitandloss >= 0 ? "+" : ""}${formatCurrency(enhancedStats.totalprofitandloss)}`
+                          : "-"}
+                      </TableCell>
+                      <TableCell
+                        className={cn(
+                          "text-right font-bold",
+                          enhancedStats &&
+                            isProfit(enhancedStats.totalpnlpercentage)
+                            ? "text-green-600"
+                            : "text-red-600",
+                        )}
+                      >
+                        {enhancedStats
+                          ? formatPercent(enhancedStats.totalpnlpercentage)
+                          : "-"}
                       </TableCell>
                     </TableRow>
-                  ))}
-                </TableBody>
-                <TableFooter>
-                  <TableRow className="bg-muted/50">
-                    <TableCell colSpan={6} className="text-right text-muted-foreground">
-                      Total P&L:
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        'text-right font-bold',
-                        enhancedStats && isProfit(enhancedStats.totalprofitandloss)
-                          ? 'text-green-600'
-                          : 'text-red-600'
-                      )}
-                    >
-                      {enhancedStats
-                        ? `${enhancedStats.totalprofitandloss >= 0 ? '+' : ''}${formatCurrency(enhancedStats.totalprofitandloss)}`
-                        : '-'}
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        'text-right font-bold',
-                        enhancedStats && isProfit(enhancedStats.totalpnlpercentage)
-                          ? 'text-green-600'
-                          : 'text-red-600'
-                      )}
-                    >
-                      {enhancedStats ? formatPercent(enhancedStats.totalpnlpercentage) : '-'}
-                    </TableCell>
-                  </TableRow>
-                </TableFooter>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+                  </TableFooter>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </ErrorBoundary>
-  )
+  );
 }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -29,6 +29,7 @@ import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 function formatPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
@@ -183,6 +184,7 @@ export default function Holdings() {
   const isProfit = (value: number) => value >= 0
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -403,5 +405,6 @@ export default function Holdings() {
         </CardContent>
       </Card>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -37,6 +37,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { onModeChange } from "@/stores/themeStore";
 import type { Holding, HoldingsStats } from "@/types/trading";
 import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
 
 function formatPercent(value: number): string {
@@ -273,9 +274,13 @@ export default function Holdings() {
             <CardHeader className="pb-2">
               <CardDescription>Total Holding Value</CardDescription>
               <CardTitle className="text-2xl text-primary">
-                {enhancedStats
-                  ? formatCurrency(enhancedStats.totalholdingvalue)
-                  : "---"}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-24" />
+                ) : enhancedStats ? (
+                  formatCurrency(enhancedStats.totalholdingvalue)
+                ) : (
+                  "---"
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -283,9 +288,13 @@ export default function Holdings() {
             <CardHeader className="pb-2">
               <CardDescription>Total Investment Value</CardDescription>
               <CardTitle className="text-2xl">
-                {enhancedStats
-                  ? formatCurrency(enhancedStats.totalinvvalue)
-                  : "---"}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-24" />
+                ) : enhancedStats ? (
+                  formatCurrency(enhancedStats.totalinvvalue)
+                ) : (
+                  "---"
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -326,9 +335,13 @@ export default function Holdings() {
                     : "text-red-600",
                 )}
               >
-                {enhancedStats
-                  ? formatPercent(enhancedStats.totalpnlpercentage)
-                  : "---"}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-16" />
+                ) : enhancedStats ? (
+                  formatPercent(enhancedStats.totalpnlpercentage)
+                ) : (
+                  "---"
+                )}
               </CardTitle>
             </CardHeader>
           </Card>

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -9,6 +9,7 @@ import {
   TrendingUp,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
+import { showToast } from "@/utils/toast";
 import { tradingApi } from "@/api/trading";
 import { Alert, AlertDescription } from "@/components/ui/alert";
 import { Badge } from "@/components/ui/badge";
@@ -163,6 +164,10 @@ export default function Holdings() {
   }, [fetchHoldings]);
 
   const exportToCSV = () => {
+    if (enhancedHoldings.length === 0) {
+      showToast.error("No data to export", "system");
+      return;
+    }
     const headers = [
       "Symbol",
       "Exchange",
@@ -193,6 +198,7 @@ export default function Holdings() {
     a.click();
     // Revoke the object URL to free memory
     URL.revokeObjectURL(url);
+    showToast.success("Downloaded holdings.csv", "clipboard");
   };
 
   const isProfit = (value: number) => value >= 0;

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -59,6 +59,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { onModeChange } from "@/stores/themeStore";
 import type { Order, OrderStats } from "@/types/trading";
 import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
 
 function formatTime(timestamp: string): string {
@@ -478,7 +479,11 @@ export default function OrderBook() {
             <CardHeader className="pb-2">
               <CardDescription>Buy Orders</CardDescription>
               <CardTitle className="text-2xl text-green-600">
-                {stats?.total_buy_orders ?? 0}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-12" />
+                ) : (
+                  (stats?.total_buy_orders ?? 0)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -486,7 +491,11 @@ export default function OrderBook() {
             <CardHeader className="pb-2">
               <CardDescription>Sell Orders</CardDescription>
               <CardTitle className="text-2xl text-red-600">
-                {stats?.total_sell_orders ?? 0}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-12" />
+                ) : (
+                  (stats?.total_sell_orders ?? 0)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -494,7 +503,11 @@ export default function OrderBook() {
             <CardHeader className="pb-2">
               <CardDescription>Completed</CardDescription>
               <CardTitle className="text-2xl">
-                {stats?.total_completed_orders ?? 0}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-12" />
+                ) : (
+                  (stats?.total_completed_orders ?? 0)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -502,7 +515,11 @@ export default function OrderBook() {
             <CardHeader className="pb-2">
               <CardDescription>Open</CardDescription>
               <CardTitle className="text-2xl text-blue-600">
-                {stats?.total_open_orders ?? 0}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-12" />
+                ) : (
+                  (stats?.total_open_orders ?? 0)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -510,7 +527,11 @@ export default function OrderBook() {
             <CardHeader className="pb-2">
               <CardDescription>Rejected</CardDescription>
               <CardTitle className="text-2xl text-red-600">
-                {stats?.total_rejected_orders ?? 0}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-12" />
+                ) : (
+                  (stats?.total_rejected_orders ?? 0)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -8,10 +8,10 @@ import {
   Settings2,
   X,
   XCircle,
-} from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { showToast } from '@/utils/toast'
-import { type QuotesData, tradingApi } from '@/api/trading'
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { showToast } from "@/utils/toast";
+import { type QuotesData, tradingApi } from "@/api/trading";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -22,10 +22,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -34,9 +40,9 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog'
-import { Input } from '@/components/ui/input'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/dialog";
+import { Input } from "@/components/ui/input";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -44,186 +50,209 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
+} from "@/components/ui/table";
+import { cn, makeFormatCurrency, sanitizeCSV } from "@/lib/utils";
 // Note: AlertDialog still used for Cancel All Orders
-import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
-import type { Order, OrderStats } from '@/types/trading'
+import { useAuthStore } from "@/stores/authStore";
+import { onModeChange } from "@/stores/themeStore";
+import type { Order, OrderStats } from "@/types/trading";
+import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
 
 function formatTime(timestamp: string): string {
   try {
-    return new Date(timestamp).toLocaleTimeString('en-IN', {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    })
+    return new Date(timestamp).toLocaleTimeString("en-IN", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
   } catch {
-    return timestamp
+    return timestamp;
   }
 }
 
-const statusConfig: Record<string, { icon: typeof CheckCircle2; color: string; label: string }> = {
-  complete: { icon: CheckCircle2, color: 'text-green-500', label: 'complete' },
-  rejected: { icon: XCircle, color: 'text-red-500', label: 'rejected' },
-  cancelled: { icon: XCircle, color: 'text-gray-500', label: 'cancelled' },
-  open: { icon: Clock, color: 'text-blue-500', label: 'open' },
-}
+const statusConfig: Record<
+  string,
+  { icon: typeof CheckCircle2; color: string; label: string }
+> = {
+  complete: { icon: CheckCircle2, color: "text-green-500", label: "complete" },
+  rejected: { icon: XCircle, color: "text-red-500", label: "rejected" },
+  cancelled: { icon: XCircle, color: "text-gray-500", label: "cancelled" },
+  open: { icon: Clock, color: "text-blue-500", label: "open" },
+};
 
 export default function OrderBook() {
-  const { apiKey, user } = useAuthStore()
-  const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
-  const [orders, setOrders] = useState<Order[]>([])
-  const [stats, setStats] = useState<OrderStats | null>(null)
-  const [isLoading, setIsLoading] = useState(true)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { apiKey, user } = useAuthStore();
+  const formatCurrency = useMemo(
+    () => makeFormatCurrency(user?.broker),
+    [user?.broker],
+  );
+  const [orders, setOrders] = useState<Order[]>([]);
+  const [stats, setStats] = useState<OrderStats | null>(null);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Filter state
-  const [statusFilter, setStatusFilter] = useState<string[]>([])
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  const [statusFilter, setStatusFilter] = useState<string[]>([]);
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Modify order state
-  const [modifyDialogOpen, setModifyDialogOpen] = useState(false)
-  const [modifyingOrder, setModifyingOrder] = useState<Order | null>(null)
-  const [quotes, setQuotes] = useState<QuotesData | null>(null)
-  const [isLoadingQuotes, setIsLoadingQuotes] = useState(false)
+  const [modifyDialogOpen, setModifyDialogOpen] = useState(false);
+  const [modifyingOrder, setModifyingOrder] = useState<Order | null>(null);
+  const [quotes, setQuotes] = useState<QuotesData | null>(null);
+  const [isLoadingQuotes, setIsLoadingQuotes] = useState(false);
   const [modifyForm, setModifyForm] = useState({
     quantity: 0,
     price: 0,
     trigger_price: 0,
-    pricetype: 'MARKET' as string,
-    product: 'MIS' as string,
-  })
+    pricetype: "MARKET" as string,
+    product: "MIS" as string,
+  });
 
   // Filter orders based on status
   const filteredOrders = useMemo(() => {
-    if (statusFilter.length === 0) return orders
-    return orders.filter((order) => statusFilter.includes(order.order_status))
-  }, [orders, statusFilter])
+    if (statusFilter.length === 0) return orders;
+    return orders.filter((order) => statusFilter.includes(order.order_status));
+  }, [orders, statusFilter]);
 
-  const hasActiveFilters = statusFilter.length > 0
+  const hasActiveFilters = statusFilter.length > 0;
 
   const toggleStatusFilter = (status: string) => {
     setStatusFilter((prev) => {
       if (prev.includes(status)) {
-        return prev.filter((s) => s !== status)
+        return prev.filter((s) => s !== status);
       }
-      return [...prev, status]
-    })
-  }
+      return [...prev, status];
+    });
+  };
 
   const clearFilters = () => {
-    setStatusFilter([])
-  }
+    setStatusFilter([]);
+  };
 
   const fetchOrders = useCallback(
     async (showRefresh = false) => {
       if (!apiKey) {
-        setIsLoading(false)
-        return
+        setIsLoading(false);
+        return;
       }
 
-      if (showRefresh) setIsRefreshing(true)
+      if (showRefresh) setIsRefreshing(true);
 
       try {
-        const response = await tradingApi.getOrders(apiKey)
-        if (response.status === 'success' && response.data) {
-          setOrders(response.data.orders || [])
-          setStats(response.data.statistics)
-          setError(null)
+        const response = await tradingApi.getOrders(apiKey);
+        if (response.status === "success" && response.data) {
+          setOrders(response.data.orders || []);
+          setStats(response.data.statistics);
+          setError(null);
         } else {
-          setError(response.message || 'Failed to fetch orders')
+          setError(response.message || "Failed to fetch orders");
         }
       } catch {
-        setError('Failed to fetch orders')
+        setError("Failed to fetch orders");
       } finally {
-        setIsLoading(false)
-        setIsRefreshing(false)
+        setIsLoading(false);
+        setIsRefreshing(false);
       }
     },
-    [apiKey]
-  )
+    [apiKey],
+  );
 
   useEffect(() => {
-    fetchOrders()
-    const interval = setInterval(() => fetchOrders(), 10000)
-    return () => clearInterval(interval)
-  }, [fetchOrders])
+    fetchOrders();
+    const interval = setInterval(() => fetchOrders(), 10000);
+    return () => clearInterval(interval);
+  }, [fetchOrders]);
 
   // Listen for mode changes (live/analyze) and refresh data
   useEffect(() => {
     const unsubscribe = onModeChange(() => {
-      fetchOrders()
-    })
-    return () => unsubscribe()
-  }, [fetchOrders])
+      fetchOrders();
+    });
+    return () => unsubscribe();
+  }, [fetchOrders]);
 
   const handleCancelOrder = async (orderid: string) => {
     try {
-      const response = await tradingApi.cancelOrder(orderid)
-      if (response.status === 'success') {
-        showToast.success(`Order cancelled: ${orderid}`, 'orders')
-        setTimeout(() => fetchOrders(true), 1000)
+      const response = await tradingApi.cancelOrder(orderid);
+      if (response.status === "success") {
+        showToast.success(`Order cancelled: ${orderid}`, "orders");
+        setTimeout(() => fetchOrders(true), 1000);
       } else {
-        showToast.error(response.message || 'Failed to cancel order', 'orders')
+        showToast.error(response.message || "Failed to cancel order", "orders");
       }
     } catch (error) {
-      const axiosError = error as { response?: { data?: { message?: string } } }
-      const message = axiosError.response?.data?.message || 'Failed to cancel order'
-      showToast.error(message, 'orders')
+      const axiosError = error as {
+        response?: { data?: { message?: string } };
+      };
+      const message =
+        axiosError.response?.data?.message || "Failed to cancel order";
+      showToast.error(message, "orders");
     }
-  }
+  };
 
   const handleCancelAllOrders = async () => {
     try {
-      const response = await tradingApi.cancelAllOrders()
-      if (response.status === 'success') {
-        showToast.success(response.message || 'All orders cancelled', 'orders')
+      const response = await tradingApi.cancelAllOrders();
+      if (response.status === "success") {
+        showToast.success(response.message || "All orders cancelled", "orders");
         // Delay refresh to allow broker to process cancellations
-        setTimeout(() => fetchOrders(true), 2000)
-      } else if (response.status === 'info') {
-        showToast.info(response.message || 'No open orders to cancel', 'orders')
+        setTimeout(() => fetchOrders(true), 2000);
+      } else if (response.status === "info") {
+        showToast.info(
+          response.message || "No open orders to cancel",
+          "orders",
+        );
       } else {
-        showToast.error(response.message || 'Failed to cancel all orders', 'orders')
+        showToast.error(
+          response.message || "Failed to cancel all orders",
+          "orders",
+        );
       }
     } catch (error) {
-      const axiosError = error as { response?: { data?: { message?: string } } }
-      const message = axiosError.response?.data?.message || 'Failed to cancel all orders'
-      showToast.error(message, 'orders')
+      const axiosError = error as {
+        response?: { data?: { message?: string } };
+      };
+      const message =
+        axiosError.response?.data?.message || "Failed to cancel all orders";
+      showToast.error(message, "orders");
     }
-  }
+  };
 
   const openModifyDialog = async (order: Order) => {
-    setModifyingOrder(order)
+    setModifyingOrder(order);
     setModifyForm({
       quantity: order.quantity,
       price: order.price,
       trigger_price: order.trigger_price,
       pricetype: order.pricetype,
       product: order.product,
-    })
-    setQuotes(null)
-    setModifyDialogOpen(true)
+    });
+    setQuotes(null);
+    setModifyDialogOpen(true);
 
     // Fetch quotes for the symbol
     if (apiKey) {
-      setIsLoadingQuotes(true)
+      setIsLoadingQuotes(true);
       try {
-        const response = await tradingApi.getQuotes(apiKey, order.symbol, order.exchange)
-        if (response.status === 'success' && response.data) {
-          setQuotes(response.data)
+        const response = await tradingApi.getQuotes(
+          apiKey,
+          order.symbol,
+          order.exchange,
+        );
+        if (response.status === "success" && response.data) {
+          setQuotes(response.data);
         }
       } catch {
         // Silently fail - quotes are optional for order modification
       } finally {
-        setIsLoadingQuotes(false)
+        setIsLoadingQuotes(false);
       }
     }
-  }
+  };
 
   const handleModifyOrder = async () => {
-    if (!modifyingOrder) return
+    if (!modifyingOrder) return;
 
     try {
       const response = await tradingApi.modifyOrder(modifyingOrder.orderid, {
@@ -235,35 +264,41 @@ export default function OrderBook() {
         price: modifyForm.price,
         quantity: modifyForm.quantity,
         trigger_price: modifyForm.trigger_price,
-      })
-      if (response.status === 'success') {
-        showToast.success(`Order modified: ${modifyingOrder.orderid}`, 'orders')
-        setModifyDialogOpen(false)
-        setTimeout(() => fetchOrders(true), 1000)
+      });
+      if (response.status === "success") {
+        showToast.success(
+          `Order modified: ${modifyingOrder.orderid}`,
+          "orders",
+        );
+        setModifyDialogOpen(false);
+        setTimeout(() => fetchOrders(true), 1000);
       } else {
-        showToast.error(response.message || 'Failed to modify order', 'orders')
+        showToast.error(response.message || "Failed to modify order", "orders");
       }
     } catch (error) {
-      const axiosError = error as { response?: { data?: { message?: string } } }
-      const message = axiosError.response?.data?.message || 'Failed to modify order'
-      showToast.error(message, 'orders')
+      const axiosError = error as {
+        response?: { data?: { message?: string } };
+      };
+      const message =
+        axiosError.response?.data?.message || "Failed to modify order";
+      showToast.error(message, "orders");
     }
-  }
+  };
 
   const exportToCSV = () => {
     const headers = [
-      'Symbol',
-      'Exchange',
-      'Action',
-      'Qty',
-      'Price',
-      'Trigger',
-      'Type',
-      'Product',
-      'Order ID',
-      'Status',
-      'Time',
-    ]
+      "Symbol",
+      "Exchange",
+      "Action",
+      "Qty",
+      "Price",
+      "Trigger",
+      "Type",
+      "Product",
+      "Order ID",
+      "Status",
+      "Time",
+    ];
     const rows = orders.map((o) => [
       sanitizeCSV(o.symbol),
       sanitizeCSV(o.exchange),
@@ -276,34 +311,36 @@ export default function OrderBook() {
       sanitizeCSV(o.orderid),
       sanitizeCSV(o.order_status),
       sanitizeCSV(o.timestamp),
-    ])
+    ]);
 
-    const csv = [headers, ...rows].map((row) => row.join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `orderbook_${new Date().toISOString().split('T')[0]}.csv`
-    a.click()
-  }
+    const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `orderbook_${new Date().toISOString().split("T")[0]}.csv`;
+    a.click();
+  };
 
-  const openOrders = orders.filter((o) => o.order_status === 'open')
+  const openOrders = orders.filter((o) => o.order_status === "open");
 
   const FilterChip = ({ status, label }: { status: string; label: string }) => (
     <Button
-      variant={statusFilter.includes(status) ? 'default' : 'outline'}
+      variant={statusFilter.includes(status) ? "default" : "outline"}
       size="sm"
       className={cn(
-        'rounded-full',
-        statusFilter.includes(status) && 'bg-pink-500 hover:bg-pink-600'
+        "rounded-full",
+        statusFilter.includes(status) && "bg-pink-500 hover:bg-pink-600",
       )}
       onClick={() => toggleStatusFilter(status)}
     >
       {label}
     </Button>
-  )
+  );
 
   return (
+    <ErrorBoundary>
+
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
@@ -316,7 +353,7 @@ export default function OrderBook() {
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
             <DialogTrigger asChild>
               <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
+                variant={hasActiveFilters ? "default" : "outline"}
                 size="sm"
                 className="relative"
               >
@@ -363,16 +400,22 @@ export default function OrderBook() {
             onClick={() => fetchOrders(true)}
             disabled={isRefreshing}
           >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+            <RefreshCw
+              className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+            />
             Refresh
           </Button>
           <Button variant="outline" size="sm" onClick={exportToCSV}>
             <Download className="h-4 w-4 mr-2" />
             Export
           </Button>
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive" size="sm" disabled={openOrders.length === 0}>
+          <AlertDialog >
+            <AlertDialogTrigger aria-describedby="" asChild>
+              <Button
+                variant="destructive"
+                size="sm"
+                disabled={openOrders.length === 0}
+              >
                 <X className="h-4 w-4 mr-2" />
                 Cancel All
               </Button>
@@ -381,13 +424,15 @@ export default function OrderBook() {
               <AlertDialogHeader>
                 <AlertDialogTitle>Cancel All Orders?</AlertDialogTitle>
                 <AlertDialogDescription>
-                  This will cancel all {openOrders.length} open orders. This action cannot be
-                  undone.
+                  This will cancel all {openOrders.length} open orders. This
+                  action cannot be undone.
                 </AlertDialogDescription>
               </AlertDialogHeader>
               <AlertDialogFooter>
                 <AlertDialogCancel>Keep Orders</AlertDialogCancel>
-                <AlertDialogAction onClick={handleCancelAllOrders}>Cancel All</AlertDialogAction>
+                <AlertDialogAction onClick={handleCancelAllOrders}>
+                  Cancel All
+                </AlertDialogAction>
               </AlertDialogFooter>
             </AlertDialogContent>
           </AlertDialog>
@@ -431,13 +476,17 @@ export default function OrderBook() {
         <Card>
           <CardHeader className="pb-2">
             <CardDescription>Sell Orders</CardDescription>
-            <CardTitle className="text-2xl text-red-600">{stats?.total_sell_orders ?? 0}</CardTitle>
+            <CardTitle className="text-2xl text-red-600">
+              {stats?.total_sell_orders ?? 0}
+            </CardTitle>
           </CardHeader>
         </Card>
         <Card>
           <CardHeader className="pb-2">
             <CardDescription>Completed</CardDescription>
-            <CardTitle className="text-2xl">{stats?.total_completed_orders ?? 0}</CardTitle>
+            <CardTitle className="text-2xl">
+              {stats?.total_completed_orders ?? 0}
+            </CardTitle>
           </CardHeader>
         </Card>
         <Card>
@@ -466,7 +515,9 @@ export default function OrderBook() {
               <Loader2 className="h-8 w-8 animate-spin" />
             </div>
           ) : error ? (
-            <div className="text-center py-12 text-muted-foreground">{error}</div>
+            <div className="text-center py-12 text-muted-foreground">
+              {error}
+            </div>
           ) : filteredOrders.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
               {hasActiveFilters ? (
@@ -477,7 +528,7 @@ export default function OrderBook() {
                   </Button>
                 </div>
               ) : (
-                'No orders today'
+                "No orders today"
               )}
             </div>
           ) : (
@@ -489,8 +540,12 @@ export default function OrderBook() {
                     <TableHead className="w-[80px]">Exchange</TableHead>
                     <TableHead className="w-[70px]">Action</TableHead>
                     <TableHead className="w-[70px] text-right">Qty</TableHead>
-                    <TableHead className="w-[100px] text-right">Price</TableHead>
-                    <TableHead className="w-[100px] text-right">Trigger</TableHead>
+                    <TableHead className="w-[100px] text-right">
+                      Price
+                    </TableHead>
+                    <TableHead className="w-[100px] text-right">
+                      Trigger
+                    </TableHead>
                     <TableHead className="w-[80px]">Type</TableHead>
                     <TableHead className="w-[70px]">Product</TableHead>
                     <TableHead className="w-[140px]">Order ID</TableHead>
@@ -502,25 +557,34 @@ export default function OrderBook() {
                 </TableHeader>
                 <TableBody>
                   {filteredOrders.map((order, index) => {
-                    const status = statusConfig[order.order_status] || statusConfig.open
-                    const StatusIcon = status.icon
-                    const canCancel = order.order_status === 'open'
+                    const status =
+                      statusConfig[order.order_status] || statusConfig.open;
+                    const StatusIcon = status.icon;
+                    const canCancel = order.order_status === "open";
 
                     return (
                       <TableRow key={`${order.orderid}-${index}`}>
-                        <TableCell className="font-medium">{order.symbol}</TableCell>
+                        <TableCell className="font-medium">
+                          {order.symbol}
+                        </TableCell>
                         <TableCell>
                           <Badge variant="outline">{order.exchange}</Badge>
                         </TableCell>
                         <TableCell>
                           <Badge
-                            variant={order.action === 'BUY' ? 'default' : 'destructive'}
-                            className={order.action === 'BUY' ? 'bg-green-500' : ''}
+                            variant={
+                              order.action === "BUY" ? "default" : "destructive"
+                            }
+                            className={
+                              order.action === "BUY" ? "bg-green-500" : ""
+                            }
                           >
                             {order.action}
                           </Badge>
                         </TableCell>
-                        <TableCell className="text-right font-mono">{order.quantity}</TableCell>
+                        <TableCell className="text-right font-mono">
+                          {order.quantity}
+                        </TableCell>
                         <TableCell className="text-right font-mono">
                           {formatCurrency(order.price)}
                         </TableCell>
@@ -533,9 +597,16 @@ export default function OrderBook() {
                         <TableCell>
                           <Badge variant="outline">{order.product}</Badge>
                         </TableCell>
-                        <TableCell className="font-mono text-xs">{order.orderid}</TableCell>
+                        <TableCell className="font-mono text-xs">
+                          {order.orderid}
+                        </TableCell>
                         <TableCell>
-                          <div className={cn('flex items-center gap-1', status.color)}>
+                          <div
+                            className={cn(
+                              "flex items-center gap-1",
+                              status.color,
+                            )}
+                          >
                             <StatusIcon className="h-4 w-4" />
                             <span className="text-sm">{status.label}</span>
                           </div>
@@ -568,7 +639,7 @@ export default function OrderBook() {
                           )}
                         </TableCell>
                       </TableRow>
-                    )
+                    );
                   })}
                 </TableBody>
               </Table>
@@ -584,25 +655,37 @@ export default function OrderBook() {
             <DialogTitle className="flex items-center gap-3">
               <span>Modify Order</span>
               <Badge
-                variant={modifyingOrder?.action === 'BUY' ? 'default' : 'destructive'}
-                className={modifyingOrder?.action === 'BUY' ? 'bg-green-500' : ''}
+                variant={
+                  modifyingOrder?.action === "BUY" ? "default" : "destructive"
+                }
+                className={
+                  modifyingOrder?.action === "BUY" ? "bg-green-500" : ""
+                }
               >
                 {modifyingOrder?.action}
               </Badge>
             </DialogTitle>
-            <DialogDescription className="sr-only">Modify order details</DialogDescription>
+            <DialogDescription className="sr-only">
+              Modify order details
+            </DialogDescription>
           </DialogHeader>
 
           {/* Symbol and Order Info */}
           <div className="rounded-lg border p-4 space-y-3">
             <div className="flex items-center justify-between">
               <div>
-                <div className="text-lg font-semibold">{modifyingOrder?.symbol}</div>
-                <div className="text-sm text-muted-foreground">{modifyingOrder?.exchange}</div>
+                <div className="text-lg font-semibold">
+                  {modifyingOrder?.symbol}
+                </div>
+                <div className="text-sm text-muted-foreground">
+                  {modifyingOrder?.exchange}
+                </div>
               </div>
               <div className="text-right">
                 <div className="text-xs text-muted-foreground">Order ID</div>
-                <div className="font-mono text-sm">{modifyingOrder?.orderid}</div>
+                <div className="font-mono text-sm">
+                  {modifyingOrder?.orderid}
+                </div>
               </div>
             </div>
             <div className="flex items-center gap-3 pt-2 border-t">
@@ -620,7 +703,9 @@ export default function OrderBook() {
               </div>
               <div className="flex items-center gap-2">
                 <span className="text-xs text-muted-foreground">Qty:</span>
-                <span className="font-mono text-sm font-medium">{modifyForm.quantity}</span>
+                <span className="font-mono text-sm font-medium">
+                  {modifyForm.quantity}
+                </span>
               </div>
             </div>
           </div>
@@ -635,19 +720,29 @@ export default function OrderBook() {
               <div className="grid grid-cols-4 gap-4 text-sm">
                 <div>
                   <div className="text-muted-foreground text-xs">LTP</div>
-                  <div className="font-mono font-semibold">{formatCurrency(quotes.ltp)}</div>
+                  <div className="font-mono font-semibold">
+                    {formatCurrency(quotes.ltp)}
+                  </div>
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">Bid</div>
-                  <div className="font-mono text-green-600">{formatCurrency(quotes.bid)}</div>
+                  <div className="font-mono text-green-600">
+                    {formatCurrency(quotes.bid)}
+                  </div>
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">Ask</div>
-                  <div className="font-mono text-red-600">{formatCurrency(quotes.ask)}</div>
+                  <div className="font-mono text-red-600">
+                    {formatCurrency(quotes.ask)}
+                  </div>
                 </div>
                 <div>
-                  <div className="text-muted-foreground text-xs">Prev Close</div>
-                  <div className="font-mono">{formatCurrency(quotes.prev_close)}</div>
+                  <div className="text-muted-foreground text-xs">
+                    Prev Close
+                  </div>
+                  <div className="font-mono">
+                    {formatCurrency(quotes.prev_close)}
+                  </div>
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">Open</div>
@@ -655,20 +750,26 @@ export default function OrderBook() {
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">High</div>
-                  <div className="font-mono text-green-600">{formatCurrency(quotes.high)}</div>
+                  <div className="font-mono text-green-600">
+                    {formatCurrency(quotes.high)}
+                  </div>
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">Low</div>
-                  <div className="font-mono text-red-600">{formatCurrency(quotes.low)}</div>
+                  <div className="font-mono text-red-600">
+                    {formatCurrency(quotes.low)}
+                  </div>
                 </div>
                 <div>
                   <div className="text-muted-foreground text-xs">Volume</div>
-                  <div className="font-mono">{quotes.volume.toLocaleString('en-IN')}</div>
+                  <div className="font-mono">
+                    {quotes.volume.toLocaleString("en-IN")}
+                  </div>
                 </div>
               </div>
             ) : (
               <div className="text-sm text-muted-foreground">
-                {isLoadingQuotes ? 'Loading quotes...' : 'Quotes not available'}
+                {isLoadingQuotes ? "Loading quotes..." : "Quotes not available"}
               </div>
             )}
           </div>
@@ -676,7 +777,8 @@ export default function OrderBook() {
           {/* Editable Fields - Based on Order Type */}
           <div className="grid gap-4 py-2">
             {/* Price field - shown for LIMIT and SL orders */}
-            {(modifyForm.pricetype === 'LIMIT' || modifyForm.pricetype === 'SL') && (
+            {(modifyForm.pricetype === "LIMIT" ||
+              modifyForm.pricetype === "SL") && (
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="price" className="text-right">
                   Price
@@ -687,14 +789,18 @@ export default function OrderBook() {
                   step="0.05"
                   value={modifyForm.price}
                   onChange={(e) =>
-                    setModifyForm({ ...modifyForm, price: parseFloat(e.target.value) || 0 })
+                    setModifyForm({
+                      ...modifyForm,
+                      price: parseFloat(e.target.value) || 0,
+                    })
                   }
                   className="col-span-3"
                 />
               </div>
             )}
             {/* Trigger Price field - shown for SL and SL-M orders */}
-            {(modifyForm.pricetype === 'SL' || modifyForm.pricetype === 'SL-M') && (
+            {(modifyForm.pricetype === "SL" ||
+              modifyForm.pricetype === "SL-M") && (
               <div className="grid grid-cols-4 items-center gap-4">
                 <Label htmlFor="trigger_price" className="text-right">
                   Trigger Price
@@ -705,21 +811,27 @@ export default function OrderBook() {
                   step="0.05"
                   value={modifyForm.trigger_price}
                   onChange={(e) =>
-                    setModifyForm({ ...modifyForm, trigger_price: parseFloat(e.target.value) || 0 })
+                    setModifyForm({
+                      ...modifyForm,
+                      trigger_price: parseFloat(e.target.value) || 0,
+                    })
                   }
                   className="col-span-3"
                 />
               </div>
             )}
             {/* Info for MARKET orders */}
-            {modifyForm.pricetype === 'MARKET' && (
+            {modifyForm.pricetype === "MARKET" && (
               <div className="text-sm text-muted-foreground text-center py-2">
                 Market orders cannot be modified. Cancel and place a new order.
               </div>
             )}
           </div>
           <DialogFooter>
-            <Button variant="outline" onClick={() => setModifyDialogOpen(false)}>
+            <Button
+              variant="outline"
+              onClick={() => setModifyDialogOpen(false)}
+            >
               Cancel
             </Button>
             <Button onClick={handleModifyOrder}>Modify Order</Button>
@@ -727,5 +839,6 @@ export default function OrderBook() {
         </DialogContent>
       </Dialog>
     </div>
-  )
+    </ErrorBoundary>
+  );
 }

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -8,6 +8,8 @@ import {
   Settings2,
   X,
   XCircle,
+  SearchX,
+  Inbox,
 } from "lucide-react";
 import { useCallback, useEffect, useMemo, useState } from "react";
 import { showToast } from "@/utils/toast";
@@ -57,6 +59,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { onModeChange } from "@/stores/themeStore";
 import type { Order, OrderStats } from "@/types/trading";
 import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { EmptyState } from "@/components/ui/empty-state";
 
 function formatTime(timestamp: string): string {
   try {
@@ -340,505 +343,523 @@ export default function OrderBook() {
 
   return (
     <ErrorBoundary>
-
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <h1 className="text-3xl font-bold tracking-tight">Order Book</h1>
-          <p className="text-muted-foreground">View and manage your orders</p>
-        </div>
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* Settings Button */}
-          <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? "default" : "outline"}
-                size="sm"
-                className="relative"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Filters
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Order Filters</DialogTitle>
-                <DialogDescription>Filter orders by status</DialogDescription>
-              </DialogHeader>
-
-              <div className="space-y-6 py-4">
-                {/* Order Status */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Order Status
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip status="complete" label="Complete" />
-                    <FilterChip status="open" label="Open" />
-                    <FilterChip status="rejected" label="Rejected" />
-                    <FilterChip status="cancelled" label="Cancelled" />
-                  </div>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <Button variant="ghost" onClick={clearFilters}>
-                  Clear All
+      <div className="space-y-6">
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <h1 className="text-3xl font-bold tracking-tight">Order Book</h1>
+            <p className="text-muted-foreground">View and manage your orders</p>
+          </div>
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Settings Button */}
+            <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+              <DialogTrigger asChild>
+                <Button
+                  variant={hasActiveFilters ? "default" : "outline"}
+                  size="sm"
+                  className="relative"
+                >
+                  <Settings2 className="h-4 w-4 mr-2" />
+                  Filters
+                  {hasActiveFilters && (
+                    <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                  )}
                 </Button>
-                <Button onClick={() => setSettingsOpen(false)}>Done</Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
+              </DialogTrigger>
+              <DialogContent className="max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Order Filters</DialogTitle>
+                  <DialogDescription>Filter orders by status</DialogDescription>
+                </DialogHeader>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchOrders(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw
-              className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
-            />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
-          <AlertDialog >
-            <AlertDialogTrigger aria-describedby="" asChild>
-              <Button
-                variant="destructive"
-                size="sm"
-                disabled={openOrders.length === 0}
-              >
-                <X className="h-4 w-4 mr-2" />
-                Cancel All
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Cancel All Orders?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will cancel all {openOrders.length} open orders. This
-                  action cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Keep Orders</AlertDialogCancel>
-                <AlertDialogAction onClick={handleCancelAllOrders}>
-                  Cancel All
-                </AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
-      </div>
+                <div className="space-y-6 py-4">
+                  {/* Order Status */}
+                  <div className="space-y-3">
+                    <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Order Status
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      <FilterChip status="complete" label="Complete" />
+                      <FilterChip status="open" label="Open" />
+                      <FilterChip status="rejected" label="Rejected" />
+                      <FilterChip status="cancelled" label="Cancelled" />
+                    </div>
+                  </div>
+                </div>
 
-      {/* Active Filters Bar */}
-      {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-sm text-muted-foreground">Active Filters:</span>
-          {statusFilter.map((status) => (
-            <Badge
-              key={status}
-              variant="secondary"
-              className="bg-pink-500/10 text-pink-600 border-pink-500/30"
-            >
-              {status}
-            </Badge>
-          ))}
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-red-500 border-red-500/50 hover:bg-red-500/10"
-            onClick={clearFilters}
-          >
-            Clear All
-          </Button>
-        </div>
-      )}
-
-      {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-5">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Buy Orders</CardDescription>
-            <CardTitle className="text-2xl text-green-600">
-              {stats?.total_buy_orders ?? 0}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Sell Orders</CardDescription>
-            <CardTitle className="text-2xl text-red-600">
-              {stats?.total_sell_orders ?? 0}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Completed</CardDescription>
-            <CardTitle className="text-2xl">
-              {stats?.total_completed_orders ?? 0}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Open</CardDescription>
-            <CardTitle className="text-2xl text-blue-600">
-              {stats?.total_open_orders ?? 0}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Rejected</CardDescription>
-            <CardTitle className="text-2xl text-red-600">
-              {stats?.total_rejected_orders ?? 0}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-      </div>
-
-      {/* Orders Table */}
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin" />
-            </div>
-          ) : error ? (
-            <div className="text-center py-12 text-muted-foreground">
-              {error}
-            </div>
-          ) : filteredOrders.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              {hasActiveFilters ? (
-                <div>
-                  <p className="mb-4">No orders match your filters</p>
-                  <Button variant="ghost" size="sm" onClick={clearFilters}>
-                    Clear Filters
+                <DialogFooter>
+                  <Button variant="ghost" onClick={clearFilters}>
+                    Clear All
                   </Button>
-                </div>
-              ) : (
-                "No orders today"
-              )}
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <TableHead className="w-[120px]">Symbol</TableHead>
-                    <TableHead className="w-[80px]">Exchange</TableHead>
-                    <TableHead className="w-[70px]">Action</TableHead>
-                    <TableHead className="w-[70px] text-right">Qty</TableHead>
-                    <TableHead className="w-[100px] text-right">
-                      Price
-                    </TableHead>
-                    <TableHead className="w-[100px] text-right">
-                      Trigger
-                    </TableHead>
-                    <TableHead className="w-[80px]">Type</TableHead>
-                    <TableHead className="w-[70px]">Product</TableHead>
-                    <TableHead className="w-[140px]">Order ID</TableHead>
-                    <TableHead className="w-[100px]">Status</TableHead>
-                    <TableHead className="w-[100px]">Time</TableHead>
-                    <TableHead className="w-[60px]">Cancel</TableHead>
-                    <TableHead className="w-[60px]">Modify</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {filteredOrders.map((order, index) => {
-                    const status =
-                      statusConfig[order.order_status] || statusConfig.open;
-                    const StatusIcon = status.icon;
-                    const canCancel = order.order_status === "open";
+                  <Button onClick={() => setSettingsOpen(false)}>Done</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
 
-                    return (
-                      <TableRow key={`${order.orderid}-${index}`}>
-                        <TableCell className="font-medium">
-                          {order.symbol}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline">{order.exchange}</Badge>
-                        </TableCell>
-                        <TableCell>
-                          <Badge
-                            variant={
-                              order.action === "BUY" ? "default" : "destructive"
-                            }
-                            className={
-                              order.action === "BUY" ? "bg-green-500" : ""
-                            }
-                          >
-                            {order.action}
-                          </Badge>
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {order.quantity}
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {formatCurrency(order.price)}
-                        </TableCell>
-                        <TableCell className="text-right font-mono">
-                          {formatCurrency(order.trigger_price)}
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="secondary">{order.pricetype}</Badge>
-                        </TableCell>
-                        <TableCell>
-                          <Badge variant="outline">{order.product}</Badge>
-                        </TableCell>
-                        <TableCell className="font-mono text-xs">
-                          {order.orderid}
-                        </TableCell>
-                        <TableCell>
-                          <div
-                            className={cn(
-                              "flex items-center gap-1",
-                              status.color,
-                            )}
-                          >
-                            <StatusIcon className="h-4 w-4" />
-                            <span className="text-sm">{status.label}</span>
-                          </div>
-                        </TableCell>
-                        <TableCell className="text-sm text-muted-foreground">
-                          {formatTime(order.timestamp)}
-                        </TableCell>
-                        <TableCell>
-                          {canCancel && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
-                              onClick={() => handleCancelOrder(order.orderid)}
-                            >
-                              <X className="h-4 w-4" />
-                            </Button>
-                          )}
-                        </TableCell>
-                        <TableCell>
-                          {canCancel && (
-                            <Button
-                              variant="ghost"
-                              size="icon"
-                              className="h-8 w-8 text-blue-500 hover:text-blue-600"
-                              onClick={() => openModifyDialog(order)}
-                            >
-                              <Pencil className="h-4 w-4" />
-                            </Button>
-                          )}
-                        </TableCell>
-                      </TableRow>
-                    );
-                  })}
-                </TableBody>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-
-      {/* Modify Order Dialog */}
-      <Dialog open={modifyDialogOpen} onOpenChange={setModifyDialogOpen}>
-        <DialogContent className="sm:max-w-[550px]">
-          <DialogHeader>
-            <DialogTitle className="flex items-center gap-3">
-              <span>Modify Order</span>
-              <Badge
-                variant={
-                  modifyingOrder?.action === "BUY" ? "default" : "destructive"
-                }
-                className={
-                  modifyingOrder?.action === "BUY" ? "bg-green-500" : ""
-                }
-              >
-                {modifyingOrder?.action}
-              </Badge>
-            </DialogTitle>
-            <DialogDescription className="sr-only">
-              Modify order details
-            </DialogDescription>
-          </DialogHeader>
-
-          {/* Symbol and Order Info */}
-          <div className="rounded-lg border p-4 space-y-3">
-            <div className="flex items-center justify-between">
-              <div>
-                <div className="text-lg font-semibold">
-                  {modifyingOrder?.symbol}
-                </div>
-                <div className="text-sm text-muted-foreground">
-                  {modifyingOrder?.exchange}
-                </div>
-              </div>
-              <div className="text-right">
-                <div className="text-xs text-muted-foreground">Order ID</div>
-                <div className="font-mono text-sm">
-                  {modifyingOrder?.orderid}
-                </div>
-              </div>
-            </div>
-            <div className="flex items-center gap-3 pt-2 border-t">
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Type:</span>
-                <Badge variant="secondary" className="text-xs">
-                  {modifyForm.pricetype}
-                </Badge>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Product:</span>
-                <Badge variant="outline" className="text-xs">
-                  {modifyForm.product}
-                </Badge>
-              </div>
-              <div className="flex items-center gap-2">
-                <span className="text-xs text-muted-foreground">Qty:</span>
-                <span className="font-mono text-sm font-medium">
-                  {modifyForm.quantity}
-                </span>
-              </div>
-            </div>
-          </div>
-
-          {/* Market Quotes Section */}
-          <div className="rounded-lg border bg-muted/50 p-4">
-            <div className="flex items-center justify-between mb-3">
-              <span className="text-sm font-medium">Market Data</span>
-              {isLoadingQuotes && <Loader2 className="h-4 w-4 animate-spin" />}
-            </div>
-            {quotes ? (
-              <div className="grid grid-cols-4 gap-4 text-sm">
-                <div>
-                  <div className="text-muted-foreground text-xs">LTP</div>
-                  <div className="font-mono font-semibold">
-                    {formatCurrency(quotes.ltp)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">Bid</div>
-                  <div className="font-mono text-green-600">
-                    {formatCurrency(quotes.bid)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">Ask</div>
-                  <div className="font-mono text-red-600">
-                    {formatCurrency(quotes.ask)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">
-                    Prev Close
-                  </div>
-                  <div className="font-mono">
-                    {formatCurrency(quotes.prev_close)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">Open</div>
-                  <div className="font-mono">{formatCurrency(quotes.open)}</div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">High</div>
-                  <div className="font-mono text-green-600">
-                    {formatCurrency(quotes.high)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">Low</div>
-                  <div className="font-mono text-red-600">
-                    {formatCurrency(quotes.low)}
-                  </div>
-                </div>
-                <div>
-                  <div className="text-muted-foreground text-xs">Volume</div>
-                  <div className="font-mono">
-                    {quotes.volume.toLocaleString("en-IN")}
-                  </div>
-                </div>
-              </div>
-            ) : (
-              <div className="text-sm text-muted-foreground">
-                {isLoadingQuotes ? "Loading quotes..." : "Quotes not available"}
-              </div>
-            )}
-          </div>
-
-          {/* Editable Fields - Based on Order Type */}
-          <div className="grid gap-4 py-2">
-            {/* Price field - shown for LIMIT and SL orders */}
-            {(modifyForm.pricetype === "LIMIT" ||
-              modifyForm.pricetype === "SL") && (
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="price" className="text-right">
-                  Price
-                </Label>
-                <Input
-                  id="price"
-                  type="number"
-                  step="0.05"
-                  value={modifyForm.price}
-                  onChange={(e) =>
-                    setModifyForm({
-                      ...modifyForm,
-                      price: parseFloat(e.target.value) || 0,
-                    })
-                  }
-                  className="col-span-3"
-                />
-              </div>
-            )}
-            {/* Trigger Price field - shown for SL and SL-M orders */}
-            {(modifyForm.pricetype === "SL" ||
-              modifyForm.pricetype === "SL-M") && (
-              <div className="grid grid-cols-4 items-center gap-4">
-                <Label htmlFor="trigger_price" className="text-right">
-                  Trigger Price
-                </Label>
-                <Input
-                  id="trigger_price"
-                  type="number"
-                  step="0.05"
-                  value={modifyForm.trigger_price}
-                  onChange={(e) =>
-                    setModifyForm({
-                      ...modifyForm,
-                      trigger_price: parseFloat(e.target.value) || 0,
-                    })
-                  }
-                  className="col-span-3"
-                />
-              </div>
-            )}
-            {/* Info for MARKET orders */}
-            {modifyForm.pricetype === "MARKET" && (
-              <div className="text-sm text-muted-foreground text-center py-2">
-                Market orders cannot be modified. Cancel and place a new order.
-              </div>
-            )}
-          </div>
-          <DialogFooter>
             <Button
               variant="outline"
-              onClick={() => setModifyDialogOpen(false)}
+              size="sm"
+              onClick={() => fetchOrders(true)}
+              disabled={isRefreshing}
             >
-              Cancel
+              <RefreshCw
+                className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+              />
+              Refresh
             </Button>
-            <Button onClick={handleModifyOrder}>Modify Order</Button>
-          </DialogFooter>
-        </DialogContent>
-      </Dialog>
-    </div>
+            <Button variant="outline" size="sm" onClick={exportToCSV}>
+              <Download className="h-4 w-4 mr-2" />
+              Export
+            </Button>
+            <AlertDialog>
+              <AlertDialogTrigger aria-describedby="" asChild>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={openOrders.length === 0}
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  Cancel All
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Cancel All Orders?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will cancel all {openOrders.length} open orders. This
+                    action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Keep Orders</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleCancelAllOrders}>
+                    Cancel All
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+
+        {/* Active Filters Bar */}
+        {hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm text-muted-foreground">
+              Active Filters:
+            </span>
+            {statusFilter.map((status) => (
+              <Badge
+                key={status}
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                {status}
+              </Badge>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-500 border-red-500/50 hover:bg-red-500/10"
+              onClick={clearFilters}
+            >
+              Clear All
+            </Button>
+          </div>
+        )}
+
+        {/* Stats Cards */}
+        <div className="grid gap-4 md:grid-cols-5">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Buy Orders</CardDescription>
+              <CardTitle className="text-2xl text-green-600">
+                {stats?.total_buy_orders ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Sell Orders</CardDescription>
+              <CardTitle className="text-2xl text-red-600">
+                {stats?.total_sell_orders ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Completed</CardDescription>
+              <CardTitle className="text-2xl">
+                {stats?.total_completed_orders ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Open</CardDescription>
+              <CardTitle className="text-2xl text-blue-600">
+                {stats?.total_open_orders ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Rejected</CardDescription>
+              <CardTitle className="text-2xl text-red-600">
+                {stats?.total_rejected_orders ?? 0}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        {/* Orders Table */}
+        <Card>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin" />
+              </div>
+            ) : error ? (
+              <div className="text-center py-12 text-muted-foreground">
+                {error}
+              </div>
+            ) : filteredOrders.length === 0 ? (
+              hasActiveFilters ? (
+                <EmptyState
+                  icon={SearchX}
+                  title="No orders match your filters"
+                  description="Try adjusting your filters to find what you're looking for."
+                  action={
+                    <Button variant="ghost" size="sm" onClick={clearFilters}>
+                      Clear Filters
+                    </Button>
+                  }
+                />
+              ) : (
+                <EmptyState
+                  icon={Inbox}
+                  title="No orders today"
+                  description="You haven't placed any orders yet."
+                />
+              )
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead className="w-[120px]">Symbol</TableHead>
+                      <TableHead className="w-[80px]">Exchange</TableHead>
+                      <TableHead className="w-[70px]">Action</TableHead>
+                      <TableHead className="w-[70px] text-right">Qty</TableHead>
+                      <TableHead className="w-[100px] text-right">
+                        Price
+                      </TableHead>
+                      <TableHead className="w-[100px] text-right">
+                        Trigger
+                      </TableHead>
+                      <TableHead className="w-[80px]">Type</TableHead>
+                      <TableHead className="w-[70px]">Product</TableHead>
+                      <TableHead className="w-[140px]">Order ID</TableHead>
+                      <TableHead className="w-[100px]">Status</TableHead>
+                      <TableHead className="w-[100px]">Time</TableHead>
+                      <TableHead className="w-[60px]">Cancel</TableHead>
+                      <TableHead className="w-[60px]">Modify</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {filteredOrders.map((order, index) => {
+                      const status =
+                        statusConfig[order.order_status] || statusConfig.open;
+                      const StatusIcon = status.icon;
+                      const canCancel = order.order_status === "open";
+
+                      return (
+                        <TableRow key={`${order.orderid}-${index}`}>
+                          <TableCell className="font-medium">
+                            {order.symbol}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline">{order.exchange}</Badge>
+                          </TableCell>
+                          <TableCell>
+                            <Badge
+                              variant={
+                                order.action === "BUY"
+                                  ? "default"
+                                  : "destructive"
+                              }
+                              className={
+                                order.action === "BUY" ? "bg-green-500" : ""
+                              }
+                            >
+                              {order.action}
+                            </Badge>
+                          </TableCell>
+                          <TableCell className="text-right font-mono">
+                            {order.quantity}
+                          </TableCell>
+                          <TableCell className="text-right font-mono">
+                            {formatCurrency(order.price)}
+                          </TableCell>
+                          <TableCell className="text-right font-mono">
+                            {formatCurrency(order.trigger_price)}
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="secondary">{order.pricetype}</Badge>
+                          </TableCell>
+                          <TableCell>
+                            <Badge variant="outline">{order.product}</Badge>
+                          </TableCell>
+                          <TableCell className="font-mono text-xs">
+                            {order.orderid}
+                          </TableCell>
+                          <TableCell>
+                            <div
+                              className={cn(
+                                "flex items-center gap-1",
+                                status.color,
+                              )}
+                            >
+                              <StatusIcon className="h-4 w-4" />
+                              <span className="text-sm">{status.label}</span>
+                            </div>
+                          </TableCell>
+                          <TableCell className="text-sm text-muted-foreground">
+                            {formatTime(order.timestamp)}
+                          </TableCell>
+                          <TableCell>
+                            {canCancel && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 text-destructive hover:text-destructive hover:bg-destructive/10"
+                                onClick={() => handleCancelOrder(order.orderid)}
+                              >
+                                <X className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </TableCell>
+                          <TableCell>
+                            {canCancel && (
+                              <Button
+                                variant="ghost"
+                                size="icon"
+                                className="h-8 w-8 text-blue-500 hover:text-blue-600"
+                                onClick={() => openModifyDialog(order)}
+                              >
+                                <Pencil className="h-4 w-4" />
+                              </Button>
+                            )}
+                          </TableCell>
+                        </TableRow>
+                      );
+                    })}
+                  </TableBody>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+
+        {/* Modify Order Dialog */}
+        <Dialog open={modifyDialogOpen} onOpenChange={setModifyDialogOpen}>
+          <DialogContent className="sm:max-w-[550px]">
+            <DialogHeader>
+              <DialogTitle className="flex items-center gap-3">
+                <span>Modify Order</span>
+                <Badge
+                  variant={
+                    modifyingOrder?.action === "BUY" ? "default" : "destructive"
+                  }
+                  className={
+                    modifyingOrder?.action === "BUY" ? "bg-green-500" : ""
+                  }
+                >
+                  {modifyingOrder?.action}
+                </Badge>
+              </DialogTitle>
+              <DialogDescription className="sr-only">
+                Modify order details
+              </DialogDescription>
+            </DialogHeader>
+
+            {/* Symbol and Order Info */}
+            <div className="rounded-lg border p-4 space-y-3">
+              <div className="flex items-center justify-between">
+                <div>
+                  <div className="text-lg font-semibold">
+                    {modifyingOrder?.symbol}
+                  </div>
+                  <div className="text-sm text-muted-foreground">
+                    {modifyingOrder?.exchange}
+                  </div>
+                </div>
+                <div className="text-right">
+                  <div className="text-xs text-muted-foreground">Order ID</div>
+                  <div className="font-mono text-sm">
+                    {modifyingOrder?.orderid}
+                  </div>
+                </div>
+              </div>
+              <div className="flex items-center gap-3 pt-2 border-t">
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">Type:</span>
+                  <Badge variant="secondary" className="text-xs">
+                    {modifyForm.pricetype}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">
+                    Product:
+                  </span>
+                  <Badge variant="outline" className="text-xs">
+                    {modifyForm.product}
+                  </Badge>
+                </div>
+                <div className="flex items-center gap-2">
+                  <span className="text-xs text-muted-foreground">Qty:</span>
+                  <span className="font-mono text-sm font-medium">
+                    {modifyForm.quantity}
+                  </span>
+                </div>
+              </div>
+            </div>
+
+            {/* Market Quotes Section */}
+            <div className="rounded-lg border bg-muted/50 p-4">
+              <div className="flex items-center justify-between mb-3">
+                <span className="text-sm font-medium">Market Data</span>
+                {isLoadingQuotes && (
+                  <Loader2 className="h-4 w-4 animate-spin" />
+                )}
+              </div>
+              {quotes ? (
+                <div className="grid grid-cols-4 gap-4 text-sm">
+                  <div>
+                    <div className="text-muted-foreground text-xs">LTP</div>
+                    <div className="font-mono font-semibold">
+                      {formatCurrency(quotes.ltp)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">Bid</div>
+                    <div className="font-mono text-green-600">
+                      {formatCurrency(quotes.bid)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">Ask</div>
+                    <div className="font-mono text-red-600">
+                      {formatCurrency(quotes.ask)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">
+                      Prev Close
+                    </div>
+                    <div className="font-mono">
+                      {formatCurrency(quotes.prev_close)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">Open</div>
+                    <div className="font-mono">
+                      {formatCurrency(quotes.open)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">High</div>
+                    <div className="font-mono text-green-600">
+                      {formatCurrency(quotes.high)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">Low</div>
+                    <div className="font-mono text-red-600">
+                      {formatCurrency(quotes.low)}
+                    </div>
+                  </div>
+                  <div>
+                    <div className="text-muted-foreground text-xs">Volume</div>
+                    <div className="font-mono">
+                      {quotes.volume.toLocaleString("en-IN")}
+                    </div>
+                  </div>
+                </div>
+              ) : (
+                <div className="text-sm text-muted-foreground">
+                  {isLoadingQuotes
+                    ? "Loading quotes..."
+                    : "Quotes not available"}
+                </div>
+              )}
+            </div>
+
+            {/* Editable Fields - Based on Order Type */}
+            <div className="grid gap-4 py-2">
+              {/* Price field - shown for LIMIT and SL orders */}
+              {(modifyForm.pricetype === "LIMIT" ||
+                modifyForm.pricetype === "SL") && (
+                <div className="grid grid-cols-4 items-center gap-4">
+                  <Label htmlFor="price" className="text-right">
+                    Price
+                  </Label>
+                  <Input
+                    id="price"
+                    type="number"
+                    step="0.05"
+                    value={modifyForm.price}
+                    onChange={(e) =>
+                      setModifyForm({
+                        ...modifyForm,
+                        price: parseFloat(e.target.value) || 0,
+                      })
+                    }
+                    className="col-span-3"
+                  />
+                </div>
+              )}
+              {/* Trigger Price field - shown for SL and SL-M orders */}
+              {(modifyForm.pricetype === "SL" ||
+                modifyForm.pricetype === "SL-M") && (
+                <div className="grid grid-cols-4 items-center gap-4">
+                  <Label htmlFor="trigger_price" className="text-right">
+                    Trigger Price
+                  </Label>
+                  <Input
+                    id="trigger_price"
+                    type="number"
+                    step="0.05"
+                    value={modifyForm.trigger_price}
+                    onChange={(e) =>
+                      setModifyForm({
+                        ...modifyForm,
+                        trigger_price: parseFloat(e.target.value) || 0,
+                      })
+                    }
+                    className="col-span-3"
+                  />
+                </div>
+              )}
+              {/* Info for MARKET orders */}
+              {modifyForm.pricetype === "MARKET" && (
+                <div className="text-sm text-muted-foreground text-center py-2">
+                  Market orders cannot be modified. Cancel and place a new
+                  order.
+                </div>
+              )}
+            </div>
+            <DialogFooter>
+              <Button
+                variant="outline"
+                onClick={() => setModifyDialogOpen(false)}
+              >
+                Cancel
+              </Button>
+              <Button onClick={handleModifyOrder}>Modify Order</Button>
+            </DialogFooter>
+          </DialogContent>
+        </Dialog>
+      </div>
     </ErrorBoundary>
   );
 }

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -289,6 +289,10 @@ export default function OrderBook() {
   };
 
   const exportToCSV = () => {
+    if (orders.length === 0) {
+      showToast.error("No data to export", "system");
+      return;
+    }
     const headers = [
       "Symbol",
       "Exchange",
@@ -323,6 +327,7 @@ export default function OrderBook() {
     a.href = url;
     a.download = `orderbook_${new Date().toISOString().split("T")[0]}.csv`;
     a.click();
+    showToast.success("Downloaded orders.csv", "clipboard");
   };
 
   const openOrders = orders.filter((o) => o.order_status === "open");

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -56,6 +56,7 @@ import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 const STORAGE_KEY = 'openalgo_positions_prefs'
 
@@ -570,6 +571,8 @@ export default function Positions() {
   })
 
   return (
+    <ErrorBoundary>
+
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -1023,5 +1026,6 @@ export default function Positions() {
         </CardContent>
       </Card>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -520,6 +520,10 @@ export default function Positions() {
   };
 
   const exportToCSV = () => {
+    if (filteredPositions.length === 0) {
+      showToast.error("No data to export", "system");
+      return;
+    }
     const headers = [
       "Symbol",
       "Exchange",
@@ -548,8 +552,8 @@ export default function Positions() {
     a.href = url;
     a.download = `positions_${new Date().toISOString().split("T")[0]}.csv`;
     a.click();
-    // Revoke the object URL to free memory
     URL.revokeObjectURL(url);
+    showToast.success("Downloaded positions.csv", "clipboard");
   };
 
   const isProfit = (value: number) => value >= 0;

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -12,11 +12,19 @@ import {
   TrendingDown,
   TrendingUp,
   X,
-} from 'lucide-react'
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
-import { showToast } from '@/utils/toast'
-import { tradingApi } from '@/api/trading'
-import { Alert, AlertDescription } from '@/components/ui/alert'
+  SearchX,
+  Inbox,
+} from "lucide-react";
+import React, {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+} from "react";
+import { showToast } from "@/utils/toast";
+import { tradingApi } from "@/api/trading";
+import { Alert, AlertDescription } from "@/components/ui/alert";
 import {
   AlertDialog,
   AlertDialogAction,
@@ -27,10 +35,16 @@ import {
   AlertDialogHeader,
   AlertDialogTitle,
   AlertDialogTrigger,
-} from '@/components/ui/alert-dialog'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+} from "@/components/ui/alert-dialog";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -39,8 +53,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -49,433 +63,473 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { useLivePrice } from '@/hooks/useLivePrice'
-import { usePageVisibility } from '@/hooks/usePageVisibility'
-import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
-import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
-import type { Position } from '@/types/trading'
-import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
+} from "@/components/ui/table";
+import { useLivePrice } from "@/hooks/useLivePrice";
+import { usePageVisibility } from "@/hooks/usePageVisibility";
+import { cn, makeFormatCurrency, sanitizeCSV } from "@/lib/utils";
+import { useAuthStore } from "@/stores/authStore";
+import { onModeChange } from "@/stores/themeStore";
+import type { Position } from "@/types/trading";
+import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { EmptyState } from "@/components/ui/empty-state";
 
-const STORAGE_KEY = 'openalgo_positions_prefs'
+const STORAGE_KEY = "openalgo_positions_prefs";
 
-type GroupingType = 'none' | 'underlying' | 'underlying_expiry'
-type SortColumn = 0 | 3 | 4 | 6 | 7 | null
-type SortDirection = 'asc' | 'desc'
+type GroupingType = "none" | "underlying" | "underlying_expiry";
+type SortColumn = 0 | 3 | 4 | 6 | 7 | null;
+type SortDirection = "asc" | "desc";
 
 interface FilterState {
-  product: string[]
-  direction: string[]
-  exchange: string[]
+  product: string[];
+  direction: string[];
+  exchange: string[];
 }
 
 interface Preferences {
-  grouping: GroupingType
-  filters: FilterState
+  grouping: GroupingType;
+  filters: FilterState;
 }
 
 function parseSymbol(symbol: string, exchange: string) {
-  if (exchange === 'NSE' || exchange === 'BSE') {
-    return { underlying: symbol, expiry: null, strike: null, optionType: null }
+  if (exchange === "NSE" || exchange === "BSE") {
+    return { underlying: symbol, expiry: null, strike: null, optionType: null };
   }
 
-  const futMatch = symbol.match(/^(.+?)(\d{1,2}[A-Z]{3}\d{2})FUT$/i)
+  const futMatch = symbol.match(/^(.+?)(\d{1,2}[A-Z]{3}\d{2})FUT$/i);
   if (futMatch) {
-    return { underlying: futMatch[1], expiry: futMatch[2], strike: null, optionType: 'FUT' }
+    return {
+      underlying: futMatch[1],
+      expiry: futMatch[2],
+      strike: null,
+      optionType: "FUT",
+    };
   }
 
-  const optMatch = symbol.match(/^(.+?)(\d{1,2}[A-Z]{3}\d{2})(\d+\.?\d*)(CE|PE)$/i)
+  const optMatch = symbol.match(
+    /^(.+?)(\d{1,2}[A-Z]{3}\d{2})(\d+\.?\d*)(CE|PE)$/i,
+  );
   if (optMatch) {
     return {
       underlying: optMatch[1],
       expiry: optMatch[2],
       strike: optMatch[3],
       optionType: optMatch[4],
-    }
+    };
   }
 
-  return { underlying: symbol, expiry: null, strike: null, optionType: null }
+  return { underlying: symbol, expiry: null, strike: null, optionType: null };
 }
 
 function calculatePnlPercent(position: Position): number {
-  const avgPrice = Number(position.average_price) || 0
-  const qty = Number(position.quantity) || 0
-  const pnl = Number(position.pnl) || 0
+  const avgPrice = Number(position.average_price) || 0;
+  const qty = Number(position.quantity) || 0;
+  const pnl = Number(position.pnl) || 0;
 
   // Use API-provided pnlpercent if available
   if (position.pnlpercent !== undefined && position.pnlpercent !== null) {
-    return Number(position.pnlpercent) || 0
+    return Number(position.pnlpercent) || 0;
   }
 
-  if (avgPrice === 0) return 0
+  if (avgPrice === 0) return 0;
 
   // For open positions with quantity, calculate based on investment
   if (qty !== 0) {
-    const investment = Math.abs(avgPrice * qty)
-    return investment > 0 ? (pnl / investment) * 100 : 0
+    const investment = Math.abs(avgPrice * qty);
+    return investment > 0 ? (pnl / investment) * 100 : 0;
   }
 
   // For closed positions (qty=0), return 0% like Zerodha
   // We cannot reliably calculate P&L% without knowing the original quantity
   // The P&L amount is still shown correctly from the API
-  return 0
+  return 0;
 }
 
 const EXCHANGE_COLORS: Record<string, string> = {
-  NSE: 'bg-cyan-500/20 text-cyan-600 border-cyan-500/30',
-  BSE: 'bg-slate-500/20 text-slate-600 border-slate-500/30',
-  NFO: 'bg-purple-500/20 text-purple-600 border-purple-500/30',
-  BFO: 'bg-amber-500/20 text-amber-600 border-amber-500/30',
-  MCX: 'bg-blue-500/20 text-blue-600 border-blue-500/30',
-  CDS: 'bg-teal-500/20 text-teal-600 border-teal-500/30',
-}
+  NSE: "bg-cyan-500/20 text-cyan-600 border-cyan-500/30",
+  BSE: "bg-slate-500/20 text-slate-600 border-slate-500/30",
+  NFO: "bg-purple-500/20 text-purple-600 border-purple-500/30",
+  BFO: "bg-amber-500/20 text-amber-600 border-amber-500/30",
+  MCX: "bg-blue-500/20 text-blue-600 border-blue-500/30",
+  CDS: "bg-teal-500/20 text-teal-600 border-teal-500/30",
+};
 
 const PRODUCT_COLORS: Record<string, string> = {
-  CNC: 'bg-purple-500/20 text-purple-600 border-purple-500/30',
-  MIS: 'bg-cyan-500/20 text-cyan-600 border-cyan-500/30',
-  NRML: 'bg-slate-500/20 text-slate-600 border-slate-500/30',
-}
+  CNC: "bg-purple-500/20 text-purple-600 border-purple-500/30",
+  MIS: "bg-cyan-500/20 text-cyan-600 border-cyan-500/30",
+  NRML: "bg-slate-500/20 text-slate-600 border-slate-500/30",
+};
 
 export default function Positions() {
-  const { apiKey, user } = useAuthStore()
-  const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
-  const [positions, setPositions] = useState<Position[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
-  const [showStaleWarning, setShowStaleWarning] = useState(false)
+  const { apiKey, user } = useAuthStore();
+  const formatCurrency = useMemo(
+    () => makeFormatCurrency(user?.broker),
+    [user?.broker],
+  );
+  const [positions, setPositions] = useState<Position[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [showStaleWarning, setShowStaleWarning] = useState(false);
 
   // Page visibility tracking for resource optimization
-  const { isVisible, wasHidden, timeSinceHidden } = usePageVisibility()
-  const lastFetchRef = useRef<number>(Date.now())
+  const { isVisible, wasHidden, timeSinceHidden } = usePageVisibility();
+  const lastFetchRef = useRef<number>(Date.now());
 
   // Filter and grouping state
-  const [grouping, setGrouping] = useState<GroupingType>('none')
+  const [grouping, setGrouping] = useState<GroupingType>("none");
   const [filters, setFilters] = useState<FilterState>({
     product: [],
     direction: [],
     exchange: [],
-  })
-  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(new Set())
-  const [sortColumn, setSortColumn] = useState<SortColumn>(null)
-  const [sortDirection, setSortDirection] = useState<SortDirection>('asc')
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  });
+  const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(
+    new Set(),
+  );
+  const [sortColumn, setSortColumn] = useState<SortColumn>(null);
+  const [sortDirection, setSortDirection] = useState<SortDirection>("asc");
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Centralized real-time price hook with WebSocket + MultiQuotes fallback
   // Automatically pauses when tab is hidden
-  const { data: enhancedPositions, isLive, isPaused } = useLivePrice(positions, {
+  const {
+    data: enhancedPositions,
+    isLive,
+    isPaused,
+  } = useLivePrice(positions, {
     enabled: positions.length > 0,
     useMultiQuotesFallback: true,
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,
     pauseWhenHidden: true,
-  })
+  });
 
   // Load preferences from localStorage
   useEffect(() => {
     try {
-      const saved = localStorage.getItem(STORAGE_KEY)
+      const saved = localStorage.getItem(STORAGE_KEY);
       if (saved) {
-        const prefs: Preferences = JSON.parse(saved)
-        if (prefs.grouping) setGrouping(prefs.grouping)
+        const prefs: Preferences = JSON.parse(saved);
+        if (prefs.grouping) setGrouping(prefs.grouping);
         if (prefs.filters)
           setFilters({
             product: prefs.filters.product || [],
             direction: prefs.filters.direction || [],
             exchange: prefs.filters.exchange || [],
-          })
+          });
       }
-    } catch (e) {
-    }
-  }, [])
+    } catch (e) {}
+  }, []);
 
   // Save preferences to localStorage
   const savePreferences = useCallback(() => {
-    localStorage.setItem(STORAGE_KEY, JSON.stringify({ grouping, filters }))
-  }, [grouping, filters])
+    localStorage.setItem(STORAGE_KEY, JSON.stringify({ grouping, filters }));
+  }, [grouping, filters]);
 
   useEffect(() => {
-    savePreferences()
-  }, [savePreferences])
+    savePreferences();
+  }, [savePreferences]);
 
   const fetchPositions = useCallback(
     async (showRefresh = false) => {
       if (!apiKey) {
-        setIsLoading(false)
-        return
+        setIsLoading(false);
+        return;
       }
 
-      if (showRefresh) setIsRefreshing(true)
+      if (showRefresh) setIsRefreshing(true);
 
       try {
-        const response = await tradingApi.getPositions(apiKey)
-        if (response.status === 'success' && response.data) {
-          setPositions(response.data)
-          setError(null)
+        const response = await tradingApi.getPositions(apiKey);
+        if (response.status === "success" && response.data) {
+          setPositions(response.data);
+          setError(null);
         } else {
-          setError(response.message || 'Failed to fetch positions')
+          setError(response.message || "Failed to fetch positions");
         }
       } catch {
-        setError('Failed to fetch positions')
+        setError("Failed to fetch positions");
       } finally {
-        setIsLoading(false)
-        setIsRefreshing(false)
+        setIsLoading(false);
+        setIsRefreshing(false);
       }
     },
-    [apiKey]
-  )
+    [apiKey],
+  );
 
   // Initial fetch and visibility-aware polling
   // Pauses polling when tab is hidden to save resources
   useEffect(() => {
     // Don't poll when tab is hidden
-    if (!isVisible) return
+    if (!isVisible) return;
 
-    fetchPositions()
-    lastFetchRef.current = Date.now()
+    fetchPositions();
+    lastFetchRef.current = Date.now();
 
     // Reduce polling interval when live (WebSocket connected AND market open)
-    const intervalMs = isLive ? 30000 : 10000
+    const intervalMs = isLive ? 30000 : 10000;
     const interval = setInterval(() => {
-      fetchPositions()
-      lastFetchRef.current = Date.now()
-    }, intervalMs)
+      fetchPositions();
+      lastFetchRef.current = Date.now();
+    }, intervalMs);
 
-    return () => clearInterval(interval)
-  }, [fetchPositions, isLive, isVisible])
+    return () => clearInterval(interval);
+  }, [fetchPositions, isLive, isVisible]);
 
   // Refresh data when tab becomes visible after being hidden
   useEffect(() => {
-    if (!wasHidden || !isVisible) return
+    if (!wasHidden || !isVisible) return;
 
-    const timeSinceLastFetch = Date.now() - lastFetchRef.current
+    const timeSinceLastFetch = Date.now() - lastFetchRef.current;
 
     // If hidden for more than 30 seconds, show stale warning and refresh
     if (timeSinceHidden > 30000 || timeSinceLastFetch > 30000) {
-      setShowStaleWarning(true)
-      fetchPositions()
-      lastFetchRef.current = Date.now()
+      setShowStaleWarning(true);
+      fetchPositions();
+      lastFetchRef.current = Date.now();
 
       // Hide the warning after 5 seconds
-      const timeout = setTimeout(() => setShowStaleWarning(false), 5000)
-      return () => clearTimeout(timeout)
+      const timeout = setTimeout(() => setShowStaleWarning(false), 5000);
+      return () => clearTimeout(timeout);
     }
-  }, [wasHidden, isVisible, timeSinceHidden, fetchPositions])
+  }, [wasHidden, isVisible, timeSinceHidden, fetchPositions]);
 
   // Listen for mode changes (live/analyze) and refresh data
   useEffect(() => {
     const unsubscribe = onModeChange(() => {
-      fetchPositions()
-    })
-    return () => unsubscribe()
-  }, [fetchPositions])
+      fetchPositions();
+    });
+    return () => unsubscribe();
+  }, [fetchPositions]);
 
   // Get group key for a position
   const getGroupKey = useCallback(
     (pos: Position): string => {
-      const exchange = pos.exchange
-      const product = pos.product
+      const exchange = pos.exchange;
+      const product = pos.product;
 
-      if (exchange === 'NSE' || exchange === 'BSE') {
-        if (product === 'CNC') return 'Equity (Delivery)'
-        if (product === 'MIS') return 'Equity (Intraday)'
+      if (exchange === "NSE" || exchange === "BSE") {
+        if (product === "CNC") return "Equity (Delivery)";
+        if (product === "MIS") return "Equity (Intraday)";
       }
 
-      const parsed = parseSymbol(pos.symbol, exchange)
+      const parsed = parseSymbol(pos.symbol, exchange);
 
-      if (grouping === 'underlying') {
-        return parsed.underlying
-      } else if (grouping === 'underlying_expiry') {
-        return parsed.expiry ? `${parsed.underlying} - ${parsed.expiry}` : parsed.underlying
+      if (grouping === "underlying") {
+        return parsed.underlying;
+      } else if (grouping === "underlying_expiry") {
+        return parsed.expiry
+          ? `${parsed.underlying} - ${parsed.expiry}`
+          : parsed.underlying;
       }
 
-      return parsed.underlying
+      return parsed.underlying;
     },
-    [grouping]
-  )
+    [grouping],
+  );
 
   // Filter positions (use enhancedPositions for real-time LTP/PnL)
   const filteredPositions = useMemo(() => {
     return enhancedPositions.filter((pos) => {
-      if (filters.product.length > 0 && !filters.product.includes(pos.product)) return false
+      if (filters.product.length > 0 && !filters.product.includes(pos.product))
+        return false;
 
-      const qty = pos.quantity || 0
+      const qty = pos.quantity || 0;
       if (filters.direction.length > 0) {
-        const isLong = qty > 0
-        const isShort = qty < 0
-        if (filters.direction.includes('LONG') && !filters.direction.includes('SHORT') && !isLong)
-          return false
-        if (filters.direction.includes('SHORT') && !filters.direction.includes('LONG') && !isShort)
-          return false
+        const isLong = qty > 0;
+        const isShort = qty < 0;
+        if (
+          filters.direction.includes("LONG") &&
+          !filters.direction.includes("SHORT") &&
+          !isLong
+        )
+          return false;
+        if (
+          filters.direction.includes("SHORT") &&
+          !filters.direction.includes("LONG") &&
+          !isShort
+        )
+          return false;
       }
 
-      if (filters.exchange.length > 0 && !filters.exchange.includes(pos.exchange)) return false
+      if (
+        filters.exchange.length > 0 &&
+        !filters.exchange.includes(pos.exchange)
+      )
+        return false;
 
-      return true
-    })
-  }, [enhancedPositions, filters])
+      return true;
+    });
+  }, [enhancedPositions, filters]);
 
   // Sort positions
   const sortedPositions = useMemo(() => {
-    if (sortColumn === null) return filteredPositions
+    if (sortColumn === null) return filteredPositions;
 
     return [...filteredPositions].sort((a, b) => {
-      let aVal: string | number
-      let bVal: string | number
+      let aVal: string | number;
+      let bVal: string | number;
 
       switch (sortColumn) {
         case 0:
-          aVal = a.symbol
-          bVal = b.symbol
-          break
+          aVal = a.symbol;
+          bVal = b.symbol;
+          break;
         case 3:
-          aVal = a.quantity || 0
-          bVal = b.quantity || 0
-          break
+          aVal = a.quantity || 0;
+          bVal = b.quantity || 0;
+          break;
         case 4:
-          aVal = a.average_price || 0
-          bVal = b.average_price || 0
-          break
+          aVal = a.average_price || 0;
+          bVal = b.average_price || 0;
+          break;
         case 6:
-          aVal = a.pnl || 0
-          bVal = b.pnl || 0
-          break
+          aVal = a.pnl || 0;
+          bVal = b.pnl || 0;
+          break;
         case 7:
-          aVal = calculatePnlPercent(a)
-          bVal = calculatePnlPercent(b)
-          break
+          aVal = calculatePnlPercent(a);
+          bVal = calculatePnlPercent(b);
+          break;
         default:
-          return 0
+          return 0;
       }
 
-      if (typeof aVal === 'string') {
-        return sortDirection === 'asc'
+      if (typeof aVal === "string") {
+        return sortDirection === "asc"
           ? aVal.localeCompare(bVal as string)
-          : (bVal as string).localeCompare(aVal)
+          : (bVal as string).localeCompare(aVal);
       }
-      return sortDirection === 'asc'
+      return sortDirection === "asc"
         ? (aVal as number) - (bVal as number)
-        : (bVal as number) - (aVal as number)
-    })
-  }, [filteredPositions, sortColumn, sortDirection])
+        : (bVal as number) - (aVal as number);
+    });
+  }, [filteredPositions, sortColumn, sortDirection]);
 
   // Group positions
   const groupedPositions = useMemo(() => {
-    if (grouping === 'none') {
-      return { _all: sortedPositions }
+    if (grouping === "none") {
+      return { _all: sortedPositions };
     }
 
-    const groups: Record<string, Position[]> = {}
+    const groups: Record<string, Position[]> = {};
     sortedPositions.forEach((pos) => {
-      const groupKey = getGroupKey(pos)
-      if (!groups[groupKey]) groups[groupKey] = []
-      groups[groupKey].push(pos)
-    })
+      const groupKey = getGroupKey(pos);
+      if (!groups[groupKey]) groups[groupKey] = [];
+      groups[groupKey].push(pos);
+    });
 
-    return groups
-  }, [sortedPositions, grouping, getGroupKey])
+    return groups;
+  }, [sortedPositions, grouping, getGroupKey]);
 
   // Calculate stats
   const stats = useMemo(() => {
-    const long = filteredPositions.filter((p) => (p.quantity || 0) > 0).length
-    const short = filteredPositions.filter((p) => (p.quantity || 0) < 0).length
+    const long = filteredPositions.filter((p) => (p.quantity || 0) > 0).length;
+    const short = filteredPositions.filter((p) => (p.quantity || 0) < 0).length;
     // Only count positions with non-zero quantity as "open"
-    const total = long + short
-    const totalPnl = filteredPositions.reduce((sum, p) => sum + (p.pnl || 0), 0)
-    return { total, long, short, totalPnl }
-  }, [filteredPositions])
+    const total = long + short;
+    const totalPnl = filteredPositions.reduce(
+      (sum, p) => sum + (p.pnl || 0),
+      0,
+    );
+    return { total, long, short, totalPnl };
+  }, [filteredPositions]);
 
   const handleSort = (column: SortColumn) => {
     if (sortColumn === column) {
-      setSortDirection(sortDirection === 'asc' ? 'desc' : 'asc')
+      setSortDirection(sortDirection === "asc" ? "desc" : "asc");
     } else {
-      setSortColumn(column)
-      setSortDirection('asc')
+      setSortColumn(column);
+      setSortDirection("asc");
     }
-  }
+  };
 
   const toggleFilter = (type: keyof FilterState, value: string) => {
     setFilters((prev) => {
-      const arr = prev[type]
-      const index = arr.indexOf(value)
+      const arr = prev[type];
+      const index = arr.indexOf(value);
       if (index > -1) {
-        return { ...prev, [type]: arr.filter((v) => v !== value) }
+        return { ...prev, [type]: arr.filter((v) => v !== value) };
       }
-      return { ...prev, [type]: [...arr, value] }
-    })
-  }
+      return { ...prev, [type]: [...arr, value] };
+    });
+  };
 
   const clearFilters = () => {
-    setFilters({ product: [], direction: [], exchange: [] })
-    setGrouping('none')
-    setCollapsedGroups(new Set())
-  }
+    setFilters({ product: [], direction: [], exchange: [] });
+    setGrouping("none");
+    setCollapsedGroups(new Set());
+  };
 
   const toggleGroup = (groupKey: string) => {
     setCollapsedGroups((prev) => {
-      const next = new Set(prev)
+      const next = new Set(prev);
       if (next.has(groupKey)) {
-        next.delete(groupKey)
+        next.delete(groupKey);
       } else {
-        next.add(groupKey)
+        next.add(groupKey);
       }
-      return next
-    })
-  }
+      return next;
+    });
+  };
 
   const hasActiveFilters =
     filters.product.length > 0 ||
     filters.direction.length > 0 ||
     filters.exchange.length > 0 ||
-    grouping !== 'none'
+    grouping !== "none";
 
   const handleClosePosition = async (position: Position) => {
     try {
       const response = await tradingApi.closePosition(
         position.symbol,
         position.exchange,
-        position.product
-      )
-      if (response.status === 'success') {
+        position.product,
+      );
+      if (response.status === "success") {
         showToast.success(
           response.message || `Position closed for ${position.symbol}`,
-          'positions'
-        )
-        fetchPositions(true)
+          "positions",
+        );
+        fetchPositions(true);
       } else {
-        showToast.error(response.message || 'Failed to close position', 'positions')
+        showToast.error(
+          response.message || "Failed to close position",
+          "positions",
+        );
       }
     } catch (err) {
-      showToast.error('Failed to close position', 'positions')
+      showToast.error("Failed to close position", "positions");
     }
-  }
+  };
 
   const handleCloseAllPositions = async () => {
     try {
-      const response = await tradingApi.closeAllPositions()
-      if (response.status === 'success') {
+      const response = await tradingApi.closeAllPositions();
+      if (response.status === "success") {
         // Toast handled by close_position_event socket
-        fetchPositions(true)
+        fetchPositions(true);
       } else {
-        showToast.error(response.message || 'Failed to close all positions', 'positions')
+        showToast.error(
+          response.message || "Failed to close all positions",
+          "positions",
+        );
       }
     } catch (err) {
-      showToast.error('Failed to close all positions', 'positions')
+      showToast.error("Failed to close all positions", "positions");
     }
-  }
+  };
 
   const exportToCSV = () => {
     const headers = [
-      'Symbol',
-      'Exchange',
-      'Product',
-      'Quantity',
-      'Avg Price',
-      'LTP',
-      'P&L',
-      'P&L %',
-    ]
+      "Symbol",
+      "Exchange",
+      "Product",
+      "Quantity",
+      "Avg Price",
+      "LTP",
+      "P&L",
+      "P&L %",
+    ];
     const rows = filteredPositions.map((p) => [
       sanitizeCSV(p.symbol),
       sanitizeCSV(p.exchange),
@@ -485,547 +539,646 @@ export default function Positions() {
       sanitizeCSV(p.ltp),
       sanitizeCSV(p.pnl),
       sanitizeCSV(calculatePnlPercent(p)),
-    ])
+    ]);
 
-    const csv = [headers, ...rows].map((row) => row.join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `positions_${new Date().toISOString().split('T')[0]}.csv`
-    a.click()
+    const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `positions_${new Date().toISOString().split("T")[0]}.csv`;
+    a.click();
     // Revoke the object URL to free memory
-    URL.revokeObjectURL(url)
-  }
+    URL.revokeObjectURL(url);
+  };
 
-  const isProfit = (value: number) => value >= 0
+  const isProfit = (value: number) => value >= 0;
 
   const FilterChip = ({
     type,
     value,
     label,
   }: {
-    type: keyof FilterState
-    value: string
-    label: string
+    type: keyof FilterState;
+    value: string;
+    label: string;
   }) => (
     <Button
-      variant={filters[type].includes(value) ? 'default' : 'outline'}
+      variant={filters[type].includes(value) ? "default" : "outline"}
       size="sm"
       className={cn(
-        'rounded-full',
-        filters[type].includes(value) && 'bg-pink-500 hover:bg-pink-600'
+        "rounded-full",
+        filters[type].includes(value) && "bg-pink-500 hover:bg-pink-600",
       )}
       onClick={() => toggleFilter(type, value)}
     >
       {label}
     </Button>
-  )
+  );
 
   const SortableHeader = ({
     column,
     label,
     className,
   }: {
-    column: SortColumn
-    label: string
-    className?: string
+    column: SortColumn;
+    label: string;
+    className?: string;
   }) => (
     <TableHead
-      className={cn('cursor-pointer hover:bg-muted/50 select-none', className)}
+      className={cn("cursor-pointer hover:bg-muted/50 select-none", className)}
       onClick={() => handleSort(column)}
     >
       <div
         className={cn(
-          'flex items-center gap-1 w-full',
-          className?.includes('text-right') && 'justify-end'
+          "flex items-center gap-1 w-full",
+          className?.includes("text-right") && "justify-end",
         )}
       >
         {label}
         <ArrowUpDown className="h-3 w-3 opacity-50" />
       </div>
     </TableHead>
-  )
+  );
 
   // Calculate group stats
   const calculateGroupStats = (positions: Position[]) => {
-    let totalPnl = 0
-    let totalInvestment = 0
+    let totalPnl = 0;
+    let totalInvestment = 0;
 
     positions.forEach((pos) => {
-      totalPnl += pos.pnl || 0
-      const avgPrice = pos.average_price || 0
-      const qty = Math.abs(pos.quantity || 0)
-      totalInvestment += avgPrice * qty
-    })
+      totalPnl += pos.pnl || 0;
+      const avgPrice = pos.average_price || 0;
+      const qty = Math.abs(pos.quantity || 0);
+      totalInvestment += avgPrice * qty;
+    });
 
-    const pnlPercent = totalInvestment > 0 ? (totalPnl / totalInvestment) * 100 : 0
-    return { totalPnl, pnlPercent, count: positions.length }
-  }
+    const pnlPercent =
+      totalInvestment > 0 ? (totalPnl / totalInvestment) * 100 : 0;
+    return { totalPnl, pnlPercent, count: positions.length };
+  };
 
   // Sort group keys
   const sortedGroupKeys = Object.keys(groupedPositions).sort((a, b) => {
-    if (a.startsWith('Equity') && !b.startsWith('Equity')) return -1
-    if (!a.startsWith('Equity') && b.startsWith('Equity')) return 1
-    return a.localeCompare(b)
-  })
+    if (a.startsWith("Equity") && !b.startsWith("Equity")) return -1;
+    if (!a.startsWith("Equity") && b.startsWith("Equity")) return 1;
+    return a.localeCompare(b);
+  });
 
   return (
     <ErrorBoundary>
+      <div className="space-y-6">
+        {/* Stale Data Warning */}
+        {showStaleWarning && (
+          <Alert
+            variant="default"
+            className="bg-amber-500/10 border-amber-500/30"
+          >
+            <AlertTriangle className="h-4 w-4 text-amber-600" />
+            <AlertDescription className="text-amber-700 dark:text-amber-400">
+              Data is being refreshed after tab was inactive...
+            </AlertDescription>
+          </Alert>
+        )}
 
-    <div className="space-y-6">
-      {/* Stale Data Warning */}
-      {showStaleWarning && (
-        <Alert variant="default" className="bg-amber-500/10 border-amber-500/30">
-          <AlertTriangle className="h-4 w-4 text-amber-600" />
-          <AlertDescription className="text-amber-700 dark:text-amber-400">
-            Data is being refreshed after tab was inactive...
-          </AlertDescription>
-        </Alert>
-      )}
-
-      {/* Header */}
-      <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
-        <div>
-          <div className="flex items-center gap-3">
-            <h1 className="text-3xl font-bold tracking-tight">Positions</h1>
-            {isPaused ? (
-              <Badge
-                variant="outline"
-                className="bg-amber-500/10 text-amber-600 border-amber-500/30 gap-1"
-              >
-                <Pause className="h-3 w-3" />
-                Paused
-              </Badge>
-            ) : isLive ? (
-              <Badge
-                variant="outline"
-                className="bg-emerald-500/10 text-emerald-600 border-emerald-500/30 gap-1"
-              >
-                <Radio className="h-3 w-3 animate-pulse" />
-                Live
-              </Badge>
-            ) : null}
+        {/* Header */}
+        <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
+          <div>
+            <div className="flex items-center gap-3">
+              <h1 className="text-3xl font-bold tracking-tight">Positions</h1>
+              {isPaused ? (
+                <Badge
+                  variant="outline"
+                  className="bg-amber-500/10 text-amber-600 border-amber-500/30 gap-1"
+                >
+                  <Pause className="h-3 w-3" />
+                  Paused
+                </Badge>
+              ) : isLive ? (
+                <Badge
+                  variant="outline"
+                  className="bg-emerald-500/10 text-emerald-600 border-emerald-500/30 gap-1"
+                >
+                  <Radio className="h-3 w-3 animate-pulse" />
+                  Live
+                </Badge>
+              ) : null}
+            </div>
+            <p className="text-muted-foreground">
+              Monitor and manage your active trading positions
+            </p>
           </div>
-          <p className="text-muted-foreground">Monitor and manage your active trading positions</p>
-        </div>
-        <div className="flex items-center gap-2 flex-wrap">
-          {/* Settings Button */}
-          <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
-                size="sm"
-                className="relative"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Settings
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Position Settings</DialogTitle>
-                <DialogDescription>Configure grouping and filters</DialogDescription>
-              </DialogHeader>
+          <div className="flex items-center gap-2 flex-wrap">
+            {/* Settings Button */}
+            <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
+              <DialogTrigger asChild>
+                <Button
+                  variant={hasActiveFilters ? "default" : "outline"}
+                  size="sm"
+                  className="relative"
+                >
+                  <Settings2 className="h-4 w-4 mr-2" />
+                  Settings
+                  {hasActiveFilters && (
+                    <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                  )}
+                </Button>
+              </DialogTrigger>
+              <DialogContent className="max-w-md">
+                <DialogHeader>
+                  <DialogTitle>Position Settings</DialogTitle>
+                  <DialogDescription>
+                    Configure grouping and filters
+                  </DialogDescription>
+                </DialogHeader>
 
-              <div className="space-y-6 py-4">
-                {/* Grouping */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Grouping
-                  </Label>
-                  <div className="space-y-2">
-                    {[
-                      { value: 'none', label: 'None' },
-                      { value: 'underlying', label: 'Underlying' },
-                      { value: 'underlying_expiry', label: 'Underlying & Expiry' },
-                    ].map((opt) => (
-                      <label
-                        key={opt.value}
-                        className={cn(
-                          'flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-muted',
-                          grouping === opt.value && 'bg-pink-500/10 border border-pink-500/30'
-                        )}
-                      >
-                        <input
-                          type="radio"
-                          name="grouping"
-                          checked={grouping === opt.value}
-                          onChange={() => {
-                            setGrouping(opt.value as GroupingType)
-                            setCollapsedGroups(new Set())
-                          }}
-                          className="accent-pink-500"
-                        />
-                        <span
-                          className={cn(grouping === opt.value && 'text-pink-500 font-semibold')}
+                <div className="space-y-6 py-4">
+                  {/* Grouping */}
+                  <div className="space-y-3">
+                    <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Grouping
+                    </Label>
+                    <div className="space-y-2">
+                      {[
+                        { value: "none", label: "None" },
+                        { value: "underlying", label: "Underlying" },
+                        {
+                          value: "underlying_expiry",
+                          label: "Underlying & Expiry",
+                        },
+                      ].map((opt) => (
+                        <label
+                          key={opt.value}
+                          className={cn(
+                            "flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-muted",
+                            grouping === opt.value &&
+                              "bg-pink-500/10 border border-pink-500/30",
+                          )}
                         >
-                          {opt.label}
-                        </span>
-                      </label>
-                    ))}
-                  </div>
-                </div>
-
-                <div className="border-t" />
-
-                {/* Product Type */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Product Type
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="product" value="CNC" label="CNC" />
-                    <FilterChip type="product" value="MIS" label="MIS" />
-                    <FilterChip type="product" value="NRML" label="NRML" />
-                  </div>
-                </div>
-
-                {/* Direction */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Direction
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="direction" value="LONG" label="Long" />
-                    <FilterChip type="direction" value="SHORT" label="Short" />
-                  </div>
-                </div>
-
-                {/* Exchange */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Exchange
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="exchange" value="NSE" label="NSE" />
-                    <FilterChip type="exchange" value="BSE" label="BSE" />
-                    <FilterChip type="exchange" value="NFO" label="NFO" />
-                    <FilterChip type="exchange" value="BFO" label="BFO" />
-                    <FilterChip type="exchange" value="MCX" label="MCX" />
-                    <FilterChip type="exchange" value="CDS" label="CDS" />
-                  </div>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <Button variant="ghost" onClick={clearFilters}>
-                  Clear All
-                </Button>
-                <Button onClick={() => setSettingsOpen(false)}>Done</Button>
-              </DialogFooter>
-            </DialogContent>
-          </Dialog>
-
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchPositions(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
-
-          <AlertDialog>
-            <AlertDialogTrigger asChild>
-              <Button variant="destructive" size="sm" disabled={stats.total === 0}>
-                <X className="h-4 w-4 mr-2" />
-                Close All
-              </Button>
-            </AlertDialogTrigger>
-            <AlertDialogContent>
-              <AlertDialogHeader>
-                <AlertDialogTitle>Close All Positions?</AlertDialogTitle>
-                <AlertDialogDescription>
-                  This will close all {stats.total} open positions at market price. This action
-                  cannot be undone.
-                </AlertDialogDescription>
-              </AlertDialogHeader>
-              <AlertDialogFooter>
-                <AlertDialogCancel>Cancel</AlertDialogCancel>
-                <AlertDialogAction onClick={handleCloseAllPositions}>Close All</AlertDialogAction>
-              </AlertDialogFooter>
-            </AlertDialogContent>
-          </AlertDialog>
-        </div>
-      </div>
-
-      {/* Active Filters Bar */}
-      {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-sm text-muted-foreground">Active Filters:</span>
-          {grouping !== 'none' && (
-            <Badge variant="secondary" className="bg-pink-500/10 text-pink-600 border-pink-500/30">
-              Grouped: {grouping === 'underlying' ? 'Underlying' : 'Underlying & Expiry'}
-            </Badge>
-          )}
-          {filters.product.map((v) => (
-            <Badge
-              key={v}
-              variant="secondary"
-              className="bg-pink-500/10 text-pink-600 border-pink-500/30"
-            >
-              {v}
-            </Badge>
-          ))}
-          {filters.direction.map((v) => (
-            <Badge
-              key={v}
-              variant="secondary"
-              className="bg-pink-500/10 text-pink-600 border-pink-500/30"
-            >
-              {v}
-            </Badge>
-          ))}
-          {filters.exchange.map((v) => (
-            <Badge
-              key={v}
-              variant="secondary"
-              className="bg-pink-500/10 text-pink-600 border-pink-500/30"
-            >
-              {v}
-            </Badge>
-          ))}
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-red-500 border-red-500/50 hover:bg-red-500/10"
-            onClick={clearFilters}
-          >
-            Clear All
-          </Button>
-        </div>
-      )}
-
-      {/* Stats Cards */}
-      <div className="grid gap-4 md:grid-cols-4">
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Open Positions</CardDescription>
-            <CardTitle className="text-2xl">{stats.total}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Long</CardDescription>
-            <CardTitle className="text-2xl text-green-600">{stats.long}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Short</CardDescription>
-            <CardTitle className="text-2xl text-red-600">{stats.short}</CardTitle>
-          </CardHeader>
-        </Card>
-        <Card>
-          <CardHeader className="pb-2">
-            <CardDescription>Total P&L</CardDescription>
-            <CardTitle
-              className={cn(
-                'text-2xl',
-                isProfit(stats.totalPnl) ? 'text-green-600' : 'text-red-600'
-              )}
-            >
-              {formatCurrency(stats.totalPnl)}
-            </CardTitle>
-          </CardHeader>
-        </Card>
-      </div>
-
-      {/* Positions Table */}
-      <Card>
-        <CardContent className="p-0">
-          {isLoading ? (
-            <div className="flex items-center justify-center py-12">
-              <Loader2 className="h-8 w-8 animate-spin" />
-            </div>
-          ) : error ? (
-            <div className="text-center py-12 text-muted-foreground">{error}</div>
-          ) : filteredPositions.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p className="mb-4">No positions match your filters</p>
-              {hasActiveFilters && (
-                <Button variant="ghost" size="sm" onClick={clearFilters}>
-                  Clear Filters
-                </Button>
-              )}
-            </div>
-          ) : (
-            <div className="overflow-x-auto">
-              <Table>
-                <TableHeader>
-                  <TableRow>
-                    <SortableHeader column={0} label="Symbol" className="w-[140px]" />
-                    <TableHead className="w-[80px]">Exchange</TableHead>
-                    <TableHead className="w-[80px]">Product</TableHead>
-                    <SortableHeader column={3} label="Qty" className="w-[80px] text-right" />
-                    <SortableHeader column={4} label="Avg Price" className="w-[120px] text-right" />
-                    <TableHead className="w-[120px] text-right">LTP</TableHead>
-                    <SortableHeader column={6} label="P&L" className="w-[120px] text-right" />
-                    <SortableHeader column={7} label="P&L %" className="w-[100px] text-right" />
-                    <TableHead className="w-[60px] text-right">Action</TableHead>
-                  </TableRow>
-                </TableHeader>
-                <TableBody>
-                  {sortedGroupKeys.map((groupKey) => {
-                    const groupPositions = groupedPositions[groupKey]
-                    const isCollapsed = collapsedGroups.has(groupKey)
-                    const groupStats = calculateGroupStats(groupPositions)
-
-                    return (
-                      <React.Fragment key={groupKey}>
-                        {/* Group Header Row */}
-                        {grouping !== 'none' && (
-                          <TableRow
-                            className="bg-muted/50 cursor-pointer hover:bg-muted"
-                            onClick={() => toggleGroup(groupKey)}
+                          <input
+                            type="radio"
+                            name="grouping"
+                            checked={grouping === opt.value}
+                            onChange={() => {
+                              setGrouping(opt.value as GroupingType);
+                              setCollapsedGroups(new Set());
+                            }}
+                            className="accent-pink-500"
+                          />
+                          <span
+                            className={cn(
+                              grouping === opt.value &&
+                                "text-pink-500 font-semibold",
+                            )}
                           >
-                            <TableCell colSpan={6}>
-                              <div className="flex items-center gap-3 py-1 font-semibold">
-                                {isCollapsed ? (
-                                  <ChevronRight className="h-4 w-4 text-muted-foreground" />
-                                ) : (
-                                  <ChevronDown className="h-4 w-4 text-muted-foreground" />
-                                )}
-                                <span>{groupKey}</span>
-                                <Badge variant="outline" className="text-xs">
-                                  {groupStats.count}
-                                </Badge>
-                              </div>
-                            </TableCell>
-                            <TableCell
-                              className={cn(
-                                'text-right font-bold',
-                                isProfit(groupStats.totalPnl) ? 'text-green-600' : 'text-red-600'
-                              )}
-                            >
-                              {groupStats.totalPnl >= 0 ? '+' : ''}
-                              {formatCurrency(groupStats.totalPnl)}
-                            </TableCell>
-                            <TableCell
-                              className={cn(
-                                'text-right font-semibold',
-                                isProfit(groupStats.pnlPercent) ? 'text-green-600' : 'text-red-600'
-                              )}
-                            >
-                              {groupStats.pnlPercent >= 0 ? '+' : ''}
-                              {groupStats.pnlPercent.toFixed(2)}%
-                            </TableCell>
-                            <TableCell />
-                          </TableRow>
-                        )}
+                            {opt.label}
+                          </span>
+                        </label>
+                      ))}
+                    </div>
+                  </div>
 
-                        {/* Position Rows */}
-                        {!isCollapsed &&
-                          groupPositions.map((position, index) => (
-                            <TableRow key={`${position.symbol}-${position.exchange}-${index}`}>
-                              <TableCell className="w-[140px] font-medium">
-                                {position.symbol}
-                              </TableCell>
-                              <TableCell className="w-[80px]">
-                                <Badge
-                                  variant="outline"
-                                  className={EXCHANGE_COLORS[position.exchange] || ''}
-                                >
-                                  {position.exchange}
-                                </Badge>
-                              </TableCell>
-                              <TableCell className="w-[80px]">
-                                <Badge
-                                  variant="outline"
-                                  className={PRODUCT_COLORS[position.product] || ''}
-                                >
-                                  {position.product}
-                                </Badge>
-                              </TableCell>
-                              <TableCell
-                                className={cn(
-                                  'w-[80px] text-right font-medium',
-                                  position.quantity > 0 ? 'text-green-600' : 'text-red-600'
-                                )}
-                              >
-                                {position.quantity}
-                              </TableCell>
-                              <TableCell className="w-[120px] text-right font-mono">
-                                {formatCurrency(position.average_price)}
-                              </TableCell>
-                              <TableCell className="w-[120px] text-right font-mono">
-                                {position.ltp !== undefined ? formatCurrency(position.ltp) : '-'}
-                              </TableCell>
-                              <TableCell
-                                className={cn(
-                                  'w-[120px] text-right font-medium',
-                                  isProfit(position.pnl) ? 'text-green-600' : 'text-red-600'
-                                )}
-                              >
-                                <div className="flex items-center justify-end gap-1">
-                                  {isProfit(position.pnl) ? (
-                                    <TrendingUp className="h-4 w-4" />
+                  <div className="border-t" />
+
+                  {/* Product Type */}
+                  <div className="space-y-3">
+                    <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Product Type
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      <FilterChip type="product" value="CNC" label="CNC" />
+                      <FilterChip type="product" value="MIS" label="MIS" />
+                      <FilterChip type="product" value="NRML" label="NRML" />
+                    </div>
+                  </div>
+
+                  {/* Direction */}
+                  <div className="space-y-3">
+                    <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Direction
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      <FilterChip type="direction" value="LONG" label="Long" />
+                      <FilterChip
+                        type="direction"
+                        value="SHORT"
+                        label="Short"
+                      />
+                    </div>
+                  </div>
+
+                  {/* Exchange */}
+                  <div className="space-y-3">
+                    <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                      Exchange
+                    </Label>
+                    <div className="flex flex-wrap gap-2">
+                      <FilterChip type="exchange" value="NSE" label="NSE" />
+                      <FilterChip type="exchange" value="BSE" label="BSE" />
+                      <FilterChip type="exchange" value="NFO" label="NFO" />
+                      <FilterChip type="exchange" value="BFO" label="BFO" />
+                      <FilterChip type="exchange" value="MCX" label="MCX" />
+                      <FilterChip type="exchange" value="CDS" label="CDS" />
+                    </div>
+                  </div>
+                </div>
+
+                <DialogFooter>
+                  <Button variant="ghost" onClick={clearFilters}>
+                    Clear All
+                  </Button>
+                  <Button onClick={() => setSettingsOpen(false)}>Done</Button>
+                </DialogFooter>
+              </DialogContent>
+            </Dialog>
+
+            <Button
+              variant="outline"
+              size="sm"
+              onClick={() => fetchPositions(true)}
+              disabled={isRefreshing}
+            >
+              <RefreshCw
+                className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+              />
+              Refresh
+            </Button>
+
+            <Button variant="outline" size="sm" onClick={exportToCSV}>
+              <Download className="h-4 w-4 mr-2" />
+              Export
+            </Button>
+
+            <AlertDialog>
+              <AlertDialogTrigger asChild>
+                <Button
+                  variant="destructive"
+                  size="sm"
+                  disabled={stats.total === 0}
+                >
+                  <X className="h-4 w-4 mr-2" />
+                  Close All
+                </Button>
+              </AlertDialogTrigger>
+              <AlertDialogContent>
+                <AlertDialogHeader>
+                  <AlertDialogTitle>Close All Positions?</AlertDialogTitle>
+                  <AlertDialogDescription>
+                    This will close all {stats.total} open positions at market
+                    price. This action cannot be undone.
+                  </AlertDialogDescription>
+                </AlertDialogHeader>
+                <AlertDialogFooter>
+                  <AlertDialogCancel>Cancel</AlertDialogCancel>
+                  <AlertDialogAction onClick={handleCloseAllPositions}>
+                    Close All
+                  </AlertDialogAction>
+                </AlertDialogFooter>
+              </AlertDialogContent>
+            </AlertDialog>
+          </div>
+        </div>
+
+        {/* Active Filters Bar */}
+        {hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm text-muted-foreground">
+              Active Filters:
+            </span>
+            {grouping !== "none" && (
+              <Badge
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                Grouped:{" "}
+                {grouping === "underlying"
+                  ? "Underlying"
+                  : "Underlying & Expiry"}
+              </Badge>
+            )}
+            {filters.product.map((v) => (
+              <Badge
+                key={v}
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                {v}
+              </Badge>
+            ))}
+            {filters.direction.map((v) => (
+              <Badge
+                key={v}
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                {v}
+              </Badge>
+            ))}
+            {filters.exchange.map((v) => (
+              <Badge
+                key={v}
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                {v}
+              </Badge>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-500 border-red-500/50 hover:bg-red-500/10"
+              onClick={clearFilters}
+            >
+              Clear All
+            </Button>
+          </div>
+        )}
+
+        {/* Stats Cards */}
+        <div className="grid gap-4 md:grid-cols-4">
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Open Positions</CardDescription>
+              <CardTitle className="text-2xl">{stats.total}</CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Long</CardDescription>
+              <CardTitle className="text-2xl text-green-600">
+                {stats.long}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Short</CardDescription>
+              <CardTitle className="text-2xl text-red-600">
+                {stats.short}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+          <Card>
+            <CardHeader className="pb-2">
+              <CardDescription>Total P&L</CardDescription>
+              <CardTitle
+                className={cn(
+                  "text-2xl",
+                  isProfit(stats.totalPnl) ? "text-green-600" : "text-red-600",
+                )}
+              >
+                {formatCurrency(stats.totalPnl)}
+              </CardTitle>
+            </CardHeader>
+          </Card>
+        </div>
+
+        {/* Positions Table */}
+        <Card>
+          <CardContent className="p-0">
+            {isLoading ? (
+              <div className="flex items-center justify-center py-12">
+                <Loader2 className="h-8 w-8 animate-spin" />
+              </div>
+            ) : error ? (
+              <div className="text-center py-12 text-muted-foreground">
+                {error}
+              </div>
+            ) : filteredPositions.length === 0 ? (
+              hasActiveFilters ? (
+                <EmptyState
+                  icon={SearchX}
+                  title="No positions match your filters"
+                  description="Try adjusting your filters to find what you're looking for."
+                  action={
+                    <Button variant="ghost" size="sm" onClick={clearFilters}>
+                      Clear Filters
+                    </Button>
+                  }
+                />
+              ) : (
+                <EmptyState
+                  icon={Inbox}
+                  title="No open positions"
+                  description="You don't have any active trading positions right now."
+                />
+              )
+            ) : (
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <SortableHeader
+                        column={0}
+                        label="Symbol"
+                        className="w-[140px]"
+                      />
+                      <TableHead className="w-[80px]">Exchange</TableHead>
+                      <TableHead className="w-[80px]">Product</TableHead>
+                      <SortableHeader
+                        column={3}
+                        label="Qty"
+                        className="w-[80px] text-right"
+                      />
+                      <SortableHeader
+                        column={4}
+                        label="Avg Price"
+                        className="w-[120px] text-right"
+                      />
+                      <TableHead className="w-[120px] text-right">
+                        LTP
+                      </TableHead>
+                      <SortableHeader
+                        column={6}
+                        label="P&L"
+                        className="w-[120px] text-right"
+                      />
+                      <SortableHeader
+                        column={7}
+                        label="P&L %"
+                        className="w-[100px] text-right"
+                      />
+                      <TableHead className="w-[60px] text-right">
+                        Action
+                      </TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {sortedGroupKeys.map((groupKey) => {
+                      const groupPositions = groupedPositions[groupKey];
+                      const isCollapsed = collapsedGroups.has(groupKey);
+                      const groupStats = calculateGroupStats(groupPositions);
+
+                      return (
+                        <React.Fragment key={groupKey}>
+                          {/* Group Header Row */}
+                          {grouping !== "none" && (
+                            <TableRow
+                              className="bg-muted/50 cursor-pointer hover:bg-muted"
+                              onClick={() => toggleGroup(groupKey)}
+                            >
+                              <TableCell colSpan={6}>
+                                <div className="flex items-center gap-3 py-1 font-semibold">
+                                  {isCollapsed ? (
+                                    <ChevronRight className="h-4 w-4 text-muted-foreground" />
                                   ) : (
-                                    <TrendingDown className="h-4 w-4" />
+                                    <ChevronDown className="h-4 w-4 text-muted-foreground" />
                                   )}
-                                  {formatCurrency(position.pnl)}
+                                  <span>{groupKey}</span>
+                                  <Badge variant="outline" className="text-xs">
+                                    {groupStats.count}
+                                  </Badge>
                                 </div>
                               </TableCell>
                               <TableCell
                                 className={cn(
-                                  'w-[100px] text-right',
-                                  isProfit(calculatePnlPercent(position))
-                                    ? 'text-green-600'
-                                    : 'text-red-600'
+                                  "text-right font-bold",
+                                  isProfit(groupStats.totalPnl)
+                                    ? "text-green-600"
+                                    : "text-red-600",
                                 )}
                               >
-                                {calculatePnlPercent(position) >= 0 ? '+' : ''}
-                                {calculatePnlPercent(position).toFixed(2)}%
+                                {groupStats.totalPnl >= 0 ? "+" : ""}
+                                {formatCurrency(groupStats.totalPnl)}
                               </TableCell>
-                              <TableCell className="w-[60px] text-right">
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                                  onClick={() => handleClosePosition(position)}
-                                >
-                                  <X className="h-4 w-4" />
-                                </Button>
+                              <TableCell
+                                className={cn(
+                                  "text-right font-semibold",
+                                  isProfit(groupStats.pnlPercent)
+                                    ? "text-green-600"
+                                    : "text-red-600",
+                                )}
+                              >
+                                {groupStats.pnlPercent >= 0 ? "+" : ""}
+                                {groupStats.pnlPercent.toFixed(2)}%
                               </TableCell>
+                              <TableCell />
                             </TableRow>
-                          ))}
-                      </React.Fragment>
-                    )
-                  })}
-                </TableBody>
-                <TableFooter>
-                  <TableRow className="bg-muted/50">
-                    <TableCell colSpan={6} className="text-right text-muted-foreground">
-                      Total P&L:
-                    </TableCell>
-                    <TableCell
-                      className={cn(
-                        'w-[120px] text-right font-bold',
-                        isProfit(stats.totalPnl) ? 'text-green-600' : 'text-red-600'
-                      )}
-                    >
-                      {stats.totalPnl >= 0 ? '+' : ''}
-                      {formatCurrency(stats.totalPnl)}
-                    </TableCell>
-                    <TableCell colSpan={2} />
-                  </TableRow>
-                </TableFooter>
-              </Table>
-            </div>
-          )}
-        </CardContent>
-      </Card>
-    </div>
+                          )}
+
+                          {/* Position Rows */}
+                          {!isCollapsed &&
+                            groupPositions.map((position, index) => (
+                              <TableRow
+                                key={`${position.symbol}-${position.exchange}-${index}`}
+                              >
+                                <TableCell className="w-[140px] font-medium">
+                                  {position.symbol}
+                                </TableCell>
+                                <TableCell className="w-[80px]">
+                                  <Badge
+                                    variant="outline"
+                                    className={
+                                      EXCHANGE_COLORS[position.exchange] || ""
+                                    }
+                                  >
+                                    {position.exchange}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell className="w-[80px]">
+                                  <Badge
+                                    variant="outline"
+                                    className={
+                                      PRODUCT_COLORS[position.product] || ""
+                                    }
+                                  >
+                                    {position.product}
+                                  </Badge>
+                                </TableCell>
+                                <TableCell
+                                  className={cn(
+                                    "w-[80px] text-right font-medium",
+                                    position.quantity > 0
+                                      ? "text-green-600"
+                                      : "text-red-600",
+                                  )}
+                                >
+                                  {position.quantity}
+                                </TableCell>
+                                <TableCell className="w-[120px] text-right font-mono">
+                                  {formatCurrency(position.average_price)}
+                                </TableCell>
+                                <TableCell className="w-[120px] text-right font-mono">
+                                  {position.ltp !== undefined
+                                    ? formatCurrency(position.ltp)
+                                    : "-"}
+                                </TableCell>
+                                <TableCell
+                                  className={cn(
+                                    "w-[120px] text-right font-medium",
+                                    isProfit(position.pnl)
+                                      ? "text-green-600"
+                                      : "text-red-600",
+                                  )}
+                                >
+                                  <div className="flex items-center justify-end gap-1">
+                                    {isProfit(position.pnl) ? (
+                                      <TrendingUp className="h-4 w-4" />
+                                    ) : (
+                                      <TrendingDown className="h-4 w-4" />
+                                    )}
+                                    {formatCurrency(position.pnl)}
+                                  </div>
+                                </TableCell>
+                                <TableCell
+                                  className={cn(
+                                    "w-[100px] text-right",
+                                    isProfit(calculatePnlPercent(position))
+                                      ? "text-green-600"
+                                      : "text-red-600",
+                                  )}
+                                >
+                                  {calculatePnlPercent(position) >= 0
+                                    ? "+"
+                                    : ""}
+                                  {calculatePnlPercent(position).toFixed(2)}%
+                                </TableCell>
+                                <TableCell className="w-[60px] text-right">
+                                  <Button
+                                    variant="ghost"
+                                    size="sm"
+                                    className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                                    onClick={() =>
+                                      handleClosePosition(position)
+                                    }
+                                  >
+                                    <X className="h-4 w-4" />
+                                  </Button>
+                                </TableCell>
+                              </TableRow>
+                            ))}
+                        </React.Fragment>
+                      );
+                    })}
+                  </TableBody>
+                  <TableFooter>
+                    <TableRow className="bg-muted/50">
+                      <TableCell
+                        colSpan={6}
+                        className="text-right text-muted-foreground"
+                      >
+                        Total P&L:
+                      </TableCell>
+                      <TableCell
+                        className={cn(
+                          "w-[120px] text-right font-bold",
+                          isProfit(stats.totalPnl)
+                            ? "text-green-600"
+                            : "text-red-600",
+                        )}
+                      >
+                        {stats.totalPnl >= 0 ? "+" : ""}
+                        {formatCurrency(stats.totalPnl)}
+                      </TableCell>
+                      <TableCell colSpan={2} />
+                    </TableRow>
+                  </TableFooter>
+                </Table>
+              </div>
+            )}
+          </CardContent>
+        </Card>
+      </div>
     </ErrorBoundary>
-  )
+  );
 }

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -71,6 +71,7 @@ import { useAuthStore } from "@/stores/authStore";
 import { onModeChange } from "@/stores/themeStore";
 import type { Position } from "@/types/trading";
 import { ErrorBoundary } from "@/components/error-boundary/ErrorBoundary";
+import { Skeleton } from "@/components/ui/skeleton";
 import { EmptyState } from "@/components/ui/empty-state";
 
 const STORAGE_KEY = "openalgo_positions_prefs";
@@ -903,14 +904,16 @@ export default function Positions() {
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>Open Positions</CardDescription>
-              <CardTitle className="text-2xl">{stats.total}</CardTitle>
+              <CardTitle className="text-2xl">
+                {isLoading ? <Skeleton className="h-6 w-12" /> : stats.total}
+              </CardTitle>
             </CardHeader>
           </Card>
           <Card>
             <CardHeader className="pb-2">
               <CardDescription>Long</CardDescription>
               <CardTitle className="text-2xl text-green-600">
-                {stats.long}
+                {isLoading ? <Skeleton className="h-6 w-12" /> : stats.long}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -918,7 +921,7 @@ export default function Positions() {
             <CardHeader className="pb-2">
               <CardDescription>Short</CardDescription>
               <CardTitle className="text-2xl text-red-600">
-                {stats.short}
+                {isLoading ? <Skeleton className="h-6 w-12" /> : stats.short}
               </CardTitle>
             </CardHeader>
           </Card>
@@ -931,7 +934,11 @@ export default function Positions() {
                   isProfit(stats.totalPnl) ? "text-green-600" : "text-red-600",
                 )}
               >
-                {formatCurrency(stats.totalPnl)}
+                {isLoading ? (
+                  <Skeleton className="h-6 w-24" />
+                ) : (
+                  formatCurrency(stats.totalPnl)
+                )}
               </CardTitle>
             </CardHeader>
           </Card>

--- a/frontend/src/pages/TradeBook.tsx
+++ b/frontend/src/pages/TradeBook.tsx
@@ -1,9 +1,23 @@
-import { Download, Loader2, RefreshCw, Settings2, TrendingDown, TrendingUp } from 'lucide-react'
-import { useCallback, useEffect, useMemo, useState } from 'react'
-import { tradingApi } from '@/api/trading'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
-import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import {
+  Download,
+  Loader2,
+  RefreshCw,
+  Settings2,
+  TrendingDown,
+  TrendingUp,
+} from "lucide-react";
+import { useCallback, useEffect, useMemo, useState } from "react";
+import { showToast } from "@/utils/toast";
+import { tradingApi } from "@/api/trading";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import {
+  Card,
+  CardContent,
+  CardDescription,
+  CardHeader,
+  CardTitle,
+} from "@/components/ui/card";
 import {
   Dialog,
   DialogContent,
@@ -12,8 +26,8 @@ import {
   DialogHeader,
   DialogTitle,
   DialogTrigger,
-} from '@/components/ui/dialog'
-import { Label } from '@/components/ui/label'
+} from "@/components/ui/dialog";
+import { Label } from "@/components/ui/label";
 import {
   Table,
   TableBody,
@@ -21,127 +35,145 @@ import {
   TableHead,
   TableHeader,
   TableRow,
-} from '@/components/ui/table'
-import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
-import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
-import type { Trade } from '@/types/trading'
+} from "@/components/ui/table";
+import { cn, makeFormatCurrency, sanitizeCSV } from "@/lib/utils";
+import { useAuthStore } from "@/stores/authStore";
+import { onModeChange } from "@/stores/themeStore";
+import type { Trade } from "@/types/trading";
 
 interface FilterState {
-  action: string[]
-  exchange: string[]
-  product: string[]
+  action: string[];
+  exchange: string[];
+  product: string[];
 }
 
 function formatTime(timestamp: string): string {
   try {
-    return new Date(timestamp).toLocaleTimeString('en-IN', {
-      hour: '2-digit',
-      minute: '2-digit',
-      second: '2-digit',
-    })
+    return new Date(timestamp).toLocaleTimeString("en-IN", {
+      hour: "2-digit",
+      minute: "2-digit",
+      second: "2-digit",
+    });
   } catch {
-    return timestamp
+    return timestamp;
   }
 }
 
 export default function TradeBook() {
-  const { apiKey, user } = useAuthStore()
-  const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
-  const [trades, setTrades] = useState<Trade[]>([])
-  const [isLoading, setIsLoading] = useState(true)
-  const [isRefreshing, setIsRefreshing] = useState(false)
-  const [error, setError] = useState<string | null>(null)
+  const { apiKey, user } = useAuthStore();
+  const formatCurrency = useMemo(
+    () => makeFormatCurrency(user?.broker),
+    [user?.broker],
+  );
+  const [trades, setTrades] = useState<Trade[]>([]);
+  const [isLoading, setIsLoading] = useState(true);
+  const [isRefreshing, setIsRefreshing] = useState(false);
+  const [error, setError] = useState<string | null>(null);
 
   // Filter state
   const [filters, setFilters] = useState<FilterState>({
     action: [],
     exchange: [],
     product: [],
-  })
-  const [settingsOpen, setSettingsOpen] = useState(false)
+  });
+  const [settingsOpen, setSettingsOpen] = useState(false);
 
   // Filter trades
   const filteredTrades = useMemo(() => {
     return trades.filter((trade) => {
-      if (filters.action.length > 0 && !filters.action.includes(trade.action)) return false
-      if (filters.exchange.length > 0 && !filters.exchange.includes(trade.exchange)) return false
-      if (filters.product.length > 0 && !filters.product.includes(trade.product)) return false
-      return true
-    })
-  }, [trades, filters])
+      if (filters.action.length > 0 && !filters.action.includes(trade.action))
+        return false;
+      if (
+        filters.exchange.length > 0 &&
+        !filters.exchange.includes(trade.exchange)
+      )
+        return false;
+      if (
+        filters.product.length > 0 &&
+        !filters.product.includes(trade.product)
+      )
+        return false;
+      return true;
+    });
+  }, [trades, filters]);
 
   const hasActiveFilters =
-    filters.action.length > 0 || filters.exchange.length > 0 || filters.product.length > 0
+    filters.action.length > 0 ||
+    filters.exchange.length > 0 ||
+    filters.product.length > 0;
 
   const toggleFilter = (type: keyof FilterState, value: string) => {
     setFilters((prev) => {
-      const arr = prev[type]
-      const index = arr.indexOf(value)
+      const arr = prev[type];
+      const index = arr.indexOf(value);
       if (index > -1) {
-        return { ...prev, [type]: arr.filter((v) => v !== value) }
+        return { ...prev, [type]: arr.filter((v) => v !== value) };
       }
-      return { ...prev, [type]: [...arr, value] }
-    })
-  }
+      return { ...prev, [type]: [...arr, value] };
+    });
+  };
 
   const clearFilters = () => {
-    setFilters({ action: [], exchange: [], product: [] })
-  }
+    setFilters({ action: [], exchange: [], product: [] });
+  };
 
   const fetchTrades = useCallback(
     async (showRefresh = false) => {
       if (!apiKey) {
-        setIsLoading(false)
-        return
+        setIsLoading(false);
+        return;
       }
 
-      if (showRefresh) setIsRefreshing(true)
+      if (showRefresh) setIsRefreshing(true);
 
       try {
-        const response = await tradingApi.getTrades(apiKey)
-        if (response.status === 'success' && response.data) {
-          setTrades(response.data)
-          setError(null)
+        const response = await tradingApi.getTrades(apiKey);
+        if (response.status === "success" && response.data) {
+          setTrades(response.data);
+          setError(null);
         } else {
-          setError(response.message || 'Failed to fetch trades')
+          setError(response.message || "Failed to fetch trades");
         }
       } catch {
-        setError('Failed to fetch trades')
+        setError("Failed to fetch trades");
       } finally {
-        setIsLoading(false)
-        setIsRefreshing(false)
+        setIsLoading(false);
+        setIsRefreshing(false);
       }
     },
-    [apiKey]
-  )
+    [apiKey],
+  );
 
   useEffect(() => {
-    fetchTrades()
-    const interval = setInterval(() => fetchTrades(), 10000)
-    return () => clearInterval(interval)
-  }, [fetchTrades])
+    fetchTrades();
+    const interval = setInterval(() => fetchTrades(), 10000);
+    return () => clearInterval(interval);
+  }, [fetchTrades]);
 
   // Listen for mode changes (live/analyze) and refresh data
   useEffect(() => {
     const unsubscribe = onModeChange(() => {
-      fetchTrades()
-    })
-    return () => unsubscribe()
-  }, [fetchTrades])
+      fetchTrades();
+    });
+    return () => unsubscribe();
+  }, [fetchTrades]);
 
   const exportToCSV = () => {
+    if (trades.length === 0) {
+      showToast.error("No data to export", "system");
+      return;
+    }
     const headers = [
-      'Symbol',
-      'Exchange',
-      'Product',
-      'Action',
-      'Qty',
-      'Price',
-      'Trade Value',
-      'Order ID',
-      'Time',
-    ]
+      "Symbol",
+      "Exchange",
+      "Product",
+      "Action",
+      "Qty",
+      "Price",
+      "Trade Value",
+      "Order ID",
+      "Time",
+    ];
     const rows = trades.map((t) => [
       sanitizeCSV(t.symbol),
       sanitizeCSV(t.exchange),
@@ -152,44 +184,45 @@ export default function TradeBook() {
       sanitizeCSV(t.trade_value),
       sanitizeCSV(t.orderid),
       sanitizeCSV(t.timestamp),
-    ])
+    ]);
 
-    const csv = [headers, ...rows].map((row) => row.join(',')).join('\n')
-    const blob = new Blob([csv], { type: 'text/csv' })
-    const url = URL.createObjectURL(blob)
-    const a = document.createElement('a')
-    a.href = url
-    a.download = `tradebook_${new Date().toISOString().split('T')[0]}.csv`
-    a.click()
-  }
+    const csv = [headers, ...rows].map((row) => row.join(",")).join("\n");
+    const blob = new Blob([csv], { type: "text/csv" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `tradebook_${new Date().toISOString().split("T")[0]}.csv`;
+    a.click();
+    showToast.success("Downloaded trades.csv", "clipboard");
+  };
 
   const stats = {
     total: filteredTrades.length,
-    buyTrades: filteredTrades.filter((t) => t.action === 'BUY').length,
-    sellTrades: filteredTrades.filter((t) => t.action === 'SELL').length,
-  }
+    buyTrades: filteredTrades.filter((t) => t.action === "BUY").length,
+    sellTrades: filteredTrades.filter((t) => t.action === "SELL").length,
+  };
 
   const FilterChip = ({
     type,
     value,
     label,
   }: {
-    type: keyof FilterState
-    value: string
-    label: string
+    type: keyof FilterState;
+    value: string;
+    label: string;
   }) => (
     <Button
-      variant={filters[type].includes(value) ? 'default' : 'outline'}
+      variant={filters[type].includes(value) ? "default" : "outline"}
       size="sm"
       className={cn(
-        'rounded-full',
-        filters[type].includes(value) && 'bg-pink-500 hover:bg-pink-600'
+        "rounded-full",
+        filters[type].includes(value) && "bg-pink-500 hover:bg-pink-600",
       )}
       onClick={() => toggleFilter(type, value)}
     >
       {label}
     </Button>
-  )
+  );
 
   return (
     <div className="space-y-6">
@@ -204,7 +237,7 @@ export default function TradeBook() {
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
             <DialogTrigger asChild>
               <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
+                variant={hasActiveFilters ? "default" : "outline"}
                 size="sm"
                 className="relative"
               >
@@ -218,7 +251,9 @@ export default function TradeBook() {
             <DialogContent className="max-w-md">
               <DialogHeader>
                 <DialogTitle>Trade Filters</DialogTitle>
-                <DialogDescription>Filter trades by action, exchange, or product</DialogDescription>
+                <DialogDescription>
+                  Filter trades by action, exchange, or product
+                </DialogDescription>
               </DialogHeader>
 
               <div className="space-y-6 py-4">
@@ -276,7 +311,9 @@ export default function TradeBook() {
             onClick={() => fetchTrades(true)}
             disabled={isRefreshing}
           >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+            <RefreshCw
+              className={cn("h-4 w-4 mr-2", isRefreshing && "animate-spin")}
+            />
             Refresh
           </Button>
           <Button variant="outline" size="sm" onClick={exportToCSV}>
@@ -364,7 +401,9 @@ export default function TradeBook() {
               <Loader2 className="h-8 w-8 animate-spin" />
             </div>
           ) : error ? (
-            <div className="text-center py-12 text-muted-foreground">{error}</div>
+            <div className="text-center py-12 text-muted-foreground">
+              {error}
+            </div>
           ) : filteredTrades.length === 0 ? (
             <div className="text-center py-12 text-muted-foreground">
               {hasActiveFilters ? (
@@ -375,7 +414,7 @@ export default function TradeBook() {
                   </Button>
                 </div>
               ) : (
-                'No trades today'
+                "No trades today"
               )}
             </div>
           ) : (
@@ -397,7 +436,9 @@ export default function TradeBook() {
                 <TableBody>
                   {filteredTrades.map((trade, index) => (
                     <TableRow key={`${trade.orderid}-${index}`}>
-                      <TableCell className="font-medium">{trade.symbol}</TableCell>
+                      <TableCell className="font-medium">
+                        {trade.symbol}
+                      </TableCell>
                       <TableCell>
                         <Badge variant="outline">{trade.exchange}</Badge>
                       </TableCell>
@@ -406,10 +447,15 @@ export default function TradeBook() {
                       </TableCell>
                       <TableCell>
                         <Badge
-                          variant={trade.action === 'BUY' ? 'default' : 'destructive'}
-                          className={cn('gap-1', trade.action === 'BUY' ? 'bg-green-500' : '')}
+                          variant={
+                            trade.action === "BUY" ? "default" : "destructive"
+                          }
+                          className={cn(
+                            "gap-1",
+                            trade.action === "BUY" ? "bg-green-500" : "",
+                          )}
                         >
-                          {trade.action === 'BUY' ? (
+                          {trade.action === "BUY" ? (
                             <TrendingUp className="h-3 w-3" />
                           ) : (
                             <TrendingDown className="h-3 w-3" />
@@ -417,14 +463,18 @@ export default function TradeBook() {
                           {trade.action}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-right font-mono">{trade.quantity}</TableCell>
+                      <TableCell className="text-right font-mono">
+                        {trade.quantity}
+                      </TableCell>
                       <TableCell className="text-right font-mono">
                         {formatCurrency(trade.average_price)}
                       </TableCell>
                       <TableCell className="text-right font-mono">
                         {formatCurrency(trade.trade_value)}
                       </TableCell>
-                      <TableCell className="font-mono text-xs">{trade.orderid}</TableCell>
+                      <TableCell className="font-mono text-xs">
+                        {trade.orderid}
+                      </TableCell>
                       <TableCell className="text-sm text-muted-foreground">
                         {formatTime(trade.timestamp)}
                       </TableCell>
@@ -437,5 +487,5 @@ export default function TradeBook() {
         </CardContent>
       </Card>
     </div>
-  )
+  );
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "openalgo",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/restx_api/analyzer.py
+++ b/restx_api/analyzer.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -11,8 +10,8 @@ from limiter import limiter
 from restx_api.account_schema import AnalyzerSchema, AnalyzerToggleSchema
 from services.analyzer_service import get_analyzer_status, toggle_analyzer_mode
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("analyzer", description="Analyzer Mode API")
 
 # Initialize logger

--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -1,5 +1,4 @@
 import copy
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -13,8 +12,8 @@ from limiter import limiter
 from restx_api.schemas import BasketOrderSchema
 from services.basket_order_service import emit_analyzer_error, place_basket_order
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("basket_order", description="Basket Order API")
 
 # Initialize logger

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -11,8 +10,8 @@ from limiter import limiter
 from restx_api.schemas import CancelAllOrderSchema
 from services.cancel_all_order_service import cancel_all_orders, emit_analyzer_error
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("cancel_all_order", description="Cancel All Orders API")
 
 # Initialize logger

--- a/restx_api/chart_api.py
+++ b/restx_api/chart_api.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.chart_service import get_chart_preferences, update_chart_preferenc
 from utils.logging import get_logger
 
 from .account_schema import ChartSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("chart", description="Chart Preferences and Cloud Workspace Sync")
 
 # Initialize logger

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -11,8 +10,8 @@ from limiter import limiter
 from restx_api.schemas import ClosePositionSchema
 from services.close_position_service import close_position, emit_analyzer_error
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("close_position", description="Close Position API")
 
 # Initialize logger

--- a/restx_api/config.py
+++ b/restx_api/config.py
@@ -1,0 +1,8 @@
+import os
+
+# Centralized API rate limit configuration
+# This value is used by all REST API endpoints via @limiter.limit(...)
+# Default: "10 per second" if API_RATE_LIMIT is not set in environment variables
+
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+

--- a/restx_api/depth.py
+++ b/restx_api/depth.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.depth_service import get_depth
 from utils.logging import get_logger
 
 from .data_schemas import DepthSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("depth", description="Market Depth API")
 
 # Initialize logger

--- a/restx_api/expiry.py
+++ b/restx_api/expiry.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.expiry_service import get_expiry_dates
 from utils.logging import get_logger
 
 from .data_schemas import ExpirySchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("expiry", description="Expiry dates API for F&O instruments")
 
 # Initialize logger

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -11,8 +10,8 @@ from services.funds_service import get_funds
 from utils.logging import get_logger
 
 from .account_schema import FundsSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("funds", description="Account Funds API")
 
 # Initialize logger

--- a/restx_api/history.py
+++ b/restx_api/history.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.history_service import get_history
 from utils.logging import get_logger
 
 from .data_schemas import HistorySchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("history", description="Historical Data API")
 
 # Initialize logger

--- a/restx_api/holdings.py
+++ b/restx_api/holdings.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.holdings_service import get_holdings
 from utils.logging import get_logger
 
 from .account_schema import HoldingsSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("holdings", description="Holdings API")
 
 # Initialize logger

--- a/restx_api/instruments.py
+++ b/restx_api/instruments.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import Response, jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,6 +8,7 @@ from services.instruments_service import get_instruments
 from utils.logging import get_logger
 
 from .data_schemas import InstrumentsSchema
+from restx_api.config import API_RATE_LIMIT
 
 
 class CSVResponse(Response):
@@ -23,7 +23,6 @@ class CSVResponse(Response):
         self._json = value
 
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("instruments", description="Instruments/Symbols download API")
 
 # Initialize logger

--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.intervals_service import get_intervals
 from utils.logging import get_logger
 
 from .data_schemas import IntervalsSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("intervals", description="Supported Intervals API")
 
 # Initialize logger

--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -1,5 +1,4 @@
-import os
-
+from restx_api.config import API_RATE_LIMIT
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
 from marshmallow import ValidationError
@@ -11,7 +10,6 @@ from restx_api.schemas import MarginCalculatorSchema
 from services.margin_service import calculate_margin
 from utils.logging import get_logger
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "50 per second")
 api = Namespace("margin", description="Margin Calculator API")
 
 # Initialize logger

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.market_calendar_service import get_holidays
 from utils.logging import get_logger
 
 from .data_schemas import MarketHolidaysSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("market/holidays", description="Market Holidays API")
 
 # Initialize logger

--- a/restx_api/market_timings.py
+++ b/restx_api/market_timings.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.market_calendar_service import get_timings
 from utils.logging import get_logger
 
 from .data_schemas import MarketTimingsSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("market/timings", description="Market Timings API")
 
 # Initialize logger

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -10,11 +9,11 @@ from services.option_greeks_service import get_multi_option_greeks
 from utils.logging import get_logger
 
 from .data_schemas import MultiOptionGreeksSchema
+from restx_api.config import API_RATE_LIMIT
 
 logger = get_logger(__name__)
 
 # Rate limit for multi option greeks API (same as multiquotes)
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 api = Namespace("multioptiongreeks", description="Batch Option Greeks API")
 

--- a/restx_api/multiquotes.py
+++ b/restx_api/multiquotes.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.quotes_service import get_multiquotes
 from utils.logging import get_logger
 
 from .data_schemas import MultiQuotesSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("multiquotes", description="Real-time Multiple Quotes API")
 
 # Initialize logger

--- a/restx_api/openposition.py
+++ b/restx_api/openposition.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -12,8 +11,8 @@ from limiter import limiter
 from restx_api.account_schema import OpenPositionSchema
 from services.openposition_service import emit_analyzer_error, get_open_position
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("openposition", description="Open Position API")
 
 # Initialize logger

--- a/restx_api/option_chain.py
+++ b/restx_api/option_chain.py
@@ -58,7 +58,6 @@ Strike Labels (different for CE and PE):
     - Strike ABOVE ATM: CE is OTM, PE is ITM
 """
 
-import os
 
 from flask import request
 from flask_restx import Namespace, Resource
@@ -69,6 +68,7 @@ from services.option_chain_service import get_option_chain
 from utils.logging import get_logger
 
 from .data_schemas import OptionChainSchema
+from restx_api.config import API_RATE_LIMIT
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -77,7 +77,6 @@ logger = get_logger(__name__)
 api = Namespace("optionchain", description="Get Option Chain with Real-time Quotes")
 
 # Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/option_symbol.py
+++ b/restx_api/option_symbol.py
@@ -29,7 +29,6 @@ Response:
 }
 """
 
-import os
 
 from flask import request
 from flask_restx import Namespace, Resource
@@ -40,6 +39,7 @@ from services.option_symbol_service import get_option_symbol
 from utils.logging import get_logger
 
 from .data_schemas import OptionSymbolSchema
+from restx_api.config import API_RATE_LIMIT
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -48,7 +48,6 @@ logger = get_logger(__name__)
 api = Namespace("optionsymbol", description="Get Option Symbol based on Underlying and Offset")
 
 # Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/orderbook.py
+++ b/restx_api/orderbook.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.orderbook_service import get_orderbook
 from utils.logging import get_logger
 
 from .account_schema import OrderbookSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("orderbook", description="Order Book API")
 
 # Initialize logger

--- a/restx_api/orderstatus.py
+++ b/restx_api/orderstatus.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -12,8 +11,8 @@ from limiter import limiter
 from restx_api.account_schema import OrderStatusSchema
 from services.orderstatus_service import emit_analyzer_error, get_order_status
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("orderstatus", description="Order Status API")
 
 # Initialize logger

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.ping_service import get_ping
 from utils.logging import get_logger
 
 from .account_schema import PingSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("ping", description="Ping API to check connectivity and authentication")
 
 # Initialize logger

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -1,4 +1,3 @@
-import os
 import traceback
 
 from flask import jsonify, make_response, request
@@ -10,8 +9,8 @@ from services.sandbox_service import is_sandbox_mode, sandbox_get_pnl_symbols
 from utils.logging import get_logger
 
 from .account_schema import PnlSymbolsSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("pnl", description="P&L Analysis API")
 
 # Initialize logger

--- a/restx_api/positionbook.py
+++ b/restx_api/positionbook.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.positionbook_service import get_positionbook
 from utils.logging import get_logger
 
 from .account_schema import PositionbookSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("positionbook", description="Position Book API")
 
 # Initialize logger

--- a/restx_api/quotes.py
+++ b/restx_api/quotes.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.quotes_service import get_quotes
 from utils.logging import get_logger
 
 from .data_schemas import QuotesSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("quotes", description="Real-time Quotes API")
 
 # Initialize logger

--- a/restx_api/search.py
+++ b/restx_api/search.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.search_service import search_symbols
 from utils.logging import get_logger
 
 from .data_schemas import SearchSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("search", description="Symbol search API")
 
 # Initialize logger

--- a/restx_api/split_order.py
+++ b/restx_api/split_order.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -11,8 +10,8 @@ from limiter import limiter
 from restx_api.schemas import SplitOrderSchema
 from services.split_order_service import emit_analyzer_error, split_order
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("split_order", description="Split Order API")
 
 # Initialize logger

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.symbol_service import get_symbol_info
 from utils.logging import get_logger
 
 from .data_schemas import SymbolSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("symbol", description="Symbol information API")
 
 # Initialize logger

--- a/restx_api/synthetic_future.py
+++ b/restx_api/synthetic_future.py
@@ -31,7 +31,6 @@ Response (Error):
 }
 """
 
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -41,6 +40,7 @@ from limiter import limiter
 from restx_api.schemas import SyntheticFutureSchema
 from services.synthetic_future_service import calculate_synthetic_future
 from utils.logging import get_logger
+from restx_api.config import API_RATE_LIMIT
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -49,7 +49,6 @@ logger = get_logger(__name__)
 api = Namespace("syntheticfuture", description="Calculate Synthetic Future Price")
 
 # Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/ticker.py
+++ b/restx_api/ticker.py
@@ -1,5 +1,4 @@
 import importlib
-import os
 from datetime import UTC, datetime, timedelta, timezone, date
 
 import pandas as pd
@@ -15,10 +14,10 @@ from utils.logging import get_logger
 from .data_schemas import TickerSchema
 
 from types import ModuleType
+from restx_api.config import API_RATE_LIMIT
 
 
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("ticker", description="Stock Ticker Data API")
 
 # Initialize logger

--- a/restx_api/tradebook.py
+++ b/restx_api/tradebook.py
@@ -1,4 +1,3 @@
-import os
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -9,8 +8,8 @@ from services.tradebook_service import get_tradebook
 from utils.logging import get_logger
 
 from .account_schema import TradebookSchema
+from restx_api.config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("tradebook", description="Trade Book API")
 
 # Initialize logger


### PR DESCRIPTION
Closes #1008 

Currently the stats cards on the Holdings, Positions, and OrderBook pages display `"---"` while data is loading. This feels a bit abrupt and doesn't provide a good loading experience.

This PR replaces the placeholder text with proper skeleton loaders using the existing `Skeleton` component from shadcn/ui.

Changes:

* Added skeleton loaders to stats cards on:

  * Holdings page
  * Positions page
  * OrderBook page
* Skeletons appear when `isLoading` is true
* Actual values render normally once data is loaded

This improves the loading experience and keeps the UI consistent with modern loading patterns.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced "---" placeholders with skeleton loaders on stats cards in Holdings, Positions, and OrderBook for a smoother loading experience. Also added an ErrorBoundary and centralized API rate limit configuration to improve stability and maintainability.

- **New Features**
  - Skeleton loaders on stats cards (Holdings, Positions, OrderBook) using the shadcn/ui Skeleton component.
  - ErrorBoundary with a friendly fallback; Dashboard wrapped to prevent UI crashes.
  - Reusable EmptyState component and toast feedback for CSV exports.

- **Refactors**
  - Centralized API rate limit in restx_api/config.py; all endpoints import API_RATE_LIMIT (default: “10 per second”, override via env).

<sup>Written for commit 68b3c504736df3b442b993bb253b151b16112069. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

