### PR TITLE
feat(ui): add tooltips to action buttons on TradeBook page

### DIFF
--- a/frontend/src/pages/TradeBook.tsx
+++ b/frontend/src/pages/TradeBook.tsx
@@ -15,6 +15,7 @@ import {
   DialogTrigger,
 } from '@/components/ui/dialog'
 import { Label } from '@/components/ui/label'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 import {
   Table,
   TableBody,
@@ -215,19 +216,28 @@ export default function TradeBook() {
         <div className="flex items-center gap-2 flex-wrap">
           {/* Settings Button */}
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
-                size="sm"
-                className="relative"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Filters
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
+            <TooltipProvider>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DialogTrigger asChild>
+                    <Button
+                      variant={hasActiveFilters ? 'default' : 'outline'}
+                      size="sm"
+                      className="relative"
+                    >
+                      <Settings2 className="h-4 w-4 mr-2" />
+                      Filters
+                      {hasActiveFilters && (
+                        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                      )}
+                    </Button>
+                  </DialogTrigger>
+                </TooltipTrigger>
+                <TooltipContent>
+                  <p>Trade Filters</p>
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
             <DialogContent className="max-w-md">
               <DialogHeader>
                 <DialogTitle>Trade Filters</DialogTitle>
@@ -283,19 +293,38 @@ export default function TradeBook() {
             </DialogContent>
           </Dialog>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchTrades(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchTrades(true)}
+                  disabled={isRefreshing}
+                >
+                  <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+                  Refresh
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Refresh Trades</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={exportToCSV}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                <p>Export to CSV</p>
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
         </div>
       </div>
 


### PR DESCRIPTION
## What does this PR do?
Adds tooltips to the Filters, Refresh, and Export buttons on the TradeBook page for better usability.

## Related Issue
Partial fix for #1011 - covers TradeBook page

## Changes
- Wrapped Filters button with TooltipProvider/Tooltip showing "Trade Filters"
- - Wrapped Refresh button with tooltip showing "Refresh Trades"
- - Wrapped Export button with tooltip showing "Export to CSV"
- - Imported Tooltip components from existing shadcn/ui
## How to Test
1. Navigate to the Trade Book page
2. 2. Hover over the Filters button - verify "Trade Filters" tooltip appears
3. 3. Hover over the Refresh button - verify "Refresh Trades" tooltip appears
4. 4. Hover over the Export button - verify "Export to CSV" tooltip appears

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added hover tooltips to the Filters, Refresh, and Export buttons on the TradeBook page to improve accessibility and clarify actions. Uses `Tooltip`, `TooltipTrigger`, and `TooltipContent` from `shadcn/ui` to show “Trade Filters”, “Refresh Trades”, and “Export to CSV”.

<sup>Written for commit 6c1b3a5d8c52431df25c00ad9b53d594320644d6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

