### PR TITLE
fix: standardize error logging with logger.exception() in order APIs

### DIFF
--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -54,8 +53,7 @@ class BasketOrder(Resource):
             return make_response(jsonify(response_data), status_code)
 
         except Exception:
-            logger.error("An unexpected error occurred in BasketOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in BasketOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -53,7 +52,7 @@ class CancelAllOrder(Resource):
 
         except KeyError as e:
             missing_field = str(e)
-            logger.error(f"KeyError: Missing field {missing_field}")
+            logger.exception(f"KeyError: Missing field {missing_field}")
             error_message = f"A required field is missing: {missing_field}"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 400)
@@ -62,8 +61,7 @@ class CancelAllOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelAllOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelAllOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_order.py
+++ b/restx_api/cancel_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -52,7 +51,7 @@ class CancelOrder(Resource):
 
         except KeyError as e:
             missing_field = str(e)
-            logger.error(f"KeyError: Missing field {missing_field}")
+            logger.exception(f"KeyError: Missing field {missing_field}")
             error_message = f"A required field is missing: {missing_field}"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 400)
@@ -61,8 +60,7 @@ class CancelOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -53,7 +52,7 @@ class ClosePosition(Resource):
 
         except KeyError as e:
             missing_field = str(e)
-            logger.error(f"KeyError: Missing field {missing_field}")
+            logger.exception(f"KeyError: Missing field {missing_field}")
             error_message = f"A required field is missing: {missing_field}"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 400)
@@ -62,8 +61,7 @@ class ClosePosition(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in ClosePosition endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in ClosePosition endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/modify_order.py
+++ b/restx_api/modify_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -53,7 +52,7 @@ class ModifyOrder(Resource):
 
         except KeyError as e:
             missing_field = str(e)
-            logger.error(f"KeyError: Missing field {missing_field}")
+            logger.exception(f"KeyError: Missing field {missing_field}")
             error_message = f"A required field is missing: {missing_field}"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 400)


### PR DESCRIPTION
## Problem
Several order API endpoints use mixed `logger.error()` + `traceback.print_exc()` patterns for exception handling. This is redundant and inconsistent — `logger.exception()` already includes the full traceback automatically.

Fixes #1017

## Solution
- Replaced `logger.error(f"...: {e}")` → `logger.exception(f"...: {e}")` in all KeyError and Exception handlers
- Removed all `traceback.print_exc()` calls (now redundant)
- Removed `import traceback` from affected files

## Files Changed
- `restx_api/cancel_order.py`
- `restx_api/close_position.py`
- `restx_api/cancel_all_order.py`
- `restx_api/basket_order.py`
- `restx_api/modify_order.py`

Note: `place_order.py` already used `logger.exception()` — no changes needed.

## Testing
No functional changes — logging behavior is equivalent but cleaner. Existing tests pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized error logging across order APIs by using logger.exception() for exceptions. This removes redundant traceback printing and makes logs consistent with full tracebacks. Addresses #1017.

- **Refactors**
  - Replaced logger.error() + traceback.print_exc() with logger.exception() in basket_order, cancel_all_order, cancel_order, close_position, and modify_order.
  - Removed traceback imports.
  - No functional changes; existing tests pass.

<sup>Written for commit 7b0a1822c9615cac6e8ec437039e9692e4823e20. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

