### PR TITLE
Migrate Zebu broker from TOTP login to OAuth 2.0 authentication

### DIFF
--- a/blueprints/brlogin.py
+++ b/blueprints/brlogin.py
@@ -438,17 +438,24 @@ def broker_callback(broker, para=None):
         forward_url = "broker.html"
 
     elif broker == "zebu":
-        if request.method == "GET":
-            # Redirect to React TOTP page
-            return redirect("/broker/zebu/totp")
-
-        elif request.method == "POST":
-            userid = request.form.get("userid")
-            password = request.form.get("password")
-            totp_code = request.form.get("totp")
-
-            auth_token, error_message = auth_function(userid, password, totp_code)
+        code = request.args.get("code")
+        if code:
+            logger.debug(f"Zebu broker - OAuth callback with code: {code}")
+            auth_token, error_message = auth_function(code)
             forward_url = "broker.html"
+        else:
+            # Initial visit — redirect to Zebu OAuth login page
+            logger.info("Redirecting to Zebu OAuth login page")
+            # BROKER_API_KEY format: userid:::client_id
+            full_api_key = os.getenv("BROKER_API_KEY")
+            if not full_api_key:
+                return handle_auth_failure(
+                    "BROKER_API_KEY not configured in environment",
+                    forward_url="broker.html",
+                )
+            client_id = full_api_key.split(":::")[1]  # OAuth client_id
+            zebu_login_url = f"https://go.mynt.in/OAuthlogin/authorize/oauth?client_id={client_id}"
+            return redirect(zebu_login_url)
 
     elif broker == "shoonya":
         if request.method == "GET":

--- a/broker/zebu/api/auth_api.py
+++ b/broker/zebu/api/auth_api.py
@@ -2,65 +2,65 @@ import hashlib
 import json
 import os
 
-import httpx
-
 from utils.httpx_client import get_httpx_client
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
-def sha256_hash(text):
-    """Generate SHA256 hash."""
-    return hashlib.sha256(text.encode("utf-8")).hexdigest()
-
-
-def authenticate_broker(userid, password, totp_code):
+def authenticate_broker(code):
     """
-    Authenticate with Zebu and return the auth token using httpx with connection pooling.
+    Authenticate with Zebu using OAuth 2.0 flow.
+    Exchanges the authorization code for an access token.
     """
-    # Get the Zebu API key and other credentials from environment variables
-    api_secretkey = os.getenv("BROKER_API_SECRET")
-    vendor_code = os.getenv("BROKER_API_KEY")
-    imei = "1234567890abcdef"  # Default IMEI if not provided
+    # BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
+    full_api_key = os.getenv("BROKER_API_KEY")
+    client_id = full_api_key.split(":::")[1]  # OAuth client_id
+    secret_key = os.getenv("BROKER_API_SECRET")
 
     try:
         # Get the shared httpx client
         client = get_httpx_client()
 
-        # Zebu API login URL
-        url = "https://go.mynt.in/NorenWClientTP/QuickAuth"
+        # Zebu OAuth token exchange endpoint
+        url = "https://go.mynt.in/NorenWClientAPI/GenAcsTok"
 
-        # Prepare login payload
+        # Compute checksum: SHA256(client_id + secret_key + code)
+        checksum_input = f"{client_id}{secret_key}{code}"
+        checksum = hashlib.sha256(checksum_input.encode()).hexdigest()
+
+        # Prepare token exchange payload
         payload = {
-            "uid": userid,  # User ID
-            "pwd": sha256_hash(password),  # SHA256 hashed password
-            "factor2": totp_code,  # PAN or TOTP or DOB (second factor)
-            "apkversion": "1.0.8",  # API version (as per Zebu's requirement)
-            "appkey": sha256_hash(f"{userid}|{api_secretkey}"),  # SHA256 of uid and API key
-            "imei": imei,  # IMEI or MAC address
-            "vc": vendor_code,  # Vendor code
-            "source": "API",  # Source of login request
+            "code": code,
+            "checksum": checksum,
         }
 
-        # Convert payload to string with 'jData=' prefix
+        # Convert payload to jData format
         payload_str = "jData=" + json.dumps(payload)
 
-        # Set headers for the API request
-        headers = {"Content-Type": "application/x-www-form-urlencoded"}
+        # Set headers as per Zebu OAuth docs
+        headers = {"Content-Type": "text/plain"}
 
-        # Send the POST request to Zebu's API using httpx client
+        logger.debug(f"Zebu OAuth token exchange request to {url}")
+
+        # Send the POST request
         response = client.post(url, content=payload_str, headers=headers)
-
-        # Add status attribute for compatibility with the existing codebase
-        response.status = response.status_code
 
         # Handle the response
         if response.status_code == 200:
             data = response.json()
-            if data["stat"] == "Ok":
-                return data["susertoken"], None  # Return the token on success
+            if data.get("stat") == "Ok" and "access_token" in data:
+                logger.info("Zebu OAuth authentication successful")
+                return data["access_token"], None
             else:
-                return None, data.get("emsg", "Authentication failed. Please try again.")
+                error_msg = data.get("emsg", "Authentication failed. Please try again.")
+                logger.error(f"Zebu OAuth auth error: {error_msg}")
+                return None, error_msg
         else:
-            return None, f"Error: {response.status_code}, {response.text}"
+            error_msg = f"Error: {response.status_code}, {response.text}"
+            logger.error(f"Zebu OAuth HTTP error: {error_msg}")
+            return None, error_msg
 
     except Exception as e:
+        logger.error(f"Zebu OAuth exception: {e}")
         return None, str(e)

--- a/broker/zebu/api/data.py
+++ b/broker/zebu/api/data.py
@@ -24,7 +24,9 @@ def get_api_response(endpoint, auth, method="POST", payload=None):
     Common function to make API calls to Zebu using httpx with connection pooling
     """
     AUTH_TOKEN = auth
-    api_key = os.getenv("BROKER_API_KEY")
+    # BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
+    full_api_key = os.getenv("BROKER_API_KEY")
+    api_key = full_api_key.split(":::")[0]  # Trading user ID
 
     if payload is None:
         data = {"uid": api_key}
@@ -32,12 +34,15 @@ def get_api_response(endpoint, auth, method="POST", payload=None):
         data = payload
         data["uid"] = api_key
 
-    payload_str = "jData=" + json.dumps(data) + "&jKey=" + AUTH_TOKEN
+    payload_str = "jData=" + json.dumps(data)
 
     # Get the shared httpx client
     client = get_httpx_client()
 
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {AUTH_TOKEN}",
+    }
     url = f"https://go.mynt.in{endpoint}"
 
     response = client.request(method, url, content=payload_str, headers=headers)
@@ -89,10 +94,10 @@ class BrokerData:
             elif exchange == "BSE_INDEX":
                 api_exchange = "BSE"
 
-            payload = {"uid": os.getenv("BROKER_API_KEY"), "exch": api_exchange, "token": token}
+            payload = {"exch": api_exchange, "token": token}
 
             response = get_api_response(
-                "/NorenWClientTP/GetQuotes", self.auth_token, payload=payload
+                "/NorenWClientAPI/GetQuotes", self.auth_token, payload=payload
             )
 
             if response.get("stat") != "Ok":
@@ -168,9 +173,12 @@ class BrokerData:
         try:
             data = {"uid": api_key, "exch": api_exchange, "token": token}
 
-            payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            url = "https://go.mynt.in/NorenWClientTP/GetQuotes"
+            payload_str = "jData=" + json.dumps(data)
+            headers = {
+                "Content-Type": "text/plain",
+                "Authorization": f"Bearer {self.auth_token}",
+            }
+            url = "https://go.mynt.in/NorenWClientAPI/GetQuotes"
 
             # Use httpx.post for sync requests
             http_response = httpx.post(url, content=payload_str, headers=headers, timeout=10.0)
@@ -217,9 +225,12 @@ class BrokerData:
         try:
             data = {"uid": api_key, "exch": api_exchange, "token": token}
 
-            payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
-            headers = {"Content-Type": "application/x-www-form-urlencoded"}
-            url = "https://go.mynt.in/NorenWClientTP/GetQuotes"
+            payload_str = "jData=" + json.dumps(data)
+            headers = {
+                "Content-Type": "text/plain",
+                "Authorization": f"Bearer {self.auth_token}",
+            }
+            url = "https://go.mynt.in/NorenWClientAPI/GetQuotes"
 
             # Use async httpx client
             http_response = await client.post(url, content=payload_str, headers=headers)
@@ -304,8 +315,9 @@ class BrokerData:
         skipped_symbols = []
         prepared_symbols = []
 
-        # Pre-fetch API key
-        api_key = os.getenv("BROKER_API_KEY")
+        # Pre-fetch API key (userid part)
+        full_api_key = os.getenv("BROKER_API_KEY")
+        api_key = full_api_key.split(":::")[0]  # Trading user ID
 
         # Step 1: Pre-resolve all tokens sequentially (database access)
         for item in symbols:
@@ -391,10 +403,10 @@ class BrokerData:
             elif exchange == "BSE_INDEX":
                 api_exchange = "BSE"
 
-            payload = {"uid": os.getenv("BROKER_API_KEY"), "exch": api_exchange, "token": token}
+            payload = {"exch": api_exchange, "token": token}
 
             response = get_api_response(
-                "/NorenWClientTP/GetQuotes", self.auth_token, payload=payload
+                "/NorenWClientAPI/GetQuotes", self.auth_token, payload=payload
             )
 
             if response.get("stat") != "Ok":
@@ -506,7 +518,7 @@ class BrokerData:
                 logger.debug(f"EOD Payload: {payload}")  # Debug print
                 try:
                     response = get_api_response(
-                        "/NorenWClientTP/EODChartData", self.auth_token, payload=payload
+                        "/NorenWClientAPI/EODChartData", self.auth_token, payload=payload
                     )
                     logger.debug(f"EOD Response: {response}")  # Debug print
                 except Exception as e:
@@ -515,7 +527,6 @@ class BrokerData:
             else:
                 # For intraday data, use TPSeries endpoint
                 payload = {
-                    "uid": os.getenv("BROKER_API_KEY"),
                     "exch": api_exchange,
                     "token": token,
                     "st": str(start_ts),
@@ -525,7 +536,7 @@ class BrokerData:
 
                 logger.debug(f"Intraday Payload: {payload}")  # Debug print
                 response = get_api_response(
-                    "/NorenWClientTP/TPSeries", self.auth_token, payload=payload
+                    "/NorenWClientAPI/TPSeries", self.auth_token, payload=payload
                 )
                 logger.debug(f"Intraday Response: {response}")  # Debug print
 
@@ -598,7 +609,7 @@ class BrokerData:
                             # Get today's data from quotes
                             payload = {"exch": api_exchange, "token": token}
                             quotes_response = get_api_response(
-                                "/NorenWClientTP/GetQuotes", self.auth_token, payload=payload
+                                "/NorenWClientAPI/GetQuotes", self.auth_token, payload=payload
                             )
                             logger.debug(f"Quotes Response: {quotes_response}")  # Debug print
 

--- a/broker/zebu/api/funds.py
+++ b/broker/zebu/api/funds.py
@@ -14,9 +14,10 @@ logger = get_logger(__name__)
 def get_margin_data(auth_token):
     """Fetch margin data from Zebu's API using the provided auth token with httpx connection pooling."""
 
-    # Fetch UserID and AccountID from environment variables
-    userid = os.getenv("BROKER_API_KEY")
-    actid = userid  # Assuming AccountID is the same as UserID
+    # BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
+    full_api_key = os.getenv("BROKER_API_KEY")
+    userid = full_api_key.split(":::")[0]  # Trading user ID
+    actid = userid
 
     # Prepare the payload for the request
     data = {
@@ -24,17 +25,20 @@ def get_margin_data(auth_token):
         "actid": actid,  # Account ID
     }
 
-    # Prepare the jData payload with the authentication token (jKey)
-    payload = "jData=" + json.dumps(data) + "&jKey=" + auth_token
+    # Prepare the jData payload
+    payload = "jData=" + json.dumps(data)
 
     # Get the shared httpx client
     client = get_httpx_client()
 
-    # Set headers - should be form-urlencoded, not json
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    # Set headers with Bearer token authentication
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {auth_token}",
+    }
 
     # Zebu API endpoint URL
-    url = "https://go.mynt.in/NorenWClientTP/Limits"
+    url = "https://go.mynt.in/NorenWClientAPI/Limits"
 
     # Send the POST request to Zebu's API using httpx
     response = client.post(url, content=payload, headers=headers)
@@ -60,7 +64,7 @@ def get_margin_data(auth_token):
         total_collateral = float(margin_data.get("brkcollamt", 0))
         total_used_margin = float(margin_data.get("marginused", 0))
         total_realised = -float(margin_data.get("rpnl", 0))
-        total_unrealised = float(margin_data.get("urmtom", 0))
+        total_unrealised = float(margin_data.get("unmtom", 0))
 
         # Construct and return the processed margin data
         processed_margin_data = {

--- a/broker/zebu/api/order_api.py
+++ b/broker/zebu/api/order_api.py
@@ -20,19 +20,24 @@ logger = get_logger(__name__)
 def get_api_response(endpoint, auth, method="GET", payload=""):
     AUTH_TOKEN = auth
 
-    api_key = os.getenv("BROKER_API_KEY")
+    # BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
+    full_api_key = os.getenv("BROKER_API_KEY")
+    api_key = full_api_key.split(":::")[0]  # Trading user ID
 
     data = f'{{"uid": "{api_key}", "actid": "{api_key}"}}'
 
-    if endpoint == "/NorenWClientTP/Holdings":
+    if endpoint == "/NorenWClientAPI/Holdings":
         data = f'{{"uid": "{api_key}", "actid": "{api_key}", "prd": "C"}}'
 
-    payload = "jData=" + data + "&jKey=" + AUTH_TOKEN
+    payload = "jData=" + data
 
     # Get the shared httpx client
     client = get_httpx_client()
 
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {AUTH_TOKEN}",
+    }
     url = f"https://go.mynt.in{endpoint}"
 
     response = client.request(method, url, content=payload, headers=headers)
@@ -42,19 +47,19 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
 
 def get_order_book(auth):
-    return get_api_response("/NorenWClientTP/OrderBook", auth, method="POST")
+    return get_api_response("/NorenWClientAPI/OrderBook", auth, method="POST")
 
 
 def get_trade_book(auth):
-    return get_api_response("/NorenWClientTP/TradeBook", auth, method="POST")
+    return get_api_response("/NorenWClientAPI/TradeBook", auth, method="POST")
 
 
 def get_positions(auth):
-    return get_api_response("/NorenWClientTP/PositionBook", auth, method="POST")
+    return get_api_response("/NorenWClientAPI/PositionBook", auth, method="POST")
 
 
 def get_holdings(auth):
-    return get_api_response("/NorenWClientTP/Holdings", auth, method="POST")
+    return get_api_response("/NorenWClientAPI/Holdings", auth, method="POST")
 
 
 def get_open_position(tradingsymbol, exchange, producttype, auth):
@@ -88,29 +93,37 @@ def get_open_position(tradingsymbol, exchange, producttype, auth):
 
 def place_order_api(data, auth):
     AUTH_TOKEN = auth
-    BROKER_API_KEY = os.getenv("BROKER_API_KEY")
+    # BROKER_API_KEY format: userid:::client_id
+    full_api_key = os.getenv("BROKER_API_KEY")
+    BROKER_API_KEY = full_api_key.split(":::")[0]  # Trading user ID
     data["apikey"] = BROKER_API_KEY
     token = get_token(data["symbol"], data["exchange"])
-    newdata = transform_data(data, token)
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    newdata = transform_data(data, token, AUTH_TOKEN)
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {AUTH_TOKEN}",
+    }
 
-    payload = "jData=" + json.dumps(newdata) + "&jKey=" + AUTH_TOKEN
+    payload = "jData=" + json.dumps(newdata)
 
     logger.info(f"{payload}")
 
     # Get the shared httpx client
     client = get_httpx_client()
-    url = "https://go.mynt.in/NorenWClientTP/PlaceOrder"
+    url = "https://go.mynt.in/NorenWClientAPI/PlaceOrder"
 
     res = client.post(url, content=payload, headers=headers)
     # Add status attribute for compatibility with existing code
     res.status = res.status_code
     response_data = json.loads(res.text)
 
-    if response_data["stat"] == "Ok":
-        orderid = response_data["norenordno"]
+    logger.info(f"PlaceOrder Response: {response_data}")
+
+    if response_data.get("stat") == "Ok":
+        orderid = response_data.get("norenordno")
     else:
         orderid = None
+        logger.error(f"PlaceOrder Error: {response_data.get('emsg', 'Unknown error')}")
     return res, response_data, orderid
 
 
@@ -251,18 +264,22 @@ def close_all_positions(current_api_key, auth):
 
 
 def cancel_order(orderid, auth):
-    # Assuming you have a function to get the authentication token
     AUTH_TOKEN = auth
-    api_key = os.getenv("BROKER_API_KEY")
+    # BROKER_API_KEY format: userid:::client_id
+    full_api_key = os.getenv("BROKER_API_KEY")
+    api_key = full_api_key.split(":::")[0]  # Trading user ID
     data = {"uid": api_key, "norenordno": orderid}
 
-    payload = "jData=" + json.dumps(data) + "&jKey=" + AUTH_TOKEN
+    payload = "jData=" + json.dumps(data)
     # Set up the request headers
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {AUTH_TOKEN}",
+    }
 
     # Get the shared httpx client
     client = get_httpx_client()
-    url = "https://go.mynt.in/NorenWClientTP/CancelOrder"
+    url = "https://go.mynt.in/NorenWClientAPI/CancelOrder"
 
     # Send the request using httpx
     res = client.post(url, content=payload, headers=headers)
@@ -282,9 +299,10 @@ def cancel_order(orderid, auth):
 
 
 def modify_order(data, auth):
-    # Assuming you have a function to get the authentication token
     AUTH_TOKEN = auth
-    api_key = os.getenv("BROKER_API_KEY")
+    # BROKER_API_KEY format: userid:::client_id
+    full_api_key = os.getenv("BROKER_API_KEY")
+    api_key = full_api_key.split(":::")[0]  # Trading user ID
 
     token = get_token(data["symbol"], data["exchange"])
     data["symbol"] = get_br_symbol(data["symbol"], data["exchange"])
@@ -296,13 +314,16 @@ def modify_order(data, auth):
 
     logger.info(f"Modify Order Request Data: {transformed_data}")
 
-    # Set up the request headers - should be form-urlencoded, not json
-    headers = {"Content-Type": "application/x-www-form-urlencoded"}
-    payload = "jData=" + json.dumps(transformed_data) + "&jKey=" + AUTH_TOKEN
+    # Set up the request headers
+    headers = {
+        "Content-Type": "text/plain",
+        "Authorization": f"Bearer {AUTH_TOKEN}",
+    }
+    payload = "jData=" + json.dumps(transformed_data)
 
     # Get the shared httpx client
     client = get_httpx_client()
-    url = "https://go.mynt.in/NorenWClientTP/ModifyOrder"
+    url = "https://go.mynt.in/NorenWClientAPI/ModifyOrder"
 
     res = client.post(url, content=payload, headers=headers)
     response = json.loads(res.text)

--- a/broker/zebu/mapping/transform_data.py
+++ b/broker/zebu/mapping/transform_data.py
@@ -1,17 +1,94 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
-# Mapping Angel Broking Parameters https://smartapi.angelbroking.com/docs/Orders
+# Mapping Zebu Broking Parameters
 
+from broker.zebu.api.data import BrokerData
 from database.token_db import get_br_symbol
+from utils.logging import get_logger
+from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
+
+logger = get_logger(__name__)
 
 
-def transform_data(data, token):
+def transform_data(data, token, auth_token=None):
     """
     Transforms the new API request structure to the current expected structure.
+    For market orders, fetches quotes and adjusts price using MPP (Market Price Protection):
+    - EQ/FUT: Price < 100: 2%, 100-500: 1%, > 500: 0.5%
+    - OPT (CE/PE): Price < 10: 5%, 10-100: 3%, 100-500: 2%, > 500: 1%
+
+    Args:
+        data: Order data dictionary
+        token: Instrument token
+        auth_token: Authentication token for fetching quotes (passed from order_api)
     """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
 
-    # For MARKET orders, price should be "0"
-    price = "0" if data["pricetype"] == "MARKET" else str(data.get("price", "0"))
+    # Default values
+    price = str(data.get("price", "0"))
+    order_type = map_order_type(data["pricetype"])
+    action = data["action"].upper()
+
+    # Apply Market Price Protection for MARKET orders
+    if data["pricetype"] == "MARKET":
+        logger.info(
+            f"MPP: MARKET order detected for Symbol={data['symbol']}, Exchange={data['exchange']}, Action={action}"
+        )
+        try:
+            if auth_token:
+                # Create BrokerData instance to fetch quotes
+                broker_data = BrokerData(auth_token)
+
+                # Fetch quotes for the symbol
+                quote_data = broker_data.get_quotes(data["symbol"], data["exchange"])
+                logger.info(
+                    f"MPP Quote Response: Symbol={data['symbol']}, Exchange={data['exchange']}, "
+                    f"LTP={quote_data.get('ltp')}, Bid={quote_data.get('bid')}, Ask={quote_data.get('ask')}"
+                )
+
+                # Get instrument type from symbol
+                instrument_type = get_instrument_type_from_symbol(data["symbol"])
+
+                # Get tick_size from quote response
+                tick_size = quote_data.get("tick_size")
+                logger.info(
+                    f"MPP Symbol Info: InstrumentType={instrument_type}, TickSize={tick_size}"
+                )
+
+                # Get LTP for price calculation
+                ltp = float(quote_data.get("ltp", 0))
+
+                if ltp > 0:
+                    # Calculate protected price using centralized MPP slab with tick size rounding
+                    protected_price = calculate_protected_price(
+                        price=ltp,
+                        action=action,
+                        symbol=data["symbol"],
+                        instrument_type=instrument_type,
+                        tick_size=tick_size,
+                    )
+                    price = str(protected_price)
+
+                    # Convert order type from MARKET to LIMIT
+                    order_type = "LMT"
+                    logger.info(
+                        f"MPP Conversion Complete: Symbol={data['symbol']}, OrderType=MARKET->LIMIT, "
+                        f"FinalPrice={protected_price}"
+                    )
+                else:
+                    logger.warning(
+                        f"MPP Warning: LTP is 0 or invalid for Symbol={data['symbol']}, "
+                        f"Exchange={data['exchange']}. Proceeding with regular market order"
+                    )
+            else:
+                logger.warning(
+                    f"MPP Warning: No auth token available for Symbol={data['symbol']}. "
+                    f"Cannot fetch quotes for MPP adjustment"
+                )
+        except Exception as e:
+            logger.error(
+                f"MPP Error: Failed to apply MPP for Symbol={data['symbol']}, "
+                f"Exchange={data['exchange']}, Error={str(e)}. Proceeding with regular market order."
+            )
 
     # Basic mapping
     transformed = {
@@ -24,13 +101,16 @@ def transform_data(data, token):
         "trgprc": str(data.get("trigger_price", "0")),
         "dscqty": str(data.get("disclosed_quantity", "0")),
         "prd": map_product_type(data["product"]),
-        "trantype": "B" if data["action"] == "BUY" else "S",
-        "prctyp": map_order_type(data["pricetype"]),
+        "trantype": "B" if action == "BUY" else "S",
+        "prctyp": order_type,
         "mkt_protection": "0",
         "ret": "DAY",
         "ordersource": "API",
     }
 
+    # Log order data without sensitive fields
+    safe_log = {k: v for k, v in transformed.items() if k not in ("uid", "actid")}
+    logger.info(f"Transformed order data: {safe_log}")
     return transformed
 
 

--- a/broker/zebu/streaming/zebu_adapter.py
+++ b/broker/zebu/streaming/zebu_adapter.py
@@ -49,7 +49,7 @@ class Config:
     MODE_DEPTH = 3
 
     # Message types (same as Noren/Flattrade)
-    MSG_AUTH = "ck"
+    MSG_AUTH = "ak"
     MSG_TOUCHLINE_FULL = "tf"
     MSG_TOUCHLINE_PARTIAL = "tk"
     MSG_DEPTH_FULL = "df"
@@ -344,23 +344,23 @@ class ZebuWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.broker_name = broker_name
 
         # Get Zebu credentials from environment
-        # For Zebu, BROKER_API_KEY should contain the vendor code (e.g., 'Z56004')
-        # This vendor code is used as both actid and uid in WebSocket authentication
+        # BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
+        # userid is used as both actid and uid in WebSocket authentication
 
-        api_key = os.getenv("BROKER_API_KEY", "")
+        full_api_key = os.getenv("BROKER_API_KEY", "")
 
-        if api_key:
-            # Use the BROKER_API_KEY (vendor code) as the account ID
-            # For Zebu, the vendor code like 'Z56004' is used as actid and uid
-            self.actid = api_key
-            self.logger.info(f"Using Zebu vendor code from BROKER_API_KEY: {self.actid}")
+        if full_api_key and ":::" in full_api_key:
+            # Extract trading user ID (before :::)
+            self.actid = full_api_key.split(":::")[0]
+            self.logger.info(f"Using Zebu user ID from BROKER_API_KEY: {self.actid}")
+        elif full_api_key:
+            # Legacy format without ::: separator
+            self.actid = full_api_key
+            self.logger.warning(f"BROKER_API_KEY missing ':::' separator, using as-is: {self.actid}")
         else:
             # Fallback to user_id if no API key is set
             self.actid = user_id
             self.logger.warning(f"No BROKER_API_KEY found. Using user_id '{user_id}' as actid.")
-            self.logger.warning(
-                "Please set BROKER_API_KEY=Z56004 (or your vendor code) in .env file"
-            )
 
         # Get auth token from database
         self.susertoken = get_auth_token(user_id)

--- a/broker/zebu/streaming/zebu_websocket.py
+++ b/broker/zebu/streaming/zebu_websocket.py
@@ -23,7 +23,7 @@ class ZebuWebSocket:
     # - Flattrade: wss://piconnect.flattrade.in/PiConnectWSTp/
     # - AliceBlue: wss://ws1.aliceblueonline.com/NorenWS/
     # - DefinEdge: wss://trade.definedgesecurities.com/NorenWSTRTP/
-    WS_URL = "wss://go.mynt.in/NorenWSTP/"  # Try NorenWSTP pattern
+    WS_URL = "wss://go.mynt.in/NorenWSAPI/"  # Zebu OAuth WebSocket endpoint
     CONNECTION_TIMEOUT = 15
     THREAD_JOIN_TIMEOUT = 5
 
@@ -33,17 +33,17 @@ class ZebuWebSocket:
     PING_INTERVAL = 30
     PING_TIMEOUT = 10
 
-    # Message types (same as Noren/Flattrade)
-    MSG_TYPE_CONNECT = "c"
+    # Message types (OAuth WebSocket API)
+    MSG_TYPE_CONNECT = "a"
     MSG_TYPE_HEARTBEAT = "h"
-    MSG_TYPE_AUTH_ACK = "ck"
+    MSG_TYPE_AUTH_ACK = "ak"
     MSG_TYPE_TOUCHLINE_SUB = "t"
     MSG_TYPE_TOUCHLINE_UNSUB = "u"
     MSG_TYPE_DEPTH_SUB = "d"
     MSG_TYPE_DEPTH_UNSUB = "ud"
 
     # Authentication response
-    AUTH_SUCCESS = "Ok"
+    AUTH_SUCCESS = "OK"
 
     def __init__(
         self,
@@ -206,20 +206,18 @@ class ZebuWebSocket:
         """
         auth_msg = {
             "t": self.MSG_TYPE_CONNECT,
-            "actid*": self.actid,  # Required field with asterisk as per Zebu docs
             "uid": self.user_id,
             "actid": self.actid,
-            "source": "API",  # Source of login request
-            "susertoken": self.susertoken,
+            "source": "API",
+            "accesstoken": self.susertoken,
         }
-
-        # No vendor code needed in WebSocket auth for Zebu
 
         # Log the authentication message for debugging (mask the token)
         debug_msg = auth_msg.copy()
-        if debug_msg.get("susertoken"):
-            debug_msg["susertoken"] = (
-                debug_msg["susertoken"][:10] + "..." if len(debug_msg["susertoken"]) > 10 else "***"
+        token_val = debug_msg.get("accesstoken", "")
+        if token_val:
+            debug_msg["accesstoken"] = (
+                token_val[:10] + "..." if len(token_val) > 10 else "***"
             )
         self.logger.info(f"Sending auth message: {debug_msg}")
 


### PR DESCRIPTION
- Auth: OAuth redirect flow via GenAcsTok endpoint with SHA256 checksum
- API calls: Bearer token auth + NorenWClientAPI endpoints (was jKey + NorenWClientTP)
- BROKER_API_KEY format: userid:::client_id (e.g., Z56004:::Z56004_U)
- Orders: MPP slab conversion for MARKET->LIMIT (MKT orders blocked by Zebu API)
- Funds: Updated field name unmtom + Bearer auth
- WebSocket: OAuth-style connect (t:a, accesstoken, NorenWSAPI/, ak auth ack)
- Data: All endpoints updated to NorenWClientAPI with Bearer header