### PR TITLE
fix: Inject documented env vars (OPENALGO_API_KEY, STRATEGY_ID, etc.) into strategy subprocess

### DIFF
--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -462,7 +462,7 @@ def start_strategy_process(strategy_id):
             strategy_env = os.environ.copy()
             strategy_env["STRATEGY_ID"] = strategy_id
             strategy_env["STRATEGY_NAME"] = config.get("name", strategy_id)
-            strategy_env["OPENALGO_HOST"] = "http://127.0.0.1:5000"
+            strategy_env.setdefault("OPENALGO_HOST", "http://127.0.0.1:5000")
             try:
                 from database.auth_db import get_api_key_for_tradingview
                 user_id = config.get("user_id")

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -457,6 +457,23 @@ def start_strategy_process(strategy_id):
             subprocess_args["stderr"] = subprocess.STDOUT
             subprocess_args["cwd"] = str(Path.cwd())
 
+            # Inject documented strategy environment variables
+            # (per strategies/README.md: STRATEGY_ID, STRATEGY_NAME, OPENALGO_API_KEY, OPENALGO_HOST)
+            strategy_env = os.environ.copy()
+            strategy_env["STRATEGY_ID"] = strategy_id
+            strategy_env["STRATEGY_NAME"] = config.get("name", strategy_id)
+            strategy_env["OPENALGO_HOST"] = "http://127.0.0.1:5000"
+            try:
+                from database.auth_db import get_api_key_for_tradingview
+                user_id = config.get("user_id")
+                if user_id:
+                    _api_key = get_api_key_for_tradingview(user_id)
+                    if _api_key:
+                        strategy_env["OPENALGO_API_KEY"] = _api_key
+            except Exception as e:
+                logger.warning(f"Could not inject API key for strategy {strategy_id}: {e}")
+            subprocess_args["env"] = strategy_env
+
             # Start the process
             # Use Python unbuffered mode for real-time output
             cmd = [get_python_executable(), "-u", str(file_path.absolute())]


### PR DESCRIPTION
## Summary

Fixes #1246 — Strategy subprocess does not receive documented environment variables.

`strategies/README.md` documents that `STRATEGY_ID`, `STRATEGY_NAME`, `OPENALGO_API_KEY`, and `OPENALGO_HOST` are "automatically set" for hosted Python strategies. However, `start_strategy_process()` in `blueprints/python_strategy.py` never actually injects them into the subprocess environment.

## Changes

In `start_strategy_process()`, after setting `subprocess_args["cwd"]` and before spawning the process:

1. Copy the parent environment (`os.environ.copy()`)
2. Inject `STRATEGY_ID` and `STRATEGY_NAME` from the strategy config
3. Set `OPENALGO_HOST` as a fallback default using `setdefault()` — respects deployment-specific config if already set in the environment
4. Decrypt and inject `OPENALGO_API_KEY` using the existing `get_api_key_for_tradingview()` helper
5. Pass the enriched env dict to `subprocess.Popen()`

## Key Design Decisions

- **`setdefault` for `OPENALGO_HOST`**: Uses `strategy_env.setdefault("OPENALGO_HOST", "http://127.0.0.1:5000")` so that deployments with a custom host/port (set via environment) are not overridden. Localhost is only a fallback default.
- **API key from database**: Uses the existing `get_api_key_for_tradingview(user_id)` function to decrypt the API key, keeping it consistent with how TradingView webhooks resolve it.
- **Wrapped in try/except**: API key injection is wrapped to avoid breaking strategy startup if the database lookup fails.

## Testing

- Verified on OpenAlgo v2.0.0.2 Docker deployment
- Strategy using `os.getenv("OPENALGO_API_KEY")` now starts successfully
- Previously crashed immediately with `Error: OPENALGO_APIKEY not set`