### PR TITLE
feat(flattrade): Update to V2 API endpoints and WebSocket payload

### DIFF
--- a/broker/flattrade/api/data.py
+++ b/broker/flattrade/api/data.py
@@ -101,7 +101,7 @@ class BrokerData:
                 "token": token,
             }
 
-            response = get_api_response("/PiConnectTP/GetQuotes", self.auth_token, payload=payload)
+            response = get_api_response("/PiConnectAPI/GetQuotes", self.auth_token, payload=payload)
 
             if response.get("stat") != "Ok":
                 raise Exception(
@@ -180,7 +180,7 @@ class BrokerData:
 
             payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            url = "https://piconnect.flattrade.in/PiConnectTP/GetQuotes"
+            url = "https://piconnect.flattrade.in/PiConnectAPI/GetQuotes"
 
             # Use httpx.post for sync requests
             http_response = httpx.post(url, content=payload_str, headers=headers, timeout=10.0)
@@ -230,7 +230,7 @@ class BrokerData:
 
             payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            url = "https://piconnect.flattrade.in/PiConnectTP/GetQuotes"
+            url = "https://piconnect.flattrade.in/PiConnectAPI/GetQuotes"
 
             # Use async httpx client
             http_response = await client.post(url, content=payload_str, headers=headers)
@@ -443,7 +443,7 @@ class BrokerData:
                 "token": token,
             }
 
-            response = get_api_response("/PiConnectTP/GetQuotes", self.auth_token, payload=payload)
+            response = get_api_response("/PiConnectAPI/GetQuotes", self.auth_token, payload=payload)
 
             if response.get("stat") != "Ok":
                 raise Exception(
@@ -555,7 +555,7 @@ class BrokerData:
                 logger.debug(f"EOD Payload: {payload}")  # Debug print
                 try:
                     response = get_api_response(
-                        "/PiConnectTP/EODChartData", self.auth_token, payload=payload
+                        "/PiConnectAPI/EODChartData", self.auth_token, payload=payload
                     )
                     logger.debug(f"EOD Response: {response}")  # Debug print
                 except Exception as e:
@@ -573,7 +573,7 @@ class BrokerData:
                 }
                 logger.debug(f"Intraday Payload: {payload}")  # Debug print
                 response = get_api_response(
-                    "/PiConnectTP/TPSeries", self.auth_token, payload=payload
+                    "/PiConnectAPI/TPSeries", self.auth_token, payload=payload
                 )
                 logger.debug(f"Intraday Response: {response}")  # Debug print
 

--- a/broker/flattrade/api/funds.py
+++ b/broker/flattrade/api/funds.py
@@ -49,7 +49,7 @@ def get_margin_data(auth_token):
     client = get_httpx_client()
 
     # Fetch margin data
-    margin_data = fetch_data("/PiConnectTP/Limits", payload, headers, client)
+    margin_data = fetch_data("/PiConnectAPI/Limits", payload, headers, client)
 
     # Check if the request was successful
     if margin_data.get("stat") != "Ok":
@@ -58,7 +58,7 @@ def get_margin_data(auth_token):
         return {}
 
     # Fetch position data
-    position_data = fetch_data("/PiConnectTP/PositionBook", payload, headers, client)
+    position_data = fetch_data("/PiConnectAPI/PositionBook", payload, headers, client)
 
     total_realised = 0
     total_unrealised = 0

--- a/broker/flattrade/api/margin_api.py
+++ b/broker/flattrade/api/margin_api.py
@@ -65,7 +65,7 @@ def calculate_margin_api(positions, auth):
     try:
         # Make the request to Flattrade Span Calculator API
         response = client.post(
-            "https://piconnect.flattrade.in/PiConnectTP/SpanCalc", headers=headers, content=payload
+            "https://piconnect.flattrade.in/PiConnectAPI/SpanCalc", headers=headers, content=payload
         )
 
         # Add status attribute for compatibility with the existing codebase

--- a/broker/flattrade/api/order_api.py
+++ b/broker/flattrade/api/order_api.py
@@ -25,7 +25,7 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
     data = f'{{"uid": "{api_key}", "actid": "{api_key}"}}'
 
-    if endpoint == "/PiConnectTP/Holdings":
+    if endpoint == "/PiConnectAPI/Holdings":
         data = f'{{"uid": "{api_key}", "actid": "{api_key}", "prd": "C"}}'
 
     payload = "jData=" + data + "&jKey=" + AUTH_TOKEN
@@ -33,7 +33,7 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
     # Get the shared httpx client
     client = get_httpx_client()
 
-    if endpoint == "/PiConnectTP/Holdings":
+    if endpoint == "/PiConnectAPI/Holdings":
         headers = {"Content-Type": "application/x-www-form-urlencoded"}
     else:
         headers = {"Content-Type": "application/json"}
@@ -46,25 +46,25 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
 
 def get_order_book(auth):
-    response = get_api_response("/PiConnectTP/OrderBook", auth, method="POST")
+    response = get_api_response("/PiConnectAPI/OrderBook", auth, method="POST")
     logger.debug(f"Flattrade OrderBook Response: {response}")
     return response
 
 
 def get_trade_book(auth):
-    response = get_api_response("/PiConnectTP/TradeBook", auth, method="POST")
+    response = get_api_response("/PiConnectAPI/TradeBook", auth, method="POST")
     logger.debug(f"Flattrade TradeBook Response: {response}")
     return response
 
 
 def get_positions(auth):
-    response = get_api_response("/PiConnectTP/PositionBook", auth, method="POST")
+    response = get_api_response("/PiConnectAPI/PositionBook", auth, method="POST")
     logger.debug(f"Flattrade PositionBook Response: {response}")
     return response
 
 
 def get_holdings(auth):
-    response = get_api_response("/PiConnectTP/Holdings", auth, method="POST")
+    response = get_api_response("/PiConnectAPI/Holdings", auth, method="POST")
     logger.debug(f"Flattrade Holdings Response: {response}")
     return response
 
@@ -114,7 +114,7 @@ def place_order_api(data, auth):
     # Get the shared httpx client
     client = get_httpx_client()
 
-    url = "https://piconnect.flattrade.in/PiConnectTP/PlaceOrder"
+    url = "https://piconnect.flattrade.in/PiConnectAPI/PlaceOrder"
     res = client.post(url, content=payload, headers=headers)
     response_data = res.json()
 
@@ -278,7 +278,7 @@ def cancel_order(orderid, auth):
     # Get the shared httpx client and send the request
     client = get_httpx_client()
 
-    url = "https://piconnect.flattrade.in/PiConnectTP/CancelOrder"
+    url = "https://piconnect.flattrade.in/PiConnectAPI/CancelOrder"
     res = client.post(url, content=payload, headers=headers)
     data = res.json()
     logger.info(f"{data}")
@@ -316,7 +316,7 @@ def modify_order(data, auth):
     # Get the shared httpx client
     client = get_httpx_client()
 
-    url = "https://piconnect.flattrade.in/PiConnectTP/ModifyOrder"
+    url = "https://piconnect.flattrade.in/PiConnectAPI/ModifyOrder"
     res = client.post(url, content=payload, headers=headers)
     response = res.json()
 

--- a/broker/flattrade/streaming/flattrade_adapter.py
+++ b/broker/flattrade/streaming/flattrade_adapter.py
@@ -353,9 +353,9 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.actid = user_id
 
         # Get auth token from database
-        self.susertoken = get_auth_token(user_id)
+        self.accesstoken = get_auth_token(user_id)
 
-        if not self.actid or not self.susertoken:
+        if not self.actid or not self.accesstoken:
             self.logger.error(f"Missing Flattrade credentials for user {user_id}")
             raise ValueError(f"Missing Flattrade credentials for user {user_id}")
 
@@ -365,7 +365,7 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.ws_client = FlattradeWebSocket(
             user_id=self.actid,
             actid=self.actid,
-            susertoken=self.susertoken,
+            accesstoken=self.accesstoken,
             on_message=self._on_message,
             on_error=self._on_error,
             on_close=self._on_close,
@@ -759,7 +759,7 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.ws_client = FlattradeWebSocket(
                     user_id=self.actid,
                     actid=self.actid,
-                    susertoken=self.susertoken,
+                    accesstoken=self.accesstoken,
                     on_message=self._on_message,
                     on_error=self._on_error,
                     on_close=self._on_close,

--- a/broker/flattrade/streaming/flattrade_websocket.py
+++ b/broker/flattrade/streaming/flattrade_websocket.py
@@ -17,7 +17,7 @@ class FlattradeWebSocket:
     """Flattrade WebSocket client for real-time market data"""
 
     # Connection constants
-    WS_URL = "wss://piconnect.flattrade.in/PiConnectWSTp/"
+    WS_URL = "wss://piconnect.flattrade.in/PiConnectWSAPI/"
     CONNECTION_TIMEOUT = 15
     THREAD_JOIN_TIMEOUT = 5
 
@@ -29,7 +29,7 @@ class FlattradeWebSocket:
     HEARTBEAT_JOIN_TIMEOUT = 3  # Timeout for heartbeat thread join
 
     # Message types
-    MSG_TYPE_CONNECT = "c"
+    MSG_TYPE_CONNECT = "a"
     MSG_TYPE_HEARTBEAT = "h"
     MSG_TYPE_AUTH_ACK = "ck"
     MSG_TYPE_TOUCHLINE_SUB = "t"
@@ -44,7 +44,7 @@ class FlattradeWebSocket:
         self,
         user_id: str,
         actid: str,
-        susertoken: str,
+        accesstoken: str,
         on_message: Callable | None = None,
         on_error: Callable | None = None,
         on_close: Callable | None = None,
@@ -56,7 +56,7 @@ class FlattradeWebSocket:
         Args:
             user_id: User ID for authentication
             actid: Account ID for authentication
-            susertoken: Session token for authentication
+            accesstoken: Access token for authentication
             on_message: Callback for incoming messages
             on_error: Callback for connection errors
             on_close: Callback for connection close
@@ -65,7 +65,7 @@ class FlattradeWebSocket:
         # Authentication credentials
         self.user_id = user_id
         self.actid = actid
-        self.susertoken = susertoken
+        self.accesstoken = accesstoken
 
         # Connection state
         self.ws = None
@@ -210,7 +210,7 @@ class FlattradeWebSocket:
             "uid": self.user_id,
             "actid": self.actid,
             "source": "API",
-            "susertoken": self.susertoken,
+            "accesstoken": self.accesstoken,
         }
 
         try:


### PR DESCRIPTION
- Replace PiConnectTP with PiConnectAPI for all REST endpoints (OrderBook, TradeBook, PositionBook, Holdings, PlaceOrder, CancelOrder, ModifyOrder, SpanCalc, Limits, GetQuotes, EODChartData, TPSeries)
- Replace PiConnectWSTp with PiConnectWSAPI for WebSocket URL
- Update WebSocket connect message type from 't':'c' to 't':'a'
- Rename susertoken to accesstoken in WebSocket auth payload
- Update FlattradeWebSocket constructor and FlattradeWebSocketAdapter to use accesstoken instead of susertoken

Flattrade V2 required pre approval from flattrade to obtain new V2 api keys
<img width="1706" height="780" alt="image" src="https://github.com/user-attachments/assets/dd28b562-05af-4508-a129-155fd78238fb" />


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrade Flattrade integration to V2. All REST calls now use `PiConnectAPI`, and the WebSocket moves to `PiConnectWSAPI` with an updated auth payload using `accesstoken`.

- **Refactors**
  - Replaced all `/PiConnectTP/*` endpoints with `/PiConnectAPI/*` (OrderBook, TradeBook, PositionBook, Holdings, Place/Cancel/ModifyOrder, SpanCalc, Limits, GetQuotes, EODChartData, TPSeries).
  - Updated WebSocket to `PiConnectWSAPI`, changed connect message to `t: 'a'`, and renamed auth field to `accesstoken`; constructors and adapter updated accordingly.

- **Migration**
  - Obtain V2 API access and keys from Flattrade (pre-approval required).
  - If you instantiate `FlattradeWebSocket` directly, pass `accesstoken` instead of `susertoken`.
  - Update stored streaming tokens in your DB/config to `accesstoken`.

<sup>Written for commit 9379aed4672d5176c2e99d902b6785d4db4a7d8e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

