### PR TITLE
fix(services): replace traceback.print_exc() with logger.exception() in data services

### DIFF
--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import Auth, db_session, get_auth_token_broker, verify_api_key
@@ -113,8 +112,7 @@ def get_depth_with_auth(
 
         return True, {"status": "success", "data": depth}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_depth: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_depth: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/funds_service.py
+++ b/services/funds_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -76,8 +75,7 @@ def get_funds_with_auth(
 
         return True, {"status": "success", "data": funds}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_margin_data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_margin_data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -1,6 +1,5 @@
 import importlib
 import time
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -138,8 +137,7 @@ def get_history_with_auth(
 
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_history: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_history: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 
@@ -214,8 +212,7 @@ def get_history_from_db(
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
 
     except Exception as e:
-        logger.error(f"Error fetching history from DB: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error fetching history from DB: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/holdings_service.py
+++ b/services/holdings_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -136,8 +135,7 @@ def get_holdings_with_auth(
             200,
         )
     except Exception as e:
-        logger.error(f"Error processing holdings data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing holdings data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/intervals_service.py
+++ b/services/intervals_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -80,8 +79,7 @@ def get_intervals_with_auth(auth_token: str, broker: str) -> tuple[bool, dict[st
 
         return True, {"status": "success", "data": intervals}, 200
     except Exception as e:
-        logger.error(f"Error getting supported intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting supported intervals: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/margin_service.py
+++ b/services/margin_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.apilog_db import async_log_order, executor
@@ -198,8 +197,7 @@ def calculate_margin_with_auth(
         executor.submit(async_log_order, "margin", original_data, error_response)
         return False, error_response, 501
     except Exception as e:
-        logger.error(f"Error in broker_module.calculate_margin_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.calculate_margin_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to calculate margin due to internal error",

--- a/services/openposition_service.py
+++ b/services/openposition_service.py
@@ -1,5 +1,4 @@
 import copy
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 import requests
@@ -175,8 +174,7 @@ def get_open_position_with_auth(
         return True, response_data, 200
 
     except Exception as e:
-        logger.error(f"Error processing open position: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing open position: {e}")
         error_response = {"status": "error", "message": str(e)}
         log_executor.submit(async_log_order, "openposition", original_data, error_response)
         return False, error_response, 500

--- a/services/positionbook_service.py
+++ b/services/positionbook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -142,8 +141,7 @@ def get_positionbook_with_auth(
 
         return True, {"status": "success", "data": formatted_positions}, 200
     except Exception as e:
-        logger.error(f"Error processing positions data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing positions data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -150,8 +149,7 @@ def get_quotes_with_auth(
             logger.debug(f"Quote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_quotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_quotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 
@@ -321,8 +319,7 @@ def get_multiquotes_with_auth(
             logger.debug(f"Multiquote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_multiquotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_multiquotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 

--- a/services/symbol_service.py
+++ b/services/symbol_service.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -78,8 +77,7 @@ def get_symbol_info_with_auth(
         return False, error_response, 404
 
     except Exception as e:
-        logger.error(f"Error retrieving symbol information: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error retrieving symbol information: {e}")
         error_response = {"status": "error", "message": str(e)}
         return False, error_response, 500
 

--- a/services/tradebook_service.py
+++ b/services/tradebook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -131,8 +130,7 @@ def get_tradebook_with_auth(
 
         return True, {"status": "success", "data": formatted_trades}, 200
     except Exception as e:
-        logger.error(f"Error processing trade data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing trade data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 


### PR DESCRIPTION

This PR refactors exception handling across all data-related services in the services/ directory. It replaces the use of traceback.print_exc() and logger.error with logger.exception(), ensuring full stack traces are captured in the application's logging system.

Key Improvements:
Full error context and stack traces are now correctly logged into files and external logging sinks instead of being lost to standard output.
Removed unnecessary import traceback statements from multiple service files, resulting in cleaner and more concise code.
Modified Data Services:
depth_service.py
funds_service.py
history_service.py
holdings_service.py
intervals_service.py
margin_service.py

openposition_service.py

positionbook_service.py

quotes_service.py

symbol_service.py

tradebook_service.py
Type of Change:
 Bug fix (non-breaking change which fixes an issue)
 Refactoring (cleanup of exception handling logic)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `traceback.print_exc()` and `logger.error` with `logger.exception` across data services to capture full stack traces in app logs. This fixes missing error context and routes errors to configured handlers instead of stdout.

- **Bug Fixes**
  - Stack traces now persist in log files and external sinks.
  - Removed redundant `traceback` imports and prints.
  - Standardized error logging across services (depth, funds, history, holdings, intervals, margin, openposition, positionbook, quotes, symbol, tradebook).

<sup>Written for commit 40419ecdd6d804130e8653131238857e3ca6d765. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

