### PR TITLE
Fix : tradejini - MPP protection parameter, Index symbol normalisation and FD Audit Fixes

### DIFF
--- a/broker/tradejini/api/data.py
+++ b/broker/tradejini/api/data.py
@@ -182,7 +182,9 @@ class TradejiniWebSocket:
                 return False
 
             # Format token as per Tradejini requirement
-            formatted_token = f"{token}_{exchange}"
+            # Strip _INDEX suffix: WebSocket expects NSE/BSE, not NSE_INDEX/BSE_INDEX
+            ws_exchange = exchange.replace("_INDEX", "")
+            formatted_token = f"{token}_{ws_exchange}"
 
             logger.info(f"Subscribing to L5 depth for {formatted_token}")
 
@@ -336,7 +338,9 @@ class BrokerData:
                 logger.debug("Cleared all cached quote data")
 
             # Subscribe to quotes - format as per Tradejini requirements
-            symbol_key = f"{token}_{exchange}"
+            # Strip _INDEX suffix: WebSocket expects NSE/BSE, not NSE_INDEX/BSE_INDEX
+            ws_exchange = exchange.replace("_INDEX", "")
+            symbol_key = f"{token}_{ws_exchange}"
             logger.debug(f"Subscribing to quotes for: {symbol_key}")
             subscription_success = self.ws.subscribe_quotes([symbol_key])
 
@@ -353,12 +357,12 @@ class BrokerData:
 
             # Possible symbol key formats the data might arrive with
             symbol_keys = [
-                symbol_key,  # token_exchange format
-                f"{token}_NSE",  # Most likely format
-                f"{token}_{exchange}",
+                symbol_key,  # token_ws_exchange format
+                f"{token}_{ws_exchange}",
+                f"{token}_NSE",
+                f"{token}_BSE",
                 str(token),
-                f"{exchange}_{token}",
-                f"NSE_{token}",
+                f"{ws_exchange}_{token}",
             ]
 
             logger.debug(f"Will look for data with these symbol keys: {symbol_keys}")
@@ -514,11 +518,13 @@ class BrokerData:
                 continue
 
             # Format as per Tradejini requirements: token_exchange
-            symbol_key = f"{token}_{exchange}"
+            # Strip _INDEX suffix: WebSocket expects NSE/BSE, not NSE_INDEX/BSE_INDEX
+            ws_exchange = exchange.replace("_INDEX", "")
+            symbol_key = f"{token}_{ws_exchange}"
             symbol_keys.append(symbol_key)
 
             # Store mapping for response processing
-            symbol_map[symbol_key] = {"symbol": symbol, "exchange": exchange, "token": token}
+            symbol_map[symbol_key] = {"symbol": symbol, "exchange": exchange, "ws_exchange": ws_exchange, "token": token}
 
         if not symbol_keys:
             logger.warning("No valid symbols to fetch quotes for")
@@ -551,12 +557,13 @@ class BrokerData:
         with self.ws.lock:
             for symbol_key, info in symbol_map.items():
                 # Try different key formats that Tradejini WebSocket might use
+                ws_exch = info.get("ws_exchange", info["exchange"].replace("_INDEX", ""))
                 possible_keys = [
-                    symbol_key,  # token_exchange (e.g., "1234_NSE")
-                    f"{info['exchange']}_{info['token']}",  # exchange_token (e.g., "NSE_1234")
-                    f"{info['token']}_NSE",  # token_NSE fallback
-                    f"{info['token']}_{info['exchange']}",  # token_exchange format
-                    f"NSE_{info['token']}",  # NSE_token format
+                    symbol_key,  # token_ws_exchange (e.g., "1234_NSE")
+                    f"{info['token']}_{ws_exch}",
+                    f"{ws_exch}_{info['token']}",
+                    f"{info['token']}_NSE",
+                    f"{info['token']}_BSE",
                     str(info["token"]),  # just token
                 ]
 
@@ -622,7 +629,9 @@ class BrokerData:
 
             # Subscribe to market depth
             logger.debug(f"Subscribing to depth for {symbol} (token: {token})")
-            success = self.ws.subscribe_depth(symbol, exchange, token)
+            # Strip _INDEX suffix for WebSocket subscription
+            ws_exchange = exchange.replace("_INDEX", "")
+            success = self.ws.subscribe_depth(symbol, ws_exchange, token)
 
             if not success:
                 raise ConnectionError("Failed to send depth subscription")
@@ -632,7 +641,7 @@ class BrokerData:
             # Wait for depth data
             max_retries = 20
             retry_count = 0
-            symbol_key = f"{token}_{exchange}"
+            symbol_key = f"{token}_{ws_exchange}"
 
             while retry_count < max_retries:
                 time.sleep(1.0)

--- a/broker/tradejini/api/data.py
+++ b/broker/tradejini/api/data.py
@@ -32,6 +32,12 @@ class TradejiniWebSocket:
         self.L1_dict = {}
         self.L5_dict = {}
 
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def connect(self, auth_token):
         """Connect to Tradejini WebSocket using official SDK"""
         try:
@@ -228,6 +234,19 @@ class BrokerData:
             "30m": "30m",  # 30 minutes
         }
 
+    def __enter__(self):
+        return self
+
+    def __exit__(self, exc_type, exc_val, exc_tb):
+        self.close()
+        return False
+
+    def __del__(self):
+        try:
+            self.close()
+        except Exception:
+            pass
+
     def connect_websocket(self):
         """Initialize WebSocket connection if not already connected"""
         try:
@@ -236,6 +255,13 @@ class BrokerData:
                 return True
 
             logger.info("Initializing new WebSocket connection...")
+
+            # Close existing WebSocket before creating a new one
+            if hasattr(self, "ws") and self.ws:
+                try:
+                    self.ws.close()
+                except Exception:
+                    pass
 
             # Initialize new WebSocket instance
             self.ws = TradejiniWebSocket()
@@ -436,6 +462,12 @@ class BrokerData:
                 "prev_close": 0.0,
                 "volume": 0,
             }
+        finally:
+            # Always close WebSocket after quotes request to prevent FD leaks
+            try:
+                self.ws.close()
+            except Exception:
+                pass
 
     def get_multiquotes(self, symbols: list) -> list:
         """
@@ -476,6 +508,12 @@ class BrokerData:
         except Exception as e:
             logger.exception("Error fetching multiquotes")
             raise Exception(f"Error fetching multiquotes: {e}")
+        finally:
+            # Always close WebSocket after multiquotes request to prevent FD leaks
+            try:
+                self.ws.close()
+            except Exception:
+                pass
 
     def _process_multiquotes_batch(self, symbols: list) -> list:
         """
@@ -671,6 +709,12 @@ class BrokerData:
         except Exception as e:
             logger.error(f"Error in get_depth: {str(e)}", exc_info=True)
             return self._get_default_depth()
+        finally:
+            # Always close WebSocket after depth request to prevent FD leaks
+            try:
+                self.ws.close()
+            except Exception:
+                pass
 
     def _format_depth(self, depth_data: dict, symbol: str, exchange: str) -> dict:
         """Format depth data from Tradejini to OpenAlgo standard format"""

--- a/broker/tradejini/api/nxtradstream.py
+++ b/broker/tradejini/api/nxtradstream.py
@@ -203,7 +203,8 @@ class NxtradStream:
             on_close=self.__on_close,
         )
 
-        threading.Thread(target=self.__task).start()
+        self._ws_thread = threading.Thread(target=self.__task)
+        self._ws_thread.start()
 
     def subscribeEvents(self, type):
         req = {}
@@ -350,8 +351,12 @@ class NxtradStream:
         return self.__send_data(req)
 
     def disconnect(self):
-        self.ws.close()
         self.isConnected = False
+        try:
+            self.ws.close()
+        except Exception:
+            pass
+
 
     def isConnected(self):
         return self.isConnected

--- a/broker/tradejini/database/master_contract_db.py
+++ b/broker/tradejini/database/master_contract_db.py
@@ -213,12 +213,6 @@ def process_scrip_data(scrip_data, group_info):
     # Get group name and format
     group_name = group_info.get("name", "")
 
-    # Common index symbol mappings
-    COMMON_INDEX_MAP = {
-        "NSE_INDEX": ["NIFTY", "NIFTYNXT50", "FINNIFTY", "BANKNIFTY", "MIDCPNIFTY", "INDIAVIX"],
-        "BSE_INDEX": ["SENSEX", "BANKEX", "SENSEX50"],
-    }
-
     # Handle index data separately
     if group_name == "Index":
         # Process index records
@@ -232,16 +226,9 @@ def process_scrip_data(scrip_data, group_info):
                     # Map exchange for OpenAlgo format
                     exchange_map = {"NSE": "NSE_INDEX", "BSE": "BSE_INDEX"}
 
-                    # Symbol mapping for special cases
-                    symbol_map = {"India VIX": "INDIAVIX", "SNXT50": "SENSEX50"}
-
-                    # Apply symbol mapping if needed
-                    if item["symbol"] in symbol_map:
-                        item["symbol"] = symbol_map[item["symbol"]]
-
                     record = {
-                        "symbol": item["symbol"],  # Use symbol field directly
-                        "brsymbol": item["dispName"],  # Use display name as broker symbol
+                        "symbol": item["symbol"],  # Raw symbol, normalized later via DataFrame
+                        "brsymbol": item["id"],  # Use id as broker symbol for reverse lookup
                         "name": item["dispName"],  # Use display name as full name
                         "exchange": exchange_map.get(raw_exchange, raw_exchange),
                         "brexchange": raw_exchange,
@@ -368,111 +355,109 @@ def process_scrip_data(scrip_data, group_info):
                             logger.info(f"Error processing option {item['id']}: {e}")
 
                 elif instr_type == "IDX":
-                    # Handle index symbols
-                    raw_exchange = parts[-1]  # Last part is exchange (NSE/BSE)
-
-                    # Map exchange for OpenAlgo format
-                    exchange_map = {"NSE": "NSE_INDEX", "BSE": "BSE_INDEX"}
-
-                    # Get OpenAlgo exchange
-                    openalgo_exchange = exchange_map.get(raw_exchange, raw_exchange)
-
-                    # Check if this is a common index symbol
-                    if openalgo_exchange == "BSE_INDEX":
-                        # Handle BSE indices
-                        if item["symbol"].upper() in COMMON_INDEX_MAP[openalgo_exchange]["common"]:
-                            # Use common symbol format for main indices
-                            record = {
-                                "symbol": item["symbol"].upper(),  # Use uppercase symbol
-                                "brsymbol": item["id"],  # Use dispName as brsymbol
-                                "name": item.get(
-                                    "symbol", item["dispName"]
-                                ),  # Use symbol field if available
-                                "exchange": openalgo_exchange,
-                                "brexchange": raw_exchange,
-                                "token": str(item["excToken"]),
-                                "expiry": "",
-                                "strike": 0,
-                                "lotsize": 1,
-                                "instrumenttype": "INDEX",
-                                "tick_size": 0.05,
-                            }
-                        elif (
-                            item["symbol"].upper()
-                            in COMMON_INDEX_MAP[openalgo_exchange]["sectoral"]
-                        ):
-                            # Use sectoral index format
-                            record = {
-                                "symbol": item["symbol"].upper(),  # Use uppercase symbol
-                                "brsymbol": COMMON_INDEX_MAP[openalgo_exchange]["sectoral"][
-                                    item["symbol"].upper()
-                                ],  # Use mapped brsymbol
-                                "name": item.get(
-                                    "symbol", item["dispName"]
-                                ),  # Use symbol field if available
-                                "exchange": openalgo_exchange,
-                                "brexchange": raw_exchange,
-                                "token": str(item["excToken"]),
-                                "expiry": "",
-                                "strike": 0,
-                                "lotsize": 1,
-                                "instrumenttype": "INDEX",
-                                "tick_size": 0.05,
-                            }
-                        else:
-                            # Use regular symbol format
-                            record = {
-                                "symbol": item["dispName"],  # Use dispName for non-common symbols
-                                "brsymbol": item["id"],
-                                "name": item.get("symbol", item["dispName"]),
-                                "exchange": openalgo_exchange,
-                                "brexchange": raw_exchange,
-                                "token": str(item["excToken"]),
-                                "expiry": "",
-                                "strike": 0,
-                                "lotsize": 1,
-                                "instrumenttype": "INDEX",
-                                "tick_size": 0.05,
-                            }
-                    else:
-                        # Handle NSE indices
-                        if item["symbol"].upper() in COMMON_INDEX_MAP[openalgo_exchange]:
-                            # Use common symbol format
-                            record = {
-                                "symbol": item["symbol"].upper(),  # Use uppercase symbol
-                                "brsymbol": item["id"],  # Use dispName as brsymbol
-                                "name": item.get(
-                                    "symbol", item["dispName"]
-                                ),  # Use symbol field if available
-                                "exchange": openalgo_exchange,
-                                "brexchange": raw_exchange,
-                                "token": str(item["excToken"]),
-                                "expiry": "",
-                                "strike": 0,
-                                "lotsize": 1,
-                                "instrumenttype": "INDEX",
-                                "tick_size": 0.05,
-                            }
-                        else:
-                            # Use regular symbol format
-                            record = {
-                                "symbol": item["dispName"],  # Use dispName for non-common symbols
-                                "brsymbol": item["id"],
-                                "name": item.get("symbol", item["dispName"]),
-                                "exchange": openalgo_exchange,
-                                "brexchange": raw_exchange,
-                                "token": str(item["excToken"]),
-                                "expiry": "",
-                                "strike": 0,
-                                "lotsize": 1,
-                                "instrumenttype": "INDEX",
-                                "tick_size": 0.05,
-                            }
+                    # Index symbols are handled by the "Index" group above; skip here
+                    continue
             except Exception as e:
                 logger.error(f"Error processing item {item}: {e}")
                 continue
 
-    return pd.DataFrame(records)
+    df = pd.DataFrame(records)
+
+    if df.empty:
+        return df
+
+    # --- NSE Index Symbol Normalization (Tradejini symbol → OpenAlgo format) ---
+    # Listed symbols are mapped explicitly; unlisted symbols get basic cleanup
+    # (uppercase, spaces removed) to preserve them without breaking format.
+    nse_idx_mask = df["exchange"] == "NSE_INDEX"
+    nse_index_map = {
+        # Major NSE Indices
+        "NIFTY": "NIFTY",
+        "NIFTYNXT50": "NIFTYNXT50",
+        "FINNIFTY": "FINNIFTY",
+        "BANKNIFTY": "BANKNIFTY",
+        "MIDCPNIFTY": "MIDCPNIFTY",
+        "India VIX": "INDIAVIX",
+        # Broad Market Indices
+        "Nifty 100": "NIFTY100",
+        "Nifty 200": "NIFTY200",
+        "NIFTY 500": "NIFTY500",
+        # Sectoral Indices
+        "Nifty Auto": "NIFTYAUTO",
+        "Nifty Commodities": "NIFTYCOMMODITIES",
+        "Nifty Consumption": "NIFTYCONSUMPTION",
+        "Nifty Energy": "NIFTYENERGY",
+        "Nifty FMCG": "NIFTYFMCG",
+        "NIFTY HEALTHCARE": "NIFTYHEALTHCARE",
+        "Nifty Infra": "NIFTYINFRA",
+        "Nifty IT": "NIFTYIT",
+        "Nifty Media": "NIFTYMEDIA",
+        "Nifty Metal": "NIFTYMETAL",
+        "Nifty MNC": "NIFTYMNC",
+        "NIFTY OIL AND GAS": "NIFTYOILANDGAS",
+        "Nifty Pharma": "NIFTYPHARMA",
+        "Nifty PSE": "NIFTYPSE",
+        "Nifty PSU Bank": "NIFTYPSUBANK",
+        "Nifty Pvt Bank": "NIFTYPVTBANK",
+        # Market Cap Indices
+        "Nifty Midcap 50": "NIFTYMIDCAP50",
+        "NIFTY MIDCAP 100": "NIFTYMIDCAP100",
+        "NIFTY SMLCAP 50": "NIFTYSMLCAP50",
+        "NIFTY SMLCAP 100": "NIFTYSMLCAP100",
+        # Other Indices
+        "NIFTY INDIA MFG": "NIFTYINDIAMFG",
+        "Nifty MidSml Hlth": "NIFTYMIDSMLHLTH",
+        "Nifty Tata 25 Cap": "NIFTYTATA25CAP",
+    }
+    original_nse = df.loc[nse_idx_mask, "symbol"]
+    mapped_nse = original_nse.map(nse_index_map)
+    # For unmapped symbols, keep raw symbol with basic cleanup (uppercase, no spaces)
+    fallback_nse = original_nse.str.upper().str.replace(" ", "", regex=False)
+    df.loc[nse_idx_mask, "symbol"] = mapped_nse.fillna(fallback_nse)
+
+    # --- BSE Index Symbol Normalization (Tradejini symbol → OpenAlgo format) ---
+    # Applied only to BSE_INDEX rows to avoid conflicts with equity symbols
+    bse_idx_mask = df["exchange"] == "BSE_INDEX"
+    bse_index_map = {
+        # Major BSE Indices
+        "SENSEX": "SENSEX",
+        "BANKEX": "BANKEX",
+        "SNXT50": "BSESENSEXNEXT50",
+        "SENSEX50": "SENSEX50",
+        # Broad Market Indices
+        "BSE100": "BSE100",
+        "BSE200": "BSE200",
+        "BSE500": "BSE500",
+        # Sectoral Indices
+        "AUTO": "BSEAUTO",
+        "BSE HC": "BSEHEALTHCARE",
+        "BSE IT": "BSEINFORMATIONTECHNOLOGY",
+        "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+        "BSEIPO": "BSEIPO",
+        "BSEPSU": "BSEPSU",
+        "ENERGY": "BSEENERGY",
+        "FIN": "BSEFINANCIALSERVICES",
+        "GREENX": "BSEGREENEX",
+        "INFRA": "BSEINDIAINFRASTRUCTUREINDEX",
+        "LRGCAP": "BSELARGECAP",
+        "METAL": "BSEMETAL",
+        "MIDCAP": "BSEMIDCAP",
+        "OILGAS": "BSEOIL&GAS",
+        "POWER": "BSEPOWER",
+        "SMLCAP": "BSESMALLCAP",
+        "TELCOM": "BSETELECOM",
+        # Other BSE Indices
+        "BSEEVI": "BSEEVI",
+        "BSEPBI": "BSEPBI",
+        "MFG": "BSEMFG",
+    }
+    original_bse = df.loc[bse_idx_mask, "symbol"]
+    mapped_bse = original_bse.map(bse_index_map)
+    # For unmapped symbols, keep raw symbol with basic cleanup (uppercase, no spaces)
+    fallback_bse = original_bse.str.upper().str.replace(" ", "", regex=False)
+    df.loc[bse_idx_mask, "symbol"] = mapped_bse.fillna(fallback_bse)
+
+    return df
 
 
 def master_contract_download():

--- a/broker/tradejini/mapping/order_data.py
+++ b/broker/tradejini/mapping/order_data.py
@@ -39,7 +39,21 @@ def map_order_data(order_data):
             # Update fields in place
             order["action"] = "BUY" if order_info.get("side") == "buy" else "SELL"
             order["exchange"] = order_info.get("exchange", "")
-            order["order_status"] = order_info.get("status", "").lower()
+            # Map Tradejini status to OpenAlgo status
+            raw_status = order_info.get("status", "").lower()
+            status_map = {
+                "completed": "complete",
+                "traded": "complete",
+                "filled": "complete",
+                "complete": "complete",
+                "open": "open",
+                "pending": "open",
+                "trigger pending": "trigger pending",
+                "rejected": "rejected",
+                "cancelled": "cancelled",
+                "canceled": "cancelled",
+            }
+            order["order_status"] = status_map.get(raw_status, raw_status)
             order["orderid"] = str(order_info.get("order_id", ""))
             order["price"] = float(order_info.get("limit_price", 0))
             order["pricetype"] = order_info.get("type", "").upper()

--- a/broker/tradejini/mapping/transform_data.py
+++ b/broker/tradejini/mapping/transform_data.py
@@ -1,5 +1,5 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
-# Mapping Angel Broking Parameters https://smartapi.angelbroking.com/docs/Orders
+# Mapping Tradejini API Parameters https://api.tradejini.com/v2
 
 from database.token_db import get_br_symbol
 
@@ -11,24 +11,29 @@ def transform_data(data, token):
     symbol = get_br_symbol(data["symbol"], data["exchange"])
 
     # Basic mapping
+    order_type = map_order_type(data["pricetype"])
+
     transformed = {
         "symId": f"{symbol}",
         "qty": str(data["quantity"]),
         "side": "buy" if data["action"] == "BUY" else "sell",
-        "type": map_order_type(data["pricetype"]),
+        "type": order_type,
         "product": map_product_type(data["product"]),
         "limitPrice": str(data.get("price", "0")),
         "trigPrice": str(data.get("trigger_price", "0")),
         "validity": map_validity(data.get("validity", "DAY")),
         "discQty": str(data.get("disclosed_quantity", "0")),
         "amo": data.get("amo", False),
-        "mktProt": str(data.get("market_protection", "0")),
         "remarks": data.get("remarks", ""),
     }
 
+    # Add market protection percentage for market and stopmarket orders
+    if order_type in ("market", "stopmarket"):
+        transformed["mktProt"] = "2"
+
     # Remove optional fields if not set
-    for key in ["limitPrice", "trigPrice", "discQty", "mktProt", "remarks"]:
-        if transformed[key] == "0" or transformed[key] == "":
+    for key in ["limitPrice", "trigPrice", "discQty", "remarks"]:
+        if transformed.get(key, "") in ("0", ""):
             del transformed[key]
 
     return transformed

--- a/broker/tradejini/streaming/nxtradstream.py
+++ b/broker/tradejini/streaming/nxtradstream.py
@@ -203,7 +203,8 @@ class NxtradStream:
             on_close=self.__on_close,
         )
 
-        threading.Thread(target=self.__task).start()
+        self._ws_thread = threading.Thread(target=self.__task)
+        self._ws_thread.start()
 
     def subscribeEvents(self, type):
         req = {}
@@ -350,8 +351,11 @@ class NxtradStream:
         return self.__send_data(req)
 
     def disconnect(self):
-        self.ws.close()
         self.isConnected = False
+        try:
+            self.ws.close()
+        except Exception:
+            pass
 
     def isConnected(self):
         return self.isConnected

--- a/broker/tradejini/streaming/tradejini_adapter.py
+++ b/broker/tradejini/streaming/tradejini_adapter.py
@@ -34,6 +34,7 @@ class TradejiniWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.running = False
         self.lock = threading.Lock()
         self.ws_url = None
+        self._connect_thread = None
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -111,7 +112,8 @@ class TradejiniWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.error("WebSocket client not initialized. Call initialize() first.")
             return
 
-        threading.Thread(target=self._connect_with_retry, daemon=True).start()
+        self._connect_thread = threading.Thread(target=self._connect_with_retry, daemon=True)
+        self._connect_thread.start()
 
     def _connect_with_retry(self) -> None:
         """Connect to Tradejini WebSocket with retry logic"""
@@ -338,7 +340,8 @@ class TradejiniWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
             # Attempt to reconnect if we're still running
             if self.running:
-                threading.Thread(target=self._connect_with_retry, daemon=True).start()
+                self._connect_thread = threading.Thread(target=self._connect_with_retry, daemon=True)
+                self._connect_thread.start()
 
     def _on_data(self, ws, message) -> None:
         """Callback for market data from the WebSocket"""


### PR DESCRIPTION
Fix : tradejini - MPP protection parameter, Index symbol normalisation and FD Audit Fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add market protection (MPP) for Tradejini orders, normalize NSE/BSE index symbols, and fix WebSocket leaks and exchange handling across quotes, depth, and streaming. This improves stability and aligns data formats and statuses with OpenAlgo.

- **New Features**
  - Add MPP: set `mktProt=2` for market/stopmarket orders and keep it in the payload.
  - Normalize index symbols: map `NSE_INDEX`/`BSE_INDEX` names to OpenAlgo format with a safe fallback; use Tradejini `id` as `brsymbol` for reliable reverse lookup.

- **Bug Fixes**
  - Prevent WebSocket FD leaks and orphan threads: always close sockets in `get_quotes`, `get_depth`, `get_multiquotes`; add context manager/`__del__`; close existing WS before reconnect; make `disconnect()` safe.
  - Fix WS exchange handling: strip `_INDEX` when subscribing and keying tokens; broaden possible key formats for quote/depth matching.
  - Correct order status mapping: map Tradejini statuses to OpenAlgo (e.g., "completed/traded/filled" → "complete", "canceled" → "cancelled").

<sup>Written for commit 01175bb93681c840539145adce7570e13a3e26ae. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

