### PR TITLE
fix: filter sandbox closeposition by strategy instead of closing all positions

### DIFF
--- a/services/close_position_service.py
+++ b/services/close_position_service.py
@@ -108,6 +108,7 @@ def close_position_with_auth(
             "symbol": position_data.get("symbol"),
             "exchange": position_data.get("exchange"),
             "product": position_data.get("product_type") or position_data.get("product"),
+            "strategy": position_data.get("strategy"),
         }
 
         return sandbox_close_position(close_data, api_key, original_data)

--- a/services/sandbox_service.py
+++ b/services/sandbox_service.py
@@ -360,6 +360,40 @@ def sandbox_get_funds(
         )
 
 
+def _get_strategy_positions(user_id: str, strategy: str) -> set[tuple[str, str, str]]:
+    """Look up which (symbol, exchange, product) positions a strategy has traded.
+
+    Uses the sandbox trades table to find instruments the strategy has
+    opened positions in, so closeposition can target only those instruments
+    instead of closing every open position.
+
+    Returns:
+        Set of (symbol, exchange, product) tuples traded by the strategy.
+    """
+    from database.sandbox_db import SandboxTrades, db_session as sandbox_session
+
+    try:
+        rows = (
+            sandbox_session.query(
+                SandboxTrades.symbol,
+                SandboxTrades.exchange,
+                SandboxTrades.product,
+            )
+            .filter(
+                SandboxTrades.user_id == user_id,
+                SandboxTrades.strategy == strategy,
+            )
+            .distinct()
+            .all()
+        )
+        return {(r.symbol, r.exchange, r.product) for r in rows}
+    except Exception as e:
+        logger.error(f"Error querying strategy positions for '{strategy}': {e}")
+        return set()
+    finally:
+        sandbox_session.remove()
+
+
 def sandbox_close_position(
     position_data: dict[str, Any], api_key: str, original_data: dict[str, Any]
 ) -> tuple[bool, dict[str, Any], int]:
@@ -390,6 +424,32 @@ def sandbox_close_position(
                     {
                         "status": "success",
                         "message": "No open positions to close",
+                        "mode": "analyze",
+                    },
+                    200,
+                )
+
+            # When a strategy is specified, only close positions for
+            # instruments that strategy has actually traded.  Without this
+            # filter, one strategy's EOD exit would close positions opened
+            # by other strategies running on the same account.
+            strategy = position_data.get("strategy")
+            if strategy:
+                strategy_instruments = _get_strategy_positions(user_id, strategy)
+                if strategy_instruments:
+                    positions = [
+                        pos
+                        for pos in positions
+                        if (pos.get("symbol"), pos.get("exchange"), pos.get("product"))
+                        in strategy_instruments
+                    ]
+
+            if not positions:
+                return (
+                    True,
+                    {
+                        "status": "success",
+                        "message": "No open positions to close for this strategy",
                         "mode": "analyze",
                     },
                     200,


### PR DESCRIPTION
## Summary

The `closeposition` API requires a `strategy` parameter (validated by `ClosePositionSchema`), but in sandbox/analyzer mode the strategy value is **silently discarded** before reaching `sandbox_close_position()`. This causes the API to close **all** open sandbox positions regardless of which strategy made the call.

**Impact:** When multiple strategies run on the same account in analyzer mode, one strategy's EOD square-off closes positions belonging to *every other strategy*. For example, an intraday scanner exiting at 15:13 would nuke NRML strangle positions that should hold until expiry.

### Root Cause

In `close_position_service.py`, `close_position_with_auth()` builds `close_data` with only `symbol`, `exchange`, and `product` — **dropping the `strategy` field** before passing it to `sandbox_close_position()`:

```python
close_data = {
    "symbol": position_data.get("symbol"),
    "exchange": position_data.get("exchange"),
    "product": position_data.get("product_type") or position_data.get("product"),
    # strategy is missing here
}
```

Since `closeposition` is called without symbol/exchange (it's a "close everything for this strategy" call), `sandbox_close_position` sees `not symbol and not exchange` → closes ALL positions.

### Fix

1. **`close_position_service.py`**: Pass `strategy` through in `close_data`
2. **`sandbox_service.py`**: New helper `_get_strategy_positions()` queries `sandbox_trades` for the distinct `(symbol, exchange, product)` combinations the strategy has traded, then filters positions to only those instruments

### Backward Compatibility

- When `strategy` is absent → all positions are closed (unchanged behavior)
- When the trade lookup returns no results → all positions are closed (safe fallback)
- Live/broker mode is unaffected (strategy filtering only applies to the sandbox path)
- No schema changes, no database migrations

## Test plan

- [ ] In analyzer mode, open positions with Strategy A (e.g. buy NIFTY CE) and Strategy B (e.g. buy BANKNIFTY PE)
- [ ] Call `closeposition` with `strategy="A"` → only NIFTY CE should close, BANKNIFTY PE should remain
- [ ] Call `closeposition` without strategy filtering → all positions close (backward compat)
- [ ] Verify live mode closeposition still works as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes sandbox/analyzer closeposition to respect the strategy parameter, so one strategy’s exit doesn’t close everyone’s positions. Live/broker mode is unchanged.

- **Bug Fixes**
  - Pass `strategy` to `sandbox_close_position()` from `close_position_service.py`.
  - In sandbox, filter positions to instruments the strategy actually traded by querying `sandbox_trades` for distinct (symbol, exchange, product).
  - Fallback: if `strategy` is missing or finds no instruments, close all positions (previous behavior).

<sup>Written for commit f59b7e8e08664a38351579c614f62aa14e04e30b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

