### PR TITLE
fix(api): add null check for request.json in market_holidays, symbol and interval

### DIFF
--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -27,20 +26,29 @@ class Intervals(Resource):
     def post(self):
         """Get supported intervals for the broker"""
         try:
+            # Get request data
+            data = request.json
+            if data is None:
+                msg = {"status": "error", "message": "Request body must be JSON"}
+                return make_response(jsonify(msg), 400)
+
             # Validate request data
-            intervals_data = intervals_schema.load(request.json)
+            intervals_data = intervals_schema.load(data)
 
             api_key = intervals_data["apikey"]
 
             # Call the service function to get intervals data with API key
-            success, response_data, status_code = get_intervals(api_key=api_key)
+            success, response_data, status_code = get_intervals(
+                api_key=api_key
+            )
 
             return make_response(jsonify(response_data), status_code)
 
         except ValidationError as err:
-            return make_response(jsonify({"status": "error", "message": err.messages}), 400)
+            return make_response(
+                jsonify({"status": "error", "message": err.messages}), 400
+            )
         except Exception as e:
             logger.exception(f"Unexpected error in intervals endpoint: {e}")
-            return make_response(
-                jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
-            )
+            msg = {"status": "error", "message": "Internal server error"}
+            return make_response(jsonify(msg), 500)

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -26,8 +26,15 @@ class MarketHolidays(Resource):
     def post(self):
         """Get market holidays for a specific year"""
         try:
+            # Get request data
+            data = request.json
+            if data is None:
+                return make_response(
+                    jsonify({"status": "error", "message": "Request body must be JSON"}), 400
+                )
+
             # Validate request data
-            holidays_data = holidays_schema.load(request.json)
+            holidays_data = holidays_schema.load(data)
 
             # Extract parameters
             year = holidays_data.get("year")

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -26,8 +26,14 @@ class Symbol(Resource):
     def post(self):
         """Get symbol information for a given symbol and exchange"""
         try:
+            # Get request data
+            data = request.json
+            if data is None:
+                msg = {"status": "error", "message": "Request body must be JSON"}
+                return make_response(jsonify(msg), 400)
+
             # Validate request data
-            symbol_data = symbol_schema.load(request.json)
+            symbol_data = symbol_schema.load(data)
 
             # Extract parameters
             api_key = symbol_data.pop("apikey", None)
@@ -42,10 +48,11 @@ class Symbol(Resource):
             return make_response(jsonify(response_data), status_code)
 
         except ValidationError as err:
-            return make_response(jsonify({"status": "error", "message": err.messages}), 400)
+            return make_response(
+                jsonify({"status": "error", "message": err.messages}), 400
+            )
 
         except Exception as e:
             logger.exception(f"Unexpected error in symbol endpoint: {e}")
-            return make_response(
-                jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
-            )
+            msg = {"status": "error", "message": "Internal server error"}
+            return make_response(jsonify(msg), 500)


### PR DESCRIPTION
## Description
Adds a `request.json is None` guard in three API endpoints that previously
crashed with an unhandled TypeError when called without a JSON body.

Closes #1015

## Problem
`market_holidays`, `symbol`, and `intervals` endpoints called `schema.load(request.json)`. If the client sent no Content-Type or empty body, `request.json` returns `None`, causing Marshmallow to raise a `TypeError` instead of a clean 400 response.

## Fix
Added an explicit null check before schema validation (following the pattern already used in [option_greeks.py](cci:7://file:///d:/sem4/openalgo/restx_api/option_greeks.py:0:0-0:0)). Also removed unused `import traceback` from `intervals.py`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add null checks for request.json in market_holidays, symbol, and intervals to prevent TypeError crashes when requests have no JSON body. Standardizes error handling and responses across these endpoints.

- **Bug Fixes**
  - Return 400 with "Request body must be JSON" when request.json is None.
  - Map ValidationError to 400; log unexpected errors and return 500 "Internal server error".
  - Remove unused traceback import in intervals.py.

<sup>Written for commit ad7a248fdbdb7b7777db8d9d231932435f68a812. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

