### PR TITLE
fix(api): replace bare except with specific exception handling in magin and gex

### DIFF
--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -60,6 +60,6 @@ class MarginCalculator(Resource):
                 log_executor.submit(
                     async_log_order, "margin", data if "data" in locals() else {}, error_response
                 )
-            except:
-                pass
+            except Exception as e:
+                logger.exception(f"Failed to log margin error to database: {e}")
             return make_response(jsonify(error_response), 500)

--- a/services/gex_service.py
+++ b/services/gex_service.py
@@ -99,8 +99,8 @@ def get_gex_data(
                             greeks = greeks_resp.get("greeks", {})
                             ce_gamma = greeks.get("gamma", 0) or 0
                             ce_gex = ce_gamma * ce_oi * current_lotsize
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"Failed to calculate greeks for CE: {e}")
 
             # Process PE
             if pe and pe.get("symbol"):
@@ -122,8 +122,8 @@ def get_gex_data(
                             greeks = greeks_resp.get("greeks", {})
                             pe_gamma = greeks.get("gamma", 0) or 0
                             pe_gex = pe_gamma * pe_oi * current_lotsize
-                    except Exception:
-                        pass
+                    except Exception as e:
+                        logger.debug(f"Failed to calculate greeks for PE: {e}")
 
             net_gex = ce_gex - pe_gex
 


### PR DESCRIPTION
## Description
Fixes bare `except:` and silent `except Exception: pass` blocks in [margin.py](cci:7://file:///d:/sem4/openalgo/restx_api/margin.py:0:0-0:0) and [gex_service.py](cci:7://file:///d:/sem4/openalgo/services/gex_service.py:0:0-0:0). 

Closes #1013

## Problem
Several try/except blocks were either using a bare `except:` or an `except Exception:` followed by a `pass`. This practice violates PEP-8 (E722) and masks critical failures like `KeyboardInterrupt`, `SystemExit`, or syntax errors. Swallowing exceptions silently also makes debugging much harder when Option Greek calculations or Database logging fails.

## Solution
- [restx_api/margin.py](cci:7://file:///d:/sem4/openalgo/restx_api/margin.py:0:0-0:0): Replaced bare `except:` with `except Exception as e: logger.exception(...)` so failures in the background database logging are visible.
- [services/gex_service.py](cci:7://file:///d:/sem4/openalgo/services/gex_service.py:0:0-0:0): Replaced `except Exception: pass` with `except Exception as e: logger.debug(...)` when the Black-76 greeks calculation fails. This prevents the API from crashing while still logging debugging context for bad option chain data.

## Testing
- Verified `flake8` no longer complains about E722 on these files.
- Ran tests via `pytest test/ -v`.
- Added security note: Verified we are not logging sensitive configuration parameters in these blocks.

## Checklist
- [x] Replaced `except:` with `except Exception`
- [x] Handled exceptions appropriately with loggers (no `pass` swallows)
- [x] Kept functional behavior identical


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace bare excepts and silent passes with explicit exception handling and logging in margin and GEX services. This prevents swallowed errors, improves observability, and clears E722 lint warnings.

- **Bug Fixes**
  - margin.py: Catch Exception when async_log_order fails and log with logger.exception; 500 response unchanged.
  - gex_service.py: Catch Exception during CE/PE greeks calculation and log with logger.debug; continue without crashing.

<sup>Written for commit da8061be76e56f0141260b612bb47b0ace56576b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

