### PR TITLE
fix: disable gunicorn control socket to prevent Permission denied in Docker

### DIFF
--- a/start.sh
+++ b/start.sh
@@ -241,5 +241,6 @@ exec /app/.venv/bin/gunicorn \
     --timeout 300 \
     --graceful-timeout 30 \
     --worker-tmp-dir /tmp/gunicorn_workers \
+    --control-socket-disable \
     --log-level warning \
     app:app


### PR DESCRIPTION
## Summary

Fixes #1171 — Gunicorn 25.x control socket fails with `Permission denied` when running as non-root user in Docker.

## Change

One line added to `start.sh`:

```diff
 exec /app/.venv/bin/gunicorn \
     --worker-class eventlet \
     --workers 1 \
     --bind 0.0.0.0:${APP_PORT} \
     --timeout 300 \
     --graceful-timeout 30 \
     --worker-tmp-dir /tmp/gunicorn_workers \
+    --control-socket-disable \
     --log-level warning \
     app:app
```

## Why

Gunicorn 24+ added a control socket (`gunicorn.ctl`) enabled by default. It tries to create the socket in `/app/`, which is owned by `root`. The process runs as `appuser` → `EACCES`. This produces 4-8 error log lines per day.

The control socket is not used by OpenAlgo — no `gunicornctl` commands are invoked anywhere in the codebase.

## Test

Before: `[ERROR] Control server error: [Errno 13] Permission denied` in logs
After: No control socket errors, gunicorn starts cleanly

Closes #1171

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable `gunicorn` control socket in Docker to stop “Permission denied” errors when running as a non-root user (fixes #1171). Adds `--control-socket-disable` to `start.sh`; no behavior change since we don’t use `gunicornctl`.

- **Bug Fixes**
  - `gunicorn` 24+ enables a control socket by default, which tries to create `gunicorn.ctl` under `/app/` (owned by root), causing EACCES. Disabling it removes noisy error logs and keeps startup clean.

<sup>Written for commit a9bcfc42af91a77d3c8f010a5630e3d778422d77. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

