### PR TITLE
fix: three-dot menu hidden by long strategy names on Python Strategy page

### DIFF
--- a/frontend/src/pages/python-strategy/PythonStrategyIndex.tsx
+++ b/frontend/src/pages/python-strategy/PythonStrategyIndex.tsx
@@ -374,19 +374,19 @@ export default function PythonStrategyIndex() {
               />
 
               <CardHeader className="pb-3">
-                <div className="flex items-start justify-between">
-                  <div className="space-y-1">
-                    <CardTitle className="text-lg">{strategy.name}</CardTitle>
-                    <CardDescription className="font-mono text-xs">
+                <div className="flex items-start justify-between gap-2 overflow-hidden">
+                  <div className="min-w-0 flex-1 space-y-1">
+                    <CardTitle className="text-lg truncate">{strategy.name}</CardTitle>
+                    <CardDescription className="font-mono text-xs truncate">
                       {strategy.file_name}
                     </CardDescription>
                   </div>
-                  <div className="flex items-center gap-2">
+                  <div className="flex items-center gap-1 shrink-0">
                     <Tooltip>
                       <TooltipTrigger>
                         <Badge
                           variant={strategy.status === 'running' ? 'default' : 'secondary'}
-                          className={STATUS_COLORS[strategy.status] || ''}
+                          className={`${STATUS_COLORS[strategy.status] || ''} whitespace-nowrap`}
                         >
                           {STATUS_LABELS[strategy.status] || strategy.status}
                         </Badge>


### PR DESCRIPTION
## Summary

- **Bug**: On the Python Strategy page, long strategy names or file names push the three-dot (MoreVertical) dropdown menu off the visible area of the card, making it impossible to access Export/Delete options.
- **Fix**: Add overflow constraints (`truncate`, `min-w-0`, `shrink-0`, `whitespace-nowrap`) to the strategy card header layout so the title/filename truncate with ellipsis and the dropdown menu button always stays visible.
- No functional changes — this is a CSS/layout-only fix.

## Changes

- `frontend/src/pages/python-strategy/PythonStrategyIndex.tsx`: Updated card header flex layout to prevent text overflow from pushing the action menu off-screen.

## Test plan

- [ ] Open the Python Strategy page with strategies that have long names (30+ characters)
- [ ] Verify the three-dot dropdown menu is visible on all strategy cards
- [ ] Verify long strategy names and file names truncate with ellipsis
- [ ] Verify the status badge text does not wrap
- [ ] Verify cards with short names still render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes overflow on Python Strategy cards so long strategy and file names truncate with ellipsis, keeping the three-dot menu and status badge always visible.

- **Bug Fixes**
  - Constrained header layout with `min-w-0`, `flex-1`, and `truncate` to prevent text from pushing actions off-screen.
  - Added `shrink-0` and `whitespace-nowrap` so the menu button and badge never wrap or disappear.

<sup>Written for commit 805f1153a84798e888215a209e2df9680d949025. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

