### PR TITLE
fix: get_first_available_api_key() skips orphaned/revoked users, caches negative auth results

### DIFF
--- a/database/auth_db.py
+++ b/database/auth_db.py
@@ -467,11 +467,21 @@ def get_first_available_api_key():
     """
     Get the first available decrypted API key from the database.
     Used for background services that don't have session context.
+
+    Only returns keys for users who have an active (non-revoked) auth session
+    with a broker configured. This prevents returning orphaned API keys for
+    deleted users or users with revoked sessions.
     """
     try:
-        api_key_obj = ApiKeys.query.first()
-        if api_key_obj and api_key_obj.api_key_encrypted:
-            return decrypt_token(api_key_obj.api_key_encrypted)
+        # Join api_keys with auth to only return keys for users with active sessions
+        api_keys = ApiKeys.query.all()
+        for api_key_obj in api_keys:
+            if not api_key_obj.api_key_encrypted:
+                continue
+            # Check if this user has an active auth session with a broker
+            auth_obj = Auth.query.filter_by(name=api_key_obj.user_id).first()
+            if auth_obj and not auth_obj.is_revoked and auth_obj.broker:
+                return decrypt_token(api_key_obj.api_key_encrypted)
         return None
     except Exception as e:
         logger.exception(f"Error getting first available API key: {e}")
@@ -642,8 +652,12 @@ def get_auth_token_broker(provided_api_key, include_feed_token=False):
                 logger.debug(f"Auth token cached for user_id: {user_id}")
                 return result
             else:
-                logger.warning(f"No valid auth token or broker found for user_id '{user_id}'.")
-                return (None, None, None) if include_feed_token else (None, None)
+                # Cache the negative result to prevent repeated DB queries and log spam
+                # (e.g., orphaned users with revoked sessions polled by background services)
+                negative_result = (None, None, None) if include_feed_token else (None, None)
+                auth_cache[cache_key] = negative_result
+                logger.warning(f"No valid auth token or broker found for user_id '{user_id}'. Cached negative result.")
+                return negative_result
         except Exception as e:
             logger.exception(f"Error while querying the database for auth token and broker: {e}")
             return (None, None, None) if include_feed_token else (None, None)

--- a/test_orphaned_apikey.py
+++ b/test_orphaned_apikey.py
@@ -1,0 +1,219 @@
+"""Test: orphaned API keys don't break background services.
+
+Simulates the scenario where:
+1. User 'admin' has an API key but their auth session is revoked (no broker)
+2. User 'jagat' has an API key with an active auth session (broker=shoonya)
+3. get_first_available_api_key() should return jagat's key, not admin's
+4. get_auth_token_broker() should cache negative results for revoked users
+   to prevent log spam from background polling (every 5s)
+
+To run inside the OpenAlgo container:
+    docker exec openalgo python test_orphaned_apikey.py
+"""
+
+import hashlib
+import os
+import sys
+
+sys.path.insert(0, os.path.dirname(__file__))
+
+# Force in-memory DB for testing
+os.environ["DATABASE_URL"] = "sqlite:///:memory:"
+
+
+def setup_test_db():
+    """Create a fresh in-memory database with test data."""
+    # Re-import to pick up the in-memory DATABASE_URL
+    # We need to patch the module's engine before it's used
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import scoped_session, sessionmaker
+
+    import database.auth_db as auth_mod
+
+    engine = create_engine("sqlite:///:memory:")
+    auth_mod.db_session = scoped_session(
+        sessionmaker(autocommit=False, autoflush=False, bind=engine)
+    )
+    auth_mod.Base.query = auth_mod.db_session.query_property()
+    auth_mod.Base.metadata.create_all(engine)
+
+    return auth_mod
+
+
+def test_get_first_available_api_key_skips_revoked():
+    """get_first_available_api_key() must skip users with revoked auth sessions."""
+    auth_mod = setup_test_db()
+
+    # Setup: admin with revoked session (no broker)
+    admin_auth = auth_mod.Auth(
+        name="admin", auth="", feed_token=None, broker="", is_revoked=1
+    )
+    auth_mod.db_session.add(admin_auth)
+    auth_mod.db_session.commit()
+
+    admin_api_key = "admin_key_abc123"
+    auth_mod.upsert_api_key("admin", admin_api_key)
+
+    # Setup: jagat with active session (broker=shoonya)
+    jagat_auth = auth_mod.Auth(
+        name="jagat_user", auth="encrypted_token", feed_token=None,
+        broker="shoonya", is_revoked=0,
+    )
+    auth_mod.db_session.add(jagat_auth)
+    auth_mod.db_session.commit()
+
+    jagat_api_key = "jagat_key_xyz789"
+    auth_mod.upsert_api_key("jagat_user", jagat_api_key)
+
+    # Test: get_first_available_api_key should return jagat's key, not admin's
+    result = auth_mod.get_first_available_api_key()
+
+    assert result is not None, "Expected a valid API key, got None"
+    assert result == jagat_api_key, (
+        f"Expected jagat's key '{jagat_api_key}', got '{result}'. "
+        "get_first_available_api_key() is returning an orphaned/revoked user's key."
+    )
+
+    print("PASS: get_first_available_api_key() correctly skips revoked users")
+
+    # Test: with ALL sessions revoked, should return None
+    jagat_auth.is_revoked = 1
+    auth_mod.db_session.commit()
+
+    result2 = auth_mod.get_first_available_api_key()
+    assert result2 is None, (
+        f"Expected None when all sessions are revoked, got '{result2}'"
+    )
+
+    print("PASS: get_first_available_api_key() returns None when all sessions revoked")
+
+
+def test_get_first_available_api_key_skips_no_broker():
+    """get_first_available_api_key() must skip users with empty broker field."""
+    auth_mod = setup_test_db()
+
+    # User with active session but no broker configured
+    no_broker_auth = auth_mod.Auth(
+        name="no_broker_user", auth="", feed_token=None,
+        broker="", is_revoked=0,
+    )
+    auth_mod.db_session.add(no_broker_auth)
+    auth_mod.db_session.commit()
+    auth_mod.upsert_api_key("no_broker_user", "no_broker_key_111")
+
+    # User with active session and broker
+    active_auth = auth_mod.Auth(
+        name="active_user", auth="token", feed_token=None,
+        broker="shoonya", is_revoked=0,
+    )
+    auth_mod.db_session.add(active_auth)
+    auth_mod.db_session.commit()
+    auth_mod.upsert_api_key("active_user", "active_key_222")
+
+    result = auth_mod.get_first_available_api_key()
+    assert result == "active_key_222", (
+        f"Expected active_user's key, got '{result}'. "
+        "get_first_available_api_key() returned key for user with no broker."
+    )
+
+    print("PASS: get_first_available_api_key() skips users with empty broker")
+
+
+def test_auth_token_broker_caches_negative_result():
+    """get_auth_token_broker() should cache revoked results to prevent log spam."""
+    auth_mod = setup_test_db()
+
+    # Clear all caches
+    auth_mod.auth_cache.clear()
+    auth_mod.verified_api_key_cache.clear()
+    auth_mod.invalid_api_key_cache.clear()
+
+    # User with revoked session
+    revoked_auth = auth_mod.Auth(
+        name="revoked_user", auth="old_token", feed_token=None,
+        broker="shoonya", is_revoked=1,
+    )
+    auth_mod.db_session.add(revoked_auth)
+    auth_mod.db_session.commit()
+
+    api_key = "revoked_user_key_333"
+    auth_mod.upsert_api_key("revoked_user", api_key)
+
+    # First call — should return None and cache the negative result
+    result1 = auth_mod.get_auth_token_broker(api_key)
+    assert result1 == (None, None), f"Expected (None, None) for revoked user, got {result1}"
+
+    # Check that the negative result was cached in auth_cache
+    cache_key = f"{hashlib.sha256(api_key.encode()).hexdigest()}_False"
+    assert cache_key in auth_mod.auth_cache, (
+        "Negative result was NOT cached in auth_cache. This causes log spam "
+        "because every subsequent call hits the DB and logs a warning."
+    )
+    assert auth_mod.auth_cache[cache_key] == (None, None), (
+        f"Expected cached (None, None), got {auth_mod.auth_cache[cache_key]}"
+    )
+
+    print("PASS: get_auth_token_broker() caches negative result for revoked users")
+
+
+def test_only_admin_revoked_reproduces_original_bug():
+    """Reproduce the exact production scenario from 2026-03-25.
+
+    State:
+    - api_keys row 1: user_id='admin' (created first, so .first() returns this)
+    - api_keys row 2: user_id='jagat_4579e4'
+    - auth row 1: name='admin', broker='', is_revoked=1
+    - auth row 2: name='jagat_4579e4', broker='shoonya', is_revoked=0
+
+    Before fix: get_first_available_api_key() returned admin's key → downstream
+    calls failed with "No valid auth token or broker found for user_id 'admin'"
+    every 5 seconds.
+
+    After fix: get_first_available_api_key() returns jagat's key.
+    """
+    auth_mod = setup_test_db()
+
+    # Exact production state
+    admin_auth = auth_mod.Auth(
+        name="admin", auth="", feed_token=None, broker="", is_revoked=1
+    )
+    jagat_auth = auth_mod.Auth(
+        name="jagat_4579e4", auth="encrypted_shoonya_token", feed_token=None,
+        broker="shoonya", is_revoked=0,
+    )
+    auth_mod.db_session.add(admin_auth)
+    auth_mod.db_session.add(jagat_auth)
+    auth_mod.db_session.commit()
+
+    auth_mod.upsert_api_key("admin", "old_admin_key")
+    auth_mod.upsert_api_key("jagat_4579e4", "a55ef11f02ae_actual_key")
+
+    result = auth_mod.get_first_available_api_key()
+
+    assert result == "a55ef11f02ae_actual_key", (
+        f"REGRESSION: get_first_available_api_key() returned '{result}' instead of "
+        "jagat's key. The orphaned admin key is being returned, which will cause "
+        "'No valid auth token or broker' warning spam every 5 seconds."
+    )
+
+    print("PASS: Production scenario (admin revoked + jagat active) returns correct key")
+
+
+if __name__ == "__main__":
+    print("=" * 60)
+    print("Testing orphaned API key handling")
+    print("=" * 60)
+    print()
+
+    test_get_first_available_api_key_skips_revoked()
+    print()
+    test_get_first_available_api_key_skips_no_broker()
+    print()
+    test_auth_token_broker_caches_negative_result()
+    print()
+    test_only_admin_revoked_reproduces_original_bug()
+
+    print()
+    print("=" * 60)
+    print("All tests passed!")
+    print("=" * 60)


### PR DESCRIPTION
## Summary

Fixes #1169 — `get_first_available_api_key()` returns API keys for users with revoked/orphaned auth sessions, causing background service failures and ~720 warning log lines per hour.

## Changes

### `database/auth_db.py`

**`get_first_available_api_key()`** — Now checks each API key owner has:
- A non-revoked auth session (`is_revoked=0`)
- A broker configured (`broker` is not empty)

Before:
```python
api_key_obj = ApiKeys.query.first()  # Returns first row blindly
```

After:
```python
for api_key_obj in ApiKeys.query.all():
    auth_obj = Auth.query.filter_by(name=api_key_obj.user_id).first()
    if auth_obj and not auth_obj.is_revoked and auth_obj.broker:
        return decrypt_token(api_key_obj.api_key_encrypted)
```

**`get_auth_token_broker()`** — Caches negative results (revoked sessions) in `auth_cache` to prevent repeated DB queries and log spam on every poll cycle.

### `test_orphaned_apikey.py` (new)

4 test cases:
| Test | Scenario |
|------|----------|
| `test_get_first_available_api_key_skips_revoked` | Revoked admin + active user → returns active user's key |
| `test_get_first_available_api_key_skips_no_broker` | Active session but no broker → skipped |
| `test_auth_token_broker_caches_negative_result` | Revoked user → `(None, None)` cached in `auth_cache` |
| `test_only_admin_revoked_reproduces_original_bug` | Exact production state reproduction |

## Test Plan

- [x] All 4 new tests pass inside OpenAlgo Docker container
- [x] Verified against live production database
- [x] `get_first_available_api_key()` returns correct key after fix
- [ ] Historify scheduler should stop generating "No valid auth token" warnings

## How to run tests

```bash
docker exec openalgo python test_orphaned_apikey.py
```

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops background jobs from using orphaned API keys and cuts warning spam by only returning keys for active users with a configured broker, and by caching negative auth lookups.

- **Bug Fixes**
  - `get_first_available_api_key()` now skips users with revoked auth or no `broker`, returning a key only when the owner has an active session.
  - `get_auth_token_broker()` caches negative results in `auth_cache` (including `include_feed_token` cases) to avoid repeated DB hits and warning logs.
  - Added `test_orphaned_apikey.py` with four cases covering revoked sessions, empty broker, negative-result caching, and the production repro.

<sup>Written for commit 2e98ad376d3adf0a727d580c803e2a1b0f05d37d. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

