### PR TITLE
refactor: centralized API_RATE_LIMIT configuration to reduce duplication across endpoints

### DIFF
--- a/restx_api/analyzer.py
+++ b/restx_api/analyzer.py
@@ -11,8 +11,9 @@ from limiter import limiter
 from restx_api.account_schema import AnalyzerSchema, AnalyzerToggleSchema
 from services.analyzer_service import get_analyzer_status, toggle_analyzer_mode
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 api = Namespace("analyzer", description="Analyzer Mode API")
 
 # Initialize logger

--- a/restx_api/analyzer.py
+++ b/restx_api/analyzer.py
@@ -11,7 +11,7 @@ from limiter import limiter
 from restx_api.account_schema import AnalyzerSchema, AnalyzerToggleSchema
 from services.analyzer_service import get_analyzer_status, toggle_analyzer_mode
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 
 api = Namespace("analyzer", description="Analyzer Mode API")

--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -13,8 +13,8 @@ from limiter import limiter
 from restx_api.schemas import BasketOrderSchema
 from services.basket_order_service import emit_analyzer_error, place_basket_order
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("basket_order", description="Basket Order API")
 
 # Initialize logger

--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -13,7 +13,7 @@ from limiter import limiter
 from restx_api.schemas import BasketOrderSchema
 from services.basket_order_service import emit_analyzer_error, place_basket_order
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("basket_order", description="Basket Order API")
 

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -11,7 +11,7 @@ from limiter import limiter
 from restx_api.schemas import CancelAllOrderSchema
 from services.cancel_all_order_service import cancel_all_orders, emit_analyzer_error
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("cancel_all_order", description="Cancel All Orders API")
 

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -11,8 +11,8 @@ from limiter import limiter
 from restx_api.schemas import CancelAllOrderSchema
 from services.cancel_all_order_service import cancel_all_orders, emit_analyzer_error
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("cancel_all_order", description="Cancel All Orders API")
 
 # Initialize logger

--- a/restx_api/chart_api.py
+++ b/restx_api/chart_api.py
@@ -10,8 +10,8 @@ from services.chart_service import get_chart_preferences, update_chart_preferenc
 from utils.logging import get_logger
 
 from .account_schema import ChartSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("chart", description="Chart Preferences and Cloud Workspace Sync")
 
 # Initialize logger

--- a/restx_api/chart_api.py
+++ b/restx_api/chart_api.py
@@ -10,7 +10,7 @@ from services.chart_service import get_chart_preferences, update_chart_preferenc
 from utils.logging import get_logger
 
 from .account_schema import ChartSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("chart", description="Chart Preferences and Cloud Workspace Sync")
 

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -11,8 +11,8 @@ from limiter import limiter
 from restx_api.schemas import ClosePositionSchema
 from services.close_position_service import close_position, emit_analyzer_error
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("close_position", description="Close Position API")
 
 # Initialize logger

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -11,7 +11,7 @@ from limiter import limiter
 from restx_api.schemas import ClosePositionSchema
 from services.close_position_service import close_position, emit_analyzer_error
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("close_position", description="Close Position API")
 

--- a/restx_api/config.py
+++ b/restx_api/config.py
@@ -1,0 +1,3 @@
+import os
+
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")

--- a/restx_api/config.py
+++ b/restx_api/config.py
@@ -1,3 +1,14 @@
 import os
+from limits import parse
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+DEFAULT_RATE_LIMIT = "10 per second"
+def _get_valid_rate_limit():
+    raw = os.getenv("API_RATE_LIMIT", DEFAULT_RATE_LIMIT)
+    try:
+        parse(raw) # validates format
+        return raw
+    except Exception:
+        print(f"Invalid API_RATE_LIMIT='{raw}', falling back to default.")
+        return DEFAULT_RATE_LIMIT
+
+API_RATE_LIMIT = _get_valid_rate_limit()

--- a/restx_api/depth.py
+++ b/restx_api/depth.py
@@ -10,8 +10,9 @@ from services.depth_service import get_depth
 from utils.logging import get_logger
 
 from .data_schemas import DepthSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 api = Namespace("depth", description="Market Depth API")
 
 # Initialize logger

--- a/restx_api/depth.py
+++ b/restx_api/depth.py
@@ -10,7 +10,7 @@ from services.depth_service import get_depth
 from utils.logging import get_logger
 
 from .data_schemas import DepthSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 
 api = Namespace("depth", description="Market Depth API")

--- a/restx_api/expiry.py
+++ b/restx_api/expiry.py
@@ -8,7 +8,7 @@ from limiter import limiter
 from services.expiry_service import get_expiry_dates
 from utils.logging import get_logger
 
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .data_schemas import ExpirySchema
 
 api = Namespace("expiry", description="Expiry dates API for F&O instruments")

--- a/restx_api/expiry.py
+++ b/restx_api/expiry.py
@@ -8,9 +8,9 @@ from limiter import limiter
 from services.expiry_service import get_expiry_dates
 from utils.logging import get_logger
 
+from config import API_RATE_LIMIT
 from .data_schemas import ExpirySchema
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("expiry", description="Expiry dates API for F&O instruments")
 
 # Initialize logger

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -9,7 +9,7 @@ from database.auth_db import get_auth_token_broker
 from limiter import limiter
 from services.funds_service import get_funds
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from .config import API_RATE_LIMIT
 
 from .account_schema import FundsSchema
 

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -9,7 +9,7 @@ from database.auth_db import get_auth_token_broker
 from limiter import limiter
 from services.funds_service import get_funds
 from utils.logging import get_logger
-from .config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 from .account_schema import FundsSchema
 

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -9,10 +9,10 @@ from database.auth_db import get_auth_token_broker
 from limiter import limiter
 from services.funds_service import get_funds
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
 from .account_schema import FundsSchema
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("funds", description="Account Funds API")
 
 # Initialize logger

--- a/restx_api/history.py
+++ b/restx_api/history.py
@@ -10,8 +10,8 @@ from services.history_service import get_history
 from utils.logging import get_logger
 
 from .data_schemas import HistorySchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("history", description="Historical Data API")
 
 # Initialize logger

--- a/restx_api/history.py
+++ b/restx_api/history.py
@@ -10,7 +10,7 @@ from services.history_service import get_history
 from utils.logging import get_logger
 
 from .data_schemas import HistorySchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("history", description="Historical Data API")
 

--- a/restx_api/holdings.py
+++ b/restx_api/holdings.py
@@ -10,7 +10,7 @@ from services.holdings_service import get_holdings
 from utils.logging import get_logger
 
 from .account_schema import HoldingsSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("holdings", description="Holdings API")
 

--- a/restx_api/holdings.py
+++ b/restx_api/holdings.py
@@ -10,8 +10,8 @@ from services.holdings_service import get_holdings
 from utils.logging import get_logger
 
 from .account_schema import HoldingsSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("holdings", description="Holdings API")
 
 # Initialize logger

--- a/restx_api/instruments.py
+++ b/restx_api/instruments.py
@@ -9,7 +9,7 @@ from services.instruments_service import get_instruments
 from utils.logging import get_logger
 
 from .data_schemas import InstrumentsSchema
-
+from config import API_RATE_LIMIT
 
 class CSVResponse(Response):
     """Custom Response class that supports both CSV and JSON properties for latency monitoring"""
@@ -23,7 +23,6 @@ class CSVResponse(Response):
         self._json = value
 
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("instruments", description="Instruments/Symbols download API")
 
 # Initialize logger

--- a/restx_api/instruments.py
+++ b/restx_api/instruments.py
@@ -9,7 +9,7 @@ from services.instruments_service import get_instruments
 from utils.logging import get_logger
 
 from .data_schemas import InstrumentsSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 class CSVResponse(Response):
     """Custom Response class that supports both CSV and JSON properties for latency monitoring"""

--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -10,7 +10,7 @@ from services.intervals_service import get_intervals
 from utils.logging import get_logger
 
 from .data_schemas import IntervalsSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("intervals", description="Supported Intervals API")
 

--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -10,8 +10,8 @@ from services.intervals_service import get_intervals
 from utils.logging import get_logger
 
 from .data_schemas import IntervalsSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("intervals", description="Supported Intervals API")
 
 # Initialize logger

--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -10,8 +10,8 @@ from limiter import limiter
 from restx_api.schemas import MarginCalculatorSchema
 from services.margin_service import calculate_margin
 from utils.logging import get_logger
-from restx_api.config import API_RATE_LIMIT
 
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "50 per second")
 api = Namespace("margin", description="Margin Calculator API")
 
 # Initialize logger

--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -10,7 +10,7 @@ from limiter import limiter
 from restx_api.schemas import MarginCalculatorSchema
 from services.margin_service import calculate_margin
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("margin", description="Margin Calculator API")
 

--- a/restx_api/margin.py
+++ b/restx_api/margin.py
@@ -10,8 +10,8 @@ from limiter import limiter
 from restx_api.schemas import MarginCalculatorSchema
 from services.margin_service import calculate_margin
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "50 per second")
 api = Namespace("margin", description="Margin Calculator API")
 
 # Initialize logger

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -9,7 +9,7 @@ from services.market_calendar_service import get_holidays
 from utils.logging import get_logger
 
 from .data_schemas import MarketHolidaysSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("market/holidays", description="Market Holidays API")
 

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -9,8 +9,8 @@ from services.market_calendar_service import get_holidays
 from utils.logging import get_logger
 
 from .data_schemas import MarketHolidaysSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("market/holidays", description="Market Holidays API")
 
 # Initialize logger

--- a/restx_api/market_timings.py
+++ b/restx_api/market_timings.py
@@ -9,7 +9,7 @@ from services.market_calendar_service import get_timings
 from utils.logging import get_logger
 
 from .data_schemas import MarketTimingsSchema
-from .config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("market/timings", description="Market Timings API")
 

--- a/restx_api/market_timings.py
+++ b/restx_api/market_timings.py
@@ -9,7 +9,7 @@ from services.market_calendar_service import get_timings
 from utils.logging import get_logger
 
 from .data_schemas import MarketTimingsSchema
-from config import API_RATE_LIMIT
+from .config import API_RATE_LIMIT
 
 api = Namespace("market/timings", description="Market Timings API")
 

--- a/restx_api/market_timings.py
+++ b/restx_api/market_timings.py
@@ -9,8 +9,8 @@ from services.market_calendar_service import get_timings
 from utils.logging import get_logger
 
 from .data_schemas import MarketTimingsSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("market/timings", description="Market Timings API")
 
 # Initialize logger

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -8,7 +8,7 @@ from database.auth_db import verify_api_key
 from limiter import limiter
 from services.option_greeks_service import get_multi_option_greeks
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 from .data_schemas import MultiOptionGreeksSchema
 

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -8,13 +8,11 @@ from database.auth_db import verify_api_key
 from limiter import limiter
 from services.option_greeks_service import get_multi_option_greeks
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
 from .data_schemas import MultiOptionGreeksSchema
 
 logger = get_logger(__name__)
-
-# Rate limit for multi option greeks API (same as multiquotes)
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 api = Namespace("multioptiongreeks", description="Batch Option Greeks API")
 

--- a/restx_api/multiquotes.py
+++ b/restx_api/multiquotes.py
@@ -9,8 +9,8 @@ from services.quotes_service import get_multiquotes
 from utils.logging import get_logger
 
 from .data_schemas import MultiQuotesSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("multiquotes", description="Real-time Multiple Quotes API")
 
 # Initialize logger

--- a/restx_api/multiquotes.py
+++ b/restx_api/multiquotes.py
@@ -9,7 +9,7 @@ from services.quotes_service import get_multiquotes
 from utils.logging import get_logger
 
 from .data_schemas import MultiQuotesSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("multiquotes", description="Real-time Multiple Quotes API")
 

--- a/restx_api/openposition.py
+++ b/restx_api/openposition.py
@@ -12,8 +12,8 @@ from limiter import limiter
 from restx_api.account_schema import OpenPositionSchema
 from services.openposition_service import emit_analyzer_error, get_open_position
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("openposition", description="Open Position API")
 
 # Initialize logger

--- a/restx_api/openposition.py
+++ b/restx_api/openposition.py
@@ -12,7 +12,7 @@ from limiter import limiter
 from restx_api.account_schema import OpenPositionSchema
 from services.openposition_service import emit_analyzer_error, get_open_position
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("openposition", description="Open Position API")
 

--- a/restx_api/option_chain.py
+++ b/restx_api/option_chain.py
@@ -69,7 +69,7 @@ from services.option_chain_service import get_option_chain
 from utils.logging import get_logger
 
 # Get rate limit from environment
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .data_schemas import OptionChainSchema
 
 # Initialize logger

--- a/restx_api/option_chain.py
+++ b/restx_api/option_chain.py
@@ -68,6 +68,8 @@ from limiter import limiter
 from services.option_chain_service import get_option_chain
 from utils.logging import get_logger
 
+# Get rate limit from environment
+from config import API_RATE_LIMIT
 from .data_schemas import OptionChainSchema
 
 # Initialize logger
@@ -76,8 +78,7 @@ logger = get_logger(__name__)
 # Create namespace
 api = Namespace("optionchain", description="Get Option Chain with Real-time Quotes")
 
-# Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/option_symbol.py
+++ b/restx_api/option_symbol.py
@@ -38,7 +38,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.option_symbol_service import get_option_symbol
 from utils.logging import get_logger
-
+from config import API_RATE_LIMIT
 from .data_schemas import OptionSymbolSchema
 
 # Initialize logger
@@ -47,8 +47,6 @@ logger = get_logger(__name__)
 # Create namespace
 api = Namespace("optionsymbol", description="Get Option Symbol based on Underlying and Offset")
 
-# Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/option_symbol.py
+++ b/restx_api/option_symbol.py
@@ -38,7 +38,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.option_symbol_service import get_option_symbol
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .data_schemas import OptionSymbolSchema
 
 # Initialize logger

--- a/restx_api/orderbook.py
+++ b/restx_api/orderbook.py
@@ -8,7 +8,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.orderbook_service import get_orderbook
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .account_schema import OrderbookSchema
 
 api = Namespace("orderbook", description="Order Book API")

--- a/restx_api/orderbook.py
+++ b/restx_api/orderbook.py
@@ -8,10 +8,9 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.orderbook_service import get_orderbook
 from utils.logging import get_logger
-
+from config import API_RATE_LIMIT
 from .account_schema import OrderbookSchema
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("orderbook", description="Order Book API")
 
 # Initialize logger

--- a/restx_api/orderstatus.py
+++ b/restx_api/orderstatus.py
@@ -12,8 +12,8 @@ from limiter import limiter
 from restx_api.account_schema import OrderStatusSchema
 from services.orderstatus_service import emit_analyzer_error, get_order_status
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("orderstatus", description="Order Status API")
 
 # Initialize logger

--- a/restx_api/orderstatus.py
+++ b/restx_api/orderstatus.py
@@ -12,7 +12,7 @@ from limiter import limiter
 from restx_api.account_schema import OrderStatusSchema
 from services.orderstatus_service import emit_analyzer_error, get_order_status
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("orderstatus", description="Order Status API")
 

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -10,7 +10,7 @@ from services.ping_service import get_ping
 from utils.logging import get_logger
 
 from .account_schema import PingSchema
-from config import API_RATE_LIMIT
+from .config import API_RATE_LIMIT
 
 api = Namespace("ping", description="Ping API to check connectivity and authentication")
 

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -10,7 +10,7 @@ from services.ping_service import get_ping
 from utils.logging import get_logger
 
 from .account_schema import PingSchema
-from .config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("ping", description="Ping API to check connectivity and authentication")
 

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -10,8 +10,8 @@ from services.ping_service import get_ping
 from utils.logging import get_logger
 
 from .account_schema import PingSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("ping", description="Ping API to check connectivity and authentication")
 
 # Initialize logger

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -8,10 +8,10 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.sandbox_service import is_sandbox_mode, sandbox_get_pnl_symbols
 from utils.logging import get_logger
-
+from config import API_RATE_LIMIT
 from .account_schema import PnlSymbolsSchema
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 api = Namespace("pnl", description="P&L Analysis API")
 
 # Initialize logger

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -8,7 +8,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.sandbox_service import is_sandbox_mode, sandbox_get_pnl_symbols
 from utils.logging import get_logger
-from .config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .account_schema import PnlSymbolsSchema
 
 

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -8,7 +8,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.sandbox_service import is_sandbox_mode, sandbox_get_pnl_symbols
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from .config import API_RATE_LIMIT
 from .account_schema import PnlSymbolsSchema
 
 

--- a/restx_api/positionbook.py
+++ b/restx_api/positionbook.py
@@ -9,8 +9,8 @@ from services.positionbook_service import get_positionbook
 from utils.logging import get_logger
 
 from .account_schema import PositionbookSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("positionbook", description="Position Book API")
 
 # Initialize logger

--- a/restx_api/positionbook.py
+++ b/restx_api/positionbook.py
@@ -9,7 +9,7 @@ from services.positionbook_service import get_positionbook
 from utils.logging import get_logger
 
 from .account_schema import PositionbookSchema
-from .config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("positionbook", description="Position Book API")
 

--- a/restx_api/positionbook.py
+++ b/restx_api/positionbook.py
@@ -9,7 +9,7 @@ from services.positionbook_service import get_positionbook
 from utils.logging import get_logger
 
 from .account_schema import PositionbookSchema
-from config import API_RATE_LIMIT
+from .config import API_RATE_LIMIT
 
 api = Namespace("positionbook", description="Position Book API")
 

--- a/restx_api/quotes.py
+++ b/restx_api/quotes.py
@@ -9,8 +9,8 @@ from services.quotes_service import get_quotes
 from utils.logging import get_logger
 
 from .data_schemas import QuotesSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("quotes", description="Real-time Quotes API")
 
 # Initialize logger

--- a/restx_api/quotes.py
+++ b/restx_api/quotes.py
@@ -9,7 +9,7 @@ from services.quotes_service import get_quotes
 from utils.logging import get_logger
 
 from .data_schemas import QuotesSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("quotes", description="Real-time Quotes API")
 

--- a/restx_api/search.py
+++ b/restx_api/search.py
@@ -7,10 +7,10 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.search_service import search_symbols
 from utils.logging import get_logger
-
+from config import API_RATE_LIMIT
 from .data_schemas import SearchSchema
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 api = Namespace("search", description="Symbol search API")
 
 # Initialize logger

--- a/restx_api/search.py
+++ b/restx_api/search.py
@@ -7,7 +7,7 @@ from marshmallow import ValidationError
 from limiter import limiter
 from services.search_service import search_symbols
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 from .data_schemas import SearchSchema
 
 

--- a/restx_api/split_order.py
+++ b/restx_api/split_order.py
@@ -11,7 +11,7 @@ from limiter import limiter
 from restx_api.schemas import SplitOrderSchema
 from services.split_order_service import emit_analyzer_error, split_order
 from utils.logging import get_logger
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("split_order", description="Split Order API")
 

--- a/restx_api/split_order.py
+++ b/restx_api/split_order.py
@@ -11,8 +11,8 @@ from limiter import limiter
 from restx_api.schemas import SplitOrderSchema
 from services.split_order_service import emit_analyzer_error, split_order
 from utils.logging import get_logger
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("split_order", description="Split Order API")
 
 # Initialize logger

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -9,7 +9,7 @@ from services.symbol_service import get_symbol_info
 from utils.logging import get_logger
 
 from .data_schemas import SymbolSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 api = Namespace("symbol", description="Symbol information API")
 

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -9,8 +9,8 @@ from services.symbol_service import get_symbol_info
 from utils.logging import get_logger
 
 from .data_schemas import SymbolSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("symbol", description="Symbol information API")
 
 # Initialize logger

--- a/restx_api/synthetic_future.py
+++ b/restx_api/synthetic_future.py
@@ -42,7 +42,7 @@ from restx_api.schemas import SyntheticFutureSchema
 from services.synthetic_future_service import calculate_synthetic_future
 from utils.logging import get_logger
 # Get rate limit from environment
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 # Initialize logger
 logger = get_logger(__name__)

--- a/restx_api/synthetic_future.py
+++ b/restx_api/synthetic_future.py
@@ -41,6 +41,8 @@ from limiter import limiter
 from restx_api.schemas import SyntheticFutureSchema
 from services.synthetic_future_service import calculate_synthetic_future
 from utils.logging import get_logger
+# Get rate limit from environment
+from config import API_RATE_LIMIT
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -48,8 +50,6 @@ logger = get_logger(__name__)
 # Create namespace
 api = Namespace("syntheticfuture", description="Calculate Synthetic Future Price")
 
-# Get rate limit from environment
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 
 
 @api.route("/", strict_slashes=False)

--- a/restx_api/ticker.py
+++ b/restx_api/ticker.py
@@ -15,10 +15,10 @@ from utils.logging import get_logger
 from .data_schemas import TickerSchema
 
 from types import ModuleType
+from config import API_RATE_LIMIT
 
 
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
 api = Namespace("ticker", description="Stock Ticker Data API")
 
 # Initialize logger

--- a/restx_api/ticker.py
+++ b/restx_api/ticker.py
@@ -15,7 +15,7 @@ from utils.logging import get_logger
 from .data_schemas import TickerSchema
 
 from types import ModuleType
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 
 

--- a/restx_api/tradebook.py
+++ b/restx_api/tradebook.py
@@ -9,8 +9,9 @@ from services.tradebook_service import get_tradebook
 from utils.logging import get_logger
 
 from .account_schema import TradebookSchema
+from config import API_RATE_LIMIT
 
-API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+
 api = Namespace("tradebook", description="Trade Book API")
 
 # Initialize logger

--- a/restx_api/tradebook.py
+++ b/restx_api/tradebook.py
@@ -9,7 +9,7 @@ from services.tradebook_service import get_tradebook
 from utils.logging import get_logger
 
 from .account_schema import TradebookSchema
-from config import API_RATE_LIMIT
+from restx_api.config import API_RATE_LIMIT
 
 
 api = Namespace("tradebook", description="Trade Book API")


### PR DESCRIPTION
Closes https://github.com/marketcalls/openalgo/issues/1020

Currently each endpoint inside restx_api/ reads the API_RATE_LIMIT
environment variable individually using:

API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")

This results in the same configuration being duplicated across many
endpoint files.

This PR centralizes the configuration by introducing a shared
restx_api/config.py module and updating all endpoints to import
API_RATE_LIMIT from there.

Changes:

Added restx_api/config.py
Defined API_RATE_LIMIT once
Updated all REST endpoint files to import the shared constant
Removed duplicated os.getenv calls
This makes the configuration easier to maintain and ensures a single
source of truth for API rate limiting.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Centralized API rate limit in restx_api/config.py and standardized imports across endpoints. Added validation for API_RATE_LIMIT and fixed a margin behavior regression.

- **Refactors**
  - Added restx_api/config.py: reads API_RATE_LIMIT (default "10 per second"), validates format, and falls back to default if invalid.
  - Replaced per-file env reads with a shared import; corrected import paths across endpoints.
  - Removed hard-coded "50 per second" in margin.

- **Migration**
  - To keep the previous margin behavior, set API_RATE_LIMIT="50 per second" in the environment (applies globally).

<sup>Written for commit 35cd77ecf99db70ef9832620625a96c186f2bfb8. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

