### PR TITLE
feat(ui): improve empty state on Search page

### DIFF
--- a/frontend/src/pages/Search.tsx
+++ b/frontend/src/pages/Search.tsx
@@ -230,11 +230,23 @@ export default function Search() {
               <TableBody>
                 {paginatedResults.length === 0 ? (
                   <TableRow>
-                    <TableCell colSpan={8} className="text-center py-8 text-muted-foreground">
+                    <TableCell colSpan={8} className="text-center py-12">
                       {error ? (
-                        <span className="text-destructive">{error}</span>
+                        <div className="text-destructive font-medium">{error}</div>
                       ) : (
-                        'No results found'
+                        <div className="flex flex-col items-center justify-center text-center">
+                          <SearchIcon className="h-12 w-12 text-muted-foreground mb-4" />
+                          <h3 className="text-lg font-semibold mb-2">No Results Found</h3>
+                          <p className="text-muted-foreground mb-4">
+                            We couldn't find any symbols matching your search criteria.
+                          </p>
+                          <Button asChild variant="outline">
+                            <Link to="/search/token">
+                              <SearchIcon className="h-4 w-4 mr-2" />
+                              Try New Search
+                            </Link>
+                          </Button>
+                        </div>
                       )}
                     </TableCell>
                   </TableRow>


### PR DESCRIPTION
## What does this PR do?
Improves the empty state UI on the Search page by replacing the plain "No results found" text with a more informative pattern including a Search icon, heading, description, and a "Try New Search" action button.

## Related Issue
Partial fix for #889 -- covers Search page only

## Changes
- Replaced plain text "No results found" with icon + heading + description pattern
- - Added `SearchIcon` (12x12) as visual indicator
- - Added descriptive heading "No Results Found"
- - Added helpful description text
- - Added "Try New Search" button linking back to search
- - Increased vertical padding from `py-8` to `py-12` for better spacing
- - Enhanced error state with `font-medium` for better visibility
## How to Test
1. Navigate to the Search page
2. 2. Search for a symbol that doesn't exist (e.g., "ZZZZZ")
3. 3. Verify the empty state shows the icon, heading, description, and action button
4. 4. Click "Try New Search" and verify it navigates correctly

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the Search page empty state with an icon, heading, helpful text, and a "Try New Search" button for clearer guidance and navigation. Also increases spacing and makes error messages more visible; partial fix for #889 (Search page only).

<sup>Written for commit 04c4331fd23f82b62f2ddaead754eccb224f2da0. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

