### PR TITLE
fix(kotak): prevent master contract data loss on failed downloads

### DIFF
--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -5,6 +5,7 @@ import io
 import json
 import os
 import shutil
+from datetime import datetime, timedelta
 
 import httpx
 import numpy as np
@@ -129,6 +130,53 @@ def download_csv_kotak_data(output_path):
 
     if not downloaded_files:
         raise Exception("No master contract files were downloaded successfully")
+
+    # Check if F&O files are stubs (< 5KB = holiday/empty CSVs with headers only)
+    nse_fo_path = f"{output_path}/NSE_FO.csv"
+    if os.path.exists(nse_fo_path) and os.path.getsize(nse_fo_path) < 5000:
+        logger.warning(
+            f"NSE_FO.csv is only {os.path.getsize(nse_fo_path)} bytes — "
+            f"likely holiday stub. Trying previous trading days..."
+        )
+        for days_back in range(1, 6):
+            prev_date = (datetime.now() - timedelta(days=days_back)).strftime("%Y-%m-%d")
+            logger.info(f"Trying scripmaster date: {prev_date}")
+
+            prev_urls = {
+                "CDE_FO": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed/cde_fo.csv",
+                "MCX_FO": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed/mcx_fo.csv",
+                "NSE_FO": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed/nse_fo.csv",
+                "BSE_FO": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed/bse_fo.csv",
+                "NSE_COM": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed/nse_com.csv",
+                "BSE_CM": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed-v1/bse_cm-v1.csv",
+                "NSE_CM": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{prev_date}/transformed-v1/nse_cm-v1.csv",
+            }
+
+            # Re-download all files with previous date
+            prev_downloaded = []
+            for key, url in prev_urls.items():
+                try:
+                    response = client.get(url, timeout=30)
+                    if response.status_code == 200:
+                        file_path = f"{output_path}/{key}.csv"
+                        with open(file_path, "wb") as file:
+                            file.write(response.content)
+                        prev_downloaded.append(file_path)
+                except Exception as e:
+                    logger.warning(f"Failed to download {key} for {prev_date}: {e}")
+
+            # Check if this date has real data
+            if os.path.exists(nse_fo_path) and os.path.getsize(nse_fo_path) >= 5000:
+                logger.info(
+                    f"Found valid scripmaster data from {prev_date} "
+                    f"({os.path.getsize(nse_fo_path)} bytes)"
+                )
+                downloaded_files = prev_downloaded
+                break
+            else:
+                logger.warning(f"{prev_date} also has stub data, trying earlier...")
+        else:
+            logger.error("No valid scripmaster data found in last 5 days")
 
     logger.info(f"Downloaded {len(downloaded_files)} files successfully")
     return downloaded_files
@@ -381,7 +429,6 @@ def get_kotak_master_filepaths():
 
     # Fallback: Use direct URLs from PowerShell test results
     logger.warning("API failed, using direct URLs from PowerShell test")
-    from datetime import datetime
 
     today = datetime.now().strftime("%Y-%m-%d")
 
@@ -557,10 +604,7 @@ def master_contract_download():
         if not downloaded_files:
             raise Exception("No CSV files were downloaded successfully")
 
-        # Clear existing data
-        delete_symtoken_table()
-
-        # Process each exchange if the file exists
+        # Process each exchange into dataframes BEFORE touching the database
         processors = [
             ("NSE_CM.csv", process_kotak_nse_csv, "NSE Cash"),
             ("NSE_FO.csv", process_kotak_nfo_csv, "NSE F&O"),
@@ -570,6 +614,7 @@ def master_contract_download():
             ("BSE_FO.csv", process_kotak_bfo_csv, "BSE F&O"),
         ]
 
+        parsed_frames = []
         total_records = 0
         for filename, processor_func, exchange_name in processors:
             file_path = f"{output_path}/{filename}"
@@ -578,7 +623,7 @@ def master_contract_download():
                     logger.info(f"Processing {exchange_name} data...")
                     token_df = processor_func(output_path)
                     if not token_df.empty:
-                        copy_from_dataframe(token_df)
+                        parsed_frames.append(token_df)
                         total_records += len(token_df)
                         logger.info(f"Processed {len(token_df)} records for {exchange_name}")
                     else:
@@ -588,24 +633,41 @@ def master_contract_download():
             else:
                 logger.warning(f"File not found: {filename}")
 
+        # Validate before wiping: require minimum records to protect
+        # against empty/corrupt downloads leaving the table blank
+        MIN_RECORDS = 1000
+        if total_records < MIN_RECORDS:
+            raise Exception(
+                f"Only {total_records} records parsed (minimum {MIN_RECORDS}). "
+                f"Keeping existing data to avoid empty master contract table."
+            )
+
+        # Safe to replace: delete old data and insert validated new data
+        delete_symtoken_table()
+
+        for token_df in parsed_frames:
+            copy_from_dataframe(token_df)
+
         # Clean up temporary files
         delete_kotak_temp_data(output_path)
 
         logger.info(f"Master contract download completed. Total records: {total_records}")
 
-        if total_records > 0:
-            return socketio.emit(
-                "master_contract_download",
-                {
-                    "status": "success",
-                    "message": f"Successfully Downloaded {total_records} records",
-                },
-            )
-        else:
-            raise Exception("No records were processed successfully")
+        return socketio.emit(
+            "master_contract_download",
+            {
+                "status": "success",
+                "message": f"Successfully Downloaded {total_records} records",
+            },
+        )
 
     except Exception as e:
         logger.error(f"Master contract download failed: {str(e)}")
+        # Clean up any downloaded files even on failure
+        try:
+            delete_kotak_temp_data(output_path)
+        except Exception:
+            pass
         return socketio.emit("master_contract_download", {"status": "error", "message": str(e)})
 
 

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -17,22 +17,23 @@ def map_order_data(order_data):
     Returns:
     - The modified order_data with updated 'tradingsymbol' and 'product' fields.
     """
-    # Check if 'data' is None
-    # if order_data has key 'data' and its value is None
+    # Handle None or non-dict input
+    if order_data is None or not isinstance(order_data, dict):
+        logger.info("No data available or invalid response format.")
+        return {}
 
-    if order_data["stat"] == "Not_Ok":
-        logger.info("No data available.")
-        order_data = {}  # or set it to an empty list if it's supposed to be a list
-        return order_data
+    # Check status using .get() to avoid KeyError
+    if order_data.get("stat") == "Not_Ok":
+        logger.info(f"Broker returned Not_Ok: {order_data.get('message', 'No message')}")
+        return {}
 
-    if order_data["data"] is None:
-        # Handle the case where there is no data
-        # For example, you might want to display a message to the user
-        # or pass an empty list or dictionary to the template.
-        logger.info("No data available.")
-        order_data = {}  # or set it to an empty list if it's supposed to be a list
-    else:
-        order_data = order_data["data"]
+    # Safely get 'data' key - handle both missing key and None value
+    data = order_data.get("data")
+    if data is None:
+        logger.info("No data available in response.")
+        return {}
+
+    order_data = data
 
     if order_data:
         for order in order_data:
@@ -153,24 +154,28 @@ def map_trade_data(trade_data):
     Processes and modifies a list of order dictionaries based on specific conditions.
 
     Parameters:
-    - order_data: A list of dictionaries, where each dictionary represents an order.
+    - trade_data: A list of dictionaries, where each dictionary represents a trade.
 
     Returns:
-    - The modified order_data with updated 'tradingsymbol' and 'product' fields.
+    - The modified trade_data with updated 'tradingsymbol' and 'product' fields.
     """
-    if trade_data["stat"] == "Not_Ok":
-        logger.info("No data available.")
-        trade_data = {}  # or set it to an empty list if it's supposed to be a list
-        return trade_data
-        # Check if 'data' is None
-    if trade_data["data"] is None:
-        # Handle the case where there is no data
-        # For example, you might want to display a message to the user
-        # or pass an empty list or dictionary to the template.
-        logger.info("No data available.")
-        trade_data = {}  # or set it to an empty list if it's supposed to be a list
-    else:
-        trade_data = trade_data["data"]
+    # Handle None or non-dict input
+    if trade_data is None or not isinstance(trade_data, dict):
+        logger.info("No trade data available or invalid response format.")
+        return {}
+
+    # Check status using .get() to avoid KeyError
+    if trade_data.get("stat") == "Not_Ok":
+        logger.info(f"Broker returned Not_Ok: {trade_data.get('message', 'No message')}")
+        return {}
+
+    # Safely get 'data' key - handle both missing key and None value
+    data = trade_data.get("data")
+    if data is None:
+        logger.info("No trade data available in response.")
+        return {}
+
+    trade_data = data
 
     if trade_data:
         for order in trade_data:


### PR DESCRIPTION
## Summary
- **master_contract_db.py**: Validates downloaded data before deleting existing records. If Kotat API returns empty/stub CSVs (holidays, outages), old data is preserved. Automatically retries with previous trading day URLs when stubs detected.
- **order_data.py**: Uses `.get()` instead of direct key access on broker responses to prevent KeyError on unexpected/empty data.

## Problem
`master_contract_download()` calls `delete_symtoken_table()` before validating new CSV data. If Kotak's scripmaster API returns empty stubs (header-only CSVs, ~1KB), the table is wiped with no recovery. All expiry/symbol lookups fail. This breaks strategy execution until the next successful download.

## Changes
1. Parse CSVs into dataframes first, validate total records >= 1,000, only then delete + insert
2. If NSE_FO.csv < 5KB after download, retry with previous dates' direct URLs (up to 5 days back)
3. Log warning when fallback is used for visibility
4. Clean up temp files on failure
5. Safe `.get()` access in order_data.py for both `map_order_data()` and `map_trade_data()`

## Test plan
- [x] Tested on exchange holiday (Good Friday) — stub detection works, falls back to last trading day data (28.5 MB, 186K records)
- [x] Strategy manager starts successfully with fallback data
- [x] Expiry API returns correct data from fallback

Fixes #1216

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents master contract data loss for Kotak by validating downloads before delete and falling back to previous trading days on holiday/stub CSVs. Also hardens order/trade mapping to safely handle empty or unexpected broker responses. Fixes #1216.

- **Bug Fixes**
  - Parse CSVs first and require >= 1,000 records; only then delete and insert to keep existing data if downloads are stubs.
  - Detect stub `NSE_FO.csv` (<5KB) and retry with previous trading-day URLs (up to 5 days), with warnings and temp cleanup.
  - Use `.get()` and input guards in order/trade mappers to handle `None`, non-dict, and `Not_Ok` responses without KeyError.

<sup>Written for commit cebaef8bc73ef0906077cbfce086a164d220f336. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

