### PR TITLE
Fix #893: add type hints to validation functions in data_schemas.py

### DIFF
--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -6,7 +6,7 @@ from utils.constants import VALID_EXCHANGES
 
 
 # Custom validator for date or timestamp string
-def validate_date_or_timestamp(data):
+def validate_date_or_timestamp(data: str) -> None:
     """
     Validates that the input string is either in 'YYYY-MM-DD' format or a numeric timestamp.
     """
@@ -19,7 +19,7 @@ def validate_date_or_timestamp(data):
 
 
 # Custom validator for option offset
-def validate_option_offset(data):
+def validate_option_offset(data: str) -> bool:
     """
     Validates option offset: ATM, ITM1-ITM50, OTM1-OTM50
     """


### PR DESCRIPTION
## Summary
- Added parameter type hint `data: str` and return type hint `-> None` to `validate_date_or_timestamp()`
- Added parameter type hint `data: str` and return type hint `-> bool` to `validate_option_offset()`

Closes #893

## Test plan
- [ ] Application starts normally
- [ ] Schema validation still works correctly for history, ticker, and option symbol endpoints

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add explicit type hints to `validate_date_or_timestamp(data: str) -> None` and `validate_option_offset(data: str) -> bool` in `restx_api/data_schemas.py` to improve IDE support and static analysis. No behavior changes; addresses #893.

<sup>Written for commit 0b028de7c22ffd9233271751317e6e4e20a52efd. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

