### PR TITLE
fix(firstock): implement basket margin calculator via /V1/basketMargin and demote per-tick and per-chunk logs from info to debug

### DIFF
--- a/broker/firstock/api/data.py
+++ b/broker/firstock/api/data.py
@@ -31,7 +31,7 @@ def get_api_response(endpoint, auth, method="POST", payload=None, custom_timeout
             data["userId"] = api_key
 
         # Debug print
-        logger.info(f"Endpoint: {endpoint}")
+        logger.debug(f"Endpoint: {endpoint}")
         logger.debug(f"Payload: {json.dumps(data, indent=2)}")
 
         headers = {"Content-Type": "application/json", "Accept": "application/json"}
@@ -628,7 +628,7 @@ class BrokerData:
 
             while current_date <= end_dt:
                 date_str = current_date.strftime("%d-%m-%Y")  # Firstock uses DD-MM-YYYY format
-                logger.info(f"Processing date: {date_str}")
+                logger.debug(f"Processing date: {date_str}")
 
                 # Define trading session chunks using full day to avoid hardcoded timings
                 time_chunks = [
@@ -651,7 +651,7 @@ class BrokerData:
                             "interval": "1mi",  # 1-minute interval
                         }
 
-                        logger.info(f"Fetching chunk: {start_time} to {end_time} on {date_str}")
+                        logger.debug(f"Fetching chunk: {start_time} to {end_time} on {date_str}")
 
                         # Make request with long timeout to prevent ReadTimeout errors
                         response = get_api_response(
@@ -689,7 +689,7 @@ class BrokerData:
 
                             if chunk_data:
                                 all_data.extend(chunk_data)
-                                logger.info(f"Retrieved {len(chunk_data)} candles for chunk")
+                                logger.debug(f"Retrieved {len(chunk_data)} candles for chunk")
                         else:
                             logger.warning(
                                 f"Failed to get data for chunk: {response.get('message', 'Unknown error')}"
@@ -825,7 +825,7 @@ class BrokerData:
                 chunk_end_str = current_end.strftime("%Y-%m-%d")
                 chunk_count += 1
 
-                logger.info(
+                logger.debug(
                     f"📊 Fetching chunk {chunk_count}: {chunk_start_str} to {chunk_end_str}"
                 )
 
@@ -838,7 +838,7 @@ class BrokerData:
                     if not chunk_df.empty:
                         dfs.append(chunk_df)
                         successful_chunks += 1
-                        logger.info(f"✅ Chunk {chunk_count} successful: {len(chunk_df)} records")
+                        logger.debug(f"✅ Chunk {chunk_count} successful: {len(chunk_df)} records")
                     else:
                         logger.warning(f"⚠️ Chunk {chunk_count} returned no data")
 
@@ -1026,7 +1026,7 @@ class BrokerData:
                     # Debug logging for daily data timestamps
                     if interval == "D":
                         debug_dt = datetime.fromtimestamp(timestamp)
-                        logger.info(f"DEBUG: Daily candle timestamp: {timestamp} -> {debug_dt}")
+                        logger.debug(f"Daily candle timestamp: {timestamp} -> {debug_dt}")
 
                     # Extract OHLCV data according to new API format
                     data.append(

--- a/broker/firstock/api/margin_api.py
+++ b/broker/firstock/api/margin_api.py
@@ -1,3 +1,8 @@
+import json
+import os
+
+from broker.firstock.mapping.margin_data import parse_margin_response, transform_margin_positions
+from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -5,19 +10,82 @@ logger = get_logger(__name__)
 
 def calculate_margin_api(positions, auth):
     """
-    Calculate margin requirement for a basket of positions.
+    Calculate basket margin via Firstock's /V1/basketMargin endpoint.
 
-    Note: Firstock does not provide a position-specific margin calculator API.
-    The available Limit API (/V1/limit) only returns account-level margin information
-    (cash, collateral, span, expo, marginused), which is not suitable for calculating
-    margin requirements for specific positions.
-
-    Args:
-        positions: List of positions in OpenAlgo format
-        auth: Authentication token for Firstock
-
-    Raises:
-        NotImplementedError: Firstock does not support position-specific margin calculator API
+    Applies MPP (Market Price Protection): MARKET/SL-M are converted to
+    LMT/SL-LMT with a protected price before being sent, matching the
+    place-order flow in broker/firstock/mapping/transform_data.py.
     """
-    logger.warning("Firstock does not provide position-specific margin calculator API")
-    raise NotImplementedError("Firstock does not support position-specific margin calculator API")
+    AUTH_TOKEN = auth
+
+    api_key = os.getenv("BROKER_API_KEY")
+    if not api_key:
+        error_response = {
+            "status": "error",
+            "message": "BROKER_API_KEY not configured",
+        }
+
+        class MockResponse:
+            status_code = 500
+            status = 500
+
+        return MockResponse(), error_response
+
+    # Firstock userId = BROKER_API_KEY with the "_API" suffix stripped,
+    # matching the convention used in order_api.py and firstock_adapter.py.
+    userid = api_key.replace("_API", "")
+
+    margin_data = transform_margin_positions(positions, userid, auth_token=AUTH_TOKEN)
+
+    if "tradingSymbol" not in margin_data:
+        error_response = {
+            "status": "error",
+            "message": "No valid positions to calculate margin. Check if symbols are valid.",
+        }
+
+        class MockResponse:
+            status_code = 400
+            status = 400
+
+        return MockResponse(), error_response
+
+    # Firstock V1 expects JSON body with jKey embedded (no Authorization header)
+    margin_data["jKey"] = AUTH_TOKEN
+
+    safe_payload = {k: v for k, v in margin_data.items() if k not in ("userId", "jKey")}
+    logger.info(f"Firstock basket margin payload: {safe_payload}")
+
+    client = get_httpx_client()
+    headers = {"Content-Type": "application/json"}
+
+    try:
+        response = client.post(
+            "https://api.firstock.in/V1/basketMargin",
+            headers=headers,
+            json=margin_data,
+            timeout=30,
+        )
+
+        response.status = response.status_code
+
+        try:
+            response_data = response.json()
+        except json.JSONDecodeError:
+            logger.error(f"Failed to parse JSON response: {response.text[:500]}")
+            error_response = {"status": "error", "message": "Invalid response from broker API"}
+            return response, error_response
+
+        logger.info(f"Firstock basket margin response: {response_data}")
+
+        standardized_response = parse_margin_response(response_data)
+        return response, standardized_response
+
+    except Exception as e:
+        logger.error(f"Error calling Firstock basketMargin API: {e}")
+        error_response = {"status": "error", "message": f"Failed to calculate margin: {str(e)}"}
+
+        class MockResponse:
+            status_code = 500
+            status = 500
+
+        return MockResponse(), error_response

--- a/broker/firstock/mapping/margin_data.py
+++ b/broker/firstock/mapping/margin_data.py
@@ -1,54 +1,215 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
-# Firstock does not provide position-specific Margin Calculator API
+# Mapping Firstock basketMargin API
 
+from broker.firstock.mapping.transform_data import map_order_type, map_product_type
+from database.token_db import get_br_symbol, get_symbol_info
 from utils.logging import get_logger
+from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
 
 logger = get_logger(__name__)
 
 
-def transform_margin_position(position, user_id):
+def _apply_mpp(position, auth_token):
     """
-    Transform a single OpenAlgo margin position to broker format.
+    Convert MARKET/SL-M to LMT/SL-LMT with a protected price for basket margin.
 
-    Note: Firstock does not provide a position-specific margin calculator API.
-    The available Limit API only returns account-level margin information.
-
-    Args:
-        position: Position in OpenAlgo format
-        user_id: Firstock user ID
-
-    Raises:
-        NotImplementedError: Firstock does not support position-specific margin calculator API
+    Matches the place-order MPP behavior: for MARKET/SL-M inputs we always
+    return a converted order type (LMT or SL-LMT) even when MPP can't fetch
+    an LTP. Fallback price when MPP fails:
+      - MARKET -> position.price (user-supplied limit, may be 0)
+      - SL-M   -> position.trigger_price (at trigger, SL-LMT becomes a LIMIT
+                  at this level)
+    Ensures the basketMargin payload never carries a bare MKT/SL-MKT with
+    price=0 that would either be rejected or produce meaningless margin.
     """
-    raise NotImplementedError("Firstock does not support position-specific margin calculator API")
+    pricetype = position.get("pricetype", "MARKET")
+    action = position["action"].upper()
+    price = str(position.get("price", 0) or 0)
+    order_type = map_order_type(pricetype)
+
+    if pricetype not in ("MARKET", "SL-M"):
+        return order_type, price
+
+    original_type = pricetype
+    converted_order_type = "LMT" if original_type == "MARKET" else "SL-LMT"
+    fallback_price = (
+        str(position.get("price", 0) or 0)
+        if original_type == "MARKET"
+        else str(position.get("trigger_price", 0) or 0)
+    )
+
+    logger.info(
+        f"Margin MPP: {original_type} detected Symbol={position['symbol']}, "
+        f"Exchange={position['exchange']}, Action={action}"
+    )
+    try:
+        if not auth_token:
+            logger.warning(
+                f"Margin MPP: no auth token for Symbol={position['symbol']}; "
+                f"converting {original_type}->{converted_order_type} at supplied price={fallback_price}"
+            )
+            return converted_order_type, fallback_price
+
+        from broker.firstock.api.data import BrokerData
+
+        broker_data = BrokerData(auth_token)
+        quote = broker_data.get_quotes(position["symbol"], position["exchange"])
+        ltp = float(quote.get("ltp", 0))
+
+        # Firstock's /getQuote response omits tick_size — fall back to the
+        # master contract DB (same pattern as kotak / place-order MPP).
+        tick_size = quote.get("tick_size")
+        if not tick_size:
+            symbol_info = get_symbol_info(position["symbol"], position["exchange"])
+            if symbol_info and symbol_info.tick_size:
+                tick_size = symbol_info.tick_size
+
+        instrument_type = get_instrument_type_from_symbol(position["symbol"])
+
+        logger.info(
+            f"Margin MPP Quote: Symbol={position['symbol']}, LTP={ltp}, "
+            f"TickSize={tick_size}, InstrumentType={instrument_type}"
+        )
+
+        if ltp > 0:
+            protected = calculate_protected_price(
+                price=ltp,
+                action=action,
+                symbol=position["symbol"],
+                instrument_type=instrument_type,
+                tick_size=tick_size,
+            )
+            logger.info(
+                f"Margin MPP Converted: {original_type}->{converted_order_type}, "
+                f"FinalPrice={protected}"
+            )
+            return converted_order_type, str(protected)
+
+        logger.warning(
+            f"Margin MPP: LTP<=0 for Symbol={position['symbol']}; "
+            f"converting {original_type}->{converted_order_type} at supplied price={fallback_price}"
+        )
+        return converted_order_type, fallback_price
+
+    except Exception as e:
+        logger.error(
+            f"Margin MPP Error: Symbol={position['symbol']}, Error={e}. "
+            f"Converting {original_type}->{converted_order_type} at supplied price={fallback_price}"
+        )
+        return converted_order_type, fallback_price
+
+
+def _build_order(position, auth_token):
+    """Build a single Firstock basketMargin leg from an OpenAlgo position."""
+    oa_symbol = position["symbol"]
+    exchange = position["exchange"]
+    br_symbol = get_br_symbol(oa_symbol, exchange)
+    if not br_symbol:
+        logger.warning(f"Symbol not found for: {oa_symbol} on exchange: {exchange}")
+        return None
+    if "&" in br_symbol:
+        br_symbol = br_symbol.replace("&", "%26")
+
+    prctyp, prc = _apply_mpp(position, auth_token)
+
+    return {
+        "exchange": exchange,
+        "tradingSymbol": br_symbol,
+        "quantity": str(int(position["quantity"])),
+        "price": prc,
+        "triggerPrice": str(position.get("trigger_price", 0) or 0),
+        "product": map_product_type(position.get("product", "NRML")),
+        "transactionType": "B" if position["action"].upper() == "BUY" else "S",
+        "priceType": prctyp,
+    }
+
+
+def transform_margin_positions(positions, userid, auth_token=None):
+    """
+    Transform a list of OpenAlgo positions into a Firstock basketMargin payload.
+
+    Firstock layout (per /V1/basketMargin docs):
+      - First leg is flat at the top level of the request body
+      - Additional legs are nested inside BasketList_Params[]
+      - userId and jKey must be at top level (jKey is added by the caller)
+    """
+    orders = []
+    for position in positions:
+        try:
+            order = _build_order(position, auth_token)
+            if order:
+                orders.append(order)
+        except Exception as e:
+            logger.error(f"Error transforming position: {position}, Error: {e}")
+            continue
+
+    if not orders:
+        return {"userId": userid, "BasketList_Params": []}
+
+    first = orders[0]
+    rest = orders[1:]
+    return {
+        "userId": userid,
+        "exchange": first["exchange"],
+        "tradingSymbol": first["tradingSymbol"],
+        "quantity": first["quantity"],
+        "price": first["price"],
+        "triggerPrice": first["triggerPrice"],
+        "product": first["product"],
+        "transactionType": first["transactionType"],
+        "priceType": first["priceType"],
+        "BasketList_Params": rest,
+    }
 
 
 def parse_margin_response(response_data):
     """
-    Parse broker margin calculator response to OpenAlgo standard format.
+    Parse Firstock /V1/basketMargin response into OpenAlgo's standard shape.
 
-    Note: Firstock does not provide a position-specific margin calculator API.
-    The available Limit API only returns account-level margin information.
+    Firstock success shape:
+      {
+        "status": "success",
+        "data": {
+          "BasketMargin": [...],
+          "MarginOnNewOrder": 126783,
+          "PreviousMargin": 0,
+          "TradedMargin": 126783
+        }
+      }
 
-    Args:
-        response_data: Raw response from broker margin calculator API
+    Firstock failure shape:
+      {"status": "failed", "error": {"message": "..."}}
+      or {"status": "failed"}
 
-    Raises:
-        NotImplementedError: Firstock does not support position-specific margin calculator API
+    TradedMargin is the post-hedge total margin (analogous to Zerodha's
+    initial.total). Map to total_margin_required. span/exposure set to 0
+    since Firstock doesn't break them down in this response.
     """
-    raise NotImplementedError("Firstock does not support position-specific margin calculator API")
+    try:
+        if not response_data or not isinstance(response_data, dict):
+            return {"status": "error", "message": "Invalid response from broker"}
 
+        if response_data.get("status") != "success":
+            error_obj = response_data.get("error") or {}
+            error_message = (
+                (error_obj.get("message") if isinstance(error_obj, dict) else None)
+                or response_data.get("message")
+                or response_data.get("emsg")
+                or "Failed to calculate margin"
+            )
+            return {"status": "error", "message": error_message}
 
-def parse_batch_margin_response(responses):
-    """
-    Parse multiple margin responses and aggregate them.
+        data = response_data.get("data") or {}
+        margin_used = float(data.get("TradedMargin", 0) or 0)
 
-    Note: Firstock does not provide a position-specific margin calculator API.
-
-    Args:
-        responses: List of individual margin responses
-
-    Raises:
-        NotImplementedError: Firstock does not support position-specific margin calculator API
-    """
-    raise NotImplementedError("Firstock does not support position-specific margin calculator API")
+        return {
+            "status": "success",
+            "data": {
+                "total_margin_required": margin_used,
+                "span_margin": 0,
+                "exposure_margin": 0,
+            },
+        }
+    except Exception as e:
+        logger.error(f"Error parsing margin response: {e}")
+        return {"status": "error", "message": f"Failed to parse margin response: {str(e)}"}

--- a/broker/firstock/streaming/firstock_adapter.py
+++ b/broker/firstock/streaming/firstock_adapter.py
@@ -469,7 +469,9 @@ class FirstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def _on_data(self, ws, data) -> None:
         """Callback for data messages from the WebSocket"""
         try:
-            self.logger.info(f"Received data from Firstock WebSocket: {data}")
+            # Per-tick — keep at debug; the live feed would otherwise dump
+            # every tick's full payload at info, drowning the log.
+            self.logger.debug(f"Received data from Firstock WebSocket: {data}")
 
             # Handle market data
             if isinstance(data, dict) and "c_symbol" in data:
@@ -678,7 +680,11 @@ class FirstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     }
                 )
 
-                self.logger.info(
+                # Per-tick publish — keep at debug to avoid per-message
+                # spam. The ZMQ publish itself is the real event; for
+                # debugging payloads, raise log level via the logging
+                # config rather than leaving this at info permanently.
+                self.logger.debug(
                     f"Publishing {mode_str} data for {symbol}.{exchange}: {market_data}"
                 )
 

--- a/broker/firstock/streaming/firstock_websocket.py
+++ b/broker/firstock/streaming/firstock_websocket.py
@@ -487,7 +487,9 @@ class FirstockWebSocket:
 
                     # Handle V1-style market data (tick fields at top level)
                     if "c_symbol" in data:
-                        self.logger.info(
+                        # Per-tick — keep at debug; steady-state market feed
+                        # would otherwise flood the log.
+                        self.logger.debug(
                             f"Received market data for symbol: {data.get('c_symbol')} on exchange: {data.get('c_exch_seg')}"
                         )
                         if self.on_data:
@@ -539,7 +541,9 @@ class FirstockWebSocket:
                             getattr(self, "_unknown_payload_samples_logged", 0) + 1
                         )
                     else:
-                        self.logger.info(
+                        # Steady-state unknown-type log — demote to debug so
+                        # a misrouted feed can't flood the log at info.
+                        self.logger.debug(
                             f"Received other message type: {list(data.keys())}"
                         )
 
@@ -553,8 +557,8 @@ class FirstockWebSocket:
                     if self.on_message:
                         self.on_message(wsapp, message)
             else:
-                # Handle binary messages (if any)
-                self.logger.info(
+                # Handle binary messages (if any) — per-message, keep at debug
+                self.logger.debug(
                     f"Received binary message of length: {len(message) if hasattr(message, '__len__') else 'unknown'}"
                 )
                 if self.on_data:


### PR DESCRIPTION
fix(firstock): implement basket margin calculator via /V1/basketMargin and demote per-tick and per-chunk logs from info to debug

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Implements Firstock basket margin calculation via /V1/basketMargin and standardizes the output. Also demotes high-frequency market data and history fetch logs from info to debug to reduce noise.

- **New Features**
  - Posts basket payload to https://api.firstock.in/V1/basketMargin with `jKey` in JSON and `userId` derived from `BROKER_API_KEY` (suffix `_API` removed).
  - Transforms OpenAlgo positions to Firstock format: first leg at top level, rest in `BasketList_Params`.
  - Applies MPP: converts MARKET→LMT and SL-M→SL-LMT with a protected price (falls back to provided price/trigger when LTP unavailable).
  - Maps Firstock response (`TradedMargin`) to OpenAlgo fields (`total_margin_required`, `span_margin`, `exposure_margin`).
  - Handles missing `BROKER_API_KEY`, invalid symbols, non-JSON broker replies, and network errors with clear error responses.

- **Refactors**
  - Demotes per-tick WebSocket and per-publish logs to debug in streaming modules.
  - Demotes per-chunk/per-date historical fetch logs and other high-frequency messages to debug in data API; keeps warnings and lifecycle events at info.

<sup>Written for commit dcc8fa078d3208c2b04190feb6026a4f80af2df6. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

