### PR TITLE
fix: handle true/false sourceHandle in condition edge filtering

### DIFF
--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -2086,11 +2086,11 @@ def execute_node_chain(
         filtered_edges = []
         for edge in edges_to_follow:
             source_handle = edge.get("sourceHandle", "")
-            if condition_met and source_handle == "yes":
+            if condition_met and source_handle in ("yes", "true"):
                 filtered_edges.append(edge)
-            elif not condition_met and source_handle == "no":
+            elif not condition_met and source_handle in ("no", "false"):
                 filtered_edges.append(edge)
-            elif source_handle not in ["yes", "no"]:
+            elif source_handle not in ("yes", "no", "true", "false"):
                 filtered_edges.append(edge)
         edges_to_follow = filtered_edges
 


### PR DESCRIPTION
## Summary

- Fixes condition node edge filtering in `flow_executor_service.py` to recognize `"true"`/`"false"` sourceHandle values in addition to `"yes"`/`"no"`
- The React flow UI emits `sourceHandle: "true"` / `sourceHandle: "false"` for condition nodes, but the executor only checked for `"yes"` / `"no"`, treating `"true"` / `"false"` as unconditional pass-throughs
- This caused downstream nodes (e.g., placeOrder) to always execute regardless of the condition result

Fixes #1108

## Test plan

- [ ] Create a workflow with a positionCheck node connected to a placeOrder node via the `"true"` handle
- [ ] Trigger with no open position (quantity = 0, threshold > 0) and verify the order is **not** placed
- [ ] Trigger with an open position exceeding threshold and verify the order **is** placed
- [ ] Verify existing workflows using `"yes"` / `"no"` handles continue to work correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes conditional edge routing by recognizing `sourceHandle` values `true`/`false` alongside `yes`/`no`, so condition nodes no longer pass edges unconditionally. Fixes #1108.

- **Bug Fixes**
  - Treat `true`/`false` as valid conditional handles in `flow_executor_service.py`.
  - Stop treating `true`/`false` edges as unconditional; existing `yes`/`no` flows still work.

<sup>Written for commit 9feac07f50ca15e642a366032e8c1b43c7762c58. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

