### PR TITLE
fix: replace traceback with logger.exception() in blueprints

### DIFF
--- a/blueprints/historify.py
+++ b/blueprints/historify.py
@@ -8,7 +8,6 @@ Note: The /historify page is served by react_app.py (React frontend).
 
 import os
 import tempfile
-import traceback
 
 from flask import Blueprint, Response, jsonify, request, send_file, session
 
@@ -35,8 +34,7 @@ def get_watchlist():
         success, response, status_code = service_get_watchlist()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -55,8 +53,7 @@ def add_watchlist():
         success, response, status_code = add_to_watchlist(symbol, exchange, display_name)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error adding to watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error adding to watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -74,8 +71,7 @@ def remove_watchlist():
         success, response, status_code = remove_from_watchlist(symbol, exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error removing from watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error removing from watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -95,8 +91,7 @@ def bulk_remove_watchlist():
         success, response, status_code = bulk_remove_from_watchlist(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk removing from watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk removing from watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -113,8 +108,7 @@ def bulk_add_watchlist():
         success, response, status_code = bulk_add_to_watchlist(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk adding to watchlist: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk adding to watchlist: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -160,8 +154,7 @@ def download_data():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error downloading data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -195,8 +188,7 @@ def download_watchlist():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error downloading watchlist data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading watchlist data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -227,8 +219,7 @@ def get_chart_data():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting chart data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting chart data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -242,8 +233,7 @@ def get_catalog():
         success, response, status_code = get_data_catalog()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting catalog: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting catalog: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -261,8 +251,7 @@ def get_symbol_info():
         success, response, status_code = get_symbol_data_info(symbol, exchange, interval)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting symbol info: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting symbol info: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -303,8 +292,7 @@ def export_data():
 
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error exporting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error exporting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -355,8 +343,7 @@ def download_export():
             headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     except Exception as e:
-        logger.error(f"Error downloading export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading export: {e}")
         # Clean up file on error
         if file_path and os.path.exists(file_path):
             try:
@@ -406,8 +393,7 @@ def get_export_preview():
 
         return jsonify({"status": "success", "data": preview}), 200
     except Exception as e:
-        logger.error(f"Error getting export preview: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting export preview: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -554,8 +540,7 @@ def bulk_export():
         ), 200
 
     except Exception as e:
-        logger.error(f"Error in bulk export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in bulk export: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -605,8 +590,7 @@ def download_bulk_export():
             headers={"Content-Disposition": f"attachment; filename={filename}"},
         )
     except Exception as e:
-        logger.error(f"Error downloading bulk export: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error downloading bulk export: {e}")
         # Clean up file on error
         if file_path and os.path.exists(file_path):
             try:
@@ -644,8 +628,7 @@ def get_intervals():
         success, response, status_code = get_supported_timeframes(api_key)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting intervals: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -659,8 +642,7 @@ def get_historify_intervals():
         success, response, status_code = service_get_intervals()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting historify intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting historify intervals: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -674,8 +656,7 @@ def get_exchanges():
         success, response, status_code = service_get_exchanges()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting exchanges: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting exchanges: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -689,8 +670,7 @@ def get_stats():
         success, response, status_code = service_get_stats()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting stats: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting stats: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -709,8 +689,7 @@ def delete_data():
         success, response, status_code = delete_symbol_data(symbol, exchange, interval)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error deleting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -730,8 +709,7 @@ def bulk_delete_data():
         success, response, status_code = bulk_delete_symbol_data(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error bulk deleting data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error bulk deleting data: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -815,8 +793,7 @@ def upload_data():
                 os.remove(temp_path)
 
     except Exception as e:
-        logger.error(f"Error uploading data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error uploading data: {e}")
         # Clean up temp file on error
         if temp_file and os.path.exists(temp_file.name):
             os.remove(temp_file.name)
@@ -890,8 +867,7 @@ def get_fno_underlyings():
         success, response, status_code = service_get_underlyings(exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO underlyings: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO underlyings: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -914,8 +890,7 @@ def get_fno_expiries():
         success, response, status_code = service_get_expiries(underlying, exchange, instrumenttype)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO expiries: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO expiries: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -948,8 +923,7 @@ def get_fno_chain():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting FNO chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting FNO chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -969,8 +943,7 @@ def get_futures_chain():
         success, response, status_code = service_get_futures(underlying, exchange)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting futures chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting futures chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -999,8 +972,7 @@ def get_option_chain():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting option chain: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting option chain: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1022,8 +994,7 @@ def get_jobs():
         success, response, status_code = get_all_jobs(status, limit)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting jobs: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting jobs: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1071,8 +1042,7 @@ def create_job():
         )
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error creating job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error creating job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1086,8 +1056,7 @@ def get_job_status(job_id):
         success, response, status_code = service_get_job_status(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting job status: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting job status: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1101,8 +1070,7 @@ def cancel_job(job_id):
         success, response, status_code = service_cancel_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error cancelling job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error cancelling job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1116,8 +1084,7 @@ def pause_job(job_id):
         success, response, status_code = service_pause_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error pausing job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error pausing job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1131,8 +1098,7 @@ def resume_job_endpoint(job_id):
         success, response, status_code = service_resume_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error resuming job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error resuming job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1159,8 +1125,7 @@ def retry_job(job_id):
         success, response, status_code = retry_failed_items(job_id, api_key)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error retrying job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error retrying job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1174,8 +1139,7 @@ def delete_job(job_id):
         success, response, status_code = service_delete_job(job_id)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error deleting job: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting job: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1198,8 +1162,7 @@ def get_catalog_grouped():
         success, response, status_code = get_catalog_grouped_service(group_by)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting grouped catalog: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting grouped catalog: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1213,8 +1176,7 @@ def get_catalog_with_metadata():
         success, response, status_code = get_catalog_with_metadata_service()
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error getting catalog with metadata: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting catalog with metadata: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1234,8 +1196,7 @@ def enrich_metadata():
         success, response, status_code = enrich_and_save_metadata(symbols)
         return jsonify(response), status_code
     except Exception as e:
-        logger.error(f"Error enriching metadata: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error enriching metadata: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1263,8 +1224,7 @@ def get_schedules():
 
         return jsonify({"status": "success", "data": schedules, "count": len(schedules)}), 200
     except Exception as e:
-        logger.error(f"Error getting schedules: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting schedules: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1358,8 +1318,7 @@ def create_schedule():
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error creating schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error creating schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1385,8 +1344,7 @@ def get_schedule(schedule_id):
         return jsonify({"status": "success", "data": schedule}), 200
 
     except Exception as e:
-        logger.error(f"Error getting schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1451,8 +1409,7 @@ def update_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error updating schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error updating schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1472,8 +1429,7 @@ def delete_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error deleting schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error deleting schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1493,8 +1449,7 @@ def enable_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error enabling schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error enabling schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1514,8 +1469,7 @@ def disable_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error disabling schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error disabling schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1535,8 +1489,7 @@ def pause_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error pausing schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error pausing schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1556,8 +1509,7 @@ def resume_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error resuming schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error resuming schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1577,8 +1529,7 @@ def trigger_schedule(schedule_id):
             return jsonify({"status": "error", "message": msg}), 400
 
     except Exception as e:
-        logger.error(f"Error triggering schedule: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error triggering schedule: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500
 
 
@@ -1595,6 +1546,5 @@ def get_schedule_executions(schedule_id):
         return jsonify({"status": "success", "data": executions, "count": len(executions)}), 200
 
     except Exception as e:
-        logger.error(f"Error getting executions: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting executions: {e}")
         return jsonify({"status": "error", "message": str(e)}), 500

--- a/blueprints/pnltracker.py
+++ b/blueprints/pnltracker.py
@@ -1,6 +1,5 @@
 import threading
 import time as time_module
-import traceback
 from datetime import datetime, timedelta
 from datetime import time as dt_time
 from importlib import import_module
@@ -183,7 +182,7 @@ def dynamic_import(broker, module_name, function_names):
             module_functions[name] = getattr(module, name)
         return module_functions
     except (ImportError, AttributeError) as e:
-        logger.error(
+        logger.exception(
             f"Error importing functions {function_names} from {module_name} for broker {broker}: {e}"
         )
         return None
@@ -1103,5 +1102,4 @@ def get_pnl_data():
 
     except Exception as e:
         logger.error(f"Error calculating intraday PnL: {e}")
-        traceback.print_exc()
         return jsonify({"status": "error", "message": str(e)}), 500


### PR DESCRIPTION
TL;DR: Replaced bare traceback.print_exc() calls with logger.exception() across the blueprints/ layer (i.e. 

historify.py
, 

pnltracker.py
) to ensure all backend tracing correctly hooks into OpenAlgo's central logging system instead of dumping unformatted errors directly to stderr.

What changed:

Located and removed import traceback modules across several blueprint controllers.
Migrated rigid traceback.print_exc() dumps inside except Exception as e: blocks into standard logger.exception().
Unused traceback module imports were cleanly removed.
Why this is valuable:

Centralized Logging: Calling logger.exception("An exception occurred") automatically grabs the full exception stack trace and routes it explicitly to the formatted logger (meaning it correctly goes to the app logs, rotating files, or monitoring integrations rather than vanishing locally to the console stderr).
Standardization: Resolves inconsistency in error handling throughout the monolith by following the standard logging practices used elsewhere in the backend.
Cleaner Console Output: Prevents hard-to-read, raw tracebacks from randomly interrupting stdout in production environments when errors happen in the PnL Tracker and Historify modules.
Files Touched:


blueprints/historify.py

blueprints/pnltracker.py
Type of Change:

 Bug fix / Code Quality improvement (non-breaking change which fixes an issue)
 New feature
 Breaking change

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced raw `traceback.print_exc()` calls with `logger.exception()` in blueprint routes to pipe stack traces into OpenAlgo’s centralized logging and stop dumping errors to stderr. Standardizes error handling across Historify and PnL Tracker.

- **Bug Fixes**
  - Swapped `traceback.print_exc()` for `logger.exception()` in `blueprints/historify.py` and adjusted error logging in `blueprints/pnltracker.py`.
  - Removed unused `traceback` imports.
  - Ensures full stack traces land in structured logs for better observability.

<sup>Written for commit e20d876cf0ea2fbea8dea5c7e92fb92152062923. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

