### PR TITLE
fix(shoonya): switch margin calculator from SpanCalc to GetBasketMargin

### DIFF
--- a/broker/shoonya/api/margin_api.py
+++ b/broker/shoonya/api/margin_api.py
@@ -10,21 +10,21 @@ logger = get_logger(__name__)
 
 def calculate_margin_api(positions, auth):
     """
-    Calculate margin requirement for a basket of positions using Shoonya Span Calculator API.
+    Calculate basket margin via Shoonya's GetBasketMargin endpoint.
 
-    Args:
-        positions: List of positions in OpenAlgo format
-        auth: Authentication token (jKey) for Shoonya
-
-    Returns:
-        Tuple of (response, response_data)
+    Applies MPP (Market Price Protection): MARKET/SL-M are converted to
+    LMT/SL-LMT with a protected price — Shoonya blocks MKT and SL-MKT on
+    API orders. See broker/shoonya/mapping/transform_data.py for the same
+    conversion used on order placement.
     """
     AUTH_TOKEN = auth
 
-    # Get account ID from BROKER_API_KEY
     api_key = os.getenv("BROKER_API_KEY")
-    if not api_key:
-        error_response = {"status": "error", "message": "BROKER_API_KEY not configured"}
+    if not api_key or ":::" not in api_key:
+        error_response = {
+            "status": "error",
+            "message": "BROKER_API_KEY not configured or invalid format",
+        }
 
         class MockResponse:
             status_code = 500
@@ -32,13 +32,11 @@ def calculate_margin_api(positions, auth):
 
         return MockResponse(), error_response
 
-    # BROKER_API_KEY format: userid:::client_id
-    account_id = api_key.split(":::")[0]  # Trading user ID
+    userid = api_key.split(":::")[0]
 
-    # Transform positions to Shoonya format
-    margin_data = transform_margin_positions(positions, account_id)
+    margin_data = transform_margin_positions(positions, userid, auth_token=AUTH_TOKEN)
 
-    if not margin_data.get("pos") or len(margin_data["pos"]) == 0:
+    if "tsym" not in margin_data:
         error_response = {
             "status": "error",
             "message": "No valid positions to calculate margin. Check if symbols are valid.",
@@ -50,31 +48,28 @@ def calculate_margin_api(positions, auth):
 
         return MockResponse(), error_response
 
-    # Prepare headers with Bearer token authentication
     headers = {
         "Content-Type": "text/plain",
         "Authorization": f"Bearer {AUTH_TOKEN}",
     }
 
-    # Prepare payload in Shoonya format
     jdata = json.dumps(margin_data)
     payload = f"jData={jdata}"
 
-    logger.info(f"Shoonya margin calculation payload: {payload}")
+    safe_payload = {k: v for k, v in margin_data.items() if k not in ("uid", "actid")}
+    logger.info(f"Shoonya basket margin payload: {safe_payload}")
 
-    # Get the shared httpx client with connection pooling
     client = get_httpx_client()
 
     try:
-        # Make the request to Shoonya Span Calculator API
         response = client.post(
-            "https://api.shoonya.com/NorenWClientAPI/SpanCalc", headers=headers, content=payload
+            "https://api.shoonya.com/NorenWClientAPI/GetBasketMargin",
+            headers=headers,
+            content=payload,
         )
 
-        # Add status attribute for compatibility with the existing codebase
         response.status = response.status_code
 
-        # Parse the JSON response
         try:
             response_data = response.json()
         except json.JSONDecodeError:
@@ -82,18 +77,15 @@ def calculate_margin_api(positions, auth):
             error_response = {"status": "error", "message": "Invalid response from broker API"}
             return response, error_response
 
-        logger.info(f"Shoonya margin response: {response_data}")
+        logger.info(f"Shoonya basket margin response: {response_data}")
 
-        # Parse and standardize the response
         standardized_response = parse_margin_response(response_data)
-
         return response, standardized_response
 
     except Exception as e:
-        logger.error(f"Error calling Shoonya margin API: {e}")
+        logger.error(f"Error calling Shoonya GetBasketMargin API: {e}")
         error_response = {"status": "error", "message": f"Failed to calculate margin: {str(e)}"}
 
-        # Create a mock response object
         class MockResponse:
             status_code = 500
             status = 500

--- a/broker/shoonya/mapping/margin_data.py
+++ b/broker/shoonya/mapping/margin_data.py
@@ -1,285 +1,158 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
-# Mapping Shoonya Span Calculator API
+# Mapping Shoonya GetBasketMargin API
 
+from broker.shoonya.mapping.transform_data import map_order_type, map_product_type
 from database.token_db import get_br_symbol
 from utils.logging import get_logger
+from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
 
 logger = get_logger(__name__)
 
 
-def transform_margin_positions(positions, account_id):
-    """
-    Transform OpenAlgo margin positions to Shoonya margin format.
+def _apply_mpp(position, auth_token):
+    """Convert MARKET/SL-M to LMT/SL-LMT with a protected price. Mirrors transform_data.py."""
+    pricetype = position.get("pricetype", "MARKET")
+    action = position["action"].upper()
+    price = str(position.get("price", 0) or 0)
+    order_type = map_order_type(pricetype)
 
-    Args:
-        positions: List of positions in OpenAlgo format
-        account_id: Shoonya account ID (API key without last 2 chars)
+    if pricetype not in ("MARKET", "SL-M"):
+        return order_type, price
 
-    Returns:
-        Dict in Shoonya margin format with actid and pos array
-    """
-    transformed_positions = []
+    original_type = pricetype
+    logger.info(
+        f"Margin MPP: {original_type} detected Symbol={position['symbol']}, "
+        f"Exchange={position['exchange']}, Action={action}"
+    )
+    try:
+        if not auth_token:
+            logger.warning(
+                f"Margin MPP: no auth token for Symbol={position['symbol']}; "
+                f"cannot fetch quote — sending {original_type} unchanged"
+            )
+            return order_type, price
 
+        from broker.shoonya.api.data import BrokerData
+
+        broker_data = BrokerData(auth_token)
+        quote = broker_data.get_quotes(position["symbol"], position["exchange"])
+        ltp = float(quote.get("ltp", 0))
+        tick_size = quote.get("tick_size")
+        instrument_type = get_instrument_type_from_symbol(position["symbol"])
+
+        logger.info(
+            f"Margin MPP Quote: Symbol={position['symbol']}, LTP={ltp}, "
+            f"TickSize={tick_size}, InstrumentType={instrument_type}"
+        )
+
+        if ltp > 0:
+            protected = calculate_protected_price(
+                price=ltp,
+                action=action,
+                symbol=position["symbol"],
+                instrument_type=instrument_type,
+                tick_size=tick_size,
+            )
+            price = str(protected)
+            order_type = "LMT" if original_type == "MARKET" else "SL-LMT"
+            logger.info(
+                f"Margin MPP Converted: {original_type}->{order_type}, "
+                f"FinalPrice={protected}"
+            )
+        else:
+            logger.warning(
+                f"Margin MPP: LTP<=0 for Symbol={position['symbol']}; "
+                f"sending {original_type} unchanged"
+            )
+    except Exception as e:
+        logger.error(
+            f"Margin MPP Error: Symbol={position['symbol']}, Error={e}. "
+            f"Sending {original_type} unchanged"
+        )
+
+    return order_type, price
+
+
+def _build_order(position, auth_token):
+    oa_symbol = position["symbol"]
+    exchange = position["exchange"]
+    br_symbol = get_br_symbol(oa_symbol, exchange)
+    if not br_symbol:
+        logger.warning(f"Symbol not found for: {oa_symbol} on exchange: {exchange}")
+        return None
+    if "&" in br_symbol:
+        br_symbol = br_symbol.replace("&", "%26")
+
+    prctyp, prc = _apply_mpp(position, auth_token)
+
+    return {
+        "exch": exchange,
+        "tsym": br_symbol,
+        "qty": str(int(position["quantity"])),
+        "prc": prc,
+        "trgprc": str(position.get("trigger_price", 0) or 0),
+        "prd": map_product_type(position.get("product", "NRML")),
+        "trantype": "B" if position["action"].upper() == "BUY" else "S",
+        "prctyp": prctyp,
+    }
+
+
+def transform_margin_positions(positions, userid, auth_token=None):
+    orders = []
     for position in positions:
         try:
-            # Use the original OpenAlgo symbol for parsing derivative details
-            oa_symbol = position["symbol"]
-
-            # Log the incoming position data
-            logger.info(
-                f"Processing position: symbol='{oa_symbol}', exchange='{position['exchange']}'"
-            )
-
-            # Get the broker symbol for validation only
-            br_symbol = get_br_symbol(oa_symbol, position["exchange"])
-            logger.info(f"Broker symbol for '{oa_symbol}': '{br_symbol}'")
-
-            if not br_symbol:
-                logger.warning(
-                    f"Symbol not found for: {oa_symbol} on exchange: {position['exchange']}"
-                )
-                continue
-
-            # Parse the OpenAlgo symbol (not broker symbol) to extract details
-            # Determine instrument name based on symbol pattern
-            instname = determine_instrument_name(oa_symbol, position["exchange"])
-
-            # Extract symbol name (without suffix for options/futures)
-            symname = extract_symbol_name(oa_symbol)
-
-            # Extract expiry date, option type, and strike price if applicable
-            exd, optt, strprc = extract_derivative_details(oa_symbol, position["exchange"])
-
-            # Log the parsed details for debugging
-            logger.info(
-                f"Parsed symbol '{oa_symbol}': instname={instname}, symname={symname}, exd={exd}, optt={optt}, strprc={strprc}"
-            )
-
-            # Map product type from OpenAlgo to Shoonya format
-            # Official SDK: C = CNC, M = NRML/Margin, H = MIS (Intraday)
-            product_map = {
-                "CNC": "C",
-                "MIS": "H",  # H = MIS (not I!)
-                "NRML": "M",
-            }
-            product = position.get("product", "NRML")  # Default to NRML for F&O
-            prd = product_map.get(product, "M")  # Default to 'M' if not found
-
-            # Calculate quantities based on action
-            quantity = int(position["quantity"])
-            if position["action"].upper() == "BUY":
-                buyqty = quantity
-                sellqty = 0
-                netqty = quantity
-            else:
-                buyqty = 0
-                sellqty = quantity
-                netqty = -quantity  # Negative for sell positions
-
-            # Transform the position - ALL VALUES MUST BE STRINGS per working test!
-            # Official SDK requires prd field: C=CNC, M=NRML, H=MIS
-            transformed_position = {
-                "prd": prd,  # Required: C=CNC, M=NRML/Margin, H=MIS
-                "exch": position["exchange"],
-                "instname": instname,
-                "symname": symname,
-                "exd": exd,  # DD-MMM-YYYY format
-                "optt": optt,  # 'CE', 'PE', or 'XX' for futures
-                "strprc": str(strprc) if strprc else "-1",  # String! '-1' for futures
-                "buyqty": str(buyqty),  # String!
-                "sellqty": str(sellqty),  # String!
-                "netqty": str(netqty),  # String!
-            }
-
-            transformed_positions.append(transformed_position)
-
+            order = _build_order(position, auth_token)
+            if order:
+                orders.append(order)
         except Exception as e:
             logger.error(f"Error transforming position: {position}, Error: {e}")
             continue
+    if not orders:
+        return {"uid": userid, "actid": userid, "basketlists": []}
 
-    return {"actid": account_id, "pos": transformed_positions}
-
-
-def determine_instrument_name(symbol, exchange):
-    """
-    Determine instrument name based on symbol and exchange.
-
-    Returns: FUTSTK, FUTIDX, OPTSTK, OPTIDX, FUTCUR, etc.
-    """
-    # For equity exchanges
-    if exchange in ["NSE", "BSE"]:
-        return "EQ"
-
-    # For derivative exchanges
-    if exchange == "NFO":
-        if "FUT" in symbol or symbol.endswith("F"):
-            if any(idx in symbol for idx in ["NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY"]):
-                return "FUTIDX"
-            else:
-                return "FUTSTK"
-        elif "CE" in symbol or "PE" in symbol or symbol.endswith("C") or symbol.endswith("P"):
-            # Check if it's an index option or stock option
-            if any(idx in symbol for idx in ["NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY"]):
-                return "OPTIDX"
-            else:
-                return "OPTSTK"
-
-    # For currency
-    if exchange == "CDS":
-        if "FUT" in symbol:
-            return "FUTCUR"
-        elif "CE" in symbol or "PE" in symbol:
-            return "OPTCUR"
-
-    # For commodity
-    if exchange == "MCX":
-        if "FUT" in symbol:
-            return "FUTCOM"
-        elif "CE" in symbol or "PE" in symbol:
-            return "OPTCOM"
-
-    # Default
-    return "EQ"
-
-
-def extract_symbol_name(symbol):
-    """
-    Extract base symbol name from trading symbol.
-    E.g., NIFTY25NOV25FUT -> NIFTY
-    E.g., NIFTY30DEC2524500CE -> NIFTY
-    """
-    import re
-
-    # Start with the full symbol
-    base = symbol
-
-    # First remove option type suffixes (CE, PE, C, P)
-    # Check for CE/PE first (longer pattern)
-    if "CE" in base:
-        base = base.split("CE")[0]
-    elif "PE" in base:
-        base = base.split("PE")[0]
-    # Then check for single character suffix
-    elif base.endswith("C") and not base.endswith("DEC"):
-        base = base[:-1]  # Remove last character 'C'
-    elif base.endswith("P"):
-        base = base[:-1]  # Remove last character 'P'
-
-    # Remove FUT suffix
-    if "FUT" in base:
-        base = base.split("FUT")[0]
-
-    # Remove -EQ suffix
-    if "-EQ" in base:
-        base = base.split("-EQ")[0]
-
-    # Remove date patterns (e.g., 30DEC25, 2025-11-28, etc.)
-    base = re.sub(r"\d{2}[A-Z]{3}\d{2}", "", base)
-    base = re.sub(r"\d{4}-\d{2}-\d{2}", "", base)
-
-    # Remove strike prices (3 or more consecutive digits)
-    base = re.sub(r"\d{3,}", "", base)
-
-    return base.strip()
-
-
-def extract_derivative_details(symbol, exchange):
-    """
-    Extract expiry date, option type, and strike price from symbol.
-
-    Returns: (exd, optt, strprc)
-    """
-    exd = ""
-    optt = ""
-    strprc = ""
-
-    # For equity exchanges, no derivatives
-    if exchange in ["NSE", "BSE"]:
-        return exd, optt, strprc
-
-    import re
-
-    # Extract expiry date (format: DDMMMYY to DD-MMM-YYYY for Shoonya)
-    date_match = re.search(r"(\d{2})([A-Z]{3})(\d{2})", symbol)
-    if date_match:
-        day = date_match.group(1)
-        month_str = date_match.group(2)
-        year_2digit = date_match.group(3)
-        year_4digit = "20" + year_2digit
-
-        # Working test uses DD-MMM-YYYY format (e.g., 29-DEC-2022)
-        exd = f"{day}-{month_str}-{year_4digit}"
-
-    # Check if it's a future or option
-    is_option = "CE" in symbol or "PE" in symbol or symbol.endswith("C") or symbol.endswith("P")
-    is_future = "FUT" in symbol and not is_option
-
-    if is_future:
-        # For futures: optt='XX' and strprc='-1' as per working test
-        optt = "XX"
-        strprc = "-1"
-    elif "CE" in symbol:
-        optt = "CE"
-        # Extract strike price: digits after date pattern and before CE
-        strike_match = re.search(r"\d{2}[A-Z]{3}\d{2}(\d+\.?\d*)CE", symbol)
-        if strike_match:
-            strprc = strike_match.group(1)
-    elif "PE" in symbol:
-        optt = "PE"
-        # Extract strike price: digits after date pattern and before PE
-        strike_match = re.search(r"\d{2}[A-Z]{3}\d{2}(\d+\.?\d*)PE", symbol)
-        if strike_match:
-            strprc = strike_match.group(1)
-    # Also handle single character suffix (C/P) in case that's the format
-    elif symbol.endswith("C") and not symbol.endswith("DEC"):
-        optt = "CE"
-        strike_match = re.search(r"\d{2}[A-Z]{3}\d{2}(\d+\.?\d*)C$", symbol)
-        if strike_match:
-            strprc = strike_match.group(1)
-    elif symbol.endswith("P") and not is_future:
-        optt = "PE"
-        strike_match = re.search(r"\d{2}[A-Z]{3}\d{2}(\d+\.?\d*)P$", symbol)
-        if strike_match:
-            strprc = strike_match.group(1)
-
-    return exd, optt, strprc
+    first = orders[0]
+    rest = orders[1:]
+    return {
+        "uid": userid,
+        "actid": userid,
+        "exch": first["exch"],
+        "tsym": first["tsym"],
+        "qty": first["qty"],
+        "prc": first["prc"],
+        "trgprc": first["trgprc"],
+        "prd": first["prd"],
+        "trantype": first["trantype"],
+        "prctyp": first["prctyp"],
+        "basketlists": rest,
+    }
 
 
 def parse_margin_response(response_data):
-    """
-    Parse Shoonya margin response to OpenAlgo standard format.
-
-    Args:
-        response_data: Raw response from Shoonya API
-
-    Returns:
-        Standardized margin response matching OpenAlgo format
-    """
     try:
         if not response_data or not isinstance(response_data, dict):
             return {"status": "error", "message": "Invalid response from broker"}
-
-        # Check if the response status is Ok
         if response_data.get("stat") != "Ok":
-            error_message = response_data.get("emsg", "Failed to calculate margin")
+            error_message = (
+                response_data.get("emsg")
+                or response_data.get("remarks")
+                or "Failed to calculate margin"
+            )
             return {"status": "error", "message": error_message}
-
-        # Extract margin data
-        # Shoonya returns: span, expo, span_trade, expo_trade
-        span = float(response_data.get("span", 0))
-        expo = float(response_data.get("expo", 0))
-        total_margin = span + expo
-
-        # Return standardized format matching OpenAlgo API specification
+        # Shoonya doc semantics:
+        #   marginused      -> "Total margin"        (pre-hedge basket total)
+        #   marginusedtrade -> "Margin after trade"  (post-hedge account total)
+        # Parallels Zerodha's initial.total vs final.total. Map total to
+        # marginused (matches Zerodha impl using initial.total) and set
+        # span/exposure to 0 since Shoonya gives no breakdown. See #1268.
+        margin_used = float(response_data.get("marginused", 0) or 0)
         return {
             "status": "success",
             "data": {
-                "total_margin_required": total_margin,
-                "span_margin": span,
-                "exposure_margin": expo,
+                "total_margin_required": margin_used,
+                "span_margin": 0,
+                "exposure_margin": 0,
             },
         }
-
     except Exception as e:
         logger.error(f"Error parsing margin response: {e}")
         return {"status": "error", "message": f"Failed to parse margin response: {str(e)}"}


### PR DESCRIPTION
SpanCalc returned gross span + exposure without portfolio-level hedge netting, inflating margins 5-6x vs Shoonya's own basket view and causing strategy trades to be falsely rejected (issue #1268).

GetBasketMargin mirrors the broker UI numbers (pre-hedge basket total and post-hedge account total) and applies real spread/hedge benefits.

- Payload now uses basketlists[] with first leg promoted to top level (uid/actid/exch/tsym/qty/prc/trgprc/prd/trantype/prctyp) per Noren API
- Applies the same MPP conversion as order placement: MARKET -> LMT and SL-M -> SL-LMT with a protected price derived from LTP (Shoonya blocks MKT/SL-MKT on API)
- Response maps Shoonya marginused ("Total margin") to total_margin_required paralleling Zerodha's use of initial.total; span/exposure are 0 since Shoonya provides no breakdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch Shoonya margin calculation from SpanCalc to GetBasketMargin to match broker basket UI and apply hedge/spread netting. Fixes inflated margins that caused false trade rejections.

- **Bug Fixes**
  - Use GetBasketMargin for portfolio-level hedge netting and UI-aligned numbers.
  - Send basket payload: first leg at top level with `uid`/`actid`, rest in `basketlists[]`; escape `&` in `tsym`.
  - Apply MPP: convert MARKET→LMT and SL-M→SL-LMT with a protected price from LTP (Shoonya blocks MKT/SL-MKT).
  - Map `marginused` to `total_margin_required`; set `span_margin` and `exposure_margin` to 0; improved error messages from `emsg`/`remarks`.
  - Validate `BROKER_API_KEY` format (`userid:::client_id`) and avoid logging `uid`/`actid`; update logs and errors to the new endpoint.

<sup>Written for commit 38a46f508f4fa600b567db30b060c3250c80204c. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

