### PR TITLE
Fix #1012: replace traceback.print_exc() with logger.exception() in restx_api

### DIFF
--- a/restx_api/analyzer.py
+++ b/restx_api/analyzer.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/basket_order.py
+++ b/restx_api/basket_order.py
@@ -1,6 +1,5 @@
 import copy
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -60,8 +59,7 @@ class BasketOrder(Resource):
             return make_response(jsonify(response_data), status_code)
 
         except Exception:
-            logger.error("An unexpected error occurred in BasketOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in BasketOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_all_order.py
+++ b/restx_api/cancel_all_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -75,8 +74,7 @@ class CancelAllOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelAllOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelAllOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/cancel_order.py
+++ b/restx_api/cancel_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -74,8 +73,7 @@ class CancelOrder(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in CancelOrder endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in CancelOrder endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/close_position.py
+++ b/restx_api/close_position.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -75,8 +74,7 @@ class ClosePosition(Resource):
             return make_response(jsonify(error_response), 400)
 
         except Exception:
-            logger.error("An unexpected error occurred in ClosePosition endpoint.")
-            traceback.print_exc()
+            logger.exception("An unexpected error occurred in ClosePosition endpoint.")
             error_message = "An unexpected error occurred"
             if get_analyze_mode():
                 return make_response(jsonify(emit_analyzer_error(data, error_message)), 500)

--- a/restx_api/depth.py
+++ b/restx_api/depth.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -44,8 +43,7 @@ class Depth(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in depth endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in depth endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/funds.py
+++ b/restx_api/funds.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -40,8 +39,7 @@ class Funds(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in funds endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in funds endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/history.py
+++ b/restx_api/history.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/holdings.py
+++ b/restx_api/holdings.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/intervals.py
+++ b/restx_api/intervals.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/modify_order.py
+++ b/restx_api/modify_order.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/openposition.py
+++ b/restx_api/openposition.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/orderbook.py
+++ b/restx_api/orderbook.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/orderstatus.py
+++ b/restx_api/orderstatus.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource

--- a/restx_api/ping.py
+++ b/restx_api/ping.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -39,8 +38,7 @@ class Ping(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in ping endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in ping endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )

--- a/restx_api/pnl_symbols.py
+++ b/restx_api/pnl_symbols.py
@@ -1,5 +1,4 @@
 import os
-import traceback
 
 from flask import jsonify, make_response, request
 from flask_restx import Namespace, Resource
@@ -51,8 +50,7 @@ class PnLSymbols(Resource):
         except ValidationError as err:
             return make_response(jsonify({"status": "error", "message": err.messages}), 400)
         except Exception as e:
-            logger.error(f"Unexpected error in pnl/symbols endpoint: {e}")
-            traceback.print_exc()
+            logger.exception(f"Unexpected error in pnl/symbols endpoint: {e}")
             return make_response(
                 jsonify({"status": "error", "message": "An unexpected error occurred"}), 500
             )


### PR DESCRIPTION
## Summary
- Replaced `logger.error()` + `traceback.print_exc()` with `logger.exception()` across 16 files in `restx_api/`
- Removed all unused `import traceback` statements
- Zero `traceback.print_exc()` calls remain in `restx_api/`

Closes #1012

## Test plan
- [ ] Application starts normally
- [ ] API error responses are unchanged
- [ ] Tracebacks appear in log output (not stdout) on exceptions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized exception logging in `restx_api` by replacing `logger.error()` + `traceback.print_exc()` with `logger.exception()` across all endpoints (fixes #1012). Stack traces now go to the configured logger instead of stdout; API responses remain unchanged.

- **Bug Fixes**
  - Replaced print-based traceback handling with `logger.exception()` in 16 endpoint files.
  - Removed unused `import traceback` statements; no `traceback.print_exc()` calls remain.
  - Ensures stack traces are captured by logging config instead of `stdout`.

<sup>Written for commit 7444b6281c6037dd8e29e3ea0fa93b40add630f4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

