### PR TITLE
docs: add Google-style docstrings to Kotak broker integration

### DIFF
--- a/broker/kotak/api/data.py
+++ b/broker/kotak/api/data.py
@@ -13,7 +13,22 @@ logger = get_logger(__name__)
 
 
 class BrokerData:
-    def __init__(self, auth_token):
+    """Kotak Neo broker data adapter for retrieving market data.
+    
+    Handles fetching live quotes, market depth, and historical data 
+    (not supported by Kotak currently) using the Kotak Neo API v2.
+    """
+
+    def __init__(self, auth_token: str):
+        """Initialize the Kotak BrokerData instance.
+
+        Args:
+            auth_token (str): Composite authentication token containing
+                session_token, session_sid, base_url, and access_token.
+                
+        Raises:
+            ValueError: If the extracted base_url is invalid or missing.
+        """
         # Updated for Neo API v2: session_token:::session_sid:::base_url:::access_token
         self.session_token, self.session_sid, self.base_url, self.access_token = auth_token.split(
             ":::"
@@ -34,8 +49,15 @@ class BrokerData:
         self.timeframe_map = {}
         logger.warning("Kotak Neo does not support historical data intervals")
 
-    def _get_kotak_exchange(self, exchange):
-        """Map OpenAlgo exchange to Kotak exchange segment"""
+    def _get_kotak_exchange(self, exchange: str) -> str:
+        """Map OpenAlgo exchange to Kotak exchange segment.
+
+        Args:
+            exchange (str): OpenAlgo standard exchange format.
+
+        Returns:
+            str: Kotak specific exchange segment code.
+        """
         exchange_map = {
             "NSE": "nse_cm",
             "BSE": "bse_cm",
@@ -48,8 +70,15 @@ class BrokerData:
         }
         return exchange_map.get(exchange)
 
-    def _get_index_symbol(self, symbol):
-        """Map OpenAlgo index symbols to Kotak Neo API format"""
+    def _get_index_symbol(self, symbol: str) -> str:
+        """Map OpenAlgo index symbols to Kotak Neo API format.
+
+        Args:
+            symbol (str): OpenAlgo standard index symbol.
+
+        Returns:
+            str: Kotak specific index symbol name.
+        """
         index_map = {
             "NIFTY": "Nifty 50",
             "NIFTY50": "Nifty 50",
@@ -62,8 +91,16 @@ class BrokerData:
         # Return mapped symbol or original symbol if not found
         return index_map.get(symbol.upper(), symbol)
 
-    def _make_quotes_request(self, query, filter_name="all"):
-        """Make HTTP request to Neo API v2 quotes endpoint using httpx connection pooling"""
+    def _make_quotes_request(self, query: str, filter_name: str = "all") -> dict:
+        """Make HTTP request to Neo API v2 quotes endpoint.
+
+        Args:
+            query (str): Formatted query string (e.g., 'nse_cm|Reliance').
+            filter_name (str): Type of data to fetch ('all' or 'depth').
+
+        Returns:
+            dict: JSON parsed API response or None on failure.
+        """
         client = get_httpx_client()
 
         # URL encode spaces but keep pipe/comma characters
@@ -115,8 +152,16 @@ class BrokerData:
         self.last_quote_error = last_error
         return None
 
-    def get_quotes(self, symbol, exchange):
-        """Get live quotes using Neo API v2 quotes endpoint with pSymbol-based queries"""
+    def get_quotes(self, symbol: str, exchange: str) -> dict:
+        """Get live quotes using Neo API v2 quotes endpoint.
+
+        Args:
+            symbol (str): Trading symbol.
+            exchange (str): Exchange segment.
+
+        Returns:
+            dict: Standardized quote data mapping (LTP, OHLC, volume, etc).
+        """
         try:
             logger.info(f"QUOTES API - Symbol: {symbol}, Exchange: {exchange}")
 
@@ -216,7 +261,15 @@ class BrokerData:
             return self._get_default_quote()
 
     def get_depth(self, symbol: str, exchange: str) -> dict:
-        """Get market depth using Neo API v2 quotes endpoint with depth filter"""
+        """Get market depth using Neo API v2 quotes endpoint with depth filter.
+
+        Args:
+            symbol (str): Trading symbol.
+            exchange (str): Exchange segment.
+
+        Returns:
+            dict: Top 5 bids and asks with quantities.
+        """
         try:
             logger.info(f"DEPTH API - Symbol: {symbol}, Exchange: {exchange}")
 
@@ -367,9 +420,11 @@ class BrokerData:
 
     def _process_quotes_batch(self, symbols: list) -> list:
         """
-        Process a single batch of symbols (internal method)
+        Process a single batch of symbols.
+
         Args:
-            symbols: List of dicts with 'symbol' and 'exchange' keys (max 50)
+            symbols (list): List of dicts with 'symbol' and 'exchange' keys (max 50)
+            
         Returns:
             list: List of quote data for the batch
         """
@@ -520,8 +575,12 @@ class BrokerData:
         # Include skipped symbols in results
         return skipped_symbols + results
 
-    def _get_default_quote(self):
-        """Return default quote structure"""
+    def _get_default_quote(self) -> dict:
+        """Return default quote structure.
+
+        Returns:
+            dict: A quote dictionary with all values set to 0.
+        """
         return {
             "bid": 0,
             "ask": 0,
@@ -534,8 +593,12 @@ class BrokerData:
             "oi": 0,
         }
 
-    def _get_default_depth(self):
-        """Return default depth structure"""
+    def _get_default_depth(self) -> dict:
+        """Return default depth structure.
+
+        Returns:
+            dict: Empty depth dictionary with 5 empty levels.
+        """
         return {
             "bids": [{"price": 0, "quantity": 0} for _ in range(5)],
             "asks": [{"price": 0, "quantity": 0} for _ in range(5)],
@@ -546,13 +609,30 @@ class BrokerData:
     def get_history(
         self, symbol: str, exchange: str, interval: str, start_date: str, end_date: str
     ) -> pd.DataFrame:
-        """Placeholder for historical data - not supported by Kotak Neo"""
+        """Retrieve historical timeframe data.
+
+        Note: Kotak Neo does not support historical data, returns empty DataFrame.
+
+        Args:
+            symbol (str): Trading symbol.
+            exchange (str): Exchange segment.
+            interval (str): Timeframe interval.
+            start_date (str): Start datetime.
+            end_date (str): End datetime.
+
+        Returns:
+            pd.DataFrame: Empty DataFrame as historical data is not supported.
+        """
         empty_df = pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
         logger.warning("Kotak Neo does not support historical data")
         return empty_df
 
     def get_supported_intervals(self) -> dict:
-        """Return supported intervals matching the format expected by intervals.py"""
+        """Return supported intervals matching the format expected by intervals.py.
+
+        Returns:
+            dict: Dictionary with empty lists since historical data is unsupported.
+        """
         intervals = {
             "seconds": [],
             "minutes": [],

--- a/broker/kotak/api/funds.py
+++ b/broker/kotak/api/funds.py
@@ -9,11 +9,18 @@ from utils.logging import get_logger
 logger = get_logger(__name__)
 
 
-def get_margin_data(auth_token):
+def get_margin_data(auth_token: str) -> dict:
     """
     Fetch margin data from the broker's API using the provided auth token.
 
-    Auth token format: trading_token:::trading_sid:::base_url:::access_token
+    Args:
+        auth_token (str): Composite authentication token in the format
+            'trading_token:::trading_sid:::base_url:::access_token'.
+
+    Returns:
+        dict: Processed margin data containing available cash, collateral,
+            M2M unrealized, M2M realized, and utilized debits. Returns an
+            empty dict if the request fails.
     """
     try:
         # Parse auth token components

--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -21,8 +21,21 @@ logger = get_logger(__name__)
 
 
 def get_api_response(endpoint, auth_token, method="GET", payload=""):
-    """
-    Updated for Kotak Neo API v2 - uses dynamic baseUrl, httpx connection pooling, and new header structure
+    """Make an authenticated API request to the Kotak Neo API v2.
+
+    Uses the dynamic base URL extracted from the composite auth token,
+    httpx connection pooling, and Kotak Neo header structure (Sid, Auth,
+    neo-fin-key).
+
+    Args:
+        endpoint: API endpoint path (e.g., '/quick/user/orders').
+        auth_token: Composite token in the format
+            'trading_token:::trading_sid:::base_url:::access_token'.
+        method: HTTP method to use. Defaults to 'GET'.
+        payload: URL-encoded request body string. Defaults to ''.
+
+    Returns:
+        dict: Parsed JSON response from the Kotak API.
     """
     session_token, session_sid, base_url, access_token = auth_token.split(":::")
 
@@ -51,22 +64,70 @@ def get_api_response(endpoint, auth_token, method="GET", payload=""):
 
 
 def get_order_book(auth_token):
+    """Retrieve the order book for the authenticated user.
+
+    Args:
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        dict: Order book data containing all orders for the session.
+    """
     return get_api_response("/quick/user/orders", auth_token)
 
 
 def get_trade_book(auth_token):
+    """Retrieve the trade book for the authenticated user.
+
+    Args:
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        dict: Trade book data containing all executed trades.
+    """
     return get_api_response("/quick/user/trades", auth_token)
 
 
 def get_positions(auth_token):
+    """Retrieve current positions for the authenticated user.
+
+    Args:
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        dict: Position data including buy/sell quantities and P&L.
+    """
     return get_api_response("/quick/user/positions", auth_token)
 
 
 def get_holdings(auth_token):
+    """Retrieve portfolio holdings for the authenticated user.
+
+    Args:
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        dict: Holdings data with instrument details and valuations.
+    """
     return get_api_response("/portfolio/v1/holdings", auth_token)
 
 
 def get_open_position(tradingsymbol, exchange, producttype, auth_token):
+    """Get the net open position quantity for a specific symbol.
+
+    Converts the OpenAlgo symbol to Kotak broker format and searches
+    through positions. Net quantity is calculated as:
+    ``(flBuyQty - flSellQty) + (cfBuyQty - cfSellQty)``.
+
+    Args:
+        tradingsymbol: Trading symbol in OpenAlgo format.
+        exchange: Exchange in OpenAlgo format (e.g., 'NSE', 'NFO').
+        producttype: Product type in Kotak format (e.g., 'CNC', 'MIS').
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        int: Net quantity of the open position. Positive for long,
+            negative for short, 0 if no position found.
+    """
     # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
     tradingsymbol = get_br_symbol(tradingsymbol, exchange)
     positions_data = get_positions(auth_token)
@@ -91,6 +152,23 @@ def get_open_position(tradingsymbol, exchange, producttype, auth_token):
 
 
 def place_order_api(data, auth_token):
+    """Place a new order through the Kotak Neo API.
+
+    Transforms the OpenAlgo order data to Kotak format, URL-encodes the
+    payload, and sends it to the order placement endpoint.
+
+    Args:
+        data: Order parameters including 'symbol', 'exchange', 'action',
+            'quantity', 'pricetype', 'product', and optional 'price'
+            and 'trigger_price'.
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (response, response_data, orderid) where response is the
+            httpx Response object (or None on error), response_data is
+            the parsed JSON dict, and orderid is the order number string
+            or None if placement failed.
+    """
     session_token, session_sid, base_url, access_token = auth_token.split(":::")
 
     # Debug logging for baseUrl
@@ -135,6 +213,21 @@ def place_order_api(data, auth_token):
 
 
 def place_smartorder_api(data, auth_token):
+    """Place a smart order that automatically manages position sizing.
+
+    Compares the target ``position_size`` with the current open position
+    and calculates the required action (BUY/SELL) and quantity to reach
+    the desired position.
+
+    Args:
+        data: Order parameters including 'symbol', 'exchange', 'product',
+            'action', 'quantity', and 'position_size'.
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (response, response_data, orderid). Returns None for
+            response if no API call was needed.
+    """
     # If no API call is made in this function then res will return None
     res = None
 
@@ -218,6 +311,19 @@ def place_smartorder_api(data, auth_token):
 
 
 def close_all_positions(current_api_key, auth_token):
+    """Close all open positions by placing opposite market orders.
+
+    Iterates through all current positions and places MARKET orders
+    to square off each non-zero position.
+
+    Args:
+        current_api_key: The OpenAlgo API key for the current user.
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (response_dict, status_code) with a success or
+            'No Open Positions Found' message.
+    """
     # Fetch the current open positions
     positions_response = get_positions(auth_token)
     # logger.info(f"{positions_response}")
@@ -276,6 +382,16 @@ def close_all_positions(current_api_key, auth_token):
 
 
 def cancel_order(orderid, auth_token):
+    """Cancel an existing order by its order number.
+
+    Args:
+        orderid: The Kotak order number to cancel.
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (response_dict, status_code). On success, returns the
+            cancelled order ID with status 200.
+    """
     session_token, session_sid, base_url, access_token = auth_token.split(":::")
 
     # Get the shared httpx client with connection pooling
@@ -313,6 +429,21 @@ def cancel_order(orderid, auth_token):
 
 
 def modify_order(data, auth_token):
+    """Modify an existing order's price, quantity, or other parameters.
+
+    Transforms the modification data to Kotak format and sends it
+    to the order modification endpoint.
+
+    Args:
+        data: Modification parameters including 'orderid', 'symbol',
+            'exchange', 'quantity', 'price', 'pricetype', 'product',
+            and 'action'.
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (response_dict, status_code). On success, returns the
+            modified order ID with status 200.
+    """
     session_token, session_sid, base_url, access_token = auth_token.split(":::")
 
     # Debug logging for baseUrl
@@ -367,6 +498,19 @@ def modify_order(data, auth_token):
 
 
 def cancel_all_orders_api(data, auth_token):
+    """Cancel all open and trigger-pending orders.
+
+    Fetches the order book, filters for orders with status 'open' or
+    'trigger pending', and cancels each one.
+
+    Args:
+        data: Additional request data (unused, kept for API consistency).
+        auth_token: Composite Kotak authentication token.
+
+    Returns:
+        tuple: (canceled_orders, failed_cancellations) — two lists of
+            order IDs that were successfully or unsuccessfully cancelled.
+    """
     # Get the order book
     order_book_response = get_order_book(auth_token)
 

--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -50,17 +50,36 @@ class SymToken(Base):
 
 
 def init_db():
+    """Initialize the master contract database tables.
+
+    Creates the symtoken table and associated indices if they
+    do not already exist.
+    """
     logger.info("Initializing Master Contract DB")
     Base.metadata.create_all(bind=engine)
 
 
 def delete_symtoken_table():
+    """Delete all records from the symtoken table.
+
+    Clears existing instrument data to prepare for a fresh
+    master contract download.
+    """
     logger.info("Deleting Symtoken Table")
     SymToken.query.delete()
     db_session.commit()
 
 
-def copy_from_dataframe(df):
+def copy_from_dataframe(df: pd.DataFrame):
+    """Bulk insert instrument records from a DataFrame into the database.
+
+    Filters out records with tokens that already exist in the database
+    to avoid duplicates, then performs a bulk insert of new records.
+
+    Args:
+        df (pd.DataFrame): DataFrame containing instrument data with columns
+            matching the SymToken model fields.
+    """
     logger.info("Performing Bulk Insert")
     # Convert DataFrame to a list of dictionaries
     data_dict = df.to_dict(orient="records")
@@ -86,7 +105,18 @@ def copy_from_dataframe(df):
         db_session.rollback()
 
 
-def download_csv_kotak_data(output_path):
+def download_csv_kotak_data(output_path: str) -> list:
+    """Download the CSV files from Kotak using Auth Credentials.
+
+    Saves the CSV files to the specified path and returns a list of
+    downloaded file paths.
+
+    Args:
+        output_path (str): Path where the CSV files will be saved.
+
+    Returns:
+        list: List of paths to the downloaded files.
+    """
     logger.info("Downloading Master Contract CSV Files")
 
     # URLs of the CSV files to be downloaded
@@ -134,9 +164,15 @@ def download_csv_kotak_data(output_path):
     return downloaded_files
 
 
-def process_kotak_nse_csv(path):
+def process_kotak_nse_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak NSE CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak NSE CSV Data")
     file_path = f"{path}/NSE_CM.csv"
@@ -180,9 +216,15 @@ def process_kotak_nse_csv(path):
     return token_df
 
 
-def process_kotak_bse_csv(path):
+def process_kotak_bse_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak BSE CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak BSE CSV Data")
     file_path = f"{path}/BSE_CM.csv"
@@ -230,7 +272,15 @@ def process_kotak_bse_csv(path):
     return token_df
 
 
-def combine_details(row):
+def combine_details(row: pd.Series) -> str:
+    """Combines details into a single symbol string.
+    
+    Args:
+        row (pd.Series): A row from the DataFrame.
+        
+    Returns:
+        str: The combined symbol formatted for OpenAlgo.
+    """
     base = f"{row['name']}{row['expiry'].replace('-', '')}"
     if row["instrumenttype"] == "FUT":
         return f"{base}FUT"
@@ -241,9 +291,15 @@ def combine_details(row):
         return base
 
 
-def process_kotak_nfo_csv(path):
+def process_kotak_nfo_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak NFO CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak NFO CSV Data")
     file_path = f"{path}/NSE_FO.csv"
@@ -419,9 +475,15 @@ def get_kotak_master_filepaths():
     return {}
 
 
-def process_kotak_cds_csv(path):
+def process_kotak_cds_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak CDS CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak CDS CSV Data")
     file_path = f"{path}/CDE_FO.csv"
@@ -457,9 +519,15 @@ def process_kotak_cds_csv(path):
     return tokensymbols
 
 
-def process_kotak_mcx_csv(path):
+def process_kotak_mcx_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak MCX CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak MCX CSV Data")
     file_path = f"{path}/MCX_FO.csv"
@@ -496,9 +564,15 @@ def process_kotak_mcx_csv(path):
     return tokensymbols
 
 
-def process_kotak_bfo_csv(path):
+def process_kotak_bfo_csv(path: str) -> pd.DataFrame:
     """
-    Processes the kotak CSV file to fit the existing database schema and performs exchange name mapping.
+    Processes the Kotak BFO CSV file to fit the existing database schema.
+
+    Args:
+        path (str): The folder path containing the CSV data.
+
+    Returns:
+        pd.DataFrame: The processed DataFrame.
     """
     logger.info("Processing kotak BFO CSV Data")
     file_path = f"{path}/BSE_FO.csv"
@@ -535,7 +609,12 @@ def process_kotak_bfo_csv(path):
     return tokensymbols
 
 
-def delete_kotak_temp_data(output_path):
+def delete_kotak_temp_data(output_path: str):
+    """Delete the temporary master contract data files.
+
+    Args:
+        output_path (str): Path to the temporary directory.
+    """
     # Check each file in the directory
     for filename in os.listdir(output_path):
         # Construct the full file path
@@ -547,6 +626,15 @@ def delete_kotak_temp_data(output_path):
 
 
 def master_contract_download():
+    """Download and process the full Kotak master contract.
+
+    Downloads the instrument CSVs, processes and normalizes the data,
+    replaces the existing symtoken table, and emits a SocketIO event
+    on completion.
+
+    Returns:
+        SocketIO emission with status 'success' or 'error'.
+    """
     logger.info("Downloading Master Contract")
 
     output_path = "tmp"
@@ -609,7 +697,16 @@ def master_contract_download():
         return socketio.emit("master_contract_download", {"status": "error", "message": str(e)})
 
 
-def search_symbols(symbol, exchange):
+def search_symbols(symbol: str, exchange: str) -> list:
+    """Search for symbols matching a pattern in the master contract database.
+
+    Args:
+        symbol (str): Symbol pattern to search for (supports SQL LIKE wildcards).
+        exchange (str): Exact exchange segment to filter by.
+
+    Returns:
+        list[SymToken]: List of matching SymToken records.
+    """
     return SymToken.query.filter(
         SymToken.symbol.like(f"%{symbol}%"), SymToken.exchange == exchange
     ).all()

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -98,6 +98,18 @@ def calculate_order_statistics(order_data):
 
 
 def transform_order_data(orders):
+    """Transform raw Kotak order data to the OpenAlgo standardized format.
+
+    Maps Kotak field names (trdSym, exSeg, trnsTp, etc.) to OpenAlgo
+    field names (symbol, exchange, action, etc.) and normalizes price
+    type codes.
+
+    Args:
+        orders: A list of order dicts from Kotak, or a single dict.
+
+    Returns:
+        list[dict]: Transformed orders with standardized field names.
+    """
     # Directly handling a dictionary assuming it's the structure we expect
     if isinstance(orders, dict):
         # Convert the single dictionary into a list of one dictionary
@@ -201,6 +213,16 @@ def map_trade_data(trade_data):
 
 
 def transform_tradebook_data(tradebook_data):
+    """Transform raw Kotak trade data to the OpenAlgo standardized format.
+
+    Computes trade_value as ``fldQty * avgPrc`` for each trade.
+
+    Args:
+        tradebook_data: List of trade dicts from the Kotak trade book.
+
+    Returns:
+        list[dict]: Transformed trades with standardized field names.
+    """
     transformed_data = []
 
     for trade in tradebook_data:
@@ -220,10 +242,33 @@ def transform_tradebook_data(tradebook_data):
 
 
 def map_position_data(position_data):
+    """Map position data from Kotak format to OpenAlgo format.
+
+    Delegates to :func:`map_order_data` since positions share the
+    same data structure in the Kotak API.
+
+    Args:
+        position_data: Raw position data dict from Kotak API.
+
+    Returns:
+        list[dict] or dict: Mapped position data.
+    """
     return map_order_data(position_data)
 
 
 def transform_positions_data(positions_data):
+    """Transform raw Kotak position data to OpenAlgo standardized format.
+
+    Calculates net quantity as ``(flBuyQty - flSellQty) + (cfBuyQty - cfSellQty)``
+    and computes average price based on the direction of the position.
+
+    Args:
+        positions_data: List of position dicts from Kotak.
+
+    Returns:
+        list[dict]: Positions with symbol, exchange, product, quantity,
+            and average_price fields.
+    """
     transformed_data = []
     for position in positions_data:
         transformed_position = {
@@ -254,6 +299,18 @@ def transform_positions_data(positions_data):
 
 
 def transform_holdings_data(holdings_data):
+    """Transform raw Kotak holdings data to OpenAlgo standardized format.
+
+    Computes P&L as ``mktValue - holdingCost`` and percentage P&L
+    relative to holding cost.
+
+    Args:
+        holdings_data: List of holding dicts from the Kotak portfolio API.
+
+    Returns:
+        list[dict]: Holdings with symbol, exchange, quantity, product,
+            pnl, and pnlpercent fields.
+    """
     transformed_data = []
     logger.info("Holdings Data")
     logger.info(f"{holdings_data}")
@@ -329,6 +386,17 @@ def map_portfolio_data(portfolio_data):
 
 
 def calculate_portfolio_statistics(holdings_data):
+    """Calculate aggregate portfolio statistics from holdings data.
+
+    Args:
+        holdings_data: List of holding dicts containing 'mktValue'
+            and 'holdingCost' fields.
+
+    Returns:
+        dict: Portfolio statistics with keys 'totalholdingvalue',
+            'totalinvvalue', 'totalprofitandloss', and
+            'totalpnlpercentage'.
+    """
     totalholdingvalue = sum(item["mktValue"] for item in holdings_data)
     totalinvvalue = sum(item["holdingCost"] for item in holdings_data)
     totalprofitandloss = sum(item["mktValue"] - item["holdingCost"] for item in holdings_data)

--- a/broker/kotak/mapping/transform_data.py
+++ b/broker/kotak/mapping/transform_data.py
@@ -1,13 +1,23 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
-# Mapping Angel Broking Parameters https://smartapi.angelbroking.com/docs/Orders
+# Mapping Kotak Neo API Parameters
 
 from database.token_db import get_br_symbol
 
 
 def transform_data(data, token):
-    """
-    Transforms the new API request structure to the current expected structure.
-    ALL values must be strings for Kotak API.
+    """Transform an OpenAlgo order request to Kotak Neo API format.
+
+    All values in the returned dict are strings, as required by the
+    Kotak Neo API.
+
+    Args:
+        data: OpenAlgo order data with keys 'symbol', 'exchange',
+            'action', 'quantity', 'pricetype', 'product', and optional
+            'price', 'trigger_price', 'disclosed_quantity'.
+        token: Instrument token (unused, kept for API consistency).
+
+    Returns:
+        dict: Transformed order payload for Kotak Neo API.
     """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
     # Basic mapping - ALL values must be strings for Kotak API
@@ -31,6 +41,19 @@ def transform_data(data, token):
 
 
 def transform_modify_order_data(data, token):
+    """Transform an OpenAlgo modify-order request to Kotak Neo format.
+
+    Includes the order number ('no') field required for modification.
+    All values are strings as required by the Kotak Neo API.
+
+    Args:
+        data: Modification data including 'orderid', 'symbol', 'exchange',
+            'quantity', 'price', 'pricetype', 'product', and 'action'.
+        token: Instrument token for the symbol.
+
+    Returns:
+        dict: Transformed modify-order payload for Kotak Neo API.
+    """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
     # Basic mapping - ALL values must be strings for Kotak API
     transformed = {
@@ -53,16 +76,28 @@ def transform_modify_order_data(data, token):
 
 
 def map_order_type(pricetype):
-    """
-    Maps the new pricetype to the existing order type.
+    """Map an OpenAlgo price type to the Kotak order type code.
+
+    Args:
+        pricetype: OpenAlgo price type ('MARKET', 'LIMIT', 'SL', 'SL-M').
+
+    Returns:
+        str: Kotak order type code ('MKT', 'L', 'SL', 'SL-M').
+            Defaults to 'MARKET' if not found.
     """
     order_type_mapping = {"MARKET": "MKT", "LIMIT": "L", "SL": "SL", "SL-M": "SL-M"}
     return order_type_mapping.get(pricetype, "MARKET")  # Default to MARKET if not found
 
 
 def map_product_type(product):
-    """
-    Maps the new product type to the existing product type.
+    """Map an OpenAlgo product type to the Kotak product type.
+
+    Args:
+        product: OpenAlgo product type ('CNC', 'NRML', 'MIS').
+
+    Returns:
+        str or None: Corresponding Kotak product type, or None if
+            not found.
     """
     product_type_mapping = {
         "CNC": "CNC",
@@ -73,16 +108,28 @@ def map_product_type(product):
 
 
 def map_variety(pricetype):
-    """
-    Maps the pricetype to the existing order variety.
+    """Map an OpenAlgo price type to the Kotak order variety.
+
+    Args:
+        pricetype: OpenAlgo price type ('MARKET', 'LIMIT', 'SL', 'SL-M').
+
+    Returns:
+        str: Kotak order variety ('NORMAL' or 'STOPLOSS').
+            Defaults to 'NORMAL'.
     """
     variety_mapping = {"MARKET": "NORMAL", "LIMIT": "NORMAL", "SL": "STOPLOSS", "SL-M": "STOPLOSS"}
     return variety_mapping.get(pricetype, "NORMAL")  # Default to DELIVERY if not found
 
 
 def map_exchange(brexchange):
-    """
-    Maps the Broker Exchange to the OpenAlgo Exchange.
+    """Map a Kotak broker exchange code to the OpenAlgo exchange name.
+
+    Args:
+        brexchange: Kotak exchange segment code (e.g., 'nse_cm', 'nse_fo').
+
+    Returns:
+        str or None: OpenAlgo exchange name (e.g., 'NSE', 'NFO'),
+            or None if not found.
     """
 
     exchange_mapping = {
@@ -98,8 +145,14 @@ def map_exchange(brexchange):
 
 
 def reverse_map_exchange(exchange):
-    """
-    Maps the Broker Exchange to the OpenAlgo Exchange.
+    """Map an OpenAlgo exchange name to the Kotak broker exchange code.
+
+    Args:
+        exchange: OpenAlgo exchange name (e.g., 'NSE', 'NFO').
+
+    Returns:
+        str or None: Kotak exchange segment code (e.g., 'nse_cm',
+            'nse_fo'), or None if not found.
     """
 
     exchange_mapping = {
@@ -115,8 +168,13 @@ def reverse_map_exchange(exchange):
 
 
 def reverse_map_product_type(product):
-    """
-    Maps the new product type to the existing product type.
+    """Map a Kotak product type to the OpenAlgo product type.
+
+    Args:
+        product: Kotak product type ('CNC', 'NRML', 'MIS').
+
+    Returns:
+        str or None: OpenAlgo product type, or None if not found.
     """
     reverse_product_type_mapping = {
         "CNC": "CNC",


### PR DESCRIPTION

This pull request introduces comprehensive Google-style docstrings to the Kotak broker integration modules. This is part of the ongoing effort to standardize documentation and improve the developer experience and maintainability of the 

openalgo
 project for the FOSS Hack contribution.

Changes Made
Google-style docstrings (including comprehensive Args and Returns blocks) have been added to functions across the following key modules:


broker/kotak/api/order_api.py
: Added documentation to core API interaction functions including:

get_api_response
, 

get_order_book
, 

get_trade_book
Position fetching and tracking (

get_positions
, 

get_holdings
, 

get_open_position
)
Order execution logic (

place_order_api
, 

place_smartorder_api
, 

modify_order
, 

cancel_order
, 

cancel_all_orders_api
)

broker/kotak/mapping/transform_data.py
: Documented broker-specific mapping utility functions such as 

transform_data
, 

transform_modify_order_data
, 

map_order_type
, 

map_product_type
, 

map_variety
, and 

map_exchange
 to clearly illustrate the mapping of OpenAlgo types to Kotak Neo types.

broker/kotak/mapping/order_data.py
: Added detailed explanations for data transformation wrappers covering formats for orders, trades, holdings, and portfolio statistics (

calculate_portfolio_statistics
, 

transform_tradebook_data
, etc.).

broker/kotak/mapping/margin_data.py
: Documented margin calculation extraction and account summary formatting logic.
Motivation and Context
The broker/kotak module had logic for handling complex nested properties specific to the Kotak Neo APIs, but lacked type information and descriptions for its parameter configurations. By adopting Google-style docstrings, we ensure consistency across the wider FOSS ecosystem while making it much easier for future contributors, maintainers, and users tracing bugs to understand payload transformations without needing to reverse-engineer Kotak API docs.

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Documentation / Code Quality enhancement (non-breaking change)
 Refactoring (internal code improvements without behavior changes)
Checklist
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have formatted all new and updated docstrings to strictly adhere to the Google python-docstring standard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Added Google-style docstrings across Kotak integration in `broker/kotak/api/{order_api.py,data.py,funds.py}`, `broker/kotak/mapping/{transform_data.py,order_data.py}`, and `broker/kotak/database/master_contract_db.py`.
Docs clarify args/returns and behavior (quotes/depth, orders, margin, master contract) to improve readability and IDE hints with no runtime changes.

<sup>Written for commit 463af63764c960917d70efd9cd923ec0e41e84bf. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

