### PR TITLE
Docs/add docstrings shoonya

### DIFF
--- a/broker/shoonya/api/auth_api.py
+++ b/broker/shoonya/api/auth_api.py
@@ -8,13 +8,33 @@ from utils.httpx_client import get_httpx_client
 
 
 def sha256_hash(text):
-    """Generate SHA256 hash."""
+    """Generate SHA256 hash of the input text.
+    
+    Args:
+        text (str): Input string to be hashed.
+        
+    Returns:
+        str: Hexadecimal string of the SHA256 hash.
+    """
     return hashlib.sha256(text.encode("utf-8")).hexdigest()
 
 
 def authenticate_broker(userid, password, totp_code):
-    """
-    Authenticate with Shoonya and return the auth token.
+    """Authenticate with Shoonya and return the auth token.
+    
+    Communicates with Shoonya's QuickAuth endpoint. Requires
+    BROKER_API_SECRET and BROKER_API_KEY environment variables
+    to be set.
+
+    Args:
+        userid (str): The Shoonya user ID.
+        password (str): The plaintext password.
+        totp_code (str): Time-based one-time password or PAN/DOB factor.
+
+    Returns:
+        tuple: (auth_token, error_message). On success, returns the
+            authentication token and None. On failure, returns None
+            and an error message.
     """
     # Get the Shoonya API key and other credentials from environment variables
     api_secretkey = os.getenv("BROKER_API_SECRET")

--- a/broker/shoonya/api/data.py
+++ b/broker/shoonya/api/data.py
@@ -28,8 +28,16 @@ logger = get_logger(__name__)
 
 
 def get_api_response(endpoint, auth, method="POST", payload=None):
-    """
-    Common function to make API calls to Shoonya using httpx with connection pooling
+    """Make common API calls to Shoonya using httpx with connection pooling.
+    
+    Args:
+        endpoint (str): API endpoint path.
+        auth (str): Authentication token.
+        method (str): HTTP method. Defaults to "POST".
+        payload (dict, optional): API payload.
+        
+    Returns:
+        dict: Parsed JSON response from the API.
     """
     AUTH_TOKEN = auth
     api_key = os.getenv("BROKER_API_KEY")
@@ -176,8 +184,17 @@ class BrokerData:
     def _fetch_single_quote_sync(
         self, symbol: str, exchange: str, api_exchange: str, token: str, api_key: str
     ) -> dict:
-        """
-        Fetch quote for a single symbol synchronously (for ThreadPoolExecutor)
+        """Fetch quote for a single symbol synchronously (for ThreadPoolExecutor).
+        
+        Args:
+            symbol (str): Trading symbol.
+            exchange (str): OpenAlgo exchange name.
+            api_exchange (str): Shoonya exchange segment.
+            token (str): Instrument token.
+            api_key (str): Shoonya API key.
+            
+        Returns:
+            dict: Standardized quote data dict or an error message.
         """
         try:
             data = {"uid": api_key, "exch": api_exchange, "token": token}
@@ -225,8 +242,18 @@ class BrokerData:
         token: str,
         api_key: str,
     ) -> dict:
-        """
-        Fetch quote for a single symbol asynchronously
+        """Fetch quote for a single symbol asynchronously.
+        
+        Args:
+            client (httpx.AsyncClient): The Async client for HTTP connections.
+            symbol (str): Trading symbol.
+            exchange (str): OpenAlgo exchange name.
+            api_exchange (str): Shoonya exchange segment.
+            token (str): Instrument token.
+            api_key (str): Shoonya API key.
+            
+        Returns:
+            dict: Standardized quote data dict or an error message.
         """
         try:
             data = {"uid": api_key, "exch": api_exchange, "token": token}
@@ -265,8 +292,14 @@ class BrokerData:
             return {"symbol": symbol, "exchange": exchange, "error": str(e)}
 
     async def _process_quotes_batch_async(self, symbols: list, api_key: str) -> list:
-        """
-        Process a batch of symbols using async httpx
+        """Process a batch of symbols using async httpx.
+        
+        Args:
+            symbols (list[dict]): List of dictionaries with symbol details.
+            api_key (str): Shoonya API key.
+            
+        Returns:
+            list[dict]: List of processed quote responses or error dicts.
         """
         results = []
 
@@ -303,12 +336,13 @@ class BrokerData:
         return final_results
 
     def _process_quotes_batch(self, symbols: list) -> list:
-        """
-        Process a single batch of symbols using concurrent API calls
+        """Process a single batch of symbols using concurrent API calls.
+        
         Args:
-            symbols: List of dicts with 'symbol' and 'exchange' keys (max 40)
+            symbols (list): List of dicts with 'symbol' and 'exchange' keys (max 40).
+            
         Returns:
-            list: List of quote data for the batch
+            list: List of quote data for the batch.
         """
         skipped_symbols = []
         prepared_symbols = []

--- a/broker/shoonya/api/funds.py
+++ b/broker/shoonya/api/funds.py
@@ -12,7 +12,21 @@ logger = get_logger(__name__)
 
 
 def get_margin_data(auth_token):
-    """Fetch margin data from Shoonya's API using the provided auth token."""
+    """Fetch margin data from Shoonya's API using the provided auth token.
+
+    Calls the NorenWClientTP/Limits endpoint and aggregates various
+    margin fields (cash, payin, collateral, realized/unrealized PnL)
+    into a standardized OpenAlgo format. Assuming the 'jKey' auth token
+    is valid.
+
+    Args:
+        auth_token (str): Shoonya session authentication token (jKey).
+
+    Returns:
+        dict: Standardized margin data including 'availablecash',
+            'collateral', 'm2munrealized', 'm2mrealized', and
+            'utiliseddebits'. Returns an empty dict on error.
+    """
 
     # Fetch UserID and AccountID from environment variables
     userid = os.getenv("BROKER_API_KEY")

--- a/broker/shoonya/api/margin_api.py
+++ b/broker/shoonya/api/margin_api.py
@@ -9,15 +9,20 @@ logger = get_logger(__name__)
 
 
 def calculate_margin_api(positions, auth):
-    """
-    Calculate margin requirement for a basket of positions using Shoonya Span Calculator API.
+    """Calculate margin requirement for a basket of positions using Shoonya Span Calculator API.
+
+    Transforms positions into the Shoonya expected format, calls the
+    NorenWClientTP/SpanCalc API with the given positions, and parses
+    the JSON response.
 
     Args:
-        positions: List of positions in OpenAlgo format
-        auth: Authentication token (jKey) for Shoonya
+        positions (list[dict]): List of position dicts in OpenAlgo format.
+        auth (str): Authentication token (jKey) for Shoonya.
 
     Returns:
-        Tuple of (response, response_data)
+        tuple: (response, response_data). `response` is an httpx Response
+            (or a MockResponse on certain errors), and `response_data`
+            is the parsed margin response in OpenAlgo standard format.
     """
     AUTH_TOKEN = auth
 

--- a/broker/shoonya/api/order_api.py
+++ b/broker/shoonya/api/order_api.py
@@ -18,6 +18,20 @@ logger = get_logger(__name__)
 
 
 def get_api_response(endpoint, auth, method="GET", payload=""):
+    """Make an authenticated API request to the Shoonya API.
+
+    Handles setting the `UID` and `ACTID` using the configured API key,
+    and formats the payload as `jData={data}&jKey={token}`.
+
+    Args:
+        endpoint: API endpoint path (e.g., '/NorenWClientTP/OrderBook').
+        auth: Shoonya authentication token (jKey).
+        method: HTTP method to use. Defaults to 'GET'.
+        payload: Optional payload string. Defaults to ''.
+
+    Returns:
+        dict: Parsed JSON response from the Shoonya API.
+    """
     AUTH_TOKEN = auth
 
     api_key = os.getenv("BROKER_API_KEY")
@@ -48,22 +62,66 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
 
 def get_order_book(auth):
+    """Retrieve the order book for the authenticated user.
+
+    Args:
+        auth: Shoonya authentication token.
+
+    Returns:
+        dict: Order book data containing all orders for the session.
+    """
     return get_api_response("/NorenWClientTP/OrderBook", auth, method="POST")
 
 
 def get_trade_book(auth):
+    """Retrieve the trade book for the authenticated user.
+
+    Args:
+        auth: Shoonya authentication token.
+
+    Returns:
+        dict: Trade book data containing all executed trades.
+    """
     return get_api_response("/NorenWClientTP/TradeBook", auth, method="POST")
 
 
 def get_positions(auth):
+    """Retrieve current positions for the authenticated user.
+
+    Args:
+        auth: Shoonya authentication token.
+
+    Returns:
+        dict: Position data including net quantities and prices.
+    """
     return get_api_response("/NorenWClientTP/PositionBook", auth, method="POST")
 
 
 def get_holdings(auth):
+    """Retrieve portfolio holdings for the authenticated user.
+
+    Args:
+        auth: Shoonya authentication token.
+
+    Returns:
+        dict: Holdings data with instrument valuations and quantities.
+    """
     return get_api_response("/NorenWClientTP/Holdings", auth, method="POST")
 
 
 def get_open_position(tradingsymbol, exchange, producttype, auth):
+    """Get the net open position quantity for a specific symbol.
+
+    Args:
+        tradingsymbol: Trading symbol in OpenAlgo format.
+        exchange: Exchange in OpenAlgo format (e.g., 'NSE', 'NFO').
+        producttype: Product type in Shoonya format (e.g., 'C', 'I').
+        auth: Shoonya authentication token.
+
+    Returns:
+        str: Net quantity of the open position as a string. Positive for long,
+            negative for short, '0' if no position found.
+    """
     # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
     tradingsymbol = get_br_symbol(tradingsymbol, exchange)
     positions_data = get_positions(auth)
@@ -93,6 +151,19 @@ def get_open_position(tradingsymbol, exchange, producttype, auth):
 
 
 def place_order_api(data, auth):
+    """Place a new order through the Shoonya API.
+
+    Args:
+        data: Order parameters including 'symbol', 'exchange', 'action',
+            'quantity', 'pricetype', 'product', and optional 'price'
+            and 'trigger_price'.
+        auth: Shoonya authentication token.
+
+    Returns:
+        tuple: (response, response_data, orderid) where response is the
+            httpx Response object, response_data is the parsed JSON dict,
+            and orderid is the order number string or None on failure.
+    """
     AUTH_TOKEN = auth
     BROKER_API_KEY = os.getenv("BROKER_API_KEY")
     data["apikey"] = BROKER_API_KEY
@@ -123,6 +194,17 @@ def place_order_api(data, auth):
 
 
 def place_smartorder_api(data, auth):
+    """Place a smart order that automatically manages position sizing.
+
+    Args:
+        data: Order parameters including 'symbol', 'exchange', 'product',
+            'action', 'quantity', and 'position_size'.
+        auth: Shoonya authentication token.
+
+    Returns:
+        tuple: (response, response_data, orderid). Returns None for
+            response if no API call was needed.
+    """
     AUTH_TOKEN = auth
 
     # If no API call is made in this function then res will return None
@@ -259,6 +341,16 @@ def close_all_positions(current_api_key, auth):
 
 
 def cancel_order(orderid, auth):
+    """Cancel an existing order by its order number.
+
+    Args:
+        orderid: The Shoonya order number (norenordno) to cancel.
+        auth: Shoonya authentication token.
+
+    Returns:
+        tuple: (response_dict, status_code). On success, returns the
+            cancelled order ID with status 200.
+    """
     # Assuming you have a function to get the authentication token
     AUTH_TOKEN = auth
     api_key = os.getenv("BROKER_API_KEY")
@@ -293,6 +385,18 @@ def cancel_order(orderid, auth):
 
 
 def modify_order(data, auth):
+    """Modify an existing order's parameters in Shoonya.
+
+    Args:
+        data: Modification parameters including 'orderid', 'symbol',
+            'exchange', 'quantity', 'price', 'pricetype', 'product',
+            and 'action'.
+        auth: Shoonya authentication token.
+
+    Returns:
+        tuple: (response_dict, status_code). On success, returns the
+            modified order ID with status 200.
+    """
     # Assuming you have a function to get the authentication token
     AUTH_TOKEN = auth
     api_key = os.getenv("BROKER_API_KEY")

--- a/broker/shoonya/database/master_contract_db.py
+++ b/broker/shoonya/database/master_contract_db.py
@@ -44,17 +44,36 @@ class SymToken(Base):
 
 
 def init_db():
+    """Initialize the master contract database.
+    
+    Creates all tables defined in the SQLAlchemy Base metadata using
+    the configured database engine.
+    """
     logger.info("Initializing Master Contract DB")
     Base.metadata.create_all(bind=engine)
 
 
 def delete_symtoken_table():
+    """Delete all records from the Symtoken table.
+    
+    Clears the existing master contracts to prepare for a fresh bulk insert.
+    """
     logger.info("Deleting Symtoken Table")
     SymToken.query.delete()
     db_session.commit()
 
 
 def copy_from_dataframe(df):
+    """Perform a bulk insert of contract data from a pandas DataFrame.
+    
+    Filters out any token-exchange combinations that already exist in the
+    database to avoid primary key constraints or duplicates, and then inserts
+    the remaining records in bulk using SQLAlchemy.
+    
+    Args:
+        df (pd.DataFrame): DataFrame containing the formatted contract data
+            with columns matching the SymToken model parameters.
+    """
     logger.info("Performing Bulk Insert")
     # Convert DataFrame to a list of dictionaries
     data_dict = df.to_dict(orient="records")
@@ -97,8 +116,18 @@ shoonya_urls = {
 
 
 def download_and_unzip_shoonya_data(output_path):
-    """
-    Downloads and unzips the shoonya text files to the tmp folder.
+    """Download and unzip the Shoonya master contract text files from their FTP.
+    
+    Iterates through the exchange URLs defined in `shoonya_urls`, downloads
+    each ZIP file in memory, and extracts its contents to the specified
+    output path.
+    
+    Args:
+        output_path (str): Directory path where the extracted text files
+            should be saved (e.g., 'tmp').
+            
+    Returns:
+        list[str]: A list of downloaded filenames (e.g., ['NSE.txt', 'NFO.txt']).
     """
     logger.info("Downloading and Unzipping shoonya Data")
 
@@ -135,9 +164,17 @@ def download_and_unzip_shoonya_data(output_path):
 
 
 def process_shoonya_nse_data(output_path):
-    """
-    Processes the shoonya NSE data (NSE_symbols.txt) to generate OpenAlgo symbols.
-    Separates EQ, BE symbols, and Index symbols.
+    """Process the Shoonya NSE data file to generate OpenAlgo symbols.
+    
+    Reads the downloaded NSE_symbols.txt, formats the equity (EQ) and
+    BE symbols, normalizes the index symbols, and structures the DataFrame
+    to match the database schema.
+    
+    Args:
+        output_path (str): The directory containing the extracted NSE data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya NSE Data")
     file_path = f"{output_path}/NSE_symbols.txt"
@@ -242,9 +279,16 @@ def process_shoonya_nse_data(output_path):
 
 
 def process_shoonya_nfo_data(output_path):
-    """
-    Processes the shoonya NFO data (NFO_symbols.txt) to generate OpenAlgo symbols.
-    Handles both futures and options formatting.
+    """Process the Shoonya NFO data file to generate OpenAlgo F&O symbols.
+    
+    Handles both futures and options formatting. Parses expiry dates into
+    the 'DD-MMM-YY' format and structures the strike prices correctly.
+    
+    Args:
+        output_path (str): The directory containing the extracted NFO data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya NFO Data")
     file_path = f"{output_path}/NFO_symbols.txt"
@@ -360,9 +404,16 @@ def process_shoonya_nfo_data(output_path):
 
 
 def process_shoonya_cds_data(output_path):
-    """
-    Processes the shoonya CDS data (CDS_symbols.txt) to generate OpenAlgo symbols.
-    Handles both futures and options formatting.
+    """Process the Shoonya CDS data file to generate OpenAlgo currency symbols.
+    
+    Reads CDS_symbols.txt, handles futures and options formatting for the
+    currency segment, and filters out dummy tokens or incorrect entries.
+    
+    Args:
+        output_path (str): The directory containing the extracted CDS data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya CDS Data")
     file_path = f"{output_path}/CDS_symbols.txt"
@@ -493,9 +544,16 @@ def process_shoonya_cds_data(output_path):
 
 
 def process_shoonya_mcx_data(output_path):
-    """
-    Processes the shoonya MCX data (MCX_symbols.txt) to generate OpenAlgo symbols.
-    Handles both futures and options formatting.
+    """Process the Shoonya MCX data file to generate OpenAlgo commodity symbols.
+    
+    Handles formatting of futures and options for commodities. Normalizes
+    strike prices and expiry dates.
+    
+    Args:
+        output_path (str): The directory containing the extracted MCX data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya MCX Data")
     file_path = f"{output_path}/MCX_symbols.txt"
@@ -620,9 +678,16 @@ def process_shoonya_mcx_data(output_path):
 
 
 def process_shoonya_bse_data(output_path):
-    """
-    Processes the shoonya BSE data (BSE_symbols.txt) to generate OpenAlgo symbols.
-    Maps all instrument types to 'EQ' and manually adds missing BSE index symbols.
+    """Process the Shoonya BSE data file to generate OpenAlgo equity symbols.
+    
+    Maps all raw BSE instrument types to 'EQ', handles numeric conversions,
+    and manually appends major BSE indices (like SENSEX, BANKEX).
+    
+    Args:
+        output_path (str): The directory containing the extracted BSE data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya BSE Data")
     file_path = f"{output_path}/BSE_symbols.txt"
@@ -739,9 +804,16 @@ def process_shoonya_bse_data(output_path):
 
 
 def process_shoonya_bfo_data(output_path):
-    """
-    Processes the shoonya BFO data (BFO_symbols.txt) to generate OpenAlgo symbols and correctly extract the name column.
-    Handles both futures and options formatting, ensuring strike prices are handled as either float or integer.
+    """Process the Shoonya BFO data file to generate OpenAlgo BFO symbols.
+    
+    Parses both BSE futures and options. Correctly extracts the base name,
+    calculates the expiry formats, and handles decimal/integer strike prices.
+    
+    Args:
+        output_path (str): The directory containing the extracted BFO data file.
+        
+    Returns:
+        pd.DataFrame: A formatted pandas DataFrame ready for bulk DB insertion.
     """
     logger.info("Processing shoonya BFO Data")
     file_path = f"{output_path}/BFO_symbols.txt"
@@ -880,8 +952,10 @@ def process_shoonya_bfo_data(output_path):
 
 
 def delete_shoonya_temp_data(output_path):
-    """
-    Deletes the shoonya symbol files from the tmp folder after processing.
+    """Delete the downloaded Shoonya text files from the temporary directory.
+    
+    Args:
+        output_path (str): The directory where the extracted texts are located.
     """
     for filename in os.listdir(output_path):
         file_path = os.path.join(output_path, filename)
@@ -891,8 +965,15 @@ def delete_shoonya_temp_data(output_path):
 
 
 def master_contract_download():
-    """
-    Downloads, processes, and deletes shoonya data.
+    """Download, process, and update the database with the latest Shoonya master contracts.
+    
+    Coordinates the entire flow: downloads ZIP files, extracts them, clears
+    the existing `SymToken` table, processes NSE, BSE, NFO, CDS, MCX, and BFO
+    text files separately, and performs bulk inserts. Finally cleans up the
+    temporary files and emits a websocket status event.
+
+    Returns:
+        socketio.emit response regarding the success or failure of the download.
     """
     logger.info("Downloading shoonya Master Contract")
 

--- a/broker/shoonya/mapping/margin_data.py
+++ b/broker/shoonya/mapping/margin_data.py
@@ -8,15 +8,19 @@ logger = get_logger(__name__)
 
 
 def transform_margin_positions(positions, account_id):
-    """
-    Transform OpenAlgo margin positions to Shoonya margin format.
+    """Transform OpenAlgo margin positions to Shoonya margin API format.
+
+    Parses OpenAlgo symbols to determine the exact instrument name,
+    base symbol name, and derivative details (strike, expiry, option type).
+    All numeric fields in the returned dict are converted to strings as required
+    by the Shoonya API.
 
     Args:
-        positions: List of positions in OpenAlgo format
-        account_id: Shoonya account ID (API key without last 2 chars)
+        positions (list[dict]): List of positions in OpenAlgo format.
+        account_id (str): Shoonya account ID (usually API key without last 2 chars).
 
     Returns:
-        Dict in Shoonya margin format with actid and pos array
+        dict: A dict containing 'actid' and 'pos' array in Shoonya format.
     """
     transformed_positions = []
 
@@ -101,10 +105,18 @@ def transform_margin_positions(positions, account_id):
 
 
 def determine_instrument_name(symbol, exchange):
-    """
-    Determine instrument name based on symbol and exchange.
+    """Determine the Shoonya instrument name based on symbol and exchange.
 
-    Returns: FUTSTK, FUTIDX, OPTSTK, OPTIDX, FUTCUR, etc.
+    Analyzes the structure of the OpenAlgo symbol and its exchange to
+    map it to Shoonya's internal instrument naming convention (e.g.,
+    FUTSTK, FUTIDX, OPTSTK, OPTIDX, FUTCUR).
+
+    Args:
+        symbol (str): OpenAlgo trading symbol.
+        exchange (str): OpenAlgo exchange (e.g., 'NSE', 'NFO', 'CDS').
+
+    Returns:
+        str: Shoonya instrument name (e.g., 'EQ', 'FUTIDX', 'OPTSTK').
     """
     # For equity exchanges
     if exchange in ["NSE", "BSE"]:
@@ -143,10 +155,20 @@ def determine_instrument_name(symbol, exchange):
 
 
 def extract_symbol_name(symbol):
-    """
-    Extract base symbol name from trading symbol.
-    E.g., NIFTY25NOV25FUT -> NIFTY
-    E.g., NIFTY30DEC2524500CE -> NIFTY
+    """Extract the base symbol name from a full trading symbol.
+
+    Removes option type suffixes (CE, PE, C, P), FUT suffixes, -EQ suffixes,
+    date patterns, and strike prices to isolate the base instrument name.
+    
+    Examples:
+        - "NIFTY25NOV25FUT" -> "NIFTY"
+        - "NIFTY30DEC2524500CE" -> "NIFTY"
+
+    Args:
+        symbol (str): Full OpenAlgo trading symbol.
+
+    Returns:
+        str: The extracted base symbol name.
     """
     import re
 
@@ -184,10 +206,18 @@ def extract_symbol_name(symbol):
 
 
 def extract_derivative_details(symbol, exchange):
-    """
-    Extract expiry date, option type, and strike price from symbol.
+    """Extract expiry date, option type, and strike price from a derivative symbol.
 
-    Returns: (exd, optt, strprc)
+    Parses the OpenAlgo symbol to find patterns matching dates and option
+    strike metadata, and converts the date format to 'DD-MMM-YYYY' for Shoonya.
+    
+    Args:
+        symbol (str): OpenAlgo derivative trading symbol.
+        exchange (str): OpenAlgo exchange name.
+        
+    Returns:
+        tuple: (exd, optt, strprc). For futures, optt is 'XX' and strprc is '-1'.
+            For equity, all three are empty strings.
     """
     exd = ""
     optt = ""
@@ -246,14 +276,17 @@ def extract_derivative_details(symbol, exchange):
 
 
 def parse_margin_response(response_data):
-    """
-    Parse Shoonya margin response to OpenAlgo standard format.
+    """Parse Shoonya margin calculation response to OpenAlgo standard format.
+
+    Extracts 'span', 'expo', and total margin requirements from the raw
+    Shoonya SpanCalc API response.
 
     Args:
-        response_data: Raw response from Shoonya API
+        response_data (dict): Raw response from Shoonya API.
 
     Returns:
-        Standardized margin response matching OpenAlgo format
+        dict: Standardized margin response matching OpenAlgo API format,
+            or an error dict if parsing fails.
     """
     try:
         if not response_data or not isinstance(response_data, dict):

--- a/broker/shoonya/mapping/order_data.py
+++ b/broker/shoonya/mapping/order_data.py
@@ -110,6 +110,17 @@ def calculate_order_statistics(order_data):
 
 
 def transform_order_data(orders):
+    """Transform raw Shoonya order data to the OpenAlgo standardized format.
+
+    Maps Shoonya field names (tsym, exch, trantype, norenordno, etc.)
+    to OpenAlgo field names (symbol, exchange, action, orderid, etc.).
+
+    Args:
+        orders: A list of order dicts from Shoonya.
+
+    Returns:
+        list[dict]: Transformed orders with standardized field names.
+    """
     transformed_orders = []
 
     for order in orders:
@@ -196,6 +207,14 @@ def map_trade_data(trade_data):
 
 
 def transform_tradebook_data(tradebook_data):
+    """Transform raw Shoonya trade data to the OpenAlgo standardized format.
+
+    Args:
+        tradebook_data: List of trade dicts from the Shoonya trade book.
+
+    Returns:
+        list[dict]: Transformed trades with standardized field names.
+    """
     transformed_data = []
     for trade in tradebook_data:
         # Parse the timestamp from Shoonya format "HH:MM:SS DD-MM-YYYY" to just "HH:MM:SS"
@@ -261,6 +280,17 @@ def map_position_data(position_data):
 
 
 def transform_positions_data(positions_data):
+    """Transform raw Shoonya position data to OpenAlgo standardized format.
+
+    Calculates net quantity, average price, and computes P&L using the
+    last traded price (lp).
+
+    Args:
+        positions_data: List of position dicts from Shoonya.
+
+    Returns:
+        list[dict]: Positions with standardized fields.
+    """
     transformed_data = []
     for position in positions_data:
         # Get position values
@@ -399,8 +429,13 @@ def calculate_portfolio_statistics(holdings_data):
 
 
 def transform_holdings_data(holdings_data):
-    """
-    Transforms holdings data according to Shoonya API specifications.
+    """Transforms holdings data according to Shoonya API specifications.
+    
+    Args:
+        holdings_data: List of raw holding dicts from Shoonya.
+        
+    Returns:
+        list[dict]: Standardized holdings data for OpenAlgo.
     """
     transformed_data = []
     if isinstance(holdings_data, list):

--- a/broker/shoonya/mapping/transform_data.py
+++ b/broker/shoonya/mapping/transform_data.py
@@ -5,8 +5,15 @@ from database.token_db import get_br_symbol
 
 
 def transform_data(data, token):
-    """
-    Transforms the new API request structure to the current expected structure.
+    """Transform the OpenAlgo API request to Shoonya's expected order structure.
+
+    Args:
+        data (dict): OpenAlgo order data including 'apikey', 'symbol',
+            'exchange', 'quantity', 'price', 'product', 'action', etc.
+        token (str): Security token for the symbol (unused in Shoonya's API).
+
+    Returns:
+        dict: Transformed payload for placing an order in Shoonya API.
     """
     userid = data["apikey"]
     userid = userid[:-2]
@@ -33,6 +40,16 @@ def transform_data(data, token):
 
 
 def transform_modify_order_data(data, token):
+    """Transform the OpenAlgo modify order request to Shoonya's expected structure.
+
+    Args:
+        data (dict): OpenAlgo modify order data including 'apikey',
+            'orderid', 'symbol', 'exchange', 'quantity', 'price', etc.
+        token (str): Security token for the symbol.
+
+    Returns:
+        dict: Transformed payload for modifying an order in Shoonya API.
+    """
     return {
         "exch": data["exchange"],
         "norenordno": data["orderid"],
@@ -49,16 +66,26 @@ def transform_modify_order_data(data, token):
 
 
 def map_order_type(pricetype):
-    """
-    Maps the new pricetype to the existing order type.
+    """Map an OpenAlgo price type to Shoonya's order type code.
+
+    Args:
+        pricetype (str): OpenAlgo price type ('MARKET', 'LIMIT', 'SL', 'SL-M').
+
+    Returns:
+        str: Shoonya order type ('MKT', 'LMT', 'SL-LMT', 'SL-MKT'). Defaults to 'MKT'.
     """
     order_type_mapping = {"MARKET": "MKT", "LIMIT": "LMT", "SL": "SL-LMT", "SL-M": "SL-MKT"}
     return order_type_mapping.get(pricetype, "MARKET")  # Default to MARKET if not found
 
 
 def map_product_type(product):
-    """
-    Maps the new product type to the existing product type.
+    """Map an OpenAlgo product type to Shoonya's product type.
+
+    Args:
+        product (str): OpenAlgo product type ('CNC', 'NRML', 'MIS').
+
+    Returns:
+        str: Shoonya product type ('C', 'M', 'I'). Defaults to 'I' (Intraday).
     """
     product_type_mapping = {
         "CNC": "C",
@@ -69,8 +96,13 @@ def map_product_type(product):
 
 
 def reverse_map_product_type(product):
-    """
-    Maps the new product type to the existing product type.
+    """Map a Shoonya product type back to OpenAlgo's product type.
+
+    Args:
+        product (str): Shoonya product type ('C', 'M', 'I').
+
+    Returns:
+        str or None: OpenAlgo product type ('CNC', 'NRML', 'MIS').
     """
     reverse_product_type_mapping = {
         "C": "CNC",


### PR DESCRIPTION
This pull request introduces comprehensive Google-style docstrings to the Shoonya broker integration modules. This is part of the ongoing effort to standardize documentation and improve the developer experience and maintainability of the 

openalgo
 project for the FOSS Hack contribution.

Changes Made
Structured and descriptive Google-style docstrings (including comprehensive Args and Returns blocks) have been added to functions across the following key modules in broker/shoonya/:

api/data.py: Added documentation to quote and multi-quote fetching functions, including async batched requests (get_quotes, get_multiquotes, _fetch_single_quote_async, _process_quotes_batch_async, etc.).
api/order_api.py: Documented core API interaction logic for placing orders, executing smart orders based on position sizing, cancelling positions, and handling modifications (place_order_api, place_smartorder_api, modify_order, cancel_order, etc.).
api/auth_api.py, funds.py, margin_api.py: Added docstrings dictating the required Shoonya-specific authentication payloads, parsing logic for the Limits API, and margin computation requests.
database/master_contract_db.py: Extensive documentation added outlining the system's workflow for downloading ZIP files from Shoonya's FTP, unzipping the data, processing individual exchange instruments (NSE, NFO, CDS, MCX, BSE, BFO), formatting them for OpenAlgo mappings, and executing database bulk inserts (copy_from_dataframe, master_contract_download, process_shoonya_nse_data).
mapping/transform_data.py & mapping/order_data.py: Explanations provided for mappings that translate OpenAlgo standard formats to Shoonya-specific codes (e.g., transforming CNC/NRML/MIS to C/M/H and standardizing incoming tradebook records).
mapping/margin_data.py: Added detailed comments regarding the extraction of expiry dates, option types, and strike prices (determine_instrument_name, extract_symbol_name, extract_derivative_details, parse_margin_response) for accurate Span Calculator API calls.
Motivation and Context
The broker/shoonya directory handles complex logic, async batching, and custom database processing that is heavily specific to the Shoonya SDK. The lack of standard Python typing and parameter descriptions made it difficult for future contributors to maintain or patch without closely analyzing the code logic inside loops. By enforcing Google-style docstrings, we ensure consistency across the FOSS ecosystem, enabling better code intellisense and significantly lowering the barrier to entry for reading the Shoonya integration.

Type of Change
 Bug fix (non-breaking change which fixes an issue)
 New feature (non-breaking change which adds functionality)
 Documentation / Code Quality enhancement (non-breaking change)
 Refactoring (internal improvements without behavior changes)
Checklist
 My code follows the style guidelines of this project
 I have performed a self-review of my code
 I have formatted all new and updated docstrings to strictly adhere to the Google python-docstring standard

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Google-style docstrings across the Shoonya broker integration to standardize documentation and improve readability, with no behavior changes. This makes APIs, mappings, and database workflows easier to understand and maintain.

- **Refactors**
  - Added Args/Returns docstrings to `api/auth_api.py`, `api/data.py`, `api/funds.py`, `api/margin_api.py`, `api/order_api.py` (incl. sync/async quote fetching and request helpers).
  - Documented master contract pipeline in `database/master_contract_db.py` (download, unzip, process NSE/BSE/NFO/CDS/MCX/BFO, bulk insert, cleanup).
  - Clarified mapping logic in `mapping/transform_data.py`, `mapping/order_data.py`, `mapping/margin_data.py` (order/product type mapping, position/holding/trade transforms, margin symbol parsing and response normalization).

<sup>Written for commit 4fdb6899cf9d21682cff22c2d015d2f8ec366184. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

