### PR TITLE
fix(fyers): replace ws_thread.join() with daemon-thread release to prevent eventlet memory leak

### DIFF
--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -1036,12 +1036,20 @@ class FyersHSMWebSocket:
                 finally:
                     self.ws = None
 
-            # WebSocket thread is daemon=True and will be collected automatically.
-            # Do NOT call ws_thread.join() here: when OpenAlgo runs under eventlet
-            # (gunicorn --worker-class eventlet), this greenlet IS the main loop and
-            # join() raises AssertionError('Cannot switch to MAINLOOP from MAINLOOP'),
-            # leaving the thread object alive and leaking ~30-40 MB per disconnect cycle.
-            # Simply release the reference - the OS reclaims resources on process exit.
+            # Wait up to 3 s for ws_thread to exit naturally before releasing the reference.
+            # We poll with time.sleep(0.1) rather than calling thread.join() because:
+            #   - OpenAlgo runs under gunicorn + eventlet; join() from an eventlet greenlet
+            #     raises AssertionError('Cannot switch to MAINLOOP from MAINLOOP').
+            #   - time.sleep() is monkey-patched by eventlet, becoming eventlet.sleep(),
+            #     which safely yields to the event loop. Works in threading mode too.
+            # This avoids both the join() deadlock AND the reconnect race condition:
+            # without any wait a fast reconnect() could set self.running=True while
+            # the old _run_websocket() loop is still running, causing duplicate threads.
+            deadline = time.time() + 3.0
+            while (self.ws_thread is not None
+                   and self.ws_thread.is_alive()
+                   and time.time() < deadline):
+                time.sleep(0.1)
             self.ws_thread = None
 
             # Reset connection parameters

--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -1036,18 +1036,13 @@ class FyersHSMWebSocket:
                 finally:
                     self.ws = None
 
-            # Wait for WebSocket thread to finish
-            if self.ws_thread and self.ws_thread.is_alive():
-                try:
-                    self.ws_thread.join(timeout=5)
-                    if self.ws_thread.is_alive():
-                        self.logger.warning("WebSocket thread did not terminate within 5 seconds")
-                    else:
-                        self.logger.debug("WebSocket thread terminated successfully")
-                except Exception as e:
-                    self.logger.error(f"Error waiting for WebSocket thread: {e}")
-                finally:
-                    self.ws_thread = None
+            # WebSocket thread is daemon=True and will be collected automatically.
+            # Do NOT call ws_thread.join() here: when OpenAlgo runs under eventlet
+            # (gunicorn --worker-class eventlet), this greenlet IS the main loop and
+            # join() raises AssertionError('Cannot switch to MAINLOOP from MAINLOOP'),
+            # leaving the thread object alive and leaking ~30-40 MB per disconnect cycle.
+            # Simply release the reference - the OS reclaims resources on process exit.
+            self.ws_thread = None
 
             # Reset connection parameters
             self.hsm_key = None


### PR DESCRIPTION
## Problem

When OpenAlgo runs under **eventlet** (`gunicorn --worker-class eventlet`), calling `threading.Thread.join()` from inside an eventlet greenlet raises:

```
AssertionError: Cannot switch to MAINLOOP from MAINLOOP
```

The greenlet that calls `disconnect()` (e.g. at 18:30 UTC market-close cron, or after a health-check-triggered force-reconnect) **is** the eventlet main loop. Calling `join()` on a native thread from within it attempts an illegal context switch that eventlet rejects.

### Consequence: memory leak

Because the `join()` raises an `AssertionError` that is caught by the outer `except Exception` block, the `finally: self.ws_thread = None` line **never runs**. The Python reference to the thread object is never released, so the GC cannot collect it. Each leaked thread holds ~30–40 MB of stack and associated state.

**Observed in production logs (18:13–18:28 UTC):**
```
AssertionError: Cannot switch to MAINLOOP from MAINLOOP
...
tradelab openalgo[...]: Memory: 487.3M   ← after 6 reconnect cycles
```

After a clean morning start the process sits at ~190 MB; by end-of-day it reaches 450–500 MB — consistent with 6 reconnect cycles × ~40 MB/leak.

## Fix

`ws_thread` is created with `daemon=True`. Daemon threads are automatically terminated when the gunicorn worker process exits, so there is **no need to join them**. Simply releasing the Python reference (`self.ws_thread = None`) is sufficient and safe.

```python
# Before (deadlocks under eventlet):
if self.ws_thread and self.ws_thread.is_alive():
    try:
        self.ws_thread.join(timeout=5)   # ← AssertionError under eventlet
        ...
    except Exception as e:
        self.logger.error(...)
    finally:
        self.ws_thread = None            # ← never reached on exception

# After (safe under both eventlet and standard threading):
# ws_thread is daemon=True — release reference, GC handles cleanup.
self.ws_thread = None
```

## Files changed

- `broker/fyers/streaming/fyers_hsm_websocket.py` — `disconnect()` method only

## Testing

Verified on a GCloud VM running `gunicorn --worker-class eventlet --workers 1`. Memory stabilises at ~190 MB after service restart and no longer climbs through the trading day after repeated disconnect/reconnect cycles.

## Notes

`_stop_health_check()` also calls `_health_check_thread.join(timeout=5)` but that thread uses `threading.Event.wait()` internally, exits almost immediately when the stop event is set, and the join completes within milliseconds — so it does not trigger the same deadlock in practice. Only the long-running `ws_thread` is problematic.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace ws_thread.join() with an eventlet‑safe 3s poll and daemon-thread release in Fyers HSM disconnect. This removes the eventlet deadlock, stops memory leaks, and prevents duplicate threads on fast reconnect.

- **Bug Fixes**
  - In broker/fyers/streaming/fyers_hsm_websocket.py::disconnect(), poll ws_thread.is_alive() for up to 3s with time.sleep(0.1), then set self.ws_thread = None (thread is daemon=True).
  - Reason: join() from an eventlet greenlet raises "Cannot switch to MAINLOOP from MAINLOOP"; polling yields under eventlet and gives the thread time to exit, avoiding fast-reconnect races.
  - Outcome: no deadlock, no leaked thread objects, no concurrent WS threads; worker memory stays stable under eventlet.

<sup>Written for commit a57c12d7edf5245629d2d387306cbb1c919d2d9b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

