### PR TITLE
Fix #895: replace magic number in broker param_count check

### DIFF
--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -7,6 +7,12 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum.
+# If param_count > _MIN_BROKER_INIT_PARAMS, the broker also accepts feed_token.
+# If param_count > _MIN_BROKER_INIT_PARAMS_WITH_FEED, it also accepts user_id.
+_MIN_BROKER_INIT_PARAMS = 2
+_MIN_BROKER_INIT_PARAMS_WITH_FEED = 3
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -96,9 +102,9 @@ def get_depth_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 3:  # More than self, auth_token, and feed_token
+            if param_count > _MIN_BROKER_INIT_PARAMS_WITH_FEED:
                 data_handler = broker_module.BrokerData(auth_token, feed_token, user_id)
-            elif param_count > 2:  # More than self and auth_token
+            elif param_count > _MIN_BROKER_INIT_PARAMS:
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -10,6 +10,10 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum.
+# If param_count > _MIN_BROKER_INIT_PARAMS, the broker also accepts feed_token.
+_MIN_BROKER_INIT_PARAMS = 2
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -118,7 +122,7 @@ def get_history_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -7,6 +7,10 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum.
+# If param_count > _MIN_BROKER_INIT_PARAMS, the broker also accepts feed_token.
+_MIN_BROKER_INIT_PARAMS = 2
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -128,7 +132,7 @@ def get_quotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)
@@ -260,7 +264,7 @@ def get_multiquotes_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)


### PR DESCRIPTION
## Summary
- Defined named constants `_MIN_BROKER_INIT_PARAMS = 2` and `_MIN_BROKER_INIT_PARAMS_WITH_FEED = 3` to replace unexplained magic numbers
- Applied across `quotes_service.py`, `history_service.py`, and `depth_service.py`
- The constants clarify that `2` = `self` + `auth_token`, and `3` adds `feed_token`

Closes #895

## Verification
- All modified files pass Python syntax validation
- No behavioral changes — only readability improvement
- Constants are module-level with explanatory comments

## Test plan
- [ ] Application starts normally
- [ ] Broker data handlers initialize correctly (quotes, history, depth)
- [ ] No regressions in broker API calls

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replace magic numbers in `BrokerData.__init__` param-count checks with named constants for clearer intent; no behavior change. Fixes #895.

- **Refactors**
  - Added `_MIN_BROKER_INIT_PARAMS = 2` (self + auth_token) in `quotes_service.py` and `history_service.py`.
  - In `depth_service.py`, also added `_MIN_BROKER_INIT_PARAMS_WITH_FEED = 3` (adds feed_token).
  - Updated conditional checks to use these constants when creating `BrokerData` (auth only, auth+feed, auth+feed+user_id).
  - Added brief comments explaining the parameter mapping.

<sup>Written for commit 347aefa3cb6cac9959d39f20450a414fecd33602. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

