### PR TITLE
fix: remove asyncio residue and fix reconnect issues in Dhan WebSocket #1226

### DIFF
--- a/broker/dhan/streaming/dhan_adapter.py
+++ b/broker/dhan/streaming/dhan_adapter.py
@@ -812,8 +812,12 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def _stop_fallback_monitor_internal(self):
         """Internal method to stop fallback monitor without affecting running flag"""
         if self.fallback_monitor_thread and self.fallback_monitor_thread.is_alive():
-            self.fallback_monitor_thread.join(timeout=2)
-            if self.fallback_monitor_thread.is_alive():
+            try:
+                self.fallback_monitor_thread.join(timeout=2)
+            except Exception:
+                # Catches eventlet.timeout.Timeout on Linux/Gunicorn
+                pass
+            if self.fallback_monitor_thread and self.fallback_monitor_thread.is_alive():
                 self.logger.debug("Fallback monitor thread timeout - will be orphaned (daemon)")
             else:
                 self.logger.debug("Fallback monitor thread stopped")

--- a/broker/dhan/streaming/dhan_adapter.py
+++ b/broker/dhan/streaming/dhan_adapter.py
@@ -3,11 +3,9 @@ Dhan WebSocket Adapter for OpenAlgo
 Manages both 5-level and 20-level depth connections
 """
 
-import asyncio
 import json
 import logging
 import os
-import platform
 import sys
 import threading
 import time
@@ -159,12 +157,14 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Disconnect from Dhan WebSocket endpoints with proper resource cleanup"""
         self.logger.debug("Starting Dhan adapter disconnect sequence...")
         self.running = False
+        self.connected = False
 
-        # Store references before clearing (prevents double cleanup attempts)
+        # Store references but clear them AFTER cleanup completes (not before).
+        # Clearing before cleanup creates a window under eventlet where another
+        # greenlet can see ws_client_5depth=None while the old connection is
+        # still being torn down, causing reused adapters to silently drop subscribes.
         ws_5depth = self.ws_client_5depth
         ws_20depth = self.ws_client_20depth
-        self.ws_client_5depth = None
-        self.ws_client_20depth = None
 
         try:
             # Disconnect 5-depth WebSocket
@@ -186,6 +186,10 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # Stop fallback monitor thread
             self._stop_fallback_monitor_internal()
 
+            # Clear WebSocket references AFTER cleanup is done
+            self.ws_client_5depth = None
+            self.ws_client_20depth = None
+
             # Clear all state for clean reconnection
             with self.lock:
                 self.subscriptions_5depth.clear()
@@ -195,7 +199,6 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.depth_20_timeouts.clear()
                 self.depth_20_data_received.clear()
                 self.depth_20_fallbacks.clear()
-                self.connected = False
 
             self.logger.debug("Dhan adapter state cleared")
 
@@ -479,24 +482,49 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def unsubscribe_all(self) -> dict[str, Any]:
         """
-        Unsubscribe from all subscriptions and disconnect from WebSocket
+        Unsubscribe from all subscriptions without disconnecting.
+
+        Clears all subscription tracking and sends unsubscribe messages to Dhan,
+        but keeps the WebSocket connections alive so future subscribes work
+        without needing to reconnect.
 
         Returns:
             Dict: Response with status
         """
-        # Count subscriptions before disconnect clears them
         with self.lock:
             unsubscribed_count = len(self.subscriptions_5depth) + len(self.subscriptions_20depth)
 
-        # Centralized teardown - disconnect() handles all cleanup
-        self.disconnect()
+            # Collect instruments to unsubscribe from each connection
+            instruments_5depth = []
+            for sub in self.subscriptions_5depth.values():
+                instruments_5depth.append(sub["instrument"])
+
+            instruments_20depth = []
+            for sub in self.subscriptions_20depth.values():
+                instruments_20depth.append(sub["instrument"])
+
+            # Clear all subscription tracking
+            self.subscriptions_5depth.clear()
+            self.subscriptions_20depth.clear()
+            self.subscriptions.clear()
+            self.depth_20_accumulator.clear()
+            self.depth_20_timeouts.clear()
+            self.depth_20_data_received.clear()
+            self.depth_20_fallbacks.clear()
+
+        # Send unsubscribe messages (outside lock to avoid deadlock)
+        if instruments_5depth and self.ws_client_5depth:
+            self.ws_client_5depth.unsubscribe(instruments_5depth)
+
+        if instruments_20depth and self.ws_client_20depth:
+            self.ws_client_20depth.unsubscribe(instruments_20depth)
 
         self.logger.info(
-            f"Dhan adapter disconnected and cleaned up after unsubscribing {unsubscribed_count} instruments"
+            f"Dhan adapter unsubscribed from {unsubscribed_count} instruments (connections kept alive)"
         )
 
         return self._create_success_response(
-            f"Unsubscribed from {unsubscribed_count} instruments and disconnected",
+            f"Unsubscribed from {unsubscribed_count} instruments",
             unsubscribed_count=unsubscribed_count,
         )
 

--- a/broker/dhan/streaming/dhan_websocket.py
+++ b/broker/dhan/streaming/dhan_websocket.py
@@ -195,10 +195,16 @@ class DhanWebSocket:
             finally:
                 self.ws = None  # Always clear WebSocket reference
 
-        # Wait for WebSocket thread to finish
+        # Wait for WebSocket thread to finish.
+        # Under eventlet, thread.join(timeout) raises eventlet.timeout.Timeout
+        # instead of returning silently, so we must catch it.
         if self.ws_thread and self.ws_thread.is_alive():
-            self.ws_thread.join(timeout=2)
-            if self.ws_thread.is_alive():
+            try:
+                self.ws_thread.join(timeout=2)
+            except Exception:
+                # Catches eventlet.timeout.Timeout (and any other join errors)
+                pass
+            if self.ws_thread and self.ws_thread.is_alive():
                 self.logger.debug("WebSocket thread timeout - will be orphaned (daemon)")
             else:
                 self.logger.debug("WebSocket thread stopped")

--- a/broker/dhan/streaming/dhan_websocket.py
+++ b/broker/dhan/streaming/dhan_websocket.py
@@ -3,10 +3,8 @@ Dhan WebSocket Client Implementation
 Handles both 5-level and 20-level market depth connections
 """
 
-import asyncio
 import json
 import logging
-import platform
 import struct
 import threading
 import time
@@ -110,35 +108,9 @@ class DhanWebSocket:
             self.logger.warning("Already connected or connecting")
             return
 
-        # Handle asyncio event loop conflict on Linux/macOS
-        self._handle_asyncio_compatibility()
-
         self.running = True
         self.ws_thread = threading.Thread(target=self._run_websocket, daemon=True)
         self.ws_thread.start()
-
-    def _handle_asyncio_compatibility(self):
-        """Handle asyncio event loop conflicts on Linux/macOS systems"""
-        try:
-            # Check if we're on a platform that might have asyncio conflicts
-            if platform.system() in ["Linux", "Darwin"]:  # Darwin is macOS
-                try:
-                    # Try to get the current event loop
-                    loop = asyncio.get_running_loop()
-                    if loop and not loop.is_closed():
-                        self.logger.info(
-                            "Detected existing asyncio event loop, using thread isolation for Dhan WebSocket"
-                        )
-                        # We'll run in a completely separate thread context
-                        # which is already what we're doing, so no additional action needed
-                except RuntimeError:
-                    # No running loop, which is fine
-                    pass
-            else:
-                self.logger.debug("Running on Windows, no asyncio compatibility adjustments needed")
-        except Exception as e:
-            self.logger.warning(f"Error checking asyncio compatibility: {e}")
-            # Continue anyway, the thread isolation should handle most cases
 
     def _run_websocket(self):
         """Run the WebSocket connection in a separate thread with exponential backoff"""


### PR DESCRIPTION
- Remove unused asyncio/platform imports from dhan_websocket.py and dhan_adapter.py
- Remove _handle_asyncio_compatibility() shim that caused greenlet conflicts under eventlet
- Fix unsubscribe_all() to clear subscriptions without destroying WebSocket connections
- Fix disconnect() ordering to clear ws_client references after cleanup completes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Cleans up asyncio remnants and fixes reconnect/unsubscribe behavior in the Dhan WebSocket to prevent greenlet conflicts and dropped subscriptions. Adds safe thread joins to keep cleanup stable under `eventlet`/Gunicorn.

- **Bug Fixes**
  - Removed unused asyncio/platform imports and the `_handle_asyncio_compatibility()` shim that caused greenlet conflicts under `eventlet`.
  - Updated `unsubscribe_all()` to send unsubscribe messages and clear state without disconnecting, keeping WebSocket connections alive.
  - Hardened disconnect/cleanup by deferring `ws_client` reference clearing until after teardown and wrapping `thread.join()` in try/except in both `dhan_websocket` and `dhan_adapter` to catch `eventlet.timeout.Timeout`, preventing cleanup crashes and broken reconnections.

<sup>Written for commit 8c9a8e8075b9aa8171eb6085eba6c7d713740040. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

