### PR TITLE
fix: correct get_open_position exchange match in Groww smart orders

### DIFF
--- a/broker/groww/api/order_api.py
+++ b/broker/groww/api/order_api.py
@@ -1480,6 +1480,16 @@ def get_open_position(tradingsymbol, exchange, product, auth):
         else:
             positions_list = []
 
+        # Accept both OpenAlgo-standard exchange codes and the segment-suffixed
+        # variants stored by get_positions() (NSE_EQ/BSE_EQ for CASH, NSE_FO/BSE_FO for FNO).
+        exchange_variants = {
+            "NSE": {"NSE", "NSE_EQ"},
+            "BSE": {"BSE", "BSE_EQ"},
+            "NFO": {"NFO", "NSE_FO", "NSE"},
+            "BFO": {"BFO", "BSE_FO", "BSE"},
+        }
+        expected_exchanges = exchange_variants.get(exchange, {map_exchange_type(exchange), exchange})
+
         for position in positions_list:
             # Check for matching position - compare with both tradingsymbol and symbol fields
             symbol_match = (
@@ -1487,7 +1497,7 @@ def get_open_position(tradingsymbol, exchange, product, auth):
                 or position.get("symbol") == tradingsymbol
                 or position.get("trading_symbol") == tradingsymbol
             )
-            exchange_match = position.get("exchange") == map_exchange_type(exchange)
+            exchange_match = position.get("exchange") in expected_exchanges
             product_match = position.get("product") == product
 
             if symbol_match and exchange_match and product_match:


### PR DESCRIPTION
get_positions() stores CASH segment positions with exchange "NSE_EQ"/"BSE_EQ" and FNO with "NSE_FO", while get_open_position() compared against map_exchange_type() output ("NSE"/"BSE"). The mismatch caused lookups to return "0", so placesmartorder computed the wrong delta (e.g. SELL 1 instead of SELL 2 when flipping from +1 to target -1). Accept both OpenAlgo codes and the suffixed variants stored by the positions transformer.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes exchange code matching in Groww `get_open_position` so smart orders compute correct deltas. The function now recognizes suffixed exchanges from `get_positions` (e.g., `NSE_EQ`, `NSE_FO`) in addition to OpenAlgo codes.

- **Bug Fixes**
  - Accept both OpenAlgo and suffixed exchange variants when matching positions: `NSE`↔`NSE_EQ`, `BSE`↔`BSE_EQ`, `NFO`↔`NSE_FO`, `BFO`↔`BSE_FO`.
  - Prevents zero-quantity lookups that caused wrong order sizes (e.g., SELL 1 instead of SELL 2 when flipping from +1 to -1).

<sup>Written for commit 06edd379924a6f44c6b6f3c9c4d3ef169e6ceb86. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

