### PR TITLE
docs: add type hints and docstrings to utils/config.py

### DIFF
--- a/utils/config.py
+++ b/utils/config.py
@@ -1,6 +1,7 @@
 # utils/config.py
 
 import os
+from typing import Optional
 
 from dotenv import load_dotenv
 
@@ -8,21 +9,46 @@ from dotenv import load_dotenv
 load_dotenv(override=True)
 
 
-def get_broker_api_key():
+def get_broker_api_key() -> Optional[str]:
+    """Get the broker API key from environment variables.
+
+    Returns:
+        The broker API key, or None if not set.
+    """
     return os.getenv("BROKER_API_KEY")
 
 
-def get_broker_api_secret():
+def get_broker_api_secret() -> Optional[str]:
+    """Get the broker API secret from environment variables.
+
+    Returns:
+        The broker API secret, or None if not set.
+    """
     return os.getenv("BROKER_API_SECRET")
 
 
-def get_login_rate_limit_min():
+def get_login_rate_limit_min() -> str:
+    """Get the per-minute login rate limit from environment variables.
+
+    Returns:
+        The per-minute rate limit string, defaults to ``'5 per minute'``.
+    """
     return os.getenv("LOGIN_RATE_LIMIT_MIN", "5 per minute")
 
 
-def get_login_rate_limit_hour():
+def get_login_rate_limit_hour() -> str:
+    """Get the per-hour login rate limit from environment variables.
+
+    Returns:
+        The per-hour rate limit string, defaults to ``'25 per hour'``.
+    """
     return os.getenv("LOGIN_RATE_LIMIT_HOUR", "25 per hour")
 
 
-def get_host_server():
+def get_host_server() -> str:
+    """Get the host server URL from environment variables.
+
+    Returns:
+        The host server URL, defaults to ``'http://127.0.0.1:5000'``.
+    """
     return os.getenv("HOST_SERVER", "http://127.0.0.1:5000")


### PR DESCRIPTION
## Problem
`utils/config.py` lacked type hints and docstrings.

Fixes #1016

## Solution
- Added Google-style docstrings to all functions
- Added Python type hints to all function signatures and return values

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added type hints and Google-style docstrings to utils/config.py to improve readability and static analysis. Addresses Linear #1016 by documenting env var accessors and making return types explicit.

- **Refactors**
  - Annotated return types: Optional[str] for broker keys; str for rate limits and host with defaults.
  - Added concise docstrings for each getter, including defaults.
  - No behavior changes; env defaults remain the same.

<sup>Written for commit da6b80d90c9b223530a9c3347ee692e00f7ed5a7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

