### PR TITLE
Add optional Adanos market sentiment module

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -1,10 +1,10 @@
 # OpenAlgo Environment Configuration File
-# Version: 1.0.6
-# Last Updated: 2026-01-17
+# Version: 1.0.7
+# Last Updated: 2026-04-21
 #
 # IMPORTANT: When updating OpenAlgo, compare this version with your .env file
 # If versions don't match, copy new variables from this file to your .env
-ENV_CONFIG_VERSION = '1.0.6'
+ENV_CONFIG_VERSION = '1.0.7'
 
 # Broker Configuration
 BROKER_API_KEY = 'YOUR_BROKER_API_KEY'
@@ -47,11 +47,11 @@ SANDBOX_DATABASE_URL = 'sqlite:///db/sandbox.db'  # Database for sandbox/analyze
 HISTORIFY_DATABASE_URL = 'db/historify.duckdb'    # Database for historical data (DuckDB)
 
 # OpenAlgo Ngrok Configuration
-NGROK_ALLOW = 'FALSE' 
+NGROK_ALLOW = 'FALSE'
 
 # OpenAlgo Hosted Server (Custom Domain Name) or Ngrok Domain Configuration
 # Change to your custom domain or Ngrok domain
-HOST_SERVER = 'http://127.0.0.1:5000'  
+HOST_SERVER = 'http://127.0.0.1:5000'
 
 # OpenAlgo Flask App Host and Port Configuration
 # For 0.0.0.0 (accessible from other devices on the network)

--- a/.sample.env
+++ b/.sample.env
@@ -140,6 +140,15 @@ STRATEGY_RATE_LIMIT="200 per minute"
 
 # OpenAlgo API Configuration
 
+# Optional External Data Modules
+# Adanos Market Sentiment can enrich stock research workflows with
+# Reddit, X, News, and Polymarket sentiment snapshots.
+# Leave ADANOS_API_KEY empty to keep the module disabled.
+ADANOS_API_KEY = ''
+ADANOS_API_BASE_URL = 'https://api.adanos.org'
+ADANOS_SENTIMENT_DEFAULT_DAYS = '7'
+ADANOS_API_TIMEOUT_MS = '10000'
+
 # Session Expiry Time (24-hour format, IST)
 # All user sessions will automatically expire at this time daily
 SESSION_EXPIRY_TIME = '03:00'
@@ -306,4 +315,3 @@ CSRF_COOKIE_NAME = 'csrf_token'
 #   - 8GB container: 1g
 #   - 16GB+ container: 2g
 # SHM_SIZE = '512m'
-

--- a/README.md
+++ b/README.md
@@ -78,6 +78,7 @@ A single, standardized API across all brokers with 30+ endpoints:
 - **Order Management**: Place, modify, cancel orders, basket orders, smart orders with position sizing
 - **Portfolio**: Get positions, holdings, order book, trade book, funds
 - **Market Data**: Real-time quotes, historical data, market depth (Level 5), symbol search
+- **External Context**: Optional Adanos market sentiment snapshots for stock tickers
 - **Advanced**: Option Greeks calculator, margin calculator, synthetic futures, auto-split orders
 
 ### Real-Time WebSocket Streaming

--- a/collections/openalgo/IN_stock/market_sentiment.bru
+++ b/collections/openalgo/IN_stock/market_sentiment.bru
@@ -1,0 +1,20 @@
+meta {
+  name: market_sentiment
+  type: http
+  seq: 60
+}
+
+post {
+  url: http://127.0.0.1:5000/api/v1/market/sentiment
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+    "apikey": "a85992a13ab7db424c239c50826116366e9f4fd8c591345a2d23aad01ffa4d00",
+    "tickers": ["AAPL", "TSLA", "NVDA"],
+    "source": "all",
+    "days": 7
+  }
+}

--- a/collections/openalgo/IN_stock/market_sentiment.bru
+++ b/collections/openalgo/IN_stock/market_sentiment.bru
@@ -12,7 +12,7 @@ post {
 
 body:json {
   {
-    "apikey": "a85992a13ab7db424c239c50826116366e9f4fd8c591345a2d23aad01ffa4d00",
+    "apikey": "<your_app_apikey>",
     "tickers": ["AAPL", "TSLA", "NVDA"],
     "source": "all",
     "days": 7

--- a/docs/api/README.md
+++ b/docs/api/README.md
@@ -56,6 +56,7 @@ Access real-time and historical market data.
 | [Depth](./market-data/depth.md) | Get market depth (Level 2) data |
 | [History](./market-data/history.md) | Get historical OHLCV data |
 | [Intervals](./market-data/intervals.md) | Get available time intervals |
+| [Sentiment](./market-data/sentiment.md) | Get optional Adanos sentiment snapshots for stock tickers |
 
 ### Symbol Services
 Symbol lookup, search, and instrument data.

--- a/docs/api/market-data/sentiment.md
+++ b/docs/api/market-data/sentiment.md
@@ -1,0 +1,122 @@
+# Sentiment
+
+Get optional Adanos market sentiment snapshots for stock tickers.
+
+This endpoint is designed as an external context module for research and strategy gating. It does not depend on broker market-data support and does not require OpenAlgo exchange codes.
+
+## Endpoint URL
+
+```http
+Local Host   :  POST http://127.0.0.1:5000/api/v1/market/sentiment
+Ngrok Domain :  POST https://<your-ngrok-domain>.ngrok-free.app/api/v1/market/sentiment
+Custom Domain:  POST https://<your-custom-domain>/api/v1/market/sentiment
+```
+
+## Optional Setup
+
+Add the following variables to your `.env` file to enable the module:
+
+```bash
+ADANOS_API_KEY=your_adanos_key
+ADANOS_API_BASE_URL=https://api.adanos.org
+ADANOS_SENTIMENT_DEFAULT_DAYS=7
+ADANOS_API_TIMEOUT_MS=10000
+```
+
+If `ADANOS_API_KEY` is not configured, the endpoint stays available and returns `enabled=false`.
+
+## Sample API Request
+
+```json
+{
+  "apikey": "<your_app_apikey>",
+  "tickers": ["AAPL", "TSLA", "NVDA"],
+  "source": "all",
+  "days": 7
+}
+```
+
+## Sample API Response
+
+```json
+{
+  "status": "success",
+  "data": {
+    "enabled": true,
+    "provider": "adanos",
+    "tickers": ["AAPL", "TSLA", "NVDA"],
+    "source": "all",
+    "days": 7,
+    "summary": "- reddit: TSLA (Tesla, Inc.): sentiment=0.31, buzz=71.2, mentions=140, trend=rising",
+    "docs_url": "https://api.adanos.org/docs/",
+    "snapshots": [
+      {
+        "source": "reddit",
+        "endpoint": "https://api.adanos.org/reddit/stocks/v1/compare",
+        "success": true,
+        "stocks": [
+          {
+            "ticker": "TSLA",
+            "company_name": "Tesla, Inc.",
+            "source": "reddit",
+            "sentiment_score": 0.31,
+            "buzz_score": 71.2,
+            "bullish_pct": 62,
+            "bearish_pct": 18,
+            "mentions": 140,
+            "subreddit_count": 11,
+            "source_count": null,
+            "unique_tweets": null,
+            "trade_count": null,
+            "market_count": null,
+            "total_liquidity": null,
+            "trend": "rising",
+            "trend_history": [52.3, 63.4, 71.2]
+          }
+        ]
+      }
+    ]
+  }
+}
+```
+
+## Request Body
+
+| Parameter | Description | Mandatory/Optional | Default Value |
+|-----------|-------------|-------------------|---------------|
+| apikey | Your OpenAlgo API key | Mandatory | - |
+| tickers | Raw stock tickers such as `AAPL`, `TSLA`, `NVDA` | Mandatory | - |
+| source | `all`, `reddit`, `x`, `news`, or `polymarket` | Optional | `all` |
+| days | Lookback window in days | Optional | `ADANOS_SENTIMENT_DEFAULT_DAYS` or `7` |
+
+## Response Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| status | string | `success` or `error` |
+| data.enabled | boolean | Whether Adanos enrichment is configured on this OpenAlgo instance |
+| data.provider | string | External provider name |
+| data.tickers | array | Normalized tickers used for the request |
+| data.source | string | Requested source or `all` |
+| data.days | integer | Effective lookback window |
+| data.summary | string | Compact human-readable summary across sources |
+| data.docs_url | string | Adanos API docs URL |
+| data.snapshots | array | Source-by-source compare results |
+
+## Notes
+
+- This is an **optional external data module**. It is not tied to broker quotes, master contracts, or exchange codes.
+- Use this endpoint for **research, filtering, ranking, or gating** before order execution.
+- `tickers` are validated as raw stock ticker strings. Do not send OpenAlgo `exchange:symbol` pairs here.
+- If Adanos is disabled locally, OpenAlgo returns `enabled=false` instead of failing the request.
+
+## Use Cases
+
+- Gate webhook or Python strategies with cross-source stock sentiment
+- Rank watchlists by current retail/news/prediction-market activity
+- Add a second opinion layer before smart-order execution
+- Build dashboards that combine OpenAlgo execution data with external market context
+
+---
+
+**Back to**: [API Documentation](../README.md)

--- a/examples/python/adanos_sentiment_example.py
+++ b/examples/python/adanos_sentiment_example.py
@@ -1,0 +1,30 @@
+"""
+Example: fetch optional Adanos market sentiment through your OpenAlgo instance.
+"""
+
+from __future__ import annotations
+
+import requests
+
+OPENALGO_HOST = "http://127.0.0.1:5000"
+OPENALGO_API_KEY = "replace-with-your-openalgo-apikey"
+
+payload = {
+    "apikey": OPENALGO_API_KEY,
+    "tickers": ["AAPL", "TSLA", "NVDA"],
+    "source": "all",
+    "days": 7,
+}
+
+response = requests.post(
+    f"{OPENALGO_HOST}/api/v1/market/sentiment",
+    json=payload,
+    timeout=15,
+)
+response.raise_for_status()
+
+data = response.json()
+print("Status:", data["status"])
+print("Enabled:", data["data"]["enabled"])
+print("Summary:")
+print(data["data"]["summary"])

--- a/restx_api/__init__.py
+++ b/restx_api/__init__.py
@@ -26,6 +26,7 @@ from .instruments import api as instruments_ns
 from .intervals import api as intervals_ns
 from .margin import api as margin_ns
 from .market_holidays import api as market_holidays_ns
+from .market_sentiment import api as market_sentiment_ns
 from .market_timings import api as market_timings_ns
 from .modify_order import api as modify_order_ns
 from .multi_option_greeks import api as multi_option_greeks_ns
@@ -92,4 +93,5 @@ api.add_namespace(instruments_ns, path="/instruments")
 api.add_namespace(chart_ns, path="/chart")
 api.add_namespace(market_holidays_ns, path="/market/holidays")
 api.add_namespace(market_timings_ns, path="/market/timings")
+api.add_namespace(market_sentiment_ns, path="/market/sentiment")
 api.add_namespace(pnl_symbols_ns, path="/pnl")

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -55,6 +55,26 @@ class MultiQuotesSchema(Schema):
     )
 
 
+class MarketSentimentSchema(Schema):
+    apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    tickers = fields.List(
+        fields.Str(validate=validate.Length(min=1, max=16)),
+        required=True,
+        validate=validate.Length(min=1, max=10),
+    )
+    source = fields.Str(
+        required=False,
+        load_default="all",
+        validate=validate.OneOf(["all", "reddit", "x", "news", "polymarket"]),
+    )
+    days = fields.Int(
+        required=False,
+        allow_none=True,
+        load_default=None,
+        validate=validate.Range(min=1, max=30),
+    )
+
+
 class HistorySchema(Schema):
     apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
     symbol = fields.Str(required=True)

--- a/restx_api/market_sentiment.py
+++ b/restx_api/market_sentiment.py
@@ -1,0 +1,43 @@
+import os
+
+from flask import jsonify, make_response, request
+from flask_restx import Namespace, Resource
+from marshmallow import ValidationError
+
+from limiter import limiter
+from services.adanos_sentiment_service import get_market_sentiment
+from utils.logging import get_logger
+
+from .data_schemas import MarketSentimentSchema
+
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+api = Namespace("market/sentiment", description="Optional external market sentiment API")
+
+logger = get_logger(__name__)
+market_sentiment_schema = MarketSentimentSchema()
+
+
+@api.route("/", strict_slashes=False)
+class MarketSentiment(Resource):
+    @limiter.limit(API_RATE_LIMIT)
+    def post(self):
+        """Get optional Adanos market sentiment snapshots for stock tickers"""
+        try:
+            sentiment_data = market_sentiment_schema.load(request.json)
+
+            success, response_data, status_code = get_market_sentiment(
+                api_key=sentiment_data["apikey"],
+                tickers=sentiment_data["tickers"],
+                source=sentiment_data["source"],
+                days=sentiment_data.get("days"),
+            )
+
+            return make_response(jsonify(response_data), status_code)
+        except ValidationError as err:
+            return make_response(jsonify({"status": "error", "message": err.messages}), 400)
+        except Exception as exc:
+            logger.exception(f"Unexpected error in market sentiment endpoint: {exc}")
+            return make_response(
+                jsonify({"status": "error", "message": "An unexpected error occurred"}),
+                500,
+            )

--- a/restx_api/market_sentiment.py
+++ b/restx_api/market_sentiment.py
@@ -23,7 +23,30 @@ class MarketSentiment(Resource):
     def post(self):
         """Get optional Adanos market sentiment snapshots for stock tickers"""
         try:
-            sentiment_data = market_sentiment_schema.load(request.json)
+            if not request.is_json:
+                return make_response(
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Content-Type must be application/json",
+                        }
+                    ),
+                    415,
+                )
+
+            payload = request.get_json(silent=True)
+            if payload is None:
+                return make_response(
+                    jsonify(
+                        {
+                            "status": "error",
+                            "message": "Invalid or malformed JSON payload",
+                        }
+                    ),
+                    400,
+                )
+
+            sentiment_data = market_sentiment_schema.load(payload)
 
             success, response_data, status_code = get_market_sentiment(
                 api_key=sentiment_data["apikey"],

--- a/services/adanos_sentiment_service.py
+++ b/services/adanos_sentiment_service.py
@@ -1,0 +1,320 @@
+import os
+import re
+from typing import Any
+
+import httpx
+
+from database.auth_db import verify_api_key
+from utils.httpx_client import get_httpx_client
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+ADANOS_DOCS_URL = "https://api.adanos.org/docs/"
+ADANOS_SUPPORTED_SOURCES = ("reddit", "x", "news", "polymarket")
+TICKER_RE = re.compile(r"^[A-Z][A-Z0-9.]{0,9}$")
+
+
+def _to_number(value: Any) -> float | int | None:
+    if value in (None, ""):
+        return None
+    try:
+        parsed = float(value)
+    except (TypeError, ValueError):
+        return None
+    if not parsed.is_integer():
+        return parsed
+    return int(parsed)
+
+
+def normalize_tickers(tickers: list[str]) -> list[str]:
+    seen: set[str] = set()
+    normalized: list[str] = []
+
+    for raw_ticker in tickers:
+        ticker = str(raw_ticker or "").strip().replace("$", "").upper()
+        if not ticker or not TICKER_RE.match(ticker) or ticker in seen:
+            continue
+        seen.add(ticker)
+        normalized.append(ticker)
+
+    return normalized[:10]
+
+
+def _pick(record: dict[str, Any], *keys: str) -> Any:
+    for key in keys:
+        if key in record:
+            return record[key]
+    return None
+
+
+def normalize_compare_rows(source: str, payload: Any) -> list[dict[str, Any]]:
+    if isinstance(payload, list):
+        rows = payload
+    elif isinstance(payload, dict):
+        rows = payload.get("stocks") or payload.get("data") or payload.get("results") or []
+    else:
+        rows = []
+
+    if not isinstance(rows, list):
+        return []
+
+    normalized_rows: list[dict[str, Any]] = []
+    for entry in rows:
+        if not isinstance(entry, dict):
+            continue
+
+        ticker = str(_pick(entry, "ticker", "symbol") or "").strip().replace("$", "").upper()
+        if not ticker or not TICKER_RE.match(ticker):
+            continue
+
+        trend_history = entry.get("trend_history")
+        if isinstance(trend_history, list):
+            normalized_history = [
+                value for value in (_to_number(item) for item in trend_history) if value is not None
+            ]
+        else:
+            normalized_history = []
+
+        normalized_rows.append(
+            {
+                "ticker": ticker,
+                "company_name": _pick(entry, "company_name", "name", "company"),
+                "source": source,
+                "sentiment_score": _to_number(
+                    _pick(entry, "sentiment_score", "sentiment", "score")
+                ),
+                "buzz_score": _to_number(_pick(entry, "buzz_score", "buzz")),
+                "bullish_pct": _to_number(entry.get("bullish_pct")),
+                "bearish_pct": _to_number(entry.get("bearish_pct")),
+                "mentions": _to_number(_pick(entry, "mentions", "mention_count")),
+                "subreddit_count": _to_number(entry.get("subreddit_count")),
+                "source_count": _to_number(entry.get("source_count")),
+                "unique_tweets": _to_number(entry.get("unique_tweets")),
+                "trade_count": _to_number(entry.get("trade_count")),
+                "market_count": _to_number(entry.get("market_count")),
+                "total_liquidity": _to_number(entry.get("total_liquidity")),
+                "trend": entry.get("trend") if isinstance(entry.get("trend"), str) else None,
+                "trend_history": normalized_history,
+            }
+        )
+
+    return normalized_rows
+
+
+def build_summary(snapshots: list[dict[str, Any]]) -> str:
+    lines: list[str] = []
+
+    for snapshot in snapshots:
+        if not snapshot.get("success") or not snapshot.get("stocks"):
+            if snapshot.get("error"):
+                lines.append(f"- {snapshot['source']}: unavailable ({snapshot['error']})")
+            else:
+                lines.append(f"- {snapshot['source']}: no qualifying sentiment rows returned")
+            continue
+
+        ranked_rows = sorted(
+            snapshot["stocks"],
+            key=lambda row: row.get("buzz_score")
+            if row.get("buzz_score") is not None
+            else float("-inf"),
+            reverse=True,
+        )[:3]
+
+        fragments = []
+        for row in ranked_rows:
+            metrics = []
+            if row.get("sentiment_score") is not None:
+                metrics.append(f"sentiment={float(row['sentiment_score']):.2f}")
+            if row.get("buzz_score") is not None:
+                metrics.append(f"buzz={float(row['buzz_score']):.1f}")
+            if row.get("bullish_pct") is not None:
+                metrics.append(f"bullish={float(row['bullish_pct']):.0f}%")
+            if row.get("mentions") is not None:
+                metrics.append(f"mentions={int(row['mentions'])}")
+            if row.get("trade_count") is not None:
+                metrics.append(f"trades={int(row['trade_count'])}")
+            if row.get("trend"):
+                metrics.append(f"trend={row['trend']}")
+
+            label = row["ticker"]
+            if row.get("company_name"):
+                label = f"{label} ({row['company_name']})"
+            fragments.append(f"{label}: {', '.join(metrics)}")
+
+        lines.append(f"- {snapshot['source']}: {' | '.join(fragments)}")
+
+    return "\n".join(lines)
+
+
+def _get_adanos_base_url() -> str:
+    return os.getenv("ADANOS_API_BASE_URL", "https://api.adanos.org").rstrip("/")
+
+
+def _get_adanos_timeout_seconds() -> float:
+    raw_timeout = os.getenv("ADANOS_API_TIMEOUT_MS", "10000")
+    try:
+        timeout_ms = int(raw_timeout)
+    except ValueError:
+        timeout_ms = 10000
+    return max(timeout_ms, 1000) / 1000
+
+
+def _get_default_days() -> int:
+    raw_days = os.getenv("ADANOS_SENTIMENT_DEFAULT_DAYS", "7")
+    try:
+        parsed_days = int(raw_days)
+    except ValueError:
+        parsed_days = 7
+    return min(max(parsed_days, 1), 30)
+
+
+def _fetch_source_snapshot(
+    client: httpx.Client,
+    base_url: str,
+    source: str,
+    tickers: list[str],
+    days: int,
+    adanos_api_key: str,
+    timeout_seconds: float,
+) -> dict[str, Any]:
+    endpoint = f"{base_url}/{source}/stocks/v1/compare"
+
+    try:
+        response = client.get(
+            endpoint,
+            headers={
+                "Accept": "application/json",
+                "X-API-Key": adanos_api_key,
+            },
+            params={"tickers": ",".join(tickers), "days": days},
+            timeout=timeout_seconds,
+        )
+    except httpx.TimeoutException:
+        return {
+            "source": source,
+            "endpoint": endpoint,
+            "success": False,
+            "error": "Request timed out",
+            "stocks": [],
+        }
+    except httpx.HTTPError as exc:
+        return {
+            "source": source,
+            "endpoint": endpoint,
+            "success": False,
+            "error": str(exc),
+            "stocks": [],
+        }
+
+    if response.status_code >= 400:
+        return {
+            "source": source,
+            "endpoint": endpoint,
+            "success": False,
+            "error": f"HTTP {response.status_code}",
+            "stocks": [],
+        }
+
+    try:
+        payload = response.json()
+    except ValueError:
+        return {
+            "source": source,
+            "endpoint": endpoint,
+            "success": False,
+            "error": "Invalid JSON response",
+            "stocks": [],
+        }
+
+    return {
+        "source": source,
+        "endpoint": endpoint,
+        "success": True,
+        "stocks": normalize_compare_rows(source, payload),
+    }
+
+
+def get_market_sentiment(
+    api_key: str, tickers: list[str], source: str = "all", days: int | None = None
+) -> tuple[bool, dict[str, Any], int]:
+    if not api_key:
+        return False, {"status": "error", "message": "Missing API Key"}, 401
+
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid openalgo apikey"}, 403
+
+    normalized_tickers = normalize_tickers(tickers)
+    if not normalized_tickers:
+        return (
+            False,
+            {
+                "status": "error",
+                "message": "No valid stock tickers provided. Use raw tickers like AAPL, TSLA, MSFT.",
+            },
+            400,
+        )
+
+    adanos_api_key = os.getenv("ADANOS_API_KEY", "").strip()
+    base_url = _get_adanos_base_url()
+    lookback_days = days or _get_default_days()
+    timeout_seconds = _get_adanos_timeout_seconds()
+
+    if not adanos_api_key:
+        return (
+            True,
+            {
+                "status": "success",
+                "data": {
+                    "enabled": False,
+                    "provider": "adanos",
+                    "tickers": normalized_tickers,
+                    "source": source,
+                    "days": lookback_days,
+                    "snapshots": [],
+                    "summary": "Adanos market sentiment is disabled because ADANOS_API_KEY is not configured.",
+                    "docs_url": ADANOS_DOCS_URL,
+                },
+            },
+            200,
+        )
+
+    sources = list(ADANOS_SUPPORTED_SOURCES) if source == "all" else [source]
+    client = get_httpx_client()
+    snapshots = [
+        _fetch_source_snapshot(
+            client=client,
+            base_url=base_url,
+            source=entry,
+            tickers=normalized_tickers,
+            days=lookback_days,
+            adanos_api_key=adanos_api_key,
+            timeout_seconds=timeout_seconds,
+        )
+        for entry in sources
+    ]
+    has_rows = any(snapshot["success"] and snapshot["stocks"] for snapshot in snapshots)
+
+    response_data = {
+        "enabled": True,
+        "provider": "adanos",
+        "tickers": normalized_tickers,
+        "source": source,
+        "days": lookback_days,
+        "snapshots": snapshots,
+        "summary": build_summary(snapshots),
+        "docs_url": ADANOS_DOCS_URL,
+    }
+
+    if not has_rows:
+        response_data["message"] = "No Adanos sentiment rows were returned for the requested tickers."
+
+    logger.info(
+        "[AdanosSentiment] user=%s source=%s tickers=%s has_rows=%s",
+        user_id,
+        source,
+        ",".join(normalized_tickers),
+        has_rows,
+    )
+    return True, {"status": "success", "data": response_data}, 200

--- a/services/adanos_sentiment_service.py
+++ b/services/adanos_sentiment_service.py
@@ -169,6 +169,23 @@ def _get_default_days() -> int:
     return min(max(parsed_days, 1), 30)
 
 
+def _normalize_source(source: str | None) -> str:
+    normalized_source = str(source or "all").strip().lower()
+    if normalized_source == "all":
+        return "all"
+    if normalized_source in ADANOS_SUPPORTED_SOURCES:
+        return normalized_source
+    raise ValueError(
+        f"Invalid source '{source}'. Must be one of: all, reddit, x, news, polymarket."
+    )
+
+
+def _normalize_days(days: int | None) -> int:
+    if days is None:
+        return _get_default_days()
+    return min(max(int(days), 1), 30)
+
+
 def _fetch_source_snapshot(
     client: httpx.Client,
     base_url: str,
@@ -256,9 +273,14 @@ def get_market_sentiment(
             400,
         )
 
+    try:
+        normalized_source = _normalize_source(source)
+    except ValueError as exc:
+        return False, {"status": "error", "message": str(exc)}, 400
+
     adanos_api_key = os.getenv("ADANOS_API_KEY", "").strip()
     base_url = _get_adanos_base_url()
-    lookback_days = days or _get_default_days()
+    lookback_days = _normalize_days(days)
     timeout_seconds = _get_adanos_timeout_seconds()
 
     if not adanos_api_key:
@@ -270,7 +292,7 @@ def get_market_sentiment(
                     "enabled": False,
                     "provider": "adanos",
                     "tickers": normalized_tickers,
-                    "source": source,
+                    "source": normalized_source,
                     "days": lookback_days,
                     "snapshots": [],
                     "summary": "Adanos market sentiment is disabled because ADANOS_API_KEY is not configured.",
@@ -280,7 +302,7 @@ def get_market_sentiment(
             200,
         )
 
-    sources = list(ADANOS_SUPPORTED_SOURCES) if source == "all" else [source]
+    sources = list(ADANOS_SUPPORTED_SOURCES) if normalized_source == "all" else [normalized_source]
     client = get_httpx_client()
     snapshots = [
         _fetch_source_snapshot(
@@ -300,7 +322,7 @@ def get_market_sentiment(
         "enabled": True,
         "provider": "adanos",
         "tickers": normalized_tickers,
-        "source": source,
+        "source": normalized_source,
         "days": lookback_days,
         "snapshots": snapshots,
         "summary": build_summary(snapshots),
@@ -313,7 +335,7 @@ def get_market_sentiment(
     logger.info(
         "[AdanosSentiment] user=%s source=%s tickers=%s has_rows=%s",
         user_id,
-        source,
+        normalized_source,
         ",".join(normalized_tickers),
         has_rows,
     )

--- a/test/test_adanos_sentiment_service.py
+++ b/test/test_adanos_sentiment_service.py
@@ -3,6 +3,9 @@ import sys
 from unittest.mock import Mock
 
 import httpx
+import pytest
+from flask import Blueprint, Flask
+from flask_restx import Api
 
 os.environ.setdefault("API_KEY_PEPPER", "a" * 64)
 os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
@@ -12,6 +15,24 @@ os.environ["LOG_COLORS"] = "False"
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from services import adanos_sentiment_service as sentiment_service
+
+
+@pytest.fixture()
+def market_sentiment_client():
+    from limiter import limiter
+    from restx_api.market_sentiment import api as market_sentiment_ns
+
+    app = Flask(__name__)
+    app.config["TESTING"] = True
+
+    limiter.init_app(app)
+
+    blueprint = Blueprint("test_api_v1", __name__, url_prefix="/api/v1")
+    api = Api(blueprint, doc=False)
+    api.add_namespace(market_sentiment_ns, path="/market/sentiment")
+    app.register_blueprint(blueprint)
+
+    return app.test_client()
 
 
 def test_normalize_tickers_deduplicates_and_filters_invalid_values():
@@ -109,3 +130,25 @@ def test_get_market_sentiment_fetches_and_normalizes_compare_rows(monkeypatch):
     assert response["data"]["tickers"] == ["TSLA"]
     assert response["data"]["snapshots"][0]["stocks"][0]["buzz_score"] == 71.2
     assert "reddit: TSLA (Tesla, Inc.): sentiment=0.31, buzz=71.2, mentions=140, trend=rising" in response["data"]["summary"]
+
+
+def test_market_sentiment_endpoint_rejects_non_json_requests(market_sentiment_client):
+    response = market_sentiment_client.post(
+        "/api/v1/market/sentiment/",
+        data="apikey=test",
+        headers={"Content-Type": "text/plain"},
+    )
+
+    assert response.status_code == 415
+    assert response.get_json()["message"] == "Content-Type must be application/json"
+
+
+def test_market_sentiment_endpoint_rejects_malformed_json_requests(market_sentiment_client):
+    response = market_sentiment_client.post(
+        "/api/v1/market/sentiment/",
+        data='{"apikey":',
+        headers={"Content-Type": "application/json"},
+    )
+
+    assert response.status_code == 400
+    assert response.get_json()["message"] == "Invalid or malformed JSON payload"

--- a/test/test_adanos_sentiment_service.py
+++ b/test/test_adanos_sentiment_service.py
@@ -1,0 +1,111 @@
+import os
+import sys
+from unittest.mock import Mock
+
+import httpx
+
+os.environ.setdefault("API_KEY_PEPPER", "a" * 64)
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+os.environ["LOG_FORMAT"] = "[%(asctime)s] %(levelname)s in %(module)s: %(message)s"
+os.environ["LOG_COLORS"] = "False"
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services import adanos_sentiment_service as sentiment_service
+
+
+def test_normalize_tickers_deduplicates_and_filters_invalid_values():
+    assert sentiment_service.normalize_tickers(
+        ["$tsla", "TSLA", " msft ", "bad ticker", "123", "AAPL"]
+    ) == ["TSLA", "MSFT", "AAPL"]
+
+
+def test_get_market_sentiment_returns_403_for_invalid_openalgo_apikey(monkeypatch):
+    monkeypatch.setattr(sentiment_service, "verify_api_key", lambda _: None)
+
+    success, response, status_code = sentiment_service.get_market_sentiment(
+        api_key="bad-key",
+        tickers=["TSLA"],
+    )
+
+    assert success is False
+    assert status_code == 403
+    assert response["message"] == "Invalid openalgo apikey"
+
+
+def test_get_market_sentiment_fails_open_when_adanos_key_missing(monkeypatch):
+    monkeypatch.setattr(sentiment_service, "verify_api_key", lambda _: "demo-user")
+    monkeypatch.delenv("ADANOS_API_KEY", raising=False)
+
+    get_client = Mock(side_effect=AssertionError("HTTP client should not be created"))
+    monkeypatch.setattr(sentiment_service, "get_httpx_client", get_client)
+
+    success, response, status_code = sentiment_service.get_market_sentiment(
+        api_key="valid-openalgo-key",
+        tickers=["TSLA", "AAPL"],
+        source="all",
+        days=7,
+    )
+
+    assert success is True
+    assert status_code == 200
+    assert response["data"]["enabled"] is False
+    assert response["data"]["tickers"] == ["TSLA", "AAPL"]
+    assert "disabled" in response["data"]["summary"].lower()
+
+
+def test_get_market_sentiment_fetches_and_normalizes_compare_rows(monkeypatch):
+    monkeypatch.setattr(sentiment_service, "verify_api_key", lambda _: "demo-user")
+    monkeypatch.setenv("ADANOS_API_KEY", "adanos-test-key")
+    monkeypatch.setenv("ADANOS_API_BASE_URL", "https://api.adanos.org")
+    monkeypatch.setenv("ADANOS_SENTIMENT_DEFAULT_DAYS", "7")
+    monkeypatch.setenv("ADANOS_API_TIMEOUT_MS", "9000")
+
+    calls = []
+
+    class FakeClient:
+        def get(self, url, headers=None, params=None, timeout=None):
+            calls.append(
+                {
+                    "url": url,
+                    "headers": headers,
+                    "params": params,
+                    "timeout": timeout,
+                }
+            )
+            return httpx.Response(
+                200,
+                json={
+                    "stocks": [
+                        {
+                            "ticker": "TSLA",
+                            "company_name": "Tesla, Inc.",
+                            "sentiment_score": "0.31",
+                            "buzz_score": "71.2",
+                            "mentions": "140",
+                            "trend": "rising",
+                        }
+                    ]
+                },
+            )
+
+    monkeypatch.setattr(sentiment_service, "get_httpx_client", lambda: FakeClient())
+
+    success, response, status_code = sentiment_service.get_market_sentiment(
+        api_key="valid-openalgo-key",
+        tickers=["$tsla", "bad ticker"],
+        source="reddit",
+        days=5,
+    )
+
+    assert success is True
+    assert status_code == 200
+    assert len(calls) == 1
+    assert calls[0]["url"] == "https://api.adanos.org/reddit/stocks/v1/compare"
+    assert calls[0]["params"] == {"tickers": "TSLA", "days": 5}
+    assert calls[0]["headers"]["X-API-Key"] == "adanos-test-key"
+    assert calls[0]["timeout"] == 9
+    assert response["data"]["enabled"] is True
+    assert response["data"]["tickers"] == ["TSLA"]
+    assert response["data"]["snapshots"][0]["stocks"][0]["buzz_score"] == 71.2
+    assert "reddit: TSLA (Tesla, Inc.): sentiment=0.31, buzz=71.2, mentions=140, trend=rising" in response["data"]["summary"]

--- a/test/test_adanos_sentiment_service.py
+++ b/test/test_adanos_sentiment_service.py
@@ -132,6 +132,47 @@ def test_get_market_sentiment_fetches_and_normalizes_compare_rows(monkeypatch):
     assert "reddit: TSLA (Tesla, Inc.): sentiment=0.31, buzz=71.2, mentions=140, trend=rising" in response["data"]["summary"]
 
 
+def test_get_market_sentiment_rejects_invalid_source(monkeypatch):
+    monkeypatch.setattr(sentiment_service, "verify_api_key", lambda _: "demo-user")
+
+    success, response, status_code = sentiment_service.get_market_sentiment(
+        api_key="valid-openalgo-key",
+        tickers=["TSLA"],
+        source="finviz",
+    )
+
+    assert success is False
+    assert status_code == 400
+    assert "Invalid source" in response["message"]
+
+
+def test_get_market_sentiment_clamps_days_for_internal_callers(monkeypatch):
+    monkeypatch.setattr(sentiment_service, "verify_api_key", lambda _: "demo-user")
+    monkeypatch.setenv("ADANOS_API_KEY", "adanos-test-key")
+    monkeypatch.setenv("ADANOS_API_BASE_URL", "https://api.adanos.org")
+
+    calls = []
+
+    class FakeClient:
+        def get(self, url, headers=None, params=None, timeout=None):
+            calls.append(params)
+            return httpx.Response(200, json={"stocks": []})
+
+    monkeypatch.setattr(sentiment_service, "get_httpx_client", lambda: FakeClient())
+
+    success, response, status_code = sentiment_service.get_market_sentiment(
+        api_key="valid-openalgo-key",
+        tickers=["TSLA"],
+        source="reddit",
+        days=99,
+    )
+
+    assert success is True
+    assert status_code == 200
+    assert response["data"]["days"] == 30
+    assert calls[0] == {"tickers": "TSLA", "days": 30}
+
+
 def test_market_sentiment_endpoint_rejects_non_json_requests(market_sentiment_client):
     response = market_sentiment_client.post(
         "/api/v1/market/sentiment/",


### PR DESCRIPTION
## Summary
- add an optional Adanos-backed market sentiment module at `/api/v1/market/sentiment`
- keep the integration fail-open: if `ADANOS_API_KEY` is not configured, the endpoint returns `enabled=false` instead of changing OpenAlgo behavior
- document the module and add a Bruno request plus a Python example

## Why this fits OpenAlgo
OpenAlgo already supports external signals, webhook workflows, Python strategies, and custom dashboards. This patch adds a broker-independent market-context module that can be used before execution, without touching broker adapters or order-routing logic.

The endpoint is intended for research, filtering, ranking, and strategy gating. It accepts raw stock tickers like `AAPL`, `TSLA`, and `NVDA`, queries Adanos compare endpoints across Reddit, X, News, and Polymarket, and returns normalized snapshots plus a compact summary.

## Design choices
- no broker code changes
- no frontend coupling required
- OpenAlgo API key is still required to call the endpoint
- Adanos configuration is fully optional via `.env`
- returns normalized source-by-source payloads suitable for Python, middleware, ChartInk/TradingView bridges, or future UI widgets

## Validation
- `uv run pytest test/test_adanos_sentiment_service.py -q`
- `python3 -m ruff check services/adanos_sentiment_service.py restx_api/market_sentiment.py restx_api/data_schemas.py test/test_adanos_sentiment_service.py examples/python/adanos_sentiment_example.py`
- `python3 -m py_compile services/adanos_sentiment_service.py restx_api/market_sentiment.py examples/python/adanos_sentiment_example.py test/test_adanos_sentiment_service.py`
- `git diff --check`

## Notes
This is deliberately modeled as an optional external context module rather than broker market data, since Adanos is not tied to OpenAlgo broker sessions or exchange master contracts.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional Adanos-backed market sentiment POST endpoint at `/api/v1/market/sentiment` for stock tickers, with hardened input validation and robust snapshot normalization. It fails open when Adanos isn’t configured.

- **New Features**
  - New POST `/api/v1/market/sentiment` with OpenAlgo `apikey`; inputs: `tickers`, `source` (`all`|`reddit`|`x`|`news`|`polymarket`), `days` (1–30).
  - Hardened handling: dedup and normalize tickers, validate `source`, clamp `days`, and parse Adanos compare payloads; returns per-source snapshots and a compact summary.
  - Strict JSON handling (415 for non-JSON, 400 for malformed) and schema validation; rate limiting via `API_RATE_LIMIT`; no broker or UI coupling.
  - Docs under Market Data → Sentiment, README note, Bruno request, Python example, and tests for service and endpoint.

- **Migration**
  - Optional env vars: `ADANOS_API_KEY`, `ADANOS_API_BASE_URL`, `ADANOS_SENTIMENT_DEFAULT_DAYS`, `ADANOS_API_TIMEOUT_MS`.
  - To enable: set `ADANOS_API_KEY` and restart; then POST with your OpenAlgo `apikey` and `tickers`. No breaking changes.

<sup>Written for commit 19558cafef07efc142482a2e51e63df029d03c83. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

