### PR TITLE
fix: use real OS threads for asyncio event loops under eventlet

### DIFF
--- a/services/websocket_client.py
+++ b/services/websocket_client.py
@@ -6,6 +6,7 @@ This client handles authentication and provides a simple interface for services.
 import asyncio
 import json
 import os
+import sys
 import threading
 import time
 from collections.abc import Callable
@@ -16,6 +17,16 @@ import websockets
 from dotenv import load_dotenv
 
 from utils.logging import get_logger
+
+# Import the original threading module to run the asyncio event loop in a real
+# OS thread, bypassing eventlet's monkey-patching which turns threading.Thread
+# into green threads where asyncio.new_event_loop() cannot work.
+if "eventlet" in sys.modules:
+    import eventlet
+
+    _original_threading = eventlet.patcher.original("threading")
+else:
+    _original_threading = threading
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -77,7 +88,7 @@ class WebSocketClient:
             self.running = True
 
             # Start the asyncio event loop in a separate thread
-            self.thread = threading.Thread(target=self._run_event_loop)
+            self.thread = _original_threading.Thread(target=self._run_event_loop)
             self.thread.daemon = True
             self.thread.start()
 

--- a/websocket_proxy/app_integration.py
+++ b/websocket_proxy/app_integration.py
@@ -10,6 +10,16 @@ from utils.logging import get_logger, highlight_url
 
 from .server import main as websocket_main
 
+# Import the original threading module to run the asyncio event loop in a real
+# OS thread, bypassing eventlet's monkey-patching which turns threading.Thread
+# into green threads where asyncio.new_event_loop() cannot work.
+if "eventlet" in sys.modules:
+    import eventlet
+
+    _original_threading = eventlet.patcher.original("threading")
+else:
+    _original_threading = threading
+
 # Set the correct event loop policy for Windows to avoid ZeroMQ warnings
 if platform.system() == "Windows":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -181,7 +191,7 @@ def start_websocket_server():
                     logger.warning(f"Error closing event loop: {loop_err}")
 
     # Start the WebSocket server in a daemon thread
-    _websocket_thread = threading.Thread(
+    _websocket_thread = _original_threading.Thread(
         target=run_websocket_server,
         daemon=False,  # Changed to False so we can properly clean up
     )


### PR DESCRIPTION
fix: use real OS threads for asyncio event loops under eventlet

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Run `asyncio` event loops in real OS threads when running under `eventlet`, preventing green-thread conflicts and fixing the “Cannot run the event loop while another loop is running” error under `Gunicorn` + `eventlet`.

- **Bug Fixes**
  - Detect `eventlet` at runtime and use `eventlet.patcher.original("threading")`; otherwise use standard `threading`.
  - Start event loop threads with `_original_threading.Thread` in `services/websocket_client.py` and `websocket_proxy/app_integration.py` to ensure real OS threads.

<sup>Written for commit 99ace9fd50b81dea14227fbc65e3830cc53610c7. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

