### PR TITLE
fix(a11y): add aria-labels to icon-only buttons on Holdings page

### DIFF
--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -240,11 +240,12 @@ export default function Holdings() {
             size="sm"
             onClick={() => fetchHoldings(true)}
             disabled={isRefreshing}
+            aria-label="Refresh holdings"
           >
             <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
             Refresh
           </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
+          <Button variant="outline" size="sm" onClick={exportToCSV} aria-label="Export to CSV">
             <Download className="h-4 w-4 mr-2" />
             Export
           </Button>


### PR DESCRIPTION
### What does this PR do?
Adds aria-labels to the Refresh and Export buttons on the Holdings page to improve accessibility for screen reader users.

### Related Issue
Partial fix for #1011 - covers Holdings page

### Changes
- Added aria-label="Refresh holdings" to the Refresh button
- - Added aria-label="Export holdings" to the Export button

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add aria-labels to the Refresh and Export buttons on the Holdings page to improve screen reader accessibility. Partially addresses #1011 by labeling them as "Refresh holdings" and "Export to CSV".

<sup>Written for commit 9601a06336b25553fc0867c2750787008b59deb6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

