### PR TITLE
fix(python-strategy): reliability + FD hygiene for long-running strategies

### DIFF
--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -76,7 +76,7 @@ def broadcast_status_update(strategy_id: str, status: str, message: str = None):
             try:
                 q.put_nowait(event)
                 active_subscribers.append(q)
-            except:
+            except Exception:
                 pass  # Queue full or dead, skip
         SSE_SUBSCRIBERS.clear()
         SSE_SUBSCRIBERS.extend(active_subscribers)
@@ -123,6 +123,19 @@ def init_scheduler():
         )
         logger.debug("Market hours enforcer scheduled (runs every minute)")
 
+        # Periodically reap crashed strategies so headless deployments don't
+        # accumulate stale entries in RUNNING_STRATEGIES. Without this, a
+        # strategy that exits unexpectedly stays tracked (and its parent-side
+        # resources pinned) until someone opens the /python UI.
+        SCHEDULER.add_job(
+            func=cleanup_dead_processes,
+            trigger="interval",
+            seconds=60,
+            id="reap_dead_strategies",
+            replace_existing=True,
+        )
+        logger.debug("Dead-process reaper scheduled (runs every 60 seconds)")
+
 
 def load_configs():
     """Load strategy configurations from file"""
@@ -138,11 +151,19 @@ def load_configs():
 
 
 def save_configs():
-    """Save strategy configurations to file"""
+    """Save strategy configurations to file atomically.
+
+    Writes to a temp file and then renames into place so a kill mid-write
+    cannot leave a half-written JSON blob behind.
+    """
     try:
         CONFIG_FILE.parent.mkdir(parents=True, exist_ok=True)
-        with open(CONFIG_FILE, "w", encoding="utf-8") as f:
+        tmp_path = CONFIG_FILE.with_suffix(CONFIG_FILE.suffix + ".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as f:
             json.dump(STRATEGY_CONFIGS, f, indent=2, default=str, ensure_ascii=False)
+            f.flush()
+            os.fsync(f.fileno())
+        os.replace(tmp_path, CONFIG_FILE)
         logger.debug("Configurations saved")
     except Exception as e:
         logger.exception(f"Failed to save configs: {e}")
@@ -507,13 +528,23 @@ def start_strategy_process(strategy_id):
                 logger.exception(f"Unexpected error starting process: {e}")
                 return False, f"Failed to start process: {str(e)}"
 
+            # The subprocess has inherited log_handle's fd, so the child can
+            # write to the log on its own. We close the parent-side handle
+            # now to avoid pinning an extra fd for the lifetime of the
+            # strategy (multiplied by every running strategy). If closing
+            # fails we swallow the error — the child's inherited fd is the
+            # authoritative one and stays open.
+            try:
+                log_handle.close()
+            except Exception as e:
+                logger.debug(f"Error closing parent-side log handle for {strategy_id}: {e}")
+
             # Store process info
             RUNNING_STRATEGIES[strategy_id] = {
                 "process": process,
                 "pid": process.pid,
                 "started_at": ist_now,
                 "log_file": str(log_file),
-                "log_handle": log_handle,  # Keep file handle open
             }
 
             # Update config with IST time
@@ -698,7 +729,13 @@ def check_process_status(pid):
 
 
 def close_log_handle_safely(strategy_info):
-    """Safely close a log file handle, handling all edge cases"""
+    """Safely close a log file handle, handling all edge cases.
+
+    As of the FD-hygiene fix, parent-side log handles are closed immediately
+    after Popen inherits them, so ``strategy_info`` normally has no
+    ``log_handle`` key. This helper is retained for defensive compatibility
+    with older records (e.g. adopted processes, future code paths).
+    """
     if not strategy_info:
         return
     log_handle = strategy_info.get("log_handle")
@@ -2106,8 +2143,14 @@ def api_get_strategies():
 
 
 @python_strategy_bp.route("/api/events")
+@check_session_validity
 def api_strategy_events():
-    """SSE endpoint for real-time strategy status updates"""
+    """SSE endpoint for real-time strategy status updates.
+
+    Authenticated-only — broadcasts strategy start/stop/error events and
+    would otherwise let any network client enumerate the user's running
+    strategies and their lifecycle timestamps.
+    """
 
     def event_stream():
         # Create a queue for this subscriber


### PR DESCRIPTION
## Summary

Five targeted fixes to the `/python` strategy runner so headless deployments and multi-day strategy runs stay healthy without manual intervention. Follows up on #1247.

All changes live in a single file (`blueprints/python_strategy.py`, +49/-6) and preserve existing behaviour for every currently-working flow.

## Changes

### 1. Background reaper for crashed strategies (critical for headless hosts)
Added a 60s APScheduler job that calls `cleanup_dead_processes`. Previously this was only invoked from three GET route handlers, so a strategy that exited unexpectedly stayed tracked in `RUNNING_STRATEGIES` — and pinned its parent-side resources — until someone opened the `/python` UI. On a headless trading VPS that could be days.

```python
SCHEDULER.add_job(
    func=cleanup_dead_processes,
    trigger=\"interval\",
    seconds=60,
    id=\"reap_dead_strategies\",
    replace_existing=True,
)
```

### 2. Close parent-side log fd after subprocess inherits it (FD hygiene)
`start_strategy_process` was holding the log file handle open for the entire strategy lifetime (one extra fd per running strategy) even though the subprocess has its own inherited fd. We now write the header, flush, and close the parent handle immediately after `Popen` succeeds — the child owns the log from that point. Stacked with the reaper above, this eliminates the per-crash fd leak class.

`close_log_handle_safely` is retained for defensive compatibility with older records (e.g. restored/adopted strategies after a restart).

### 3. Authenticate `/python/api/events`
The SSE endpoint was the only route in the blueprint missing `@check_session_validity`. Every sibling route has it (confirmed via grep). Any network client could subscribe and stream strategy start/stop/error events + timestamps indefinitely.

### 4. Atomic `save_configs` write
Rewrites `strategy_configs.json` via `open(.tmp)` + `fsync` + `os.replace` so a kill mid-write cannot leave a half-written JSON blob that would break every subsequent `load_configs`.

### 5. Narrow bare `except` in SSE broadcast
`broadcast_status_update` was catching `KeyboardInterrupt` / `SystemExit` along with queue-full errors. Tightened to `except Exception:`.

## Why this matters

For long-running sample strategies like [`examples/python/emacrossover_strategy_python.py`](https://github.com/marketcalls/openalgo/blob/main/examples/python/emacrossover_strategy_python.py) that run 6+ trading hours with verbose WebSocket LTP prints, the combination of these fixes means:

- Crashed strategies no longer pin resources until a UI refresh.
- Running strategies cost one fd (the child's) instead of two.
- Config file survives unclean shutdowns.
- SSE status stream is access-controlled.

## What's deferred (not in this PR)

- **Mid-run log rotation** — `cleanup_strategy_logs` still refuses to touch running strategies, so a chatty 24/7 bot can still fill disk. This needs a proper rotating log design (wrapper process or size-capped segments) and is worth its own PR. Documented as the #1 remaining long-running reliability issue.
- **`os.killpg` vs. Gunicorn** — when `start_new_session=True` silently fails on some hosts, `stop_strategy_process` can signal Gunicorn's process group. Needs per-process tracking of whether `start_new_session` took effect; deferred pending a repro environment.

## Test plan

- [ ] Start a strategy, verify `lsof -p <gunicorn-pid> | grep /strategies/` shows only the subprocess inheriting the fd (not the parent).
- [ ] Kill a strategy subprocess externally (`kill -9 <pid>`). Within 60s, verify `RUNNING_STRATEGIES` no longer contains the entry and `/python` UI reflects the stopped state without requiring a page refresh.
- [ ] Subscribe to `/python/api/events` without a valid session cookie — verify 401/redirect instead of event stream.
- [ ] `kill -9` the Flask process during a `save_configs` call; restart; verify `strategy_configs.json` still parses (the `.tmp` file may remain but the main file is intact).
- [ ] Start, stop, schedule, and delete a strategy via the UI — no regressions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)