### PR TITLE
Fix #892: replace traceback.print_exc() with logger.exception() across services

### DIFF
--- a/services/basket_order_service.py
+++ b/services/basket_order_service.py
@@ -1,7 +1,6 @@
 import copy
 import importlib
 import time
-import traceback
 from concurrent.futures import ThreadPoolExecutor, as_completed
 from typing import Any, Dict, List, Optional, Tuple, Union
 

--- a/services/cancel_all_order_service.py
+++ b/services/cancel_all_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -133,8 +132,7 @@ def cancel_all_orders_with_auth(
             order_data, auth_token
         )
     except Exception as e:
-        logger.error(f"Error in broker_module.cancel_all_orders_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.cancel_all_orders_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to cancel all orders due to internal error",

--- a/services/cancel_order_service.py
+++ b/services/cancel_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -135,8 +134,7 @@ def cancel_order_with_auth(
         # Use the dynamically imported module's function to cancel the order
         response_message, status_code = broker_module.cancel_order(orderid, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.cancel_order: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.cancel_order: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to cancel order due to internal error",

--- a/services/close_position_service.py
+++ b/services/close_position_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -141,8 +140,7 @@ def close_position_with_auth(
         api_key = position_data.get("apikey", "")
         response_code, status_code = broker_module.close_all_positions(api_key, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.close_all_positions: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.close_all_positions: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to close positions due to internal error",

--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import Auth, db_session, get_auth_token_broker, verify_api_key
@@ -113,8 +112,7 @@ def get_depth_with_auth(
 
         return True, {"status": "success", "data": depth}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_depth: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_depth: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/funds_service.py
+++ b/services/funds_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -76,8 +75,7 @@ def get_funds_with_auth(
 
         return True, {"status": "success", "data": funds}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_margin_data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_margin_data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -1,6 +1,5 @@
 import importlib
 import time
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 import pandas as pd
@@ -138,8 +137,7 @@ def get_history_with_auth(
 
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
     except Exception as e:
-        logger.error(f"Error in broker_module.get_history: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.get_history: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 
@@ -214,8 +212,7 @@ def get_history_from_db(
         return True, {"status": "success", "data": df.to_dict(orient="records")}, 200
 
     except Exception as e:
-        logger.error(f"Error fetching history from DB: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error fetching history from DB: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/holdings_service.py
+++ b/services/holdings_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -136,8 +135,7 @@ def get_holdings_with_auth(
             200,
         )
     except Exception as e:
-        logger.error(f"Error processing holdings data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing holdings data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/intervals_service.py
+++ b/services/intervals_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -80,8 +79,7 @@ def get_intervals_with_auth(auth_token: str, broker: str) -> tuple[bool, dict[st
 
         return True, {"status": "success", "data": intervals}, 200
     except Exception as e:
-        logger.error(f"Error getting supported intervals: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error getting supported intervals: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/margin_service.py
+++ b/services/margin_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.apilog_db import async_log_order, executor
@@ -198,8 +197,7 @@ def calculate_margin_with_auth(
         executor.submit(async_log_order, "margin", original_data, error_response)
         return False, error_response, 501
     except Exception as e:
-        logger.error(f"Error in broker_module.calculate_margin_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.calculate_margin_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to calculate margin due to internal error",

--- a/services/modify_order_service.py
+++ b/services/modify_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -139,8 +138,7 @@ def modify_order_with_auth(
         # Use the dynamically imported module's function to modify the order
         response_message, status_code = broker_module.modify_order(order_data, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.modify_order: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.modify_order: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to modify order due to internal error",

--- a/services/openposition_service.py
+++ b/services/openposition_service.py
@@ -1,5 +1,4 @@
 import copy
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 import requests
@@ -175,8 +174,7 @@ def get_open_position_with_auth(
         return True, response_data, 200
 
     except Exception as e:
-        logger.error(f"Error processing open position: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing open position: {e}")
         error_response = {"status": "error", "message": str(e)}
         log_executor.submit(async_log_order, "openposition", original_data, error_response)
         return False, error_response, 500

--- a/services/orderbook_service.py
+++ b/services/orderbook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -176,8 +175,7 @@ def get_orderbook_with_auth(
             200,
         )
     except Exception as e:
-        logger.error(f"Error processing order data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing order data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -1,6 +1,5 @@
 import copy
 import importlib
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -196,8 +195,7 @@ def place_order_with_auth(
     try:
         res, response_data, order_id = broker_module.place_order_api(order_data, auth_token)
     except Exception as e:
-        logger.error(f"Error in broker_module.place_order_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.place_order_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to place order due to internal error",

--- a/services/place_smart_order_service.py
+++ b/services/place_smart_order_service.py
@@ -1,7 +1,6 @@
 import copy
 import importlib
 import time
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
@@ -254,8 +253,7 @@ def place_smart_order_with_auth(
             ))
 
     except Exception as e:
-        logger.error(f"Error in broker_module.place_smartorder_api: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error in broker_module.place_smartorder_api: {e}")
         error_response = {
             "status": "error",
             "message": "Failed to place smart order due to internal error",
@@ -271,8 +269,7 @@ def place_smart_order_with_auth(
     try:
         time.sleep(float(smart_order_delay))
     except Exception:
-        logger.error(f"Invalid SMART_ORDER_DELAY value: {smart_order_delay}")
-        traceback.print_exc()
+        logger.exception(f"Invalid SMART_ORDER_DELAY value: {smart_order_delay}")
 
     if res and res.status == 200:
         return True, order_response_data, 200

--- a/services/positionbook_service.py
+++ b/services/positionbook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -142,8 +141,7 @@ def get_positionbook_with_auth(
 
         return True, {"status": "success", "data": formatted_positions}, 200
     except Exception as e:
-        logger.error(f"Error processing positions data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing positions data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -150,8 +149,7 @@ def get_quotes_with_auth(
             logger.debug(f"Quote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_quotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_quotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 
@@ -321,8 +319,7 @@ def get_multiquotes_with_auth(
             logger.debug(f"Multiquote fetch permission denied: {error_msg}")
         else:
             # Log other errors normally
-            logger.error(f"Error in broker_module.get_multiquotes: {e}")
-            traceback.print_exc()
+            logger.exception(f"Error in broker_module.get_multiquotes: {e}")
 
         return False, {"status": "error", "message": str(e)}, 500
 

--- a/services/split_order_service.py
+++ b/services/split_order_service.py
@@ -2,7 +2,6 @@ import copy
 import importlib
 import os
 import time
-import traceback
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker

--- a/services/symbol_service.py
+++ b/services/symbol_service.py
@@ -1,4 +1,3 @@
-import traceback
 from typing import Any, Dict, Optional, Tuple
 
 from sqlalchemy.orm.exc import NoResultFound
@@ -78,8 +77,7 @@ def get_symbol_info_with_auth(
         return False, error_response, 404
 
     except Exception as e:
-        logger.error(f"Error retrieving symbol information: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error retrieving symbol information: {e}")
         error_response = {"status": "error", "message": str(e)}
         return False, error_response, 500
 

--- a/services/tradebook_service.py
+++ b/services/tradebook_service.py
@@ -1,5 +1,4 @@
 import importlib
-import traceback
 from typing import Any, Dict, List, Optional, Tuple, Union
 
 from database.auth_db import get_auth_token_broker
@@ -131,8 +130,7 @@ def get_tradebook_with_auth(
 
         return True, {"status": "success", "data": formatted_trades}, 200
     except Exception as e:
-        logger.error(f"Error processing trade data: {e}")
-        traceback.print_exc()
+        logger.exception(f"Error processing trade data: {e}")
         return False, {"status": "error", "message": str(e)}, 500
 
 


### PR DESCRIPTION
## Summary
- Replaced `logger.error()` + `traceback.print_exc()` with `logger.exception()` in 20 service files
- Removed all unused `import traceback` statements
- `logger.exception()` automatically includes the full traceback in log output without writing directly to stdout/stderr

Closes #892

## Affected files
All files in `services/` that used the `traceback.print_exc()` pattern: depth_service, history_service, quotes_service, funds_service, symbol_service, intervals_service, orderbook_service, tradebook_service, place_order_service, modify_order_service, cancel_order_service, cancel_all_order_service, close_position_service, holdings_service, openposition_service, positionbook_service, margin_service, place_smart_order_service, basket_order_service, split_order_service.

## Test plan
- [ ] Application starts normally
- [ ] Tracebacks appear in log output (not stdout) when service exceptions occur
- [ ] No remaining `traceback.print_exc()` calls in `services/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced all logger.error() + traceback.print_exc() usages with logger.exception() across service modules to include full tracebacks in structured logs and stop printing to stdout/stderr. Closes #892.

- **Refactors**
  - Standardized exception logging with logger.exception(...) in 20 files under services.
  - Removed unused `import traceback` statements.
  - Tracebacks now captured in log entries; no direct stdout/stderr output.
  - No changes to API responses or control flow.

<sup>Written for commit 775271e4e5fcfc5afcac41560cf49dff1c80864e. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

