### PR TITLE
feat: pure-scipy Black-76 fallback for option Greeks

### DIFF
--- a/services/option_greeks_service.py
+++ b/services/option_greeks_service.py
@@ -66,19 +66,39 @@ def _black76_iv(
     price: float, F: float, K: float, r: float, T: float, flag: str
 ) -> float:
     """Implied volatility via Brent's method.  Same arg order as py_vollib.
-    
-    Raises ValueError with 'convergence' keyword on failure to match 
-    py_vollib error handling expectations.
+
+    Raises ValueError whose message lets the caller distinguish:
+      - 'below intrinsic'  → price is below theoretical minimum (deep ITM)
+      - 'exceeds theoretical maximum' → price above max Black-76 value (bad data)
+      - 'convergence' → generic iteration / other failure
     """
+    def _obj(sigma: float) -> float:
+        return _black76_price(F, K, T, r, sigma, flag) - price
+
     try:
-        def _obj(sigma: float) -> float:
-            return _black76_price(F, K, T, r, sigma, flag) - price
         # brentq returns scalar root when full_output=False (default)
         root: float = brentq(_obj, 1e-6, 50.0, xtol=1e-12, maxiter=200)  # type: ignore
         return float(root)
     except (ValueError, RuntimeError) as e:
-        # Normalize scipy errors to match py_vollib error handling patterns
-        # Original error: "f(a) and f(b) must have different signs" or maxiter
+        # Diagnose *why* brentq failed so the caller can react appropriately.
+        try:
+            low_residual = _obj(1e-6)
+            high_residual = _obj(50.0)
+        except Exception:
+            # Pricing itself blew up (e.g. log of negative) — generic error
+            raise ValueError(f"IV convergence failed: {e}") from e
+
+        if low_residual > 0 and high_residual > 0:
+            # Theoretical price > market price at all vols → price below intrinsic
+            raise ValueError(
+                "Option price is below intrinsic value — IV not calculable"
+            ) from e
+        if low_residual < 0 and high_residual < 0:
+            # Theoretical price < market price at all vols → impossibly high price
+            raise ValueError(
+                "Option price exceeds theoretical maximum — IV not calculable"
+            ) from e
+        # Mixed signs but brentq still failed (maxiter, tolerance, etc.)
         raise ValueError(f"IV convergence failed: {e}") from e
 
 
@@ -491,8 +511,6 @@ def calculate_greeks(
                 "intrinsic" in error_msg.lower()
                 or "below" in error_msg.lower()
                 or "convergence" in error_msg.lower()
-                or "bracket" in error_msg.lower()
-                or "different signs" in error_msg.lower()
             ):
                 logger.info(
                     "IV calculation failed - returning theoretical Greeks for deep ITM option"


### PR DESCRIPTION
Add automatic fallback to pure math+scipy implementation when py_vollib is unavailable (e.g. Python 3.13 where numba cannot write JIT cache to site-packages on Windows Store installs).

Implementation:
- Black-76 IV via scipy.optimize.brentq with proper error normalization to match py_vollib error patterns
- Delta, gamma, theta, vega, rho via scipy.stats.norm
- All functions return float() casts for type safety
- Transparent fallback: import py_vollib at module load, use scipy functions if import fails

No behavioral change when py_vollib is available.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a pure-scipy Black-76 fallback for IV and Greeks when py_vollib isn’t usable, plus better IV error diagnosis so deep-ITM prices return valid Greeks instead of errors. Behavior is unchanged when py_vollib loads.

- **New Features**
  - Auto-detect py_vollib at module load and fallback to scipy if needed.
  - IV via brentq with error messages aligned to py_vollib.
  - Greeks (delta, gamma, theta, vega, rho) via scipy.stats.norm with float casts.
  - check_pyvollib_availability now always succeeds due to the fallback.

- **Bug Fixes**
  - IV fallback now checks residual signs to distinguish below intrinsic vs above theoretical max.
  - Deep-ITM cases return valid Greeks instead of a 500 error; removed broad keyword checks that masked bad data.

<sup>Written for commit 58c30bef077b24c736b165b97cc924cda0922eca. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

