### PR TITLE
feat(ui): add tooltip to Close Position button on Positions page

### DIFF
--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -41,6 +41,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Table,
   TableBody,
@@ -999,14 +1000,23 @@ export default function Positions() {
                                 {calculatePnlPercent(position).toFixed(2)}%
                               </TableCell>
                               <TableCell className="w-[60px] text-right">
-                                <Button
-                                  variant="ghost"
-                                  size="sm"
-                                  className="text-destructive hover:text-destructive hover:bg-destructive/10"
-                                  onClick={() => handleClosePosition(position)}
-                                >
-                                  <X className="h-4 w-4" />
-                                </Button>
+                                <TooltipProvider>
+                                  <Tooltip>
+                                    <TooltipTrigger asChild>
+                                      <Button
+                                        variant="ghost"
+                                        size="sm"
+                                        className="text-destructive hover:text-destructive hover:bg-destructive/10"
+                                        onClick={() => handleClosePosition(position)}
+                                      >
+                                        <X className="h-4 w-4" />
+                                      </Button>
+                                    </TooltipTrigger>
+                                    <TooltipContent>
+                                      <p>Close Position</p>
+                                    </TooltipContent>
+                                  </Tooltip>
+                                </TooltipProvider>
                               </TableCell>
                             </TableRow>
                           ))}


### PR DESCRIPTION
## What does this PR do?
Adds a tooltip to the "Close Position" icon button on the Positions page for better usability.

## Related Issue
Partial fix for #1011 - covers Positions page

## Changes
- Wrapped the Close Position X button with TooltipProvider/Tooltip/TooltipTrigger/TooltipContent
- - Added "Close Position" tooltip text on hover
- - Imported Tooltip components from existing shadcn/ui
## How to Test
1. Navigate to the Positions page
2. 2. Hover over the X (close) button on any position row
3. 3. Verify the "Close Position" tooltip appears on hover

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a tooltip to the Close Position icon button on the Positions page to improve clarity and accessibility. Partial fix for #1011.

- **New Features**
  - Wraps the button with `TooltipProvider`, `Tooltip`, `TooltipTrigger`, and `TooltipContent` from `@/components/ui/tooltip`, showing "Close Position" on hover.

<sup>Written for commit ecbc7c6a9fc6b1e427ba31935db317bed1024173. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

