### PR TITLE
fix: order quantity sent as float instead of int causing broker rejections

### DIFF
--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -9,8 +9,8 @@ class OrderSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
     action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
-    quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+    quantity = fields.Int(
+        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive integer.")
     )
     pricetype = fields.Str(
         missing="MARKET", validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
@@ -38,9 +38,9 @@ class SmartOrderSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
     action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
-    quantity = fields.Float(
+    quantity = fields.Int(
         required=True,
-        validate=validate.Range(min=0, error="Quantity must be a non-negative number."),
+        validate=validate.Range(min=0, error="Quantity must be a non-negative integer."),
     )
     position_size = fields.Float(required=True)
     pricetype = fields.Str(
@@ -74,8 +74,8 @@ class ModifyOrderSchema(Schema):
     price = fields.Float(
         required=True, validate=validate.Range(min=0, error="Price must be a non-negative number.")
     )
-    quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+    quantity = fields.Int(
+        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive integer.")
     )
     disclosed_quantity = fields.Int(
         required=True,
@@ -107,8 +107,8 @@ class BasketOrderItemSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
     action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
-    quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+    quantity = fields.Int(
+        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive integer.")
     )
     pricetype = fields.Str(
         missing="MARKET", validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
@@ -141,9 +141,9 @@ class SplitOrderSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
     action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
-    quantity = fields.Float(
+    quantity = fields.Int(
         required=True,
-        validate=validate.Range(min=0, min_inclusive=False, error="Total quantity must be a positive number."),
+        validate=validate.Range(min=0, min_inclusive=False, error="Total quantity must be a positive integer."),
     )  # Total quantity to split
     splitsize = fields.Int(
         required=True,


### PR DESCRIPTION
## Summary

- **Bug:** Order quantity (e.g. `65`) was being deserialized as a float (`65.0`) by the marshmallow schema, causing broker APIs like Zerodha to reject orders with: `"Invalid request (failed to decode 'quantity', got: '65.0' (expected int))"`
- **Root cause:** The `quantity` field in `OrderSchema`, `SmartOrderSchema`, `ModifyOrderSchema`, `BasketOrderItemSchema`, and `SplitOrderSchema` used `fields.Float(...)`, which converts integer input like `"65"` or `65` to `65.0`
- **Fix:** Changed `quantity` from `fields.Float` to `fields.Int` in all 5 affected schemas, and updated validation error messages from "number" to "integer"
- Note: `OptionsOrderSchema` and `OptionsMultiOrderLegSchema` already correctly used `fields.Int` for quantity — this PR brings the remaining schemas in line

## Affected schemas in `restx_api/schemas.py`

- `OrderSchema`
- `SmartOrderSchema`
- `ModifyOrderSchema`
- `BasketOrderItemSchema`
- `SplitOrderSchema`

## Test plan

- [ ] Send a placeorder API request with integer quantity and verify it reaches the broker as an int (not float)
- [ ] Send a smartorder API request and verify quantity is passed as int
- [ ] Send a modify order request and verify quantity is int
- [ ] Send a basket order and verify each leg's quantity is int
- [ ] Send a split order and verify quantity is int
- [ ] Verify that non-integer quantity values (e.g. `65.5`) are properly rejected with a validation error

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes broker order rejections by sending order quantity as an integer instead of a float. Quantity now uses `fields.Int` across affected schemas, and validation messages reflect "integer".

- **Bug Fixes**
  - Switched `quantity` to `fields.Int` in: `OrderSchema`, `SmartOrderSchema`, `ModifyOrderSchema`, `BasketOrderItemSchema`, `SplitOrderSchema`.
  - Updated validation text from "number" to "integer".
  - Brings these schemas in line with existing options schemas that already use integers.

<sup>Written for commit c78bb1b92526c8558f152025f50a3a6a9824e371. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

