### PR TITLE
fix: add missing file header comment to broker funds.py files

### DIFF
--- a/broker/dhan_sandbox/api/funds.py
+++ b/broker/dhan_sandbox/api/funds.py
@@ -1,3 +1,5 @@
+# api/funds.py
+
 import json
 import os
 

--- a/broker/fivepaisa/api/funds.py
+++ b/broker/fivepaisa/api/funds.py
@@ -1,3 +1,5 @@
+# api/funds.py
+
 import json
 import os
 from typing import Any, Dict

--- a/broker/flattrade/api/funds.py
+++ b/broker/flattrade/api/funds.py
@@ -1,3 +1,5 @@
+# api/funds.py
+
 import json
 import os
 

--- a/broker/shoonya/api/funds.py
+++ b/broker/shoonya/api/funds.py
@@ -1,3 +1,5 @@
+# api/funds.py
+
 import json
 import os
 

--- a/broker/zebu/api/funds.py
+++ b/broker/zebu/api/funds.py
@@ -1,3 +1,5 @@
+# api/funds.py
+
 import json
 import os
 

--- a/utils/version.py
+++ b/utils/version.py
@@ -4,6 +4,10 @@
 VERSION = "2.0.0.1"
 
 
-def get_version():
-    """Return the current OpenAlgo version"""
+def get_version() -> str:
+    """Return the current OpenAlgo version.
+
+    Returns:
+        str: The current version string (e.g. '2.0.0.1')
+    """
     return VERSION


### PR DESCRIPTION
add missing file header comment to broker funds.py files, Also updated utils/version.py docstring to follow the 
Google-style docstring convention as mentioned in CONTRIBUTING.md

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added missing file header comments to broker funds modules and updated `utils/version.py` docstring to follow Google-style for consistency and tooling.

- **Refactors**
  - Added "# api/funds.py" header to `broker/dhan_sandbox/api/funds.py`, `broker/fivepaisa/api/funds.py`, `broker/flattrade/api/funds.py`, `broker/shoonya/api/funds.py`, `broker/zebu/api/funds.py`.
  - Converted `utils/version.py` to Google-style docstring and added return type annotation for `get_version()`.

<sup>Written for commit e68dda541c945ea540467029afc8ade55ff59144. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

