### PR TITLE
fix: add ErrorBoundary with minimal integration (clean PR)

### DIFF
--- a/frontend/src/components/error-boundary/ErrorBoundary.tsx
+++ b/frontend/src/components/error-boundary/ErrorBoundary.tsx
@@ -1,0 +1,47 @@
+import { Component, type ErrorInfo, type ReactNode } from "react";
+import ErrorFallback from "./ErrorFallback";
+
+interface Props {
+  children: ReactNode;
+  fallback?: ReactNode;
+}
+
+interface State {
+  hasError: boolean;
+  error?: Error;
+}
+
+/**
+ * ErrorBoundary catches rendering errors in its child component tree
+ * and displays a fallback UI instead of crashing the entire app.
+ */
+export class ErrorBoundary extends Component<Props, State> {
+  state: State = { hasError: false, error: undefined };
+
+  // Triggered when a child component throws an error
+  static getDerivedStateFromError(error: Error): State {
+    return { hasError: true, error };
+  }
+
+  // Useful for logging errors to monitoring tools (Sentry, etc.)
+  componentDidCatch(error: Error, info: ErrorInfo) {
+    console.error("ErrorBoundary caught:", error, info);
+  }
+
+  // Reset error state when user clicks "Try Again"
+  resetError = () => {
+    this.setState({ hasError: false, error: undefined });
+  };
+
+  render() {
+    if (this.state.hasError) {
+      return (
+        this.props.fallback || (
+          <ErrorFallback error={this.state.error} resetError={this.resetError} />
+        )
+      );
+    }
+
+    return this.props.children;
+  }
+}

--- a/frontend/src/components/error-boundary/ErrorFallback.tsx
+++ b/frontend/src/components/error-boundary/ErrorFallback.tsx
@@ -1,0 +1,33 @@
+import React from "react";
+
+interface ErrorFallbackProps {
+  error?: Error;
+  resetError: () => void;
+}
+
+export default function ErrorFallback({ error, resetError }: ErrorFallbackProps) {
+  return (
+    <div className="flex min-h-[300px] flex-col items-center justify-center rounded-lg border bg-background p-8 text-center shadow-sm">
+      <h2 className="text-xl font-semibold text-foreground">
+        Something went wrong
+      </h2>
+
+      <p className="mt-2 text-sm text-muted-foreground">
+        Please try refreshing the page or retry the action.
+      </p>
+
+      {error && (
+        <p className="mt-2 text-xs text-destructive">
+          {error.message}
+        </p>
+      )}
+
+      <button
+        onClick={resetError}
+        className="mt-6 rounded-md bg-primary px-4 py-2 text-sm font-medium text-primary-foreground transition hover:opacity-90"
+      >
+        Try Again
+      </button>
+    </div>
+  );
+}

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -59,7 +59,7 @@ function getPnLBadgeVariant(value: string | number): 'default' | 'destructive' |
   return 'secondary'
 }
 
-export default function Dashboard() {
+function DashboardPage() {
   const [marginData, setMarginData] = useState<MarginData | null>(null)
   const [isLoading, setIsLoading] = useState(true)
   const [error, setError] = useState<string | null>(null)
@@ -271,7 +271,6 @@ export default function Dashboard() {
   }
 
   return (
-    <ErrorBoundary>
     <div className="space-y-6 md:space-y-12">
       {/* Dashboard Header */}
       <div className="flex flex-col lg:flex-row lg:items-start gap-4">
@@ -472,6 +471,13 @@ export default function Dashboard() {
         </div>
       </div>
     </div>
+  )
+}
+
+export default function Dashboard() {
+  return (
+    <ErrorBoundary>
+      <DashboardPage />
     </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Dashboard.tsx
+++ b/frontend/src/pages/Dashboard.tsx
@@ -5,6 +5,7 @@ import { Badge } from '@/components/ui/badge'
 import { Card, CardContent } from '@/components/ui/card'
 import { cn } from '@/lib/utils'
 import { onModeChange } from '@/stores/themeStore'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 interface MarginData {
   availablecash: string
@@ -270,6 +271,7 @@ export default function Dashboard() {
   }
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6 md:space-y-12">
       {/* Dashboard Header */}
       <div className="flex flex-col lg:flex-row lg:items-start gap-4">
@@ -470,5 +472,6 @@ export default function Dashboard() {
         </div>
       </div>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -30,6 +30,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 function formatPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
@@ -198,6 +199,7 @@ export default function Holdings() {
   const isProfit = (value: number) => value >= 0
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -418,5 +420,6 @@ export default function Holdings() {
         </CardContent>
       </Card>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -36,7 +36,7 @@ function formatPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
 }
 
-export default function Holdings() {
+function HoldingsPage() {
   const { apiKey, user } = useAuthStore()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
   const [holdings, setHoldings] = useState<Holding[]>([])
@@ -199,7 +199,6 @@ export default function Holdings() {
   const isProfit = (value: number) => value >= 0
 
   return (
-    <ErrorBoundary>
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -420,6 +419,13 @@ export default function Holdings() {
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+export default function Holdings() {
+  return (
+    <ErrorBoundary>
+      <HoldingsPage />
     </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -97,7 +97,7 @@ const statusConfig: Record<string, { icon: typeof CheckCircle2; color: string; l
   open: { icon: Clock, color: 'text-blue-500', label: 'open' },
 }
 
-export default function OrderBook() {
+function OrderBookPage() {
   const { apiKey, user } = useAuthStore()
   const { isCrypto } = useSupportedExchanges()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
@@ -344,7 +344,6 @@ export default function OrderBook() {
   )
 
   return (
-    <ErrorBoundary>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
@@ -774,6 +773,13 @@ export default function OrderBook() {
         </DialogContent>
       </Dialog>
     </div>
+  )
+}
+
+export default function OrderBook() {
+  return (
+    <ErrorBoundary>
+      <OrderBookPage />
     </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -51,6 +51,7 @@ import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Order, OrderStats } from '@/types/trading'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 function formatTime(timestamp: string): string {
   if (!timestamp) return '-'
@@ -343,6 +344,7 @@ export default function OrderBook() {
   )
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6">
       {/* Header */}
       <div className="flex flex-col sm:flex-row sm:items-center sm:justify-between gap-4">
@@ -772,6 +774,7 @@ export default function OrderBook() {
         </DialogContent>
       </Dialog>
     </div>
+    </ErrorBoundary>
   )
 }
 

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -57,6 +57,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { onModeChange } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
+import { ErrorBoundary } from '@/components/error-boundary/ErrorBoundary'
 
 const STORAGE_KEY = 'openalgo_positions_prefs'
 
@@ -586,6 +587,7 @@ export default function Positions() {
   })
 
   return (
+    <ErrorBoundary>
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -1044,5 +1046,6 @@ export default function Positions() {
         </CardContent>
       </Card>
     </div>
+    </ErrorBoundary>
   )
 }

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -138,7 +138,7 @@ const PRODUCT_COLORS: Record<string, string> = {
   NRML: 'bg-slate-500/20 text-slate-600 border-slate-500/30',
 }
 
-export default function Positions() {
+function PositionsPage() {
   const { apiKey, user } = useAuthStore()
   const { isCrypto } = useSupportedExchanges()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
@@ -587,7 +587,6 @@ export default function Positions() {
   })
 
   return (
-    <ErrorBoundary>
     <div className="space-y-6">
       {/* Stale Data Warning */}
       {showStaleWarning && (
@@ -1046,6 +1045,13 @@ export default function Positions() {
         </CardContent>
       </Card>
     </div>
+  )
+}
+
+export default function Positions() {
+  return (
+    <ErrorBoundary>
+      <PositionsPage />
     </ErrorBoundary>
   )
 }


### PR DESCRIPTION
## Summary

Fixes #1021

This PR adds an ErrorBoundary to prevent the UI from crashing when rendering errors occur in key pages.

## Changes

* Added `ErrorBoundary` component
* Added `ErrorFallback` UI
* Wrapped the following pages:

  * Dashboard
  * Holdings
  * OrderBook
  * Positions

## Behavior

If a rendering error occurs, the app no longer shows a blank screen. Instead, users see a fallback UI with a "Something went wrong" message and an option to retry.

## Notes

* This is a clean PR based on the latest main branch
* Contains only ErrorBoundary-related changes
* No unrelated refactors or dependency updates included

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an ErrorBoundary to stop full-page crashes from render errors and show a friendly fallback with a retry. Addresses #1021 by preventing blank screens on key pages.

- **Bug Fixes**
  - Implemented `ErrorBoundary` with default `ErrorFallback` and optional custom fallback; includes a “Try Again” reset.
  - Wrapped Dashboard, Holdings, OrderBook, and Positions by exporting a wrapper that renders the page inside `<ErrorBoundary>`.
  - Logs errors via componentDidCatch and shows the error message when available.

<sup>Written for commit 722c5ea538a1a9b61138b9a2b6d36869bbc9896f. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

