### PR TITLE
fix: use async_mode=eventlet to eliminate Socket.IO long-polling latency under gunicorn

### DIFF
--- a/extensions.py
+++ b/extensions.py
@@ -1,11 +1,14 @@
 from flask_socketio import SocketIO
 
-# Disable eventlet to prevent greenlet threading errors
-# This fixes concurrent order placement issues in Docker
-# Added error handling for disconnected sessions
+# Use async_mode="eventlet" to match the gunicorn worker class.
+# With async_mode="threading", Socket.IO cannot complete the WebSocket upgrade
+# handshake under gunicorn+eventlet and falls back to HTTP long-polling.
+# Each poll holds the connection for ~ping_timeout seconds, serialising all
+# requests through the single worker and causing severe UI latency.
+# See: https://flask-socketio.readthedocs.io/en/latest/deployment.html
 socketio = SocketIO(
     cors_allowed_origins="*",
-    async_mode="threading",
+    async_mode="eventlet",
     ping_timeout=10,  # Time in seconds before considering the connection lost
     ping_interval=5,  # Interval in seconds between pings
     logger=False,  # Disable built-in logging to avoid noise from disconnection errors


### PR DESCRIPTION
## Problem

When OpenAlgo runs under `gunicorn --worker-class eventlet` (the standard production deployment), setting `async_mode="threading"` in `extensions.py` causes Socket.IO to **never upgrade to a WebSocket connection**. Instead, every browser tab falls back to HTTP long-polling.

Each poll request holds the connection open for `ping_timeout` seconds (currently 10s), and since gunicorn runs a single eventlet worker, **all other requests queue behind the open poll**. This causes:

- **4–5 second latency** on every page navigation (GEX dashboard, OI tracker, option chain, etc.)
- Cascading delays when multiple browser tabs are open simultaneously
- Eventually, file descriptor exhaustion if the session expires while polling is active (observed: FD count climbing from 50 → 900 over a few hours, triggering a health alert and freezing the process)

### Evidence

Chrome DevTools network trace showing Socket.IO **before** this fix:
```
4474ms   200   /socket.io/?EIO=4&transport=polling&t=bum2k6mr   ← long poll blocking worker
 824ms   200   /search/api/underlyings                           ← queued behind poll
 529ms   200   /search/api/expiries
```

**After** switching to `async_mode="eventlet"`:
```
HTTP 101  /socket.io/?EIO=4&transport=websocket   ← WebSocket upgrade succeeds
  35ms   200   /search/api/underlyings             ← immediate
```

## Fix

One line change in `extensions.py`: `async_mode="threading"` → `async_mode="eventlet"`.

This is the correct mode when running under `gunicorn --worker-class eventlet`. Flask-SocketIO's own documentation states that `async_mode` must match the async framework used by the WSGI server.

The previous `async_mode="threading"` was added to fix concurrent order placement issues in Docker. In a standard gunicorn+eventlet deployment those issues do not apply — eventlet's cooperative multitasking handles concurrency correctly.

## Files changed

- `extensions.py` — one-line change

## Additional finding: Python 3.14 incompatibility with py_vollib

While diagnosing the GEX dashboard, I found that `py_vollib` (used by `services/option_greeks_service.py` for Greeks/GEX calculation) fails to import on **Python 3.14** with:

```
ModuleNotFoundError: No module named '_testcapi'
```

This is because `py_lets_be_rational` (a `py_vollib` dependency) imports `DBL_MIN`/`DBL_MAX` from `_testcapi`, which was made private in Python 3.14. The result is that the Net GEX Walls chart shows all zeros and `Net GEX: 0` in the header.

**Workaround** (applied on my instance):
```python
# In py_lets_be_rational/constants.py, replace:
from _testcapi import DBL_MIN, DBL_MAX
# with:
import sys
DBL_MIN = sys.float_info.min
DBL_MAX = sys.float_info.max
```

**Recommended fix**: either pin `python<3.14` in your setup docs/`pyproject.toml`, or open a PR on `py_lets_be_rational` to use `sys.float_info`. Python 3.12 is the safest production choice today.

## Testing

Verified on GCloud VM running Ubuntu, gunicorn 23.x, eventlet 0.38, flask-socketio 5.x, Python 3.14 (openalgo venv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Socket.IO to async_mode="eventlet" to match gunicorn’s eventlet workers. This enables WebSocket upgrades and removes long‑polling that caused 4–5s latency and request queueing.

- **Bug Fixes**
  - WebSocket upgrade now works under gunicorn+eventlet; no HTTP long‑polling.
  - Navigation drops from ~4.5s to ~35ms and avoids request backlogs/FD spikes.

<sup>Written for commit ae8ea3c5357c2ded37da9c71907dcbc382483620. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

