### PR TITLE
refactor: replace magic number in broker param_count with named constant

### DIFF
--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import Auth, db_session, get_auth_token_broker, verify_api_key
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_BASE_PARAMS, BROKER_INIT_FEED_PARAMS, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
@@ -96,9 +96,9 @@ def get_depth_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 3:  # More than self, auth_token, and feed_token
+            if param_count > BROKER_INIT_FEED_PARAMS:  # More than self, auth_token, and feed_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token, user_id)
-            elif param_count > 2:  # More than self and auth_token
+            elif param_count > BROKER_INIT_BASE_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from database.auth_db import get_auth_token_broker
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_BASE_PARAMS, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
@@ -118,7 +118,7 @@ def get_history_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_BASE_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -4,7 +4,7 @@ from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
 from database.token_db import get_token
-from utils.constants import VALID_EXCHANGES
+from utils.constants import BROKER_INIT_BASE_PARAMS, VALID_EXCHANGES
 from utils.logging import get_logger
 
 # Initialize logger
@@ -128,7 +128,7 @@ def get_quotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_BASE_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)
@@ -260,7 +260,7 @@ def get_multiquotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > BROKER_INIT_BASE_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/utils/constants.py
+++ b/utils/constants.py
@@ -134,6 +134,11 @@ REQUIRED_MODIFY_ORDER_FIELDS = [
     "trigger_price",
 ]
 
+# Broker __init__ parameter count thresholds (includes 'self')
+# Used to determine how to instantiate BrokerData based on its __init__ signature.
+BROKER_INIT_BASE_PARAMS = 2   # self + auth_token
+BROKER_INIT_FEED_PARAMS = 3   # self + auth_token + feed_token
+
 # Default Values for Optional Fields
 DEFAULT_PRODUCT_TYPE = PRODUCT_MIS
 DEFAULT_PRICE_TYPE = PRICE_TYPE_MARKET


### PR DESCRIPTION
## Problem
Broker initialization used a hardcoded magic number for `param_count` validation, making the code harder to understand and maintain.

Fixes #895

## Solution
- Replaced magic number with a named constant
- Makes intent explicit and easier to update in one place

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced hardcoded broker __init__ param_count checks with named constants to make intent clear and centralize thresholds. Improves readability and maintenance in depth, history, and quotes services. Addresses #895.

- **Refactors**
  - Added BROKER_INIT_BASE_PARAMS and BROKER_INIT_FEED_PARAMS in utils/constants.
  - Updated services to use these constants instead of magic numbers.

<sup>Written for commit cba10249c25948ca1f6413ab82804fe27d689c23. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

