### PR TITLE
Fix #1015: add null check for request.json in 3 endpoints

### DIFF
--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -27,6 +26,11 @@ class Intervals(Resource):
     def post(self):
         """Get supported intervals for the broker"""
         try:
+            if request.json is None:
+                return make_response(
+                    jsonify({"status": "error", "message": "Request body must be JSON"}), 400
+                )
+
             # Validate request data
             intervals_data = intervals_schema.load(request.json)
 

--- a/restx_api/market_holidays.py
+++ b/restx_api/market_holidays.py
@@ -26,6 +26,11 @@ class MarketHolidays(Resource):
     def post(self):
         """Get market holidays for a specific year"""
         try:
+            if request.json is None:
+                return make_response(
+                    jsonify({"status": "error", "message": "Request body must be JSON"}), 400
+                )
+
             # Validate request data
             holidays_data = holidays_schema.load(request.json)
 

--- a/restx_api/symbol.py
+++ b/restx_api/symbol.py
@@ -26,6 +26,11 @@ class Symbol(Resource):
     def post(self):
         """Get symbol information for a given symbol and exchange"""
         try:
+            if request.json is None:
+                return make_response(
+                    jsonify({"status": "error", "message": "Request body must be JSON"}), 400
+                )
+
             # Validate request data
             symbol_data = symbol_schema.load(request.json)
 


### PR DESCRIPTION
## Summary
- Added `request.json is None` validation before schema loading in `market_holidays.py`, `symbol.py`, and `intervals.py`
- Returns 400 with clear error message for non-JSON requests
- Follows the existing pattern from `option_greeks.py`
- Also removed unused `import traceback` from `intervals.py`

Closes #1015

## Test plan
- [ ] Sending a POST with `Content-Type: application/json` and valid body works as before
- [ ] Sending a POST with no body or wrong Content-Type returns 400 with "Request body must be JSON"
- [ ] All three endpoints still function normally with valid requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1015 by adding a null check for `request.json` in `market_holidays.py`, `symbol.py`, and `intervals.py` so non-JSON or empty requests return 400 with "Request body must be JSON" instead of failing schema validation. Also removes the unused `traceback` import from `intervals.py` and aligns behavior with `option_greeks.py`.

<sup>Written for commit 4335120678ba083beb05a2538faf0aae712268ea. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

