### PR TITLE
fix: replace bare except with specific exception in _safe_timestamp()

### DIFF
--- a/database/historify_db.py
+++ b/database/historify_db.py
@@ -1855,7 +1855,8 @@ def _safe_timestamp(val) -> str | None:
         if hasattr(val, "isoformat"):
             return val.isoformat()
         return str(val)
-    except:
+    except (TypeError, ValueError) as e:
+        logger.warning(f"Failed to parse timestamp {val}: {e}")
         return None
 
 


### PR DESCRIPTION
### What does this PR do?
Replaces a bare except: block with a more specific Exception: catch in the _safe_timestamp() helper function within historify_db.py.

### Changes
- Updated except: to except Exception: to follow Python best practices and avoid catching system-exiting exceptions (like KeyboardInterrupt).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced the bare except in _safe_timestamp() with explicit (TypeError, ValueError) handling and added a warning log on failures. This avoids swallowing interrupts and makes timestamp parsing errors visible.

<sup>Written for commit 02ce7ea6dfa67d4ebbfd092c0cb5c252966e9c9e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

