### PR TITLE
Fix #1019: add CSRF validation warnings

### DIFF
--- a/app.py
+++ b/app.py
@@ -279,6 +279,9 @@ def create_app():
     csrf_enabled = os.getenv("CSRF_ENABLED", "TRUE").upper() == "TRUE"
     app.config["WTF_CSRF_ENABLED"] = csrf_enabled
 
+    if not csrf_enabled:
+        logger.warning("CSRF protection is DISABLED. This is not recommended for production.")
+
     # Configure CSRF cookie security to match session cookie
     csrf_cookie_name = os.getenv("CSRF_COOKIE_NAME", "csrf_token")
     app.config.update(
@@ -296,9 +299,15 @@ def create_app():
     csrf_time_limit = os.getenv("CSRF_TIME_LIMIT", "").strip()
     if csrf_time_limit:
         try:
-            app.config["WTF_CSRF_TIME_LIMIT"] = int(csrf_time_limit)
+            limit = int(csrf_time_limit)
+            if limit < 300:
+                logger.warning(f"CSRF_TIME_LIMIT={limit}s is very short. Minimum recommended: 300s")
+            elif limit > 86400:
+                logger.warning(f"CSRF_TIME_LIMIT={limit}s is very long. Maximum recommended: 86400s")
+            app.config["WTF_CSRF_TIME_LIMIT"] = limit
         except ValueError:
-            app.config["WTF_CSRF_TIME_LIMIT"] = None  # Default to no limit if invalid
+            logger.warning(f"Invalid CSRF_TIME_LIMIT: {csrf_time_limit}. Using default.")
+            app.config["WTF_CSRF_TIME_LIMIT"] = None
     else:
         app.config["WTF_CSRF_TIME_LIMIT"] = None  # No time limit if empty
 


### PR DESCRIPTION
## Summary
- Added `logger.warning()` when CSRF protection is disabled via `CSRF_ENABLED=FALSE`
- Added min/max validation for `CSRF_TIME_LIMIT` (warns if < 300s or > 86400s)
- Added warning on invalid non-numeric `CSRF_TIME_LIMIT` values instead of silent fallback

Closes #1019

## Verification
- `app.py` passes Python syntax validation
- Changes are limited to the CSRF configuration block (~lines 278-309)
- No functional behavior changes — only adds logging warnings for edge cases

## Test plan
- [ ] Application starts normally with default config
- [ ] Setting `CSRF_ENABLED=FALSE` logs a warning on startup
- [ ] Setting `CSRF_TIME_LIMIT=100` logs a "very short" warning
- [ ] Setting `CSRF_TIME_LIMIT=100000` logs a "very long" warning
- [ ] Setting `CSRF_TIME_LIMIT=abc` logs an "invalid" warning

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add startup warnings for CSRF configuration to catch risky settings early. Logs when CSRF is disabled and validates CSRF_TIME_LIMIT; no behavior changes. Addresses #1019.

- **New Features**
  - Warn at startup if CSRF is disabled.
  - Validate CSRF_TIME_LIMIT and warn if <300s or >86400s.
  - Warn and use default when CSRF_TIME_LIMIT is non-numeric.

<sup>Written for commit 09868c865aca593d79aa4914df5a82f41ec2fa97. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

