### PR TITLE
fix(api): standardize error response format in option greeks

### DIFF
--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -89,9 +89,7 @@ class MultiOptionGreeks(Resource):
             except ValidationError as err:
                 logger.warning(f"Validation error in multi option greeks request: {err.messages}")
                 return make_response(
-                    jsonify(
-                        {"status": "error", "message": "Validation failed", "errors": err.messages}
-                    ),
+                    jsonify({"status": "error", "message": f"Validation failed: {err.messages}"}),
                     400,
                 )
 

--- a/restx_api/option_greeks.py
+++ b/restx_api/option_greeks.py
@@ -95,9 +95,7 @@ class OptionGreeks(Resource):
             except ValidationError as err:
                 logger.warning(f"Validation error in option greeks request: {err.messages}")
                 return make_response(
-                    jsonify(
-                        {"status": "error", "message": "Validation failed", "errors": err.messages}
-                    ),
+                    jsonify({"status": "error", "message": f"Validation failed: {err.messages}"}),
                     400,
                 )
 


### PR DESCRIPTION
This PR standardizes the API error response format in 

option_greeks.py
 and 

multi_option_greeks.py
 to {"status": "error", "message": "error_message"}. Previously, validation failures would return a redundant "errors" field along with "message": "Validation failed". With this change:

Standardized Response Structure: All API error responses now follow the same unified format (status + message), making them more consistent and easier for clients to parse.
Detailed Error Messages: The full validation error details are now included within the "message" field itself (e.g., "message": "Validation failed: {'symbol': ['Unknown field.']}").
Improved Client Experience: Clients no longer need to check for two different ways of reporting errors depending on whether it was a validation failure or an internal server error.
Files Modified:

restx_api/option_greeks.py

restx_api/multi_option_greeks.py
Type of Change:
 Bug fix (non-breaking change which fixes an issue)
 Refactoring (standardization of API response format)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized API error responses in the option greeks endpoints to a single format: {"status": "error", "message": "<details>"}.
Removed the separate "errors" field and embedded validation details in "message" for consistent client handling.

<sup>Written for commit 8c3c24195a473c50a8344f3285c51e33acca0b2f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

