### PR TITLE
fix: coerce order quantity to int for non-crypto brokers (ref PR #1102)

### DIFF
--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -1,12 +1,21 @@
-from marshmallow import Schema, fields, post_load, validate
+from marshmallow import Schema, ValidationError, fields, post_load, validate
 
 from utils.constants import CRYPTO_EXCHANGES, VALID_EXCHANGES
 
 
 def _coerce_quantity_to_int(data):
-    """Convert quantity from float to int for non-crypto exchanges."""
+    """Convert quantity from float to int for non-crypto exchanges.
+
+    Raises ValidationError if a fractional quantity (e.g. 1.9) is sent
+    to a non-crypto exchange, since brokers like Zerodha only accept integers.
+    """
     if data.get("exchange") not in CRYPTO_EXCHANGES and "quantity" in data:
-        data["quantity"] = int(data["quantity"])
+        qty = data["quantity"]
+        if qty != int(qty):
+            raise ValidationError(
+                {"quantity": [f"Fractional quantity ({qty}) is not allowed for non-crypto exchanges."]}
+            )
+        data["quantity"] = int(qty)
     return data
 
 


### PR DESCRIPTION
Zerodha rejects float quantities (e.g. 1.0 instead of 1). Added @post_load hook to convert quantity to int for all non-CRYPTO exchanges while preserving float support for Delta Exchange spot orders.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reject fractional order quantities for non-crypto exchanges and convert whole-number floats to int to prevent broker rejections (e.g., Zerodha). Crypto spot orders (e.g., Delta Exchange) still accept floats.

- **Bug Fixes**
  - Added `marshmallow` `@post_load` hooks across order schemas to run `_coerce_quantity_to_int`.
  - Raise `ValidationError` for fractional quantities on non-`CRYPTO_EXCHANGES` instead of silently truncating.

<sup>Written for commit c7bbcb5fec284a9d061bee4cd4164fdf98b90134. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

