### PR TITLE
fix(mstock): overhaul quotes to WebSocket, add BCD exchange, fix login and smart order bugs

### DIFF
--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -2617,6 +2617,8 @@ def save_strategy(strategy_id):
 def cleanup_on_exit():
     """Clean up all running processes on application exit"""
     logger.info("Cleaning up running strategies...")
+    if SCHEDULER and SCHEDULER.running:
+        SCHEDULER.shutdown(wait=False)
     with PROCESS_LOCK:
         for strategy_id in list(RUNNING_STRATEGIES.keys()):
             try:

--- a/broker/mstock/api/data.py
+++ b/broker/mstock/api/data.py
@@ -7,7 +7,7 @@ import pandas as pd
 
 from broker.mstock.api.mstockwebsocket import MstockWebSocket
 from broker.mstock.mapping.order_data import transform_holdings_data, transform_positions_data
-from database.token_db import get_br_symbol, get_oa_symbol, get_token
+from database.token_db import get_br_symbol, get_brexchange, get_oa_symbol, get_token
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
@@ -131,7 +131,8 @@ class BrokerData:
             "BSE": "BSE",
             "NFO": "NFO",
             "BFO": "BFO",
-            "CDS": "CDS",
+            "CDS": "NSE",
+            "BCD": "BSE",
             "MCX": "MCX",
             "NSE_INDEX": "NSE",
             "BSE_INDEX": "BSE",
@@ -145,6 +146,7 @@ class BrokerData:
             "NFO": "2",
             "BFO": "5",
             "CDS": "3",
+            "BCD": "4",
             "MCX": "6",
             "NSE_INDEX": "1",
             "BSE_INDEX": "4",
@@ -171,73 +173,73 @@ class BrokerData:
             "BSE": 3,
             "BFO": 4,
             "CDS": 13,
-            "MCX": 5,  # Assuming MCX
+            "BCD": 3,
+            "MCX": 5,
             "NSE_INDEX": 1,
             "BSE_INDEX": 3,
         }
 
     def get_quotes(self, symbol: str, exchange: str) -> dict:
         """
-        Get real-time quotes for given symbol using REST API
-        Args:
-            symbol: Trading symbol
-            exchange: Exchange (e.g., NSE, BSE, NFO, BFO, CDS, MCX)
-        Returns:
-            dict: Quote data with required fields
+        Get real-time quotes for given symbol using WebSocket SnapQuote (mode 3).
+        Falls back to REST OHLC if WebSocket fails.
         """
         try:
-            # Get token for the symbol
             token = get_token(symbol, exchange)
-
             if not token:
                 raise Exception(f"Token not found for symbol: {symbol}, exchange: {exchange}")
 
-            # Map exchange for API
-            quote_exchange_map = {
-                "NSE": "NSE",
-                "BSE": "BSE",
-                "NFO": "NFO",
-                "BFO": "BFO",
-                "CDS": "CDS",
-                "MCX": "MCX",
-                "NSE_INDEX": "NSE",
-                "BSE_INDEX": "BSE",
-                "MCX_INDEX": "MCX",
-            }
+            ws_exchange_type = self.ws_exchange_map.get(exchange)
+            if ws_exchange_type is None:
+                brexchange = get_brexchange(symbol, exchange)
+                ws_exchange_type = self.ws_exchange_map.get(brexchange, 1)
 
-            api_exchange = quote_exchange_map.get(exchange)
+            logger.debug(f"Fetching quotes for {symbol} via WebSocket (token: {token}, ws_type: {ws_exchange_type})")
+
+            quote = self.websocket.fetch_quote(str(token), ws_exchange_type, mode=3)
+
+            if quote:
+                best_bid = quote["bids"][0]["price"] if quote.get("bids") else 0
+                best_ask = quote["asks"][0]["price"] if quote.get("asks") else 0
+                return {
+                    "bid": float(best_bid),
+                    "ask": float(best_ask),
+                    "open": float(quote.get("open", 0)),
+                    "high": float(quote.get("high", 0)),
+                    "low": float(quote.get("low", 0)),
+                    "ltp": float(quote.get("ltp", 0)),
+                    "prev_close": float(quote.get("close", 0)),
+                    "volume": int(quote.get("volume", 0)),
+                    "oi": int(quote.get("oi", 0)),
+                }
+
+            # Fallback to REST OHLC
+            logger.warning(f"WebSocket quote failed for {symbol}, falling back to REST OHLC")
+            api_exchange = get_brexchange(symbol, exchange)
             if not api_exchange:
-                raise Exception(f"Exchange '{exchange}' not supported for quotes")
+                raise Exception(f"brexchange not found for {symbol} on {exchange}")
 
-            logger.debug(f"Fetching quotes for {symbol} (token: {token}, exchange: {api_exchange})")
-
-            # Call REST API for quote
             payload = {"mode": "OHLC", "exchangeTokens": {api_exchange: [str(token)]}}
-
             response = get_api_response("/instruments/quote", self.auth_token, "GET", payload)
 
             if not response.get("status"):
                 raise Exception(f"API error: {response.get('message', 'Unknown error')}")
 
-            # Extract quote from response
             fetched = response.get("data", {}).get("fetched", [])
-
             if not fetched:
                 raise Exception("No quote data received from API")
 
             quote_data = fetched[0]
-
-            # Return in OpenAlgo standard format
             return {
-                "bid": 0,  # Not provided in OHLC mode
-                "ask": 0,  # Not provided in OHLC mode
+                "bid": 0,
+                "ask": 0,
                 "open": float(quote_data.get("open", 0)),
                 "high": float(quote_data.get("high", 0)),
                 "low": float(quote_data.get("low", 0)),
                 "ltp": float(quote_data.get("ltp", 0)),
                 "prev_close": float(quote_data.get("close", 0)),
                 "volume": int(quote_data.get("volume", 0)) if quote_data.get("volume") else 0,
-                "oi": 0,  # Not provided in OHLC mode
+                "oi": 0,
             }
 
         except Exception as e:
@@ -298,20 +300,7 @@ class BrokerData:
         skipped_symbols = []
         symbol_map = {}  # Map token to original symbol/exchange
 
-        # Exchange mapping for quote API (uses exchange names like NSE, BSE)
-        quote_exchange_map = {
-            "NSE": "NSE",
-            "BSE": "BSE",
-            "NFO": "NFO",
-            "BFO": "BFO",
-            "CDS": "CDS",
-            "MCX": "MCX",
-            "NSE_INDEX": "NSE",
-            "BSE_INDEX": "BSE",
-            "MCX_INDEX": "MCX",
-        }
-
-        # Step 1: Prepare tokens grouped by exchange
+        # Step 1: Prepare tokens grouped by brexchange
         exchange_tokens = {}  # {"NSE": ["3045", "1594"], "BSE": ["500410"]}
 
         for item in symbols:
@@ -332,7 +321,9 @@ class BrokerData:
 
             try:
                 token = get_token(symbol, exchange)
-                api_exchange = quote_exchange_map.get(exchange)
+                # Use brexchange (mStock native exchange) for API call
+                # NFO options → brexchange=NSE, BFO options → brexchange=BSE
+                api_exchange = get_brexchange(symbol, exchange)
 
                 if not token:
                     logger.warning(
@@ -349,13 +340,13 @@ class BrokerData:
                     continue
 
                 if not api_exchange:
-                    logger.warning(f"Skipping symbol {symbol}: Exchange '{exchange}' not supported")
+                    logger.warning(f"Skipping symbol {symbol}: brexchange not found for {exchange}")
                     skipped_symbols.append(
                         {
                             "symbol": symbol,
                             "exchange": exchange,
                             "data": None,
-                            "error": f"Exchange '{exchange}' not supported",
+                            "error": f"brexchange not found for exchange '{exchange}'",
                         }
                     )
                     continue
@@ -378,59 +369,51 @@ class BrokerData:
             logger.warning("No valid symbols to fetch quotes for")
             return skipped_symbols
 
-        # Step 2: Call REST API for bulk quotes
+        # Step 2: Fetch quotes via WebSocket batch (mode 3 = SnapQuote: ltp/ohlc/oi/bid/ask)
         try:
-            payload = {"mode": "OHLC", "exchangeTokens": exchange_tokens}
+            # Build (token, ws_exchange_type) list for batch fetch
+            token_exchange_list = []
+            for token_str, info in symbol_map.items():
+                ws_exchange_type = self.ws_exchange_map.get(info["exchange"])
+                if ws_exchange_type is None:
+                    # fallback: use brexchange to derive ws type
+                    brexchange = get_brexchange(info["symbol"], info["exchange"])
+                    ws_exchange_type = self.ws_exchange_map.get(brexchange, 1)
+                token_exchange_list.append((token_str, ws_exchange_type))
 
-            logger.info(f"Fetching {len(symbol_map)} quotes via REST API")
-            response = get_api_response("/instruments/quote", self.auth_token, "GET", payload)
+            logger.info(f"Fetching {len(token_exchange_list)} quotes via WebSocket batch (mode 3)")
+            ws_results = self.websocket.fetch_quotes_batch(token_exchange_list, mode=3)
 
-            if not response.get("status"):
-                raise Exception(f"API error: {response.get('message', 'Unknown error')}")
-
-            # Step 3: Process response - fetched quotes
-            fetched = response.get("data", {}).get("fetched", [])
-
-            for quote_data in fetched:
-                token_str = str(quote_data.get("symbolToken", ""))
-                info = symbol_map.get(token_str)
-
-                if info:
+            # Step 3: Map results back to symbols
+            for token_str, info in symbol_map.items():
+                quote = ws_results.get(token_str)
+                if quote:
+                    best_bid = quote["bids"][0]["price"] if quote.get("bids") else 0
+                    best_ask = quote["asks"][0]["price"] if quote.get("asks") else 0
                     results.append(
                         {
                             "symbol": info["symbol"],
                             "exchange": info["exchange"],
                             "data": {
-                                "bid": 0,  # Not provided in OHLC mode
-                                "ask": 0,  # Not provided in OHLC mode
-                                "open": float(quote_data.get("open", 0)),
-                                "high": float(quote_data.get("high", 0)),
-                                "low": float(quote_data.get("low", 0)),
-                                "ltp": float(quote_data.get("ltp", 0)),
-                                "prev_close": float(quote_data.get("close", 0)),
-                                "volume": int(quote_data.get("volume", 0))
-                                if quote_data.get("volume")
-                                else 0,
-                                "oi": 0,  # Not provided in OHLC mode
+                                "bid": float(best_bid),
+                                "ask": float(best_ask),
+                                "open": float(quote.get("open", 0)),
+                                "high": float(quote.get("high", 0)),
+                                "low": float(quote.get("low", 0)),
+                                "ltp": float(quote.get("ltp", 0)),
+                                "prev_close": float(quote.get("close", 0)),
+                                "volume": int(quote.get("volume", 0)),
+                                "oi": int(quote.get("oi", 0)),
                             },
                         }
                     )
-                    # Remove from symbol_map to track unfetched
-                    del symbol_map[token_str]
-
-            # Add unfetched symbols as errors
-            for token_str, info in symbol_map.items():
-                results.append(
-                    {
-                        "symbol": info["symbol"],
-                        "exchange": info["exchange"],
-                        "error": "No data received",
-                    }
-                )
+                else:
+                    results.append(
+                        {"symbol": info["symbol"], "exchange": info["exchange"], "error": "No data received"}
+                    )
 
         except Exception as e:
-            logger.error(f"Error calling quote API: {str(e)}")
-            # Mark all remaining as errors
+            logger.error(f"Error in WebSocket batch quotes: {str(e)}")
             for info in symbol_map.values():
                 results.append(
                     {"symbol": info["symbol"], "exchange": info["exchange"], "error": str(e)}
@@ -837,6 +820,134 @@ class BrokerData:
         except Exception as e:
             logger.error(f"Debug - Error fetching intraday data: {str(e)}")
             raise Exception(f"Error fetching intraday data: {str(e)}")
+
+    def get_ltp_rest(self, symbol: str, exchange: str) -> float | None:
+        """
+        Fetch LTP via REST OHLC endpoint (no WebSocket connection).
+        Used as a lightweight preliminary fetch when a full WS batch follows immediately.
+        Returns the LTP float, or None on failure.
+        """
+        try:
+            token = get_token(symbol, exchange)
+            if not token:
+                return None
+            api_exchange = get_brexchange(symbol, exchange)
+            if not api_exchange:
+                return None
+            payload = {"mode": "OHLC", "exchangeTokens": {api_exchange: [str(token)]}}
+            response = get_api_response("/instruments/quote", self.auth_token, "GET", payload)
+            if not response.get("status"):
+                return None
+            fetched = response.get("data", {}).get("fetched", [])
+            if not fetched:
+                return None
+            return float(fetched[0].get("ltp", 0)) or None
+        except Exception as e:
+            logger.warning(f"REST LTP fetch failed for {symbol}: {e}")
+            return None
+
+    def get_quotes_with_batch(self, underlying_symbol: str, underlying_exchange: str, option_symbols: list) -> tuple:
+        """
+        Fetch underlying LTP and all option quotes in a single WebSocket connection.
+        Eliminates the second TCP/TLS handshake that happens when get_quotes and
+        get_multiquotes are called separately for option chain requests.
+
+        Args:
+            underlying_symbol: e.g. "NIFTY"
+            underlying_exchange: e.g. "NSE_INDEX"
+            option_symbols: list of {"symbol": ..., "exchange": ...} dicts
+
+        Returns:
+            (underlying_quote_dict, option_results_list) — same shapes as
+            get_quotes() and _process_multiquotes_batch() respectively.
+            Returns (None, []) on failure.
+        """
+        try:
+            # Resolve underlying token
+            underlying_token = get_token(underlying_symbol, underlying_exchange)
+            if not underlying_token:
+                raise Exception(f"Token not found for {underlying_symbol} on {underlying_exchange}")
+
+            underlying_ws_type = self.ws_exchange_map.get(underlying_exchange)
+            if underlying_ws_type is None:
+                brexchange = get_brexchange(underlying_symbol, underlying_exchange)
+                underlying_ws_type = self.ws_exchange_map.get(brexchange, 1)
+
+            # Resolve option tokens
+            symbol_map = {}
+            skipped = []
+            for item in option_symbols:
+                sym, exch = item.get("symbol"), item.get("exchange")
+                if not sym or not exch:
+                    skipped.append({"symbol": sym, "exchange": exch, "data": None, "error": "Missing symbol/exchange"})
+                    continue
+                tok = get_token(sym, exch)
+                if not tok:
+                    skipped.append({"symbol": sym, "exchange": exch, "data": None, "error": "Token not found"})
+                    continue
+                ws_type = self.ws_exchange_map.get(exch)
+                if ws_type is None:
+                    brexch = get_brexchange(sym, exch)
+                    ws_type = self.ws_exchange_map.get(brexch, 1)
+                symbol_map[str(tok)] = {"symbol": sym, "exchange": exch, "ws_type": ws_type}
+
+            # Build combined token list: underlying first, then options
+            token_exchange_list = [(str(underlying_token), underlying_ws_type)]
+            for tok_str, info in symbol_map.items():
+                token_exchange_list.append((tok_str, info["ws_type"]))
+
+            # Single WS fetch for everything
+            ws_results = self.websocket.fetch_quotes_batch(token_exchange_list, mode=3)
+
+            # Extract underlying quote
+            underlying_raw = ws_results.get(str(underlying_token))
+            if underlying_raw:
+                best_bid = underlying_raw["bids"][0]["price"] if underlying_raw.get("bids") else 0
+                best_ask = underlying_raw["asks"][0]["price"] if underlying_raw.get("asks") else 0
+                underlying_quote = {
+                    "bid": float(best_bid),
+                    "ask": float(best_ask),
+                    "open": float(underlying_raw.get("open", 0)),
+                    "high": float(underlying_raw.get("high", 0)),
+                    "low": float(underlying_raw.get("low", 0)),
+                    "ltp": float(underlying_raw.get("ltp", 0)),
+                    "prev_close": float(underlying_raw.get("close", 0)),
+                    "volume": int(underlying_raw.get("volume", 0)),
+                    "oi": int(underlying_raw.get("oi", 0)),
+                }
+            else:
+                underlying_quote = None
+
+            # Extract option quotes
+            option_results = list(skipped)
+            for tok_str, info in symbol_map.items():
+                quote = ws_results.get(tok_str)
+                if quote:
+                    best_bid = quote["bids"][0]["price"] if quote.get("bids") else 0
+                    best_ask = quote["asks"][0]["price"] if quote.get("asks") else 0
+                    option_results.append({
+                        "symbol": info["symbol"],
+                        "exchange": info["exchange"],
+                        "data": {
+                            "bid": float(best_bid),
+                            "ask": float(best_ask),
+                            "open": float(quote.get("open", 0)),
+                            "high": float(quote.get("high", 0)),
+                            "low": float(quote.get("low", 0)),
+                            "ltp": float(quote.get("ltp", 0)),
+                            "prev_close": float(quote.get("close", 0)),
+                            "volume": int(quote.get("volume", 0)),
+                            "oi": int(quote.get("oi", 0)),
+                        },
+                    })
+                else:
+                    option_results.append({"symbol": info["symbol"], "exchange": info["exchange"], "error": "No data received"})
+
+            return underlying_quote, option_results
+
+        except Exception as e:
+            logger.exception(f"Error in get_quotes_with_batch: {e}")
+            return None, []
 
     def get_depth(self, symbol: str, exchange: str) -> dict:
         """

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -240,6 +240,16 @@ class MstockWebSocket:
         ws.send(login_msg)
         logger.debug("Sent LOGIN message")
 
+        # Mark as logged in immediately after sending LOGIN.
+        # mStock may not send a text response to LOGIN — the one-off
+        # fetch_quote path confirms login works without waiting for a reply.
+        self._logged_in = True
+        self._login_event.set()
+        logger.info("mstock WebSocket login sent, marking as ready")
+
+        # Re-subscribe to existing subscriptions (needed after reconnection)
+        self._resubscribe_all()
+
     def _on_ws_message(self, ws, message):
         """Called for both binary and text messages"""
         if isinstance(message, bytes):
@@ -250,14 +260,6 @@ class MstockWebSocket:
                     self.data_callback(quote_data)
         elif isinstance(message, str):
             logger.debug(f"Received string message: {message}")
-            # Mark as logged in after receiving login response
-            if not self._logged_in:
-                self._logged_in = True
-                self._login_event.set()
-                logger.info("mstock login confirmed")
-
-                # Re-subscribe to existing subscriptions
-                self._resubscribe_all()
 
     def _on_ws_error(self, ws, error):
         """Called on WebSocket error"""
@@ -403,22 +405,107 @@ class MstockWebSocket:
             }
             ws.send(json.dumps(subscribe_msg))
 
-            # Wait for binary response
-            for _ in range(3):
+            # Wait for binary response — for mode 3 keep reading until we get
+            # the full 379-byte SnapQuote packet (broker may send 51-byte LTP first)
+            full_mode_size = 379 if mode == 3 else None
+            best_quote = None
+            for _ in range(6):
                 try:
                     response = ws.recv()
                     if isinstance(response, bytes):
                         if len(response) in [51, 123, 379] or len(response) >= 383:
                             quote = self.parse_binary_packet(response)
                             if quote:
-                                ws.close()
-                                return quote
+                                best_quote = quote
+                                if not full_mode_size or len(response) >= full_mode_size:
+                                    break  # got the full packet we wanted
                 except Exception:
                     break
 
             ws.close()
-            return None
+            return best_quote
 
         except Exception as e:
             logger.error(f"Error fetching quote: {e}")
             return None
+
+    def fetch_quotes_batch(self, token_exchange_list: list, mode: int = 3) -> dict:
+        """
+        Fetch quotes for multiple tokens in a single WebSocket connection.
+
+        Args:
+            token_exchange_list: List of (token, exchange_type) tuples
+            mode: 1=LTP, 2=Quote, 3=SnapQuote (default, includes oi/bid/ask)
+
+        Returns:
+            dict: Map of token_str -> parsed quote dict
+        """
+        results = {}
+        if not token_exchange_list:
+            return results
+
+        try:
+            import websocket as ws_module
+
+            ws = ws_module.create_connection(
+                self.ws_url,
+                sslopt={"cert_reqs": ssl.CERT_NONE},
+                timeout=15,
+            )
+
+            # Login
+            ws.send(f"LOGIN:{self.auth_token}")
+            try:
+                ws.recv()
+            except Exception:
+                pass
+
+            # Group tokens by exchange_type
+            exchange_groups: dict[int, list[str]] = {}
+            for token, exchange_type in token_exchange_list:
+                if exchange_type not in exchange_groups:
+                    exchange_groups[exchange_type] = []
+                exchange_groups[exchange_type].append(str(token))
+
+            token_list = [
+                {"exchangeType": et, "tokens": tokens}
+                for et, tokens in exchange_groups.items()
+            ]
+
+            subscribe_msg = {
+                "action": 1,
+                "params": {"mode": mode, "tokenList": token_list},
+            }
+            ws.send(json.dumps(subscribe_msg))
+
+            expected = len(token_exchange_list)
+            full_mode_size = 379 if mode == 3 else None
+            full_packets: set[str] = set()  # tokens for which we have a full packet
+            ws.settimeout(10)
+
+            for _ in range(expected * 3):
+                try:
+                    response = ws.recv()
+                    if isinstance(response, bytes):
+                        if len(response) in [51, 123, 379] or len(response) >= 383:
+                            quote = self.parse_binary_packet(response)
+                            if quote and quote.get("token"):
+                                token_key = quote["token"]
+                                is_full = not full_mode_size or len(response) >= full_mode_size
+                                if is_full:
+                                    results[token_key] = quote
+                                    full_packets.add(token_key)
+                                elif token_key not in results:
+                                    results[token_key] = quote  # partial fallback only
+                                if len(full_packets) >= expected:
+                                    break
+                except Exception:
+                    break
+
+            ws.close()
+            logger.info(f"Batch WS fetch: got {len(results)}/{expected} quotes ({len(full_packets)} full)")
+            return results
+
+        except Exception as e:
+            logger.error(f"Error in fetch_quotes_batch: {e}")
+            return results

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -513,19 +513,20 @@ class MstockWebSocket:
                     response = ws.recv()
                     if isinstance(response, bytes):
                         quotes = []
+                        per_packet_size = len(response)
                         if len(response) in [51, 123, 379]:
                             q = self.parse_binary_packet(response)
                             if q:
                                 quotes = [q]
                         elif len(response) >= 383:
                             num_packets = struct.unpack("<H", response[0:2])[0]
-                            packet_size = struct.unpack("<H", response[2:4])[0]
-                            quotes = self._parse_multi_packet(response, num_packets, packet_size)
+                            per_packet_size = struct.unpack("<H", response[2:4])[0]
+                            quotes = self._parse_multi_packet(response, num_packets, per_packet_size)
 
                         for quote in quotes:
                             if quote.get("token"):
                                 token_key = quote["token"]
-                                is_full = not full_mode_size or len(response) >= full_mode_size
+                                is_full = not full_mode_size or per_packet_size >= full_mode_size
                                 if is_full:
                                     results[token_key] = quote
                                     full_packets.add(token_key)

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -18,6 +18,11 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# Module-level persistent WebSocket connection cache.
+# Keyed by (api_key, auth_token) so daily token rotation auto-invalidates.
+_persistent_ws_lock = threading.Lock()
+_persistent_ws: dict = {}  # {(api_key, auth_token): websocket connection}
+
 
 class MstockWebSocket:
     """
@@ -454,9 +459,62 @@ class MstockWebSocket:
             logger.error(f"Error fetching quote: {e}")
             return None
 
+    def _get_persistent_ws(self):
+        """
+        Get or create a persistent WebSocket connection for batch fetches.
+        Reuses an existing connection if available and healthy, avoiding
+        repeated TCP/TLS handshake + LOGIN overhead.
+        """
+        import websocket as ws_module
+
+        cache_key = (self.api_key, self.auth_token)
+
+        with _persistent_ws_lock:
+            ws = _persistent_ws.get(cache_key)
+
+            if ws is not None:
+                try:
+                    ws.ping()
+                    return ws
+                except Exception:
+                    logger.debug("Persistent WS stale, reconnecting")
+                    try:
+                        ws.close()
+                    except Exception:
+                        pass
+                    _persistent_ws.pop(cache_key, None)
+
+            # Create new connection
+            ws = ws_module.create_connection(
+                self.ws_url,
+                sslopt={"cert_reqs": ssl.CERT_NONE},
+                timeout=15,
+            )
+            ws.send(f"LOGIN:{self.auth_token}")
+            try:
+                ws.recv()
+            except Exception:
+                pass
+
+            _persistent_ws[cache_key] = ws
+            logger.info("Persistent WS connection established for batch fetches")
+            return ws
+
+    def _discard_persistent_ws(self):
+        """Remove and close the cached connection for this auth token."""
+        cache_key = (self.api_key, self.auth_token)
+        with _persistent_ws_lock:
+            ws = _persistent_ws.pop(cache_key, None)
+        if ws:
+            try:
+                ws.close()
+            except Exception:
+                pass
+
     def fetch_quotes_batch(self, token_exchange_list: list, mode: int = 3) -> dict:
         """
-        Fetch quotes for multiple tokens in a single WebSocket connection.
+        Fetch quotes for multiple tokens, reusing a persistent WebSocket
+        connection to avoid TCP/TLS/LOGIN overhead on every call.
 
         Args:
             token_exchange_list: List of (token, exchange_type) tuples
@@ -469,78 +527,80 @@ class MstockWebSocket:
         if not token_exchange_list:
             return results
 
-        try:
-            import websocket as ws_module
-
-            ws = ws_module.create_connection(
-                self.ws_url,
-                sslopt={"cert_reqs": ssl.CERT_NONE},
-                timeout=15,
-            )
-
-            # Login
-            ws.send(f"LOGIN:{self.auth_token}")
+        for attempt in range(2):
             try:
-                ws.recv()
-            except Exception:
-                pass
+                ws = self._get_persistent_ws()
 
-            # Group tokens by exchange_type
-            exchange_groups: dict[int, list[str]] = {}
-            for token, exchange_type in token_exchange_list:
-                if exchange_type not in exchange_groups:
-                    exchange_groups[exchange_type] = []
-                exchange_groups[exchange_type].append(str(token))
+                # Group tokens by exchange_type
+                exchange_groups: dict[int, list[str]] = {}
+                for token, exchange_type in token_exchange_list:
+                    if exchange_type not in exchange_groups:
+                        exchange_groups[exchange_type] = []
+                    exchange_groups[exchange_type].append(str(token))
 
-            token_list = [
-                {"exchangeType": et, "tokens": tokens}
-                for et, tokens in exchange_groups.items()
-            ]
+                token_list = [
+                    {"exchangeType": et, "tokens": tokens}
+                    for et, tokens in exchange_groups.items()
+                ]
 
-            subscribe_msg = {
-                "action": 1,
-                "params": {"mode": mode, "tokenList": token_list},
-            }
-            ws.send(json.dumps(subscribe_msg))
+                subscribe_msg = {
+                    "action": 1,
+                    "params": {"mode": mode, "tokenList": token_list},
+                }
+                ws.send(json.dumps(subscribe_msg))
 
-            expected = len(token_exchange_list)
-            full_mode_size = 379 if mode == 3 else None
-            full_packets: set[str] = set()  # tokens for which we have a full packet
-            ws.settimeout(10)
+                expected = len(token_exchange_list)
+                full_mode_size = 379 if mode == 3 else None
+                full_packets: set[str] = set()
+                ws.settimeout(10)
 
-            for _ in range(expected * 3):
+                for _ in range(expected * 3):
+                    try:
+                        response = ws.recv()
+                        if isinstance(response, bytes):
+                            quotes = []
+                            per_packet_size = len(response)
+                            if len(response) in [51, 123, 379]:
+                                q = self.parse_binary_packet(response)
+                                if q:
+                                    quotes = [q]
+                            elif len(response) >= 383:
+                                num_packets = struct.unpack("<H", response[0:2])[0]
+                                per_packet_size = struct.unpack("<H", response[2:4])[0]
+                                quotes = self._parse_multi_packet(response, num_packets, per_packet_size)
+
+                            for quote in quotes:
+                                if quote.get("token"):
+                                    token_key = quote["token"]
+                                    is_full = not full_mode_size or per_packet_size >= full_mode_size
+                                    if is_full:
+                                        results[token_key] = quote
+                                        full_packets.add(token_key)
+                                    elif token_key not in results:
+                                        results[token_key] = quote
+                            if len(full_packets) >= expected:
+                                break
+                    except Exception:
+                        break
+
+                # Unsubscribe to keep the connection clean for next call
+                unsub_msg = {
+                    "action": 0,
+                    "params": {"mode": mode, "tokenList": token_list},
+                }
                 try:
-                    response = ws.recv()
-                    if isinstance(response, bytes):
-                        quotes = []
-                        per_packet_size = len(response)
-                        if len(response) in [51, 123, 379]:
-                            q = self.parse_binary_packet(response)
-                            if q:
-                                quotes = [q]
-                        elif len(response) >= 383:
-                            num_packets = struct.unpack("<H", response[0:2])[0]
-                            per_packet_size = struct.unpack("<H", response[2:4])[0]
-                            quotes = self._parse_multi_packet(response, num_packets, per_packet_size)
-
-                        for quote in quotes:
-                            if quote.get("token"):
-                                token_key = quote["token"]
-                                is_full = not full_mode_size or per_packet_size >= full_mode_size
-                                if is_full:
-                                    results[token_key] = quote
-                                    full_packets.add(token_key)
-                                elif token_key not in results:
-                                    results[token_key] = quote
-                        if len(full_packets) >= expected:
-                            break
+                    ws.send(json.dumps(unsub_msg))
                 except Exception:
-                    break
+                    pass
 
-            ws.close()
-            logger.info(f"Batch WS fetch: got {len(results)}/{expected} quotes ({len(full_packets)} full)")
-            return results
+                logger.info(f"Batch WS fetch: got {len(results)}/{expected} quotes ({len(full_packets)} full)")
+                return results
 
-        except Exception as e:
-            logger.error(f"Error in fetch_quotes_batch: {e}")
-            return results
+            except Exception as e:
+                logger.warning(f"Batch WS fetch attempt {attempt + 1} failed: {e}")
+                self._discard_persistent_ws()
+                results = {}
+                if attempt == 1:
+                    logger.error(f"Error in fetch_quotes_batch after retry: {e}")
+
+        return results

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -101,6 +101,9 @@ class MstockWebSocket:
             elif len(data) >= 383:
                 num_packets = struct.unpack("<H", data[0:2])[0]
                 packet_size = struct.unpack("<H", data[2:4])[0]
+                if num_packets > 1:
+                    quotes = MstockWebSocket._parse_multi_packet(data, num_packets, packet_size)
+                    return quotes[0] if quotes else None
                 packet = data[4:4 + 379]
             else:
                 logger.error(f"Invalid packet size: {len(data)} bytes")
@@ -162,6 +165,23 @@ class MstockWebSocket:
         except Exception as e:
             logger.error(f"Error parsing binary packet: {str(e)}")
             return None
+
+    @staticmethod
+    def _parse_multi_packet(data: bytes, num_packets: int, packet_size: int) -> list[dict]:
+        """
+        Parse a multi-packet frame and return all successfully parsed quotes.
+        """
+        results = []
+        offset = 4
+        for _ in range(num_packets):
+            if offset + packet_size > len(data):
+                break
+            chunk = data[offset:offset + packet_size]
+            quote = MstockWebSocket.parse_binary_packet(chunk)
+            if quote:
+                results.append(quote)
+            offset += packet_size
+        return results
 
     # ==================== Streaming Mode Methods ====================
 
@@ -253,11 +273,16 @@ class MstockWebSocket:
     def _on_ws_message(self, ws, message):
         """Called for both binary and text messages"""
         if isinstance(message, bytes):
-            # Parse binary packet
-            if len(message) in [51, 123, 379] or len(message) >= 383:
+            if len(message) in [51, 123, 379]:
                 quote_data = self.parse_binary_packet(message)
                 if quote_data and self.data_callback:
                     self.data_callback(quote_data)
+            elif len(message) >= 383:
+                num_packets = struct.unpack("<H", message[0:2])[0]
+                packet_size = struct.unpack("<H", message[2:4])[0]
+                for quote_data in self._parse_multi_packet(message, num_packets, packet_size):
+                    if self.data_callback:
+                        self.data_callback(quote_data)
         elif isinstance(message, str):
             logger.debug(f"Received string message: {message}")
 
@@ -487,18 +512,27 @@ class MstockWebSocket:
                 try:
                     response = ws.recv()
                     if isinstance(response, bytes):
-                        if len(response) in [51, 123, 379] or len(response) >= 383:
-                            quote = self.parse_binary_packet(response)
-                            if quote and quote.get("token"):
+                        quotes = []
+                        if len(response) in [51, 123, 379]:
+                            q = self.parse_binary_packet(response)
+                            if q:
+                                quotes = [q]
+                        elif len(response) >= 383:
+                            num_packets = struct.unpack("<H", response[0:2])[0]
+                            packet_size = struct.unpack("<H", response[2:4])[0]
+                            quotes = self._parse_multi_packet(response, num_packets, packet_size)
+
+                        for quote in quotes:
+                            if quote.get("token"):
                                 token_key = quote["token"]
                                 is_full = not full_mode_size or len(response) >= full_mode_size
                                 if is_full:
                                     results[token_key] = quote
                                     full_packets.add(token_key)
                                 elif token_key not in results:
-                                    results[token_key] = quote  # partial fallback only
-                                if len(full_packets) >= expected:
-                                    break
+                                    results[token_key] = quote
+                        if len(full_packets) >= expected:
+                            break
                 except Exception:
                     break
 

--- a/broker/mstock/api/order_api.py
+++ b/broker/mstock/api/order_api.py
@@ -285,8 +285,8 @@ def place_smartorder_api(data, auth):
         if position_size == 0 and current_position == 0 and int(data["quantity"]) != 0:
             action = data["action"]
             quantity = data["quantity"]
-            res, response, orderid = place_order_api(data, auth_token)
-            _invalidate_position_cache(AUTH_TOKEN)
+            res, response, orderid = place_order_api(data, auth)
+            _invalidate_position_cache(auth)
             return res, response, orderid
 
         elif position_size == current_position:
@@ -328,7 +328,7 @@ def place_smartorder_api(data, auth):
 
             # Place the order
             res, response, orderid = place_order_api(order_data, auth)
-            _invalidate_position_cache(AUTH_TOKEN)
+            _invalidate_position_cache(auth)
             logger.debug(f"Smart order response: {response}")
             logger.debug(f"Smart order ID: {orderid}")
 

--- a/broker/mstock/database/master_contract_db.py
+++ b/broker/mstock/database/master_contract_db.py
@@ -678,6 +678,25 @@ def process_mstock_json(json_data):
         + "PE"
     )
 
+    # -------------------------------------------------------------------
+    # Normalize instrumenttype to OpenAlgo standard: FUT, CE, PE
+    # mStock API returns legacy types (FUTIDX, OPTSTK, OPTIDX, etc.)
+    # -------------------------------------------------------------------
+    futures_mask = df["instrumenttype"].isin(
+        ["FUTIDX", "FUTSTK", "FUTCOM", "FUTCUR", "FUTIRC", "FUTIRT"]
+    )
+    df.loc[futures_mask, "instrumenttype"] = "FUT"
+
+    options_ce_mask = df["instrumenttype"].isin(
+        ["OPTIDX", "OPTSTK", "OPTFUT", "OPTCUR", "OPTIRC"]
+    ) & df["brsymbol"].str.endswith("CE", na=False)
+    df.loc[options_ce_mask, "instrumenttype"] = "CE"
+
+    options_pe_mask = df["instrumenttype"].isin(
+        ["OPTIDX", "OPTSTK", "OPTFUT", "OPTCUR", "OPTIRC"]
+    ) & df["brsymbol"].str.endswith("PE", na=False)
+    df.loc[options_pe_mask, "instrumenttype"] = "PE"
+
     # Return the processed DataFrame
     # Note: Index symbol formatting is handled in fetch_and_process_mstock_indices()
     return df

--- a/broker/mstock/mapping/order_data.py
+++ b/broker/mstock/mapping/order_data.py
@@ -90,7 +90,7 @@ def map_order_data(order_data):
                 order["producttype"] = "CNC"
             elif producttype == "INTRADAY":
                 order["producttype"] = "MIS"
-            elif exchange in ["NFO", "MCX", "BFO", "CDS"] and producttype == "CARRYFORWARD":
+            elif exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
                 order["producttype"] = "NRML"
 
             # Normalize status values for statistics
@@ -326,7 +326,7 @@ def map_trade_data(trade_data):
             trade["producttype"] = "CNC"
         elif producttype == "INTRADAY":
             trade["producttype"] = "MIS"
-        elif lookup_exchange in ["NFO", "MCX", "BFO", "CDS"] and producttype == "CARRYFORWARD":
+        elif lookup_exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
             trade["producttype"] = "NRML"
         else:
             trade["producttype"] = producttype
@@ -452,7 +452,7 @@ def map_position_data(position_data):
                 position["producttype"] = "CNC"
             elif producttype == "INTRADAY":
                 position["producttype"] = "MIS"
-            elif exchange in ["NFO", "MCX", "BFO", "CDS"] and producttype == "CARRYFORWARD":
+            elif exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
                 position["producttype"] = "NRML"
 
     return position_data

--- a/broker/mstock/mapping/order_data.py
+++ b/broker/mstock/mapping/order_data.py
@@ -90,7 +90,7 @@ def map_order_data(order_data):
                 order["producttype"] = "CNC"
             elif producttype == "INTRADAY":
                 order["producttype"] = "MIS"
-            elif exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
+            elif lookup_exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
                 order["producttype"] = "NRML"
 
             # Normalize status values for statistics
@@ -452,7 +452,7 @@ def map_position_data(position_data):
                 position["producttype"] = "CNC"
             elif producttype == "INTRADAY":
                 position["producttype"] = "MIS"
-            elif exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
+            elif lookup_exchange in ["NFO", "MCX", "BFO", "CDS", "BCD"] and producttype == "CARRYFORWARD":
                 position["producttype"] = "NRML"
 
     return position_data

--- a/broker/mstock/streaming/mstock_adapter.py
+++ b/broker/mstock/streaming/mstock_adapter.py
@@ -74,15 +74,21 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info("Connecting to mstock WebSocket in streaming mode...")
         self.running = True
 
-        # Start streaming — returns immediately (same as Angel/Upstox pattern)
+        # Start streaming — returns immediately, login happens asynchronously
         self.ws_client.connect_stream(self._on_data)
-        self.connected = True
-        self.logger.info("mstock WebSocket adapter connected")
+
+        # Wait for login to complete before marking as connected
+        if self.ws_client._login_event.wait(timeout=10):
+            self.connected = True
+            self.logger.info("mstock WebSocket adapter connected and logged in")
+        else:
+            self.connected = False
+            self.logger.warning("mstock WebSocket login timed out — subscriptions will be queued")
 
     def _on_data(self, quote_data: dict) -> None:
         """Callback function called when data is received from WebSocket"""
         try:
-            token = quote_data.get("token")
+            token = str(quote_data.get("token", ""))
             if not token:
                 self.logger.warning("Received data without token")
                 return
@@ -90,7 +96,7 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
             matching_subscriptions = []
             with self.lock:
                 for correlation_id, sub in self.subscriptions.items():
-                    if sub["token"] == token:
+                    if str(sub["token"]) == token:
                         matching_subscriptions.append(sub)
 
             if not matching_subscriptions:
@@ -153,7 +159,7 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
         token = token_info["token"]
         brexchange = token_info["brexchange"]
-        exchange_type = MstockExchangeMapper.get_exchange_type(brexchange)
+        exchange_type = MstockExchangeMapper.get_exchange_type(exchange)
         correlation_id = f"{symbol}_{exchange}_{mode}"
 
         needs_ws_subscribe = False

--- a/broker/mstock/streaming/mstock_mapping.py
+++ b/broker/mstock/streaming/mstock_mapping.py
@@ -38,7 +38,7 @@ class MstockCapabilityRegistry:
     """
 
     # mstock broker capabilities
-    exchanges = ["NSE", "BSE", "BFO", "NFO", "MCX", "CDS"]
+    exchanges = ["NSE", "BSE", "BFO", "NFO", "MCX", "CDS", "BCD"]
 
     # Available subscription modes for mstock
     # 1: LTP only
@@ -48,12 +48,13 @@ class MstockCapabilityRegistry:
 
     # Market depth support - mstock provides 5 levels for all exchanges
     depth_support = {
-        "NSE": [5],  # NSE supports 5 levels
-        "BSE": [5],  # BSE supports 5 levels
-        "BFO": [5],  # BFO supports 5 levels
-        "NFO": [5],  # NFO supports 5 levels
-        "MCX": [5],  # MCX supports 5 levels
-        "CDS": [5],  # CDS supports 5 levels
+        "NSE": [5],
+        "BSE": [5],
+        "BFO": [5],
+        "NFO": [5],
+        "MCX": [5],
+        "CDS": [5],
+        "BCD": [5],
     }
 
     @classmethod

--- a/broker/mstock/streaming/mstock_mapping.py
+++ b/broker/mstock/streaming/mstock_mapping.py
@@ -12,6 +12,7 @@ class MstockExchangeMapper:
         "BSE": 3,  # BSE Cash Market
         "BFO": 4,  # BSE F&O
         "CDS": 13,  # Currency derivatives
+        "BCD": 4,  # BSE Currency Derivatives (BSEFO)
         "MCX": 5,  # MCX (assuming)
         "NSE_INDEX": 1,  # NSE Index
         "BSE_INDEX": 3,  # BSE Index

--- a/services/option_chain_service.py
+++ b/services/option_chain_service.py
@@ -49,7 +49,7 @@ from typing import Any, Dict, List, Optional, Tuple
 
 from database.auth_db import get_auth_token_broker
 from database.symbol import SymToken, db_session
-from database.token_db_enhanced import fno_search_symbols
+from database.token_db_enhanced import fno_search_symbols, get_symbol_info
 from services.option_symbol_service import (
     construct_option_symbol,
     find_atm_strike_from_actual,
@@ -57,7 +57,7 @@ from services.option_symbol_service import (
     get_option_exchange,
     parse_underlying_symbol,
 )
-from services.quotes_service import get_multiquotes, get_quotes, import_broker_module
+from services.quotes_service import get_multiquotes, get_option_chain_quotes, get_quotes, get_underlying_ltp, import_broker_module
 from utils.constants import CRYPTO_EXCHANGES, INSTRUMENT_PERPFUT
 from utils.logging import get_logger
 
@@ -180,18 +180,9 @@ def get_option_symbols_for_chain(
             ce_symbol = construct_option_symbol(base_symbol, expiry_date, strike, "CE")
             pe_symbol = construct_option_symbol(base_symbol, expiry_date, strike, "PE")
 
-            # Query database for both CE and PE
-            ce_record = (
-                db_session.query(SymToken)
-                .filter(SymToken.symbol == ce_symbol, SymToken.exchange == exchange)
-                .first()
-            )
-
-            pe_record = (
-                db_session.query(SymToken)
-                .filter(SymToken.symbol == pe_symbol, SymToken.exchange == exchange)
-                .first()
-            )
+            # Use in-memory cache instead of DB queries
+            ce_record = get_symbol_info(ce_symbol, exchange)
+            pe_record = get_symbol_info(pe_symbol, exchange)
 
         chain_symbols.append(
             {
@@ -298,24 +289,29 @@ def get_option_chain(
                     {"status": "error", "message": f"Failed to fetch LTP for {quote_symbol}: {_e}"},
                     500,
                 )
+
+            if not success:
+                return (
+                    False,
+                    {
+                        "status": "error",
+                        "message": f"Failed to fetch LTP for {quote_symbol}: {quote_response.get('message', 'Unknown error')}",
+                    },
+                    status_code,
+                )
+
+            underlying_data = quote_response.get("data", {})
+            underlying_ltp = underlying_data.get("ltp")
+            underlying_prev_close = underlying_data.get("prev_close", 0)
         else:
-            success, quote_response, status_code = get_quotes(
-                symbol=quote_symbol, exchange=quote_exchange, api_key=api_key
-            )
+            # Non-crypto: resolve auth once, use lightweight REST LTP for ATM calc
+            _auth, _feed, _broker = get_auth_token_broker(api_key, include_feed_token=True)
+            if _auth is None:
+                return False, {"status": "error", "message": "Invalid openalgo apikey"}, 403
 
-        if not success:
-            return (
-                False,
-                {
-                    "status": "error",
-                    "message": f"Failed to fetch LTP for {quote_symbol}: {quote_response.get('message', 'Unknown error')}",
-                },
-                status_code,
-            )
+            underlying_ltp = get_underlying_ltp(_auth, _feed, _broker, quote_symbol, quote_exchange)
+            underlying_prev_close = 0  # will be populated from batch fetch below
 
-        underlying_data = quote_response.get("data", {})
-        underlying_ltp = underlying_data.get("ltp")
-        underlying_prev_close = underlying_data.get("prev_close", 0)
         if underlying_ltp is None:
             return (
                 False,
@@ -323,7 +319,7 @@ def get_option_chain(
                 500,
             )
 
-        logger.info(f"Underlying LTP: {underlying_ltp}, Prev Close: {underlying_prev_close}")
+        logger.info(f"Underlying LTP: {underlying_ltp}")
 
         # Step 4: Get options exchange and available strikes
         options_exchange = get_option_exchange(quote_exchange)
@@ -378,7 +374,7 @@ def get_option_chain(
                 404,
             )
 
-        # Step 8: Fetch quotes for all options using multiquotes
+        # Step 8: Fetch quotes for all options (+ underlying for non-crypto batch path)
         logger.info(f"Fetching quotes for {len(symbols_to_fetch)} option symbols")
         if exchange.upper() in CRYPTO_EXCHANGES:
             # Reuse _auth, _bmod, _dh already initialised in Step 3 — no second
@@ -396,9 +392,7 @@ def get_option_chain(
                         _results.append(
                             {"symbol": _item["symbol"], "exchange": _item["exchange"], "error": str(_qe)}
                         )
-                quotes_response = {"status": "success", "results": _results}
-                success = True
-                status_code = 200
+                option_results = _results
             except Exception as _e:
                 return (
                     False,
@@ -406,21 +400,24 @@ def get_option_chain(
                     500,
                 )
         else:
-            success, quotes_response, status_code = get_multiquotes(
-                symbols=symbols_to_fetch, api_key=api_key
+            # Single batch fetch: underlying + all options in one WS connection
+            underlying_quote, option_results = get_option_chain_quotes(
+                _auth, _feed, _broker,
+                quote_symbol, quote_exchange,
+                symbols_to_fetch,
             )
+            if underlying_quote:
+                underlying_prev_close = underlying_quote.get("prev_close", 0)
 
         # Build quote lookup map
         quotes_map = {}
-        if success and "results" in quotes_response:
-            for result in quotes_response["results"]:
-                symbol = result.get("symbol")
-                if symbol:
-                    # Handle both formats: direct data or nested data
-                    if "data" in result:
-                        quotes_map[symbol] = result["data"]
-                    elif "error" not in result:
-                        quotes_map[symbol] = result
+        for result in option_results:
+            symbol = result.get("symbol")
+            if symbol:
+                if "data" in result:
+                    quotes_map[symbol] = result["data"]
+                elif "error" not in result:
+                    quotes_map[symbol] = result
 
         # Step 9: Build final chain response
         chain = []

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -371,3 +371,101 @@ def get_multiquotes(
             },
             400,
         )
+
+
+def _create_data_handler(broker_module, auth_token, feed_token):
+    """Create a BrokerData instance, passing feed_token if the broker accepts it."""
+    if hasattr(broker_module.BrokerData.__init__, "__code__"):
+        param_count = broker_module.BrokerData.__init__.__code__.co_argcount
+        if param_count > 2:
+            return broker_module.BrokerData(auth_token, feed_token)
+    return broker_module.BrokerData(auth_token)
+
+
+def get_option_chain_quotes(
+    auth_token: str,
+    feed_token: str | None,
+    broker: str,
+    underlying_symbol: str,
+    underlying_exchange: str,
+    option_symbols: list[dict[str, str]],
+) -> tuple[dict | None, list[dict]]:
+    """
+    Fetch underlying quote + all option quotes, using a single batch WS
+    connection when the broker supports it.
+
+    Returns:
+        (underlying_quote_dict, option_results_list)
+        underlying_quote_dict has keys: bid, ask, open, high, low, ltp, prev_close, volume, oi
+        option_results_list items: {symbol, exchange, data: {...}} or {symbol, exchange, error: ...}
+    """
+    broker_module = import_broker_module(broker)
+    if broker_module is None:
+        logger.error(f"Broker module not found for {broker}")
+        return None, []
+
+    data_handler = _create_data_handler(broker_module, auth_token, feed_token)
+
+    # Fast path: broker supports combined batch fetch
+    if hasattr(data_handler, "get_quotes_with_batch"):
+        underlying_quote, option_results = data_handler.get_quotes_with_batch(
+            underlying_symbol, underlying_exchange, option_symbols
+        )
+        return underlying_quote, option_results
+
+    # Fallback: separate calls for brokers without batch support
+    try:
+        underlying_quote = data_handler.get_quotes(underlying_symbol, underlying_exchange)
+    except Exception as e:
+        logger.exception(f"Error fetching underlying quote: {e}")
+        underlying_quote = None
+
+    option_results = []
+    if hasattr(data_handler, "get_multiquotes"):
+        try:
+            results = data_handler.get_multiquotes(option_symbols)
+            if results:
+                option_results = results
+        except Exception as e:
+            logger.exception(f"Error fetching multiquotes: {e}")
+    else:
+        for item in option_symbols:
+            try:
+                q = data_handler.get_quotes(item["symbol"], item["exchange"])
+                option_results.append({"symbol": item["symbol"], "exchange": item["exchange"], "data": q})
+            except Exception as e:
+                option_results.append({"symbol": item["symbol"], "exchange": item["exchange"], "error": str(e)})
+
+    return underlying_quote, option_results
+
+
+def get_underlying_ltp(
+    auth_token: str,
+    feed_token: str | None,
+    broker: str,
+    symbol: str,
+    exchange: str,
+) -> float | None:
+    """
+    Lightweight LTP fetch for ATM calculation.
+    Uses REST endpoint if broker supports it, otherwise falls back to full quote.
+    """
+    broker_module = import_broker_module(broker)
+    if broker_module is None:
+        return None
+
+    data_handler = _create_data_handler(broker_module, auth_token, feed_token)
+
+    if hasattr(data_handler, "get_ltp_rest"):
+        ltp = data_handler.get_ltp_rest(symbol, exchange)
+        if ltp is not None:
+            return ltp
+
+    try:
+        quotes = data_handler.get_quotes(symbol, exchange)
+        if quotes:
+            return quotes.get("ltp")
+    except Exception as e:
+        logger.exception(f"Error fetching LTP for {symbol}: {e}")
+
+    return None

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -439,6 +439,9 @@ def get_option_chain_quotes(
     return underlying_quote, option_results
 
 
+_EQUITY_EXCHANGE_FALLBACKS = {"BSE": "NSE", "NSE": "BSE"}
+
+
 def get_underlying_ltp(
     auth_token: str,
     feed_token: str | None,
@@ -449,6 +452,8 @@ def get_underlying_ltp(
     """
     Lightweight LTP fetch for ATM calculation.
     Uses REST endpoint if broker supports it, otherwise falls back to full quote.
+    If the primary exchange fails, tries the alternate equity exchange (BSE↔NSE)
+    since some brokers only carry a stock on one exchange in their master contract.
     """
     broker_module = import_broker_module(broker)
     if broker_module is None:
@@ -456,16 +461,25 @@ def get_underlying_ltp(
 
     data_handler = _create_data_handler(broker_module, auth_token, feed_token)
 
-    if hasattr(data_handler, "get_ltp_rest"):
-        ltp = data_handler.get_ltp_rest(symbol, exchange)
-        if ltp is not None:
-            return ltp
+    exchanges_to_try = [exchange]
+    fallback = _EQUITY_EXCHANGE_FALLBACKS.get(exchange.upper())
+    if fallback:
+        exchanges_to_try.append(fallback)
 
-    try:
-        quotes = data_handler.get_quotes(symbol, exchange)
-        if quotes:
-            return quotes.get("ltp")
-    except Exception as e:
-        logger.exception(f"Error fetching LTP for {symbol}: {e}")
+    for exch in exchanges_to_try:
+        if hasattr(data_handler, "get_ltp_rest"):
+            ltp = data_handler.get_ltp_rest(symbol, exch)
+            if ltp is not None:
+                return ltp
 
+        try:
+            quotes = data_handler.get_quotes(symbol, exch)
+            if quotes:
+                ltp = quotes.get("ltp")
+                if ltp is not None:
+                    return ltp
+        except Exception as e:
+            logger.debug(f"LTP fetch failed for {symbol} on {exch}: {e}")
+
+    logger.warning(f"Could not fetch LTP for {symbol} on any exchange: {exchanges_to_try}")
     return None


### PR DESCRIPTION
## Summary

- **WebSocket-first quotes**: `get_quotes` and `get_multiquotes` now use WebSocket SnapQuote (mode 3) instead of REST OHLC, providing real-time bid/ask/oi data. REST OHLC kept as fallback.
- **Batch WebSocket fetch**: New `fetch_quotes_batch` on `MstockWebSocket` and `get_quotes_with_batch` on `BrokerData` fetch underlying + all option quotes in a single WS connection, eliminating redundant TCP/TLS handshakes for option chain requests.
- **BCD exchange support**: Added BSE Currency Derivatives across exchange maps, product type mappings (`CARRYFORWARD` → `NRML`), streaming capability registry, and depth support.
- **Exchange mapping fixes**: CDS now correctly maps to NSE (was "CDS"). Uses `get_brexchange` for NFO/BFO options routing instead of hardcoded maps. Streaming adapter uses OpenAlgo exchange for exchange type lookup.
- **Instrument type normalization**: Master contract DB normalizes mStock legacy types (`FUTIDX`, `OPTSTK`, `OPTIDX`, etc.) to OpenAlgo standard (`FUT`, `CE`, `PE`).
- **WebSocket login fix**: Marks login as ready immediately after sending LOGIN — mStock doesn't always send a text reply, which caused the previous approach to hang.
- **Smart order bug fix**: `place_smartorder_api` was passing undefined `AUTH_TOKEN` instead of the `auth` parameter for order placement and cache invalidation.
- **Token type consistency**: Streaming adapter coerces tokens to strings for reliable subscription matching.

## Test plan

- [ ] Verify mStock quotes return non-zero bid/ask/oi values for NSE, NFO, and MCX symbols
- [ ] Test option chain loading — confirm single WS connection fetches underlying + all strikes
- [ ] Place a smart order and verify it executes without `AUTH_TOKEN` NameError
- [ ] Test BCD (BSE Currency Derivatives) symbol lookup, quotes, and order placement
- [ ] Verify CDS symbols route correctly through the updated exchange mapping
- [ ] Confirm master contract download normalizes instrument types (check SymToken table for FUT/CE/PE)
- [ ] Test WebSocket streaming reconnection — adapter should re-subscribe after disconnect
- [ ] Verify REST OHLC fallback triggers when WebSocket quote fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches mStock quotes to WebSocket SnapQuote (mode 3) and speeds up option‑chain loads with a single WS batch, a persistent WS connection, and cached lookups. Adds BCD exchange and NSE/BSE LTP fallback, and fixes login, smart‑order, streaming, and shutdown issues.

- **New Features**
  - `get_quotes`/`get_multiquotes` now use WebSocket SnapQuote; REST OHLC is a fallback.
  - Single‑connection batch for option chains via `MstockWebSocket.fetch_quotes_batch` and `BrokerData.get_quotes_with_batch`; `quotes_service.get_option_chain_quotes` fetches underlying + options together; persistent WS connection reused across calls; in‑memory symbol cache (`get_symbol_info`); resolve auth once.
  - Handle multi‑packet WS frames in streaming and batch; use per‑packet size to return complete SnapQuote.
  - Lightweight LTP helpers: `get_ltp_rest` and `quotes_service.get_underlying_ltp` with NSE↔BSE fallback for ATM strike calculation.
  - Exchange/mapping: add BCD (BSE Currency Derivatives); fix CDS→NSE; route NFO/BFO/BCD via `get_brexchange`; normalize master contract instrument types to `FUT`/`CE`/`PE`.

- **Bug Fixes**
  - WebSocket login: mark ready right after sending LOGIN; adapter waits for login before marking connected; auto re‑subscribe on reconnect.
  - Smart orders: use provided `auth` for placement and cache invalidation (fixes `AUTH_TOKEN` NameError).
  - Streaming: compare tokens as strings; use OpenAlgo `exchange` for subscription `exchange_type`; add BCD to mapper/capabilities.
  - Product mapping: use `lookup_exchange` for CARRYFORWARD→NRML on orders/trades/positions.
  - Shut down `SCHEDULER` on exit to prevent APScheduler errors.

<sup>Written for commit 338744d5ef81f9bce41861a550d1e5fdc854ab6a. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

