### PR TITLE
fix: add CSRF time limit validation and warning when CSRF is disabled

### DIFF
--- a/app.py
+++ b/app.py
@@ -295,18 +295,20 @@ def create_app():
                 app.config["WTF_CSRF_TIME_LIMIT"] = csrf_time_limit_int
             else:
                 logger.warning(
-                    "CSRF_TIME_LIMIT=%d is out of valid range (300-86400 seconds). Using default.",
+                    "CSRF_TIME_LIMIT=%d is out of valid range (300-86400 seconds). "
+                    "Disabling CSRF token expiry (no time limit).",
                     csrf_time_limit_int,
                 )
-                app.config["WTF_CSRF_TIME_LIMIT"] = None
+                app.config["WTF_CSRF_TIME_LIMIT"] = None  # None = no expiry
         except ValueError:
             logger.warning(
-                "CSRF_TIME_LIMIT='%s' is not a valid integer. Using default.",
+                "CSRF_TIME_LIMIT='%s' is not a valid integer. "
+                "Disabling CSRF token expiry (no time limit).",
                 csrf_time_limit,
             )
-            app.config["WTF_CSRF_TIME_LIMIT"] = None
+            app.config["WTF_CSRF_TIME_LIMIT"] = None  # None = no expiry
     else:
-        app.config["WTF_CSRF_TIME_LIMIT"] = None  # No time limit if empty
+        app.config["WTF_CSRF_TIME_LIMIT"] = None  # No time limit if not set
 
     # Register RESTx API blueprint first
     # Register React frontend blueprint FIRST for migrated routes


### PR DESCRIPTION
## Problem
The CSRF configuration in `app.py` had two issues:
1. No warning when CSRF protection is disabled
2. `CSRF_TIME_LIMIT` accepted any integer without range validation

Fixes #1019

## Solution
1. Added `logger.warning()` when `CSRF_ENABLED` is set to false
2. Added min/max validation for `CSRF_TIME_LIMIT` (valid range: 300–86400 seconds). Out-of-range or non-integer values now log a warning and fall back to the default

## Testing
No functional changes to normal operation. Invalid config values now surface as warnings in logs instead of silently misbehaving.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add CSRF config validation, warn when CSRF is disabled, and clarify that WTF_CSRF_TIME_LIMIT=None means no token expiry. Addresses #1019.

- **Bug Fixes**
  - Warn when CSRF is disabled (CSRF_ENABLED=false).
  - Validate CSRF_TIME_LIMIT (300–86400 seconds); invalid or empty values warn and set WTF_CSRF_TIME_LIMIT=None (no expiry).

<sup>Written for commit 49489d4e40282ddc7a2ee16308b63381120c7b9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

