### PR TITLE
fix: clean up logs_session for non-banned IPs in SecurityMiddleware

### DIFF
--- a/utils/security_middleware.py
+++ b/utils/security_middleware.py
@@ -55,12 +55,15 @@ class SecurityMiddleware:
         # Get real client IP (handles proxies)
         client_ip = get_real_ip_from_environ(environ)
 
-        # Check if IP is banned
-        if IPBan.is_ip_banned(client_ip):
-            # Clean up scoped session — this runs at WSGI level, outside Flask
-            # request context, so blueprint/app teardown handlers won't fire.
+        # Check if IP is banned — this opens a logs_session connection.
+        # Must clean up in ALL paths (banned and non-banned) because this
+        # runs at WSGI level, outside Flask's teardown_appcontext scope.
+        try:
+            is_banned = IPBan.is_ip_banned(client_ip)
+        finally:
             logs_session.remove()
 
+        if is_banned:
             # Return 403 Forbidden for banned IPs
             status = "403 Forbidden"
             headers = [("Content-Type", "text/plain")]
@@ -68,8 +71,6 @@ class SecurityMiddleware:
             logger.warning(f"Blocked banned IP: {client_ip}")
             return [b"Access Denied: Your IP has been banned"]
 
-        # For non-banned IPs: session cleanup is handled by Flask's
-        # teardown_app_request in traffic.py and security.py blueprints.
         return self.app(environ, start_response)
 
 


### PR DESCRIPTION
## Summary
- `IPBan.is_ip_banned()` in `SecurityMiddleware.__call__()` opens a `logs_session` connection on every request at the WSGI level
- Previously, `logs_session.remove()` was only called for **banned IPs** (line 62)
- For **non-banned IPs** (99.9% of requests), the session was never cleaned up — the comment said "cleanup handled by Flask's teardown" but `teardown_appcontext` doesn't reliably fire for WSGI middleware running outside the Flask app context
- This causes file descriptor leaks on `logs.db` (~1 leaked FD per request, accumulating to 200+ over hours and eventually crashing the server with "unable to open database file")

## Fix
Wrap the `is_ip_banned()` call in `try/finally` so `logs_session.remove()` runs for **all** code paths (banned and non-banned).

## Test plan
- [ ] Verify banned IP path still returns 403
- [ ] Monitor `lsof -p <PID> | grep logs.db` under sustained load — FD count should stay stable instead of growing unbounded
- [ ] Run 1000+ concurrent API requests and confirm no "unable to open database file" errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a resource leak in `SecurityMiddleware` by ensuring `logs_session.remove()` runs for every request, preventing `logs.db` file-descriptor buildup and related crashes.

- **Bug Fixes**
  - Wrap `IPBan.is_ip_banned()` in try/finally to guarantee session cleanup for both banned and non-banned IPs (runs outside Flask teardown scope).
  - Preserve 403 response behavior for banned IPs; no other behavior changes.

<sup>Written for commit 9e6bd58d2c909140f28cdda29b88e59ed9417400. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

