### PR TITLE
feat: add index symbol normalization for XTS brokers (fivepaisaxts, ibulls, iifl, jainamxts, wisdom)

### DIFF
--- a/broker/fivepaisaxts/database/master_contract_db.py
+++ b/broker/fivepaisaxts/database/master_contract_db.py
@@ -180,6 +180,55 @@ def reformat_symbol_detail(s):
     return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
 
 
+# Shared BSE index normalization map used by both BSECM SPOT ingestion
+# and indexlist ingestion paths.
+BSE_INDEX_SYMBOL_MAP = {
+    "SNSX50": "SENSEX50",
+    "SNXT50": "BSESENSEXNEXT50",
+    "MID150": "BSE150MIDCAPINDEX",
+    "LMI250": "BSE250LARGEMIDCAPINDEX",
+    "MSL400": "BSE400MIDSMALLCAPINDEX",
+    "AUTO": "BSEAUTO",
+    "BSE CG": "BSECAPITALGOODS",
+    "CARBON": "BSECARBONEX",
+    "BSE CD": "BSECONSUMERDURABLES",
+    "CPSE": "BSECPSE",
+    "DOL100": "BSEDOLLEX100",
+    "DOL200": "BSEDOLLEX200",
+    "DOL30": "BSEDOLLEX30",
+    "ENERGY": "BSEENERGY",
+    "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+    "FIN": "BSEFINANCIALSERVICES",
+    "FINSER": "BSEFINANCIALSERVICES",
+    "GREENX": "BSEGREENEX",
+    "BSE HC": "BSEHEALTHCARE",
+    "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+    "INDSTR": "BSEINDUSTRIALS",
+    "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+    "LRGCAP": "BSELARGECAP",
+    "METAL": "BSEMETAL",
+    "MIDCAP": "BSEMIDCAP",
+    "MIDSEL": "BSEMIDCAPSELECTINDEX",
+    "OILGAS": "BSEOIL&GAS",
+    "POWER": "BSEPOWER",
+    "BSEPBI": "BSEPSU",
+    "REALTY": "BSEREALTY",
+    "SMLCAP": "BSESMALLCAP",
+    "SMLSEL": "BSESMALLCAPSELECTINDEX",
+    "SMEIPO": "BSESMEIPO",
+    "TECK": "BSETECK",
+    "TELCOM": "BSETELECOM",
+}
+
+
+def normalize_bse_index_symbols(symbol_series: pd.Series) -> pd.Series:
+    """Normalize raw BSE index symbols to OpenAlgo naming and format."""
+    normalized = symbol_series.astype(str).str.upper().str.strip()
+    normalized = normalized.str.replace(r"\s+", " ", regex=True)
+    normalized = normalized.replace(BSE_INDEX_SYMBOL_MAP)
+    return normalized.str.replace(r"[\s\-]+", "", regex=True)
+
+
 def process_compositedge_nse_csv(path):
     """
     Processes the compositedge CSV file to fit the existing database schema and performs exchange name mapping.
@@ -222,7 +271,6 @@ def process_compositedge_bse_csv(path):
     token_df["symbol"] = df["Name"]
     token_df["brsymbol"] = df["DisplayName"]
     token_df["name"] = df["Name"]
-    token_df["exchange"] = df["ExchangeSegment"].map({"BSECM": "BSE"})
     token_df["exchange"] = df.apply(
         lambda row: "BSE_INDEX" if row["Series"] == "SPOT" else "BSE", axis=1
     )
@@ -233,6 +281,13 @@ def process_compositedge_bse_csv(path):
     token_df["lotsize"] = df["LotSize"]
     token_df["instrumenttype"] = df["Series"]
     token_df["tick_size"] = df["TickSize"]
+
+    # Normalize BSE index short codes from SPOT rows to OpenAlgo index symbols
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        token_df.loc[bse_idx_mask, "symbol"]
+    )
+    token_df.loc[bse_idx_mask, "name"] = token_df.loc[bse_idx_mask, "symbol"]
 
     return token_df
 
@@ -425,23 +480,46 @@ def process_compositedge_mcx_csv(path):
 
 
 def process_index_data(index_data):
+    """
+    Processes index data from API to fit the OpenAlgo database schema.
+    Uses regex normalization to handle spacing variations in symbol names.
+
+    Input format from API (index_entry format: "SYMBOL_TOKEN"):
+    - brsymbol: Full format (e.g., "NIFTY 100_26004")
+    - symbol: Raw symbol before mapping (e.g., "NIFTY 100")
+    - exchange: NSE_INDEX or BSE_INDEX
+    - token: Token value
+    """
     logger.info("Processing Index Data")
     df = pd.DataFrame(index_data)
+    if df.empty:
+        return df
 
-    # Map Symbols to Standard Format
-    df["symbol"] = df["symbol"].replace(
-        {
-            "NIFTY 50": "NIFTY",
-            "NIFTY BANK": "BANKNIFTY",
-            "INDIA VIX": "INDIAVIX",
-            "NIFTY FIN SERVICE": "FINNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "NIFTY NEXT 50": "NIFTYNXT50",
-            "SENSEX": "SENSEX",
-            "BANKEX": "BANKEX",
-            "SNSX50": "SENSEX50",
-        }
+    # Normalize casing and spacing first
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+    df["symbol"] = df["symbol"].str.replace(r"\s+", " ", regex=True)
+
+    # NSE index mapping (raw broker index names -> OpenAlgo symbols)
+    nse_index_map = {
+        "NIFTY 50": "NIFTY",
+        "NIFTY BANK": "BANKNIFTY",
+        "INDIA VIX": "INDIAVIX",
+        "NIFTY FIN SERVICE": "FINNIFTY",
+        "NIFTY MID SELECT": "MIDCPNIFTY",
+        "NIFTY NEXT 50": "NIFTYNXT50",
+        "HANGSENG BEES NAV": "HANGSENGBEESNAV",
+        "HANGSENG BEES-NAV": "HANGSENGBEESNAV",
+    }
+    df["symbol"] = df["symbol"].replace(nse_index_map)
+
+    # BSE short-code mapping (applied only to BSE_INDEX symbols)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        df.loc[bse_idx_mask, "symbol"]
     )
+
+    # Final cleanup: enforce no spaces/hyphens in symbols
+    df["symbol"] = df["symbol"].str.replace(r"[\s\-]+", "", regex=True)
 
     df["name"] = df["symbol"]
     df["brexchange"] = df["exchange"]
@@ -450,7 +528,6 @@ def process_index_data(index_data):
     df["lotsize"] = 1  # Default index lot size
     df["instrumenttype"] = "INDEX"
     df["tick_size"] = 0.05
-    # logger.info(f"{df}")
 
     return df
 

--- a/broker/ibulls/database/master_contract_db.py
+++ b/broker/ibulls/database/master_contract_db.py
@@ -178,6 +178,55 @@ def reformat_symbol_detail(s):
     return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
 
 
+# Shared BSE index normalization map used by both BSECM SPOT ingestion
+# and indexlist ingestion paths.
+BSE_INDEX_SYMBOL_MAP = {
+    "SNSX50": "SENSEX50",
+    "SNXT50": "BSESENSEXNEXT50",
+    "MID150": "BSE150MIDCAPINDEX",
+    "LMI250": "BSE250LARGEMIDCAPINDEX",
+    "MSL400": "BSE400MIDSMALLCAPINDEX",
+    "AUTO": "BSEAUTO",
+    "BSE CG": "BSECAPITALGOODS",
+    "CARBON": "BSECARBONEX",
+    "BSE CD": "BSECONSUMERDURABLES",
+    "CPSE": "BSECPSE",
+    "DOL100": "BSEDOLLEX100",
+    "DOL200": "BSEDOLLEX200",
+    "DOL30": "BSEDOLLEX30",
+    "ENERGY": "BSEENERGY",
+    "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+    "FIN": "BSEFINANCIALSERVICES",
+    "FINSER": "BSEFINANCIALSERVICES",
+    "GREENX": "BSEGREENEX",
+    "BSE HC": "BSEHEALTHCARE",
+    "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+    "INDSTR": "BSEINDUSTRIALS",
+    "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+    "LRGCAP": "BSELARGECAP",
+    "METAL": "BSEMETAL",
+    "MIDCAP": "BSEMIDCAP",
+    "MIDSEL": "BSEMIDCAPSELECTINDEX",
+    "OILGAS": "BSEOIL&GAS",
+    "POWER": "BSEPOWER",
+    "BSEPBI": "BSEPSU",
+    "REALTY": "BSEREALTY",
+    "SMLCAP": "BSESMALLCAP",
+    "SMLSEL": "BSESMALLCAPSELECTINDEX",
+    "SMEIPO": "BSESMEIPO",
+    "TECK": "BSETECK",
+    "TELCOM": "BSETELECOM",
+}
+
+
+def normalize_bse_index_symbols(symbol_series: pd.Series) -> pd.Series:
+    """Normalize raw BSE index symbols to OpenAlgo naming and format."""
+    normalized = symbol_series.astype(str).str.upper().str.strip()
+    normalized = normalized.str.replace(r"\s+", " ", regex=True)
+    normalized = normalized.replace(BSE_INDEX_SYMBOL_MAP)
+    return normalized.str.replace(r"[\s\-]+", "", regex=True)
+
+
 def process_compositedge_nse_csv(path):
     """
     Processes the compositedge CSV file to fit the existing database schema and performs exchange name mapping.
@@ -220,7 +269,6 @@ def process_compositedge_bse_csv(path):
     token_df["symbol"] = df["Name"]
     token_df["brsymbol"] = df["DisplayName"]
     token_df["name"] = df["Name"]
-    token_df["exchange"] = df["ExchangeSegment"].map({"BSECM": "BSE"})
     token_df["exchange"] = df.apply(
         lambda row: "BSE_INDEX" if row["Series"] == "SPOT" else "BSE", axis=1
     )
@@ -231,6 +279,13 @@ def process_compositedge_bse_csv(path):
     token_df["lotsize"] = df["LotSize"]
     token_df["instrumenttype"] = df["Series"]
     token_df["tick_size"] = df["TickSize"]
+
+    # Normalize BSE index short codes from SPOT rows to OpenAlgo index symbols
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        token_df.loc[bse_idx_mask, "symbol"]
+    )
+    token_df.loc[bse_idx_mask, "name"] = token_df.loc[bse_idx_mask, "symbol"]
 
     return token_df
 
@@ -363,23 +418,46 @@ def process_compositedge_mcx_csv(path):
 
 
 def process_index_data(index_data):
+    """
+    Processes index data from API to fit the OpenAlgo database schema.
+    Uses regex normalization to handle spacing variations in symbol names.
+
+    Input format from API (index_entry format: "SYMBOL_TOKEN"):
+    - brsymbol: Full format (e.g., "NIFTY 100_26004")
+    - symbol: Raw symbol before mapping (e.g., "NIFTY 100")
+    - exchange: NSE_INDEX or BSE_INDEX
+    - token: Token value
+    """
     logger.info("Processing Index Data")
     df = pd.DataFrame(index_data)
+    if df.empty:
+        return df
 
-    # Map Symbols to Standard Format
-    df["symbol"] = df["symbol"].replace(
-        {
-            "NIFTY 50": "NIFTY",
-            "NIFTY BANK": "BANKNIFTY",
-            "INDIA VIX": "INDIAVIX",
-            "NIFTY FIN SERVICE": "FINNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "NIFTY NEXT 50": "NIFTYNXT50",
-            "SENSEX": "SENSEX",
-            "BANKEX": "BANKEX",
-            "SNSX50": "SENSEX50",
-        }
+    # Normalize casing and spacing first
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+    df["symbol"] = df["symbol"].str.replace(r"\s+", " ", regex=True)
+
+    # NSE index mapping (raw broker index names -> OpenAlgo symbols)
+    nse_index_map = {
+        "NIFTY 50": "NIFTY",
+        "NIFTY BANK": "BANKNIFTY",
+        "INDIA VIX": "INDIAVIX",
+        "NIFTY FIN SERVICE": "FINNIFTY",
+        "NIFTY MID SELECT": "MIDCPNIFTY",
+        "NIFTY NEXT 50": "NIFTYNXT50",
+        "HANGSENG BEES NAV": "HANGSENGBEESNAV",
+        "HANGSENG BEES-NAV": "HANGSENGBEESNAV",
+    }
+    df["symbol"] = df["symbol"].replace(nse_index_map)
+
+    # BSE short-code mapping (applied only to BSE_INDEX symbols)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        df.loc[bse_idx_mask, "symbol"]
     )
+
+    # Final cleanup: enforce no spaces/hyphens in symbols
+    df["symbol"] = df["symbol"].str.replace(r"[\s\-]+", "", regex=True)
 
     df["name"] = df["symbol"]
     df["brexchange"] = df["exchange"]
@@ -388,7 +466,6 @@ def process_index_data(index_data):
     df["lotsize"] = 1  # Default index lot size
     df["instrumenttype"] = "INDEX"
     df["tick_size"] = 0.05
-    # logger.info(f"{df}")
 
     return df
 

--- a/broker/iifl/database/master_contract_db.py
+++ b/broker/iifl/database/master_contract_db.py
@@ -178,6 +178,55 @@ def reformat_symbol_detail(s):
     return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
 
 
+# Shared BSE index normalization map used by both BSECM SPOT ingestion
+# and indexlist ingestion paths.
+BSE_INDEX_SYMBOL_MAP = {
+    "SNSX50": "SENSEX50",
+    "SNXT50": "BSESENSEXNEXT50",
+    "MID150": "BSE150MIDCAPINDEX",
+    "LMI250": "BSE250LARGEMIDCAPINDEX",
+    "MSL400": "BSE400MIDSMALLCAPINDEX",
+    "AUTO": "BSEAUTO",
+    "BSE CG": "BSECAPITALGOODS",
+    "CARBON": "BSECARBONEX",
+    "BSE CD": "BSECONSUMERDURABLES",
+    "CPSE": "BSECPSE",
+    "DOL100": "BSEDOLLEX100",
+    "DOL200": "BSEDOLLEX200",
+    "DOL30": "BSEDOLLEX30",
+    "ENERGY": "BSEENERGY",
+    "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+    "FIN": "BSEFINANCIALSERVICES",
+    "FINSER": "BSEFINANCIALSERVICES",
+    "GREENX": "BSEGREENEX",
+    "BSE HC": "BSEHEALTHCARE",
+    "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+    "INDSTR": "BSEINDUSTRIALS",
+    "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+    "LRGCAP": "BSELARGECAP",
+    "METAL": "BSEMETAL",
+    "MIDCAP": "BSEMIDCAP",
+    "MIDSEL": "BSEMIDCAPSELECTINDEX",
+    "OILGAS": "BSEOIL&GAS",
+    "POWER": "BSEPOWER",
+    "BSEPBI": "BSEPSU",
+    "REALTY": "BSEREALTY",
+    "SMLCAP": "BSESMALLCAP",
+    "SMLSEL": "BSESMALLCAPSELECTINDEX",
+    "SMEIPO": "BSESMEIPO",
+    "TECK": "BSETECK",
+    "TELCOM": "BSETELECOM",
+}
+
+
+def normalize_bse_index_symbols(symbol_series: pd.Series) -> pd.Series:
+    """Normalize raw BSE index symbols to OpenAlgo naming and format."""
+    normalized = symbol_series.astype(str).str.upper().str.strip()
+    normalized = normalized.str.replace(r"\s+", " ", regex=True)
+    normalized = normalized.replace(BSE_INDEX_SYMBOL_MAP)
+    return normalized.str.replace(r"[\s\-]+", "", regex=True)
+
+
 def process_compositedge_nse_csv(path):
     """
     Processes the compositedge CSV file to fit the existing database schema and performs exchange name mapping.
@@ -220,7 +269,6 @@ def process_compositedge_bse_csv(path):
     token_df["symbol"] = df["Name"]
     token_df["brsymbol"] = df["DisplayName"]
     token_df["name"] = df["Name"]
-    token_df["exchange"] = df["ExchangeSegment"].map({"BSECM": "BSE"})
     token_df["exchange"] = df.apply(
         lambda row: "BSE_INDEX" if row["Series"] == "SPOT" else "BSE", axis=1
     )
@@ -231,6 +279,13 @@ def process_compositedge_bse_csv(path):
     token_df["lotsize"] = df["LotSize"]
     token_df["instrumenttype"] = df["Series"]
     token_df["tick_size"] = df["TickSize"]
+
+    # Normalize BSE index short codes from SPOT rows to OpenAlgo index symbols
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        token_df.loc[bse_idx_mask, "symbol"]
+    )
+    token_df.loc[bse_idx_mask, "name"] = token_df.loc[bse_idx_mask, "symbol"]
 
     return token_df
 
@@ -423,23 +478,46 @@ def process_compositedge_mcx_csv(path):
 
 
 def process_index_data(index_data):
+    """
+    Processes index data from API to fit the OpenAlgo database schema.
+    Uses regex normalization to handle spacing variations in symbol names.
+
+    Input format from API (index_entry format: "SYMBOL_TOKEN"):
+    - brsymbol: Full format (e.g., "NIFTY 100_26004")
+    - symbol: Raw symbol before mapping (e.g., "NIFTY 100")
+    - exchange: NSE_INDEX or BSE_INDEX
+    - token: Token value
+    """
     logger.info("Processing Index Data")
     df = pd.DataFrame(index_data)
+    if df.empty:
+        return df
 
-    # Map Symbols to Standard Format
-    df["symbol"] = df["symbol"].replace(
-        {
-            "NIFTY 50": "NIFTY",
-            "NIFTY BANK": "BANKNIFTY",
-            "INDIA VIX": "INDIAVIX",
-            "NIFTY FIN SERVICE": "FINNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "NIFTY NEXT 50": "NIFTYNXT50",
-            "SENSEX": "SENSEX",
-            "BANKEX": "BANKEX",
-            "SNSX50": "SENSEX50",
-        }
+    # Normalize casing and spacing first
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+    df["symbol"] = df["symbol"].str.replace(r"\s+", " ", regex=True)
+
+    # NSE index mapping (raw broker index names -> OpenAlgo symbols)
+    nse_index_map = {
+        "NIFTY 50": "NIFTY",
+        "NIFTY BANK": "BANKNIFTY",
+        "INDIA VIX": "INDIAVIX",
+        "NIFTY FIN SERVICE": "FINNIFTY",
+        "NIFTY MID SELECT": "MIDCPNIFTY",
+        "NIFTY NEXT 50": "NIFTYNXT50",
+        "HANGSENG BEES NAV": "HANGSENGBEESNAV",
+        "HANGSENG BEES-NAV": "HANGSENGBEESNAV",
+    }
+    df["symbol"] = df["symbol"].replace(nse_index_map)
+
+    # BSE short-code mapping (applied only to BSE_INDEX symbols)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        df.loc[bse_idx_mask, "symbol"]
     )
+
+    # Final cleanup: enforce no spaces/hyphens in symbols
+    df["symbol"] = df["symbol"].str.replace(r"[\s\-]+", "", regex=True)
 
     df["name"] = df["symbol"]
     df["brexchange"] = df["exchange"]
@@ -448,7 +526,6 @@ def process_index_data(index_data):
     df["lotsize"] = 1  # Default index lot size
     df["instrumenttype"] = "INDEX"
     df["tick_size"] = 0.05
-    # logger.info(f"{df}")
 
     return df
 

--- a/broker/jainamxts/database/master_contract_db.py
+++ b/broker/jainamxts/database/master_contract_db.py
@@ -180,6 +180,55 @@ def reformat_symbol_detail(s):
     return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
 
 
+# Shared BSE index normalization map used by both BSECM SPOT ingestion
+# and indexlist ingestion paths.
+BSE_INDEX_SYMBOL_MAP = {
+    "SNSX50": "SENSEX50",
+    "SNXT50": "BSESENSEXNEXT50",
+    "MID150": "BSE150MIDCAPINDEX",
+    "LMI250": "BSE250LARGEMIDCAPINDEX",
+    "MSL400": "BSE400MIDSMALLCAPINDEX",
+    "AUTO": "BSEAUTO",
+    "BSE CG": "BSECAPITALGOODS",
+    "CARBON": "BSECARBONEX",
+    "BSE CD": "BSECONSUMERDURABLES",
+    "CPSE": "BSECPSE",
+    "DOL100": "BSEDOLLEX100",
+    "DOL200": "BSEDOLLEX200",
+    "DOL30": "BSEDOLLEX30",
+    "ENERGY": "BSEENERGY",
+    "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+    "FIN": "BSEFINANCIALSERVICES",
+    "FINSER": "BSEFINANCIALSERVICES",
+    "GREENX": "BSEGREENEX",
+    "BSE HC": "BSEHEALTHCARE",
+    "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+    "INDSTR": "BSEINDUSTRIALS",
+    "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+    "LRGCAP": "BSELARGECAP",
+    "METAL": "BSEMETAL",
+    "MIDCAP": "BSEMIDCAP",
+    "MIDSEL": "BSEMIDCAPSELECTINDEX",
+    "OILGAS": "BSEOIL&GAS",
+    "POWER": "BSEPOWER",
+    "BSEPBI": "BSEPSU",
+    "REALTY": "BSEREALTY",
+    "SMLCAP": "BSESMALLCAP",
+    "SMLSEL": "BSESMALLCAPSELECTINDEX",
+    "SMEIPO": "BSESMEIPO",
+    "TECK": "BSETECK",
+    "TELCOM": "BSETELECOM",
+}
+
+
+def normalize_bse_index_symbols(symbol_series: pd.Series) -> pd.Series:
+    """Normalize raw BSE index symbols to OpenAlgo naming and format."""
+    normalized = symbol_series.astype(str).str.upper().str.strip()
+    normalized = normalized.str.replace(r"\s+", " ", regex=True)
+    normalized = normalized.replace(BSE_INDEX_SYMBOL_MAP)
+    return normalized.str.replace(r"[\s\-]+", "", regex=True)
+
+
 def process_jainamxts_nse_csv(path):
     """
     Processes the JainamXTS CSV file to fit the existing database schema and performs exchange name mapping.
@@ -222,7 +271,6 @@ def process_jainamxts_bse_csv(path):
     token_df["symbol"] = df["Name"]
     token_df["brsymbol"] = df["DisplayName"]
     token_df["name"] = df["Name"]
-    token_df["exchange"] = df["ExchangeSegment"].map({"BSECM": "BSE"})
     token_df["exchange"] = df.apply(
         lambda row: "BSE_INDEX" if row["Series"] == "SPOT" else "BSE", axis=1
     )
@@ -233,6 +281,13 @@ def process_jainamxts_bse_csv(path):
     token_df["lotsize"] = df["LotSize"]
     token_df["instrumenttype"] = df["Series"]
     token_df["tick_size"] = df["TickSize"]
+
+    # Normalize BSE index short codes from SPOT rows to OpenAlgo index symbols
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        token_df.loc[bse_idx_mask, "symbol"]
+    )
+    token_df.loc[bse_idx_mask, "name"] = token_df.loc[bse_idx_mask, "symbol"]
 
     return token_df
 
@@ -433,23 +488,46 @@ def process_jainamxts_mcx_csv(path):
 
 
 def process_index_data(index_data):
+    """
+    Processes index data from API to fit the OpenAlgo database schema.
+    Uses regex normalization to handle spacing variations in symbol names.
+
+    Input format from API (index_entry format: "SYMBOL_TOKEN"):
+    - brsymbol: Full format (e.g., "NIFTY 100_26004")
+    - symbol: Raw symbol before mapping (e.g., "NIFTY 100")
+    - exchange: NSE_INDEX or BSE_INDEX
+    - token: Token value
+    """
     logger.info("Processing Index Data")
     df = pd.DataFrame(index_data)
+    if df.empty:
+        return df
 
-    # Map Symbols to Standard Format
-    df["symbol"] = df["symbol"].replace(
-        {
-            "NIFTY 50": "NIFTY",
-            "NIFTY BANK": "BANKNIFTY",
-            "INDIA VIX": "INDIAVIX",
-            "NIFTY FIN SERVICE": "FINNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "NIFTY NEXT 50": "NIFTYNXT50",
-            "SENSEX": "SENSEX",
-            "BANKEX": "BANKEX",
-            "SNSX50": "SENSEX50",
-        }
+    # Normalize casing and spacing first
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+    df["symbol"] = df["symbol"].str.replace(r"\s+", " ", regex=True)
+
+    # NSE index mapping (raw broker index names -> OpenAlgo symbols)
+    nse_index_map = {
+        "NIFTY 50": "NIFTY",
+        "NIFTY BANK": "BANKNIFTY",
+        "INDIA VIX": "INDIAVIX",
+        "NIFTY FIN SERVICE": "FINNIFTY",
+        "NIFTY MID SELECT": "MIDCPNIFTY",
+        "NIFTY NEXT 50": "NIFTYNXT50",
+        "HANGSENG BEES NAV": "HANGSENGBEESNAV",
+        "HANGSENG BEES-NAV": "HANGSENGBEESNAV",
+    }
+    df["symbol"] = df["symbol"].replace(nse_index_map)
+
+    # BSE short-code mapping (applied only to BSE_INDEX symbols)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        df.loc[bse_idx_mask, "symbol"]
     )
+
+    # Final cleanup: enforce no spaces/hyphens in symbols
+    df["symbol"] = df["symbol"].str.replace(r"[\s\-]+", "", regex=True)
 
     df["name"] = df["symbol"]
     df["brexchange"] = df["exchange"]
@@ -458,7 +536,6 @@ def process_index_data(index_data):
     df["lotsize"] = 1  # Default index lot size
     df["instrumenttype"] = "INDEX"
     df["tick_size"] = 0.05
-    # logger.info(f"{df}")
 
     return df
 

--- a/broker/wisdom/database/master_contract_db.py
+++ b/broker/wisdom/database/master_contract_db.py
@@ -178,6 +178,55 @@ def reformat_symbol_detail(s):
     return f"{parts[0]}{parts[3]}{parts[2].upper()}{parts[1]}{parts[4]}"
 
 
+# Shared BSE index normalization map used by both BSECM SPOT ingestion
+# and indexlist ingestion paths.
+BSE_INDEX_SYMBOL_MAP = {
+    "SNSX50": "SENSEX50",
+    "SNXT50": "BSESENSEXNEXT50",
+    "MID150": "BSE150MIDCAPINDEX",
+    "LMI250": "BSE250LARGEMIDCAPINDEX",
+    "MSL400": "BSE400MIDSMALLCAPINDEX",
+    "AUTO": "BSEAUTO",
+    "BSE CG": "BSECAPITALGOODS",
+    "CARBON": "BSECARBONEX",
+    "BSE CD": "BSECONSUMERDURABLES",
+    "CPSE": "BSECPSE",
+    "DOL100": "BSEDOLLEX100",
+    "DOL200": "BSEDOLLEX200",
+    "DOL30": "BSEDOLLEX30",
+    "ENERGY": "BSEENERGY",
+    "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+    "FIN": "BSEFINANCIALSERVICES",
+    "FINSER": "BSEFINANCIALSERVICES",
+    "GREENX": "BSEGREENEX",
+    "BSE HC": "BSEHEALTHCARE",
+    "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+    "INDSTR": "BSEINDUSTRIALS",
+    "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+    "LRGCAP": "BSELARGECAP",
+    "METAL": "BSEMETAL",
+    "MIDCAP": "BSEMIDCAP",
+    "MIDSEL": "BSEMIDCAPSELECTINDEX",
+    "OILGAS": "BSEOIL&GAS",
+    "POWER": "BSEPOWER",
+    "BSEPBI": "BSEPSU",
+    "REALTY": "BSEREALTY",
+    "SMLCAP": "BSESMALLCAP",
+    "SMLSEL": "BSESMALLCAPSELECTINDEX",
+    "SMEIPO": "BSESMEIPO",
+    "TECK": "BSETECK",
+    "TELCOM": "BSETELECOM",
+}
+
+
+def normalize_bse_index_symbols(symbol_series: pd.Series) -> pd.Series:
+    """Normalize raw BSE index symbols to OpenAlgo naming and format."""
+    normalized = symbol_series.astype(str).str.upper().str.strip()
+    normalized = normalized.str.replace(r"\s+", " ", regex=True)
+    normalized = normalized.replace(BSE_INDEX_SYMBOL_MAP)
+    return normalized.str.replace(r"[\s\-]+", "", regex=True)
+
+
 def process_compositedge_nse_csv(path):
     """
     Processes the compositedge CSV file to fit the existing database schema and performs exchange name mapping.
@@ -220,7 +269,6 @@ def process_compositedge_bse_csv(path):
     token_df["symbol"] = df["Name"]
     token_df["brsymbol"] = df["DisplayName"]
     token_df["name"] = df["Name"]
-    token_df["exchange"] = df["ExchangeSegment"].map({"BSECM": "BSE"})
     token_df["exchange"] = df.apply(
         lambda row: "BSE_INDEX" if row["Series"] == "SPOT" else "BSE", axis=1
     )
@@ -231,6 +279,13 @@ def process_compositedge_bse_csv(path):
     token_df["lotsize"] = df["LotSize"]
     token_df["instrumenttype"] = df["Series"]
     token_df["tick_size"] = df["TickSize"]
+
+    # Normalize BSE index short codes from SPOT rows to OpenAlgo index symbols
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        token_df.loc[bse_idx_mask, "symbol"]
+    )
+    token_df.loc[bse_idx_mask, "name"] = token_df.loc[bse_idx_mask, "symbol"]
 
     return token_df
 
@@ -423,23 +478,46 @@ def process_compositedge_mcx_csv(path):
 
 
 def process_index_data(index_data):
+    """
+    Processes index data from API to fit the OpenAlgo database schema.
+    Uses regex normalization to handle spacing variations in symbol names.
+
+    Input format from API (index_entry format: "SYMBOL_TOKEN"):
+    - brsymbol: Full format (e.g., "NIFTY 100_26004")
+    - symbol: Raw symbol before mapping (e.g., "NIFTY 100")
+    - exchange: NSE_INDEX or BSE_INDEX
+    - token: Token value
+    """
     logger.info("Processing Index Data")
     df = pd.DataFrame(index_data)
+    if df.empty:
+        return df
 
-    # Map Symbols to Standard Format
-    df["symbol"] = df["symbol"].replace(
-        {
-            "NIFTY 50": "NIFTY",
-            "NIFTY BANK": "BANKNIFTY",
-            "INDIA VIX": "INDIAVIX",
-            "NIFTY FIN SERVICE": "FINNIFTY",
-            "NIFTY MID SELECT": "MIDCPNIFTY",
-            "NIFTY NEXT 50": "NIFTYNXT50",
-            "SENSEX": "SENSEX",
-            "BANKEX": "BANKEX",
-            "SNSX50": "SENSEX50",
-        }
+    # Normalize casing and spacing first
+    df["symbol"] = df["symbol"].astype(str).str.upper().str.strip()
+    df["symbol"] = df["symbol"].str.replace(r"\s+", " ", regex=True)
+
+    # NSE index mapping (raw broker index names -> OpenAlgo symbols)
+    nse_index_map = {
+        "NIFTY 50": "NIFTY",
+        "NIFTY BANK": "BANKNIFTY",
+        "INDIA VIX": "INDIAVIX",
+        "NIFTY FIN SERVICE": "FINNIFTY",
+        "NIFTY MID SELECT": "MIDCPNIFTY",
+        "NIFTY NEXT 50": "NIFTYNXT50",
+        "HANGSENG BEES NAV": "HANGSENGBEESNAV",
+        "HANGSENG BEES-NAV": "HANGSENGBEESNAV",
+    }
+    df["symbol"] = df["symbol"].replace(nse_index_map)
+
+    # BSE short-code mapping (applied only to BSE_INDEX symbols)
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    df.loc[bse_idx_mask, "symbol"] = normalize_bse_index_symbols(
+        df.loc[bse_idx_mask, "symbol"]
     )
+
+    # Final cleanup: enforce no spaces/hyphens in symbols
+    df["symbol"] = df["symbol"].str.replace(r"[\s\-]+", "", regex=True)
 
     df["name"] = df["symbol"]
     df["brexchange"] = df["exchange"]
@@ -448,7 +526,6 @@ def process_index_data(index_data):
     df["lotsize"] = 1  # Default index lot size
     df["instrumenttype"] = "INDEX"
     df["tick_size"] = 0.05
-    # logger.info(f"{df}")
 
     return df
 


### PR DESCRIPTION
feat: add index symbol normalization for XTS brokers (fivepaisaxts, ibulls, iifl, jainamxts, wisdom)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized index symbol normalization across XTS brokers to match OpenAlgo naming. Fixes inconsistent NSE/BSE index symbols in BSE SPOT CSVs and index API data for `fivepaisaxts`, `ibulls`, `iifl`, `jainamxts`, and `wisdom`.

- **New Features**
  - Added shared BSE normalization map and helper to convert short codes (e.g., SNSX50 → SENSEX50), unify casing/spacing, and remove spaces/hyphens.
  - Updated BSE CSV ingestion to mark SPOT rows as `BSE_INDEX` and normalize `symbol` and `name`.
  - Improved index API processing to normalize casing/spacing, apply NSE index mappings (including HANGSENGBEESNAV), and apply BSE normalization only for `BSE_INDEX`.

<sup>Written for commit c3e7e9f6cefdc32f9e545775fcec239cb2164d53. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

