### PR TITLE
fix(kotak): use native MPP via mp parameter instead of local MKT->LMT…

### DIFF
--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -380,7 +380,7 @@ def modify_order(data, auth_token):
     client = get_httpx_client()
 
     token_id = get_token(data["symbol"], data["exchange"])
-    newdata = transform_modify_order_data(data, token_id)
+    newdata = transform_modify_order_data(data, token_id, auth_token)
 
     logger.info(f"MODIFY ORDER - Transformed data: {newdata}")
 

--- a/broker/kotak/mapping/transform_data.py
+++ b/broker/kotak/mapping/transform_data.py
@@ -71,8 +71,14 @@ def _compute_mp(data, auth_token):
             f"MPP: trigger_price invalid for SL-M {symbol}/{exchange}, using mp={FALLBACK_MP}"
         )
         return FALLBACK_MP
-    percentage = get_mpp_percentage(trigger_price, instrument_type)
-    mp_value = _mp_from_percentage(percentage)
+    try:
+        percentage = get_mpp_percentage(trigger_price, instrument_type)
+        mp_value = _mp_from_percentage(percentage)
+    except Exception as e:
+        logger.warning(
+            f"MPP: Failed to compute mp for SL-M {symbol}/{exchange}: {e}. Using mp={FALLBACK_MP}"
+        )
+        return FALLBACK_MP
     logger.info(
         f"MPP (SL-M): Symbol={symbol}, TriggerPrice={trigger_price}, "
         f"InstrumentType={instrument_type}, SlabPct={percentage}%, mp={mp_value}"
@@ -124,14 +130,14 @@ def transform_data(data, token, auth_token=None):
     return transformed
 
 
-def transform_modify_order_data(data, token):
+def transform_modify_order_data(data, token, auth_token=None):
     symbol = get_br_symbol(data["symbol"], data["exchange"])
     # Basic mapping - ALL values must be strings for Kotak API
     transformed = {
         "tk": str(token),
         "dq": str(data.get("disclosed_quantity", "0")),
         "es": reverse_map_exchange(data["exchange"]),
-        "mp": _compute_mp(data, auth_token=None),
+        "mp": _compute_mp(data, auth_token),
         "dd": "NA",
         "vd": "DAY",
         "pc": data.get("product", "MIS"),

--- a/broker/kotak/mapping/transform_data.py
+++ b/broker/kotak/mapping/transform_data.py
@@ -1,12 +1,83 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Kotak Neo API Parameters
 
+import math
+
 from broker.kotak.api.data import BrokerData
-from database.token_db import get_br_symbol, get_symbol_info
+from database.token_db import get_br_symbol
 from utils.logging import get_logger
-from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
+from utils.mpp_slab import get_instrument_type_from_symbol, get_mpp_percentage
 
 logger = get_logger(__name__)
+
+# mp=0 means "no MPP" — correct for limit-priced orders (LIMIT/SL) where price is specified.
+NO_MPP = "0"
+# Minimum integer slab value; used only as a safe fallback for MARKET/SL-M when slab lookup fails.
+FALLBACK_MP = "1"
+
+
+def _mp_from_percentage(percentage):
+    """Kotak mp is an integer percentage; slabs < 1% floor to 1."""
+    return str(max(1, math.ceil(percentage)))
+
+
+def _compute_mp(data, auth_token):
+    """
+    Compute Kotak's mp (market protection %) from the MPP slab.
+
+    Only MARKET and SL-M orders need MPP — they execute at market price.
+    LIMIT/SL orders carry their own price, so mp is not applicable and is sent as 0.
+
+    Reference price for slab lookup:
+      - MARKET: LTP (fetched via quotes)
+      - SL-M:   trigger_price (the level at which the order converts to MARKET)
+    """
+    pricetype = data.get("pricetype")
+    symbol = data["symbol"]
+    exchange = data["exchange"]
+
+    if pricetype not in ("MARKET", "SL-M"):
+        return NO_MPP
+
+    instrument_type = get_instrument_type_from_symbol(symbol)
+
+    if pricetype == "MARKET":
+        if not auth_token:
+            return FALLBACK_MP
+        try:
+            quote_data = BrokerData(auth_token).get_quotes(symbol, exchange)
+            ltp = float(quote_data.get("ltp", 0)) if quote_data else 0.0
+            if ltp <= 0:
+                logger.warning(f"MPP: LTP invalid for {symbol}/{exchange}, using mp={FALLBACK_MP}")
+                return FALLBACK_MP
+            percentage = get_mpp_percentage(ltp, instrument_type)
+            mp_value = _mp_from_percentage(percentage)
+            logger.info(
+                f"MPP (MARKET): Symbol={symbol}, LTP={ltp}, InstrumentType={instrument_type}, "
+                f"SlabPct={percentage}%, mp={mp_value}"
+            )
+            return mp_value
+        except Exception as e:
+            logger.warning(f"MPP: Failed to compute mp for {symbol}/{exchange}: {e}. Using mp={FALLBACK_MP}")
+            return FALLBACK_MP
+
+    # SL-M
+    try:
+        trigger_price = float(data.get("trigger_price", 0))
+    except (TypeError, ValueError):
+        trigger_price = 0.0
+    if trigger_price <= 0:
+        logger.warning(
+            f"MPP: trigger_price invalid for SL-M {symbol}/{exchange}, using mp={FALLBACK_MP}"
+        )
+        return FALLBACK_MP
+    percentage = get_mpp_percentage(trigger_price, instrument_type)
+    mp_value = _mp_from_percentage(percentage)
+    logger.info(
+        f"MPP (SL-M): Symbol={symbol}, TriggerPrice={trigger_price}, "
+        f"InstrumentType={instrument_type}, SlabPct={percentage}%, mp={mp_value}"
+    )
+    return mp_value
 
 
 def transform_data(data, token, auth_token=None):
@@ -14,145 +85,21 @@ def transform_data(data, token, auth_token=None):
     Transforms the new API request structure to the current expected structure.
     ALL values must be strings for Kotak API.
 
-    For market orders, fetches quotes and adjusts price using MPP (Market Price Protection):
-    - EQ/FUT: Price < 100: 2%, 100-500: 1%, > 500: 0.5%
-    - OPT (CE/PE): Price < 10: 5%, 10-100: 3%, 100-500: 2%, > 500: 1%
+    Kotak Neo applies Market Price Protection natively when mp > 0 is passed.
+    For MARKET orders, mp is derived from the MPP slab based on LTP + instrument type.
+    MARKET/SL-M orders are forwarded as-is (no local MKT->L / SL-M->SL conversion).
 
     Args:
         data: Order data dictionary
         token: Instrument token
-        auth_token: Authentication token for fetching quotes (passed from order_api)
+        auth_token: Authentication token used to fetch LTP for mp computation
     """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
 
-    # Default values
     price = str(data.get("price", "0"))
     order_type = map_order_type(data["pricetype"])
     action = data["action"].upper()
-
-    # Apply Market Price Protection for MARKET orders
-    if data["pricetype"] == "MARKET":
-        logger.info(
-            f"MPP: MARKET order detected for Symbol={data['symbol']}, Exchange={data['exchange']}, Action={action}"
-        )
-        try:
-            if auth_token:
-                # Create BrokerData instance to fetch quotes
-                broker_data = BrokerData(auth_token)
-
-                # Fetch quotes for the symbol
-                quote_data = broker_data.get_quotes(data["symbol"], data["exchange"])
-                logger.info(
-                    f"MPP Quote Response: Symbol={data['symbol']}, Exchange={data['exchange']}, "
-                    f"LTP={quote_data.get('ltp') if quote_data else None}"
-                )
-
-                if quote_data:
-                    # Get instrument type from symbol
-                    instrument_type = get_instrument_type_from_symbol(data["symbol"])
-
-                    # Get tick_size from master contract database
-                    tick_size = None
-                    symbol_info = get_symbol_info(data["symbol"], data["exchange"])
-                    if symbol_info and symbol_info.tick_size:
-                        tick_size = symbol_info.tick_size
-                    logger.info(
-                        f"MPP Symbol Info: InstrumentType={instrument_type}, TickSize={tick_size}"
-                    )
-
-                    # Get LTP for price calculation
-                    ltp = float(quote_data.get("ltp", 0))
-
-                    if ltp > 0:
-                        # Calculate protected price using centralized MPP slab with tick size rounding
-                        protected_price = calculate_protected_price(
-                            price=ltp,
-                            action=action,
-                            symbol=data["symbol"],
-                            instrument_type=instrument_type,
-                            tick_size=tick_size,
-                        )
-                        price = str(protected_price)
-
-                        # Convert order type from MARKET to LIMIT
-                        order_type = "L"
-                        logger.info(
-                            f"MPP Conversion Complete: Symbol={data['symbol']}, OrderType=MKT->L, "
-                            f"FinalPrice={protected_price}"
-                        )
-                    else:
-                        logger.warning(
-                            f"MPP Warning: LTP is 0 or invalid for Symbol={data['symbol']}, "
-                            f"Exchange={data['exchange']}. Proceeding with regular market order"
-                        )
-                else:
-                    logger.warning(
-                        f"MPP Warning: No quote data for Symbol={data['symbol']}. "
-                        f"Proceeding with regular market order"
-                    )
-            else:
-                logger.warning(
-                    f"MPP Warning: No auth token available for Symbol={data['symbol']}. "
-                    f"Cannot fetch quotes for MPP adjustment"
-                )
-        except Exception as e:
-            logger.error(
-                f"MPP Error: Failed to apply MPP for Symbol={data['symbol']}, "
-                f"Exchange={data['exchange']}, Error={str(e)}. Proceeding with regular market order."
-            )
-
-    # Apply Market Price Protection for SL-M orders (convert SL-M to SL with protected price)
-    elif data["pricetype"] == "SL-M":
-        try:
-            trigger_price = float(data.get("trigger_price", 0))
-        except (TypeError, ValueError):
-            trigger_price = 0.0
-            logger.warning(
-                f"MPP Warning: Invalid trigger_price for SL-M Symbol={data['symbol']}. "
-                f"Proceeding with SL-M order."
-            )
-        logger.info(
-            f"MPP: SL-M order detected for Symbol={data['symbol']}, Exchange={data['exchange']}, "
-            f"Action={action}, TriggerPrice={trigger_price}"
-        )
-        if trigger_price > 0:
-            try:
-                # Get instrument type and tick_size from master contract
-                instrument_type = get_instrument_type_from_symbol(data["symbol"])
-                tick_size = None
-                symbol_info = get_symbol_info(data["symbol"], data["exchange"])
-                if symbol_info and symbol_info.tick_size:
-                    tick_size = symbol_info.tick_size
-                logger.info(
-                    f"MPP Symbol Info: InstrumentType={instrument_type}, TickSize={tick_size}"
-                )
-
-                # Calculate protected price based on trigger price
-                protected_price = calculate_protected_price(
-                    price=trigger_price,
-                    action=action,
-                    symbol=data["symbol"],
-                    instrument_type=instrument_type,
-                    tick_size=tick_size,
-                )
-                price = str(protected_price)
-
-                # Convert SL-M to SL (stop loss limit)
-                order_type = "SL"
-                logger.info(
-                    f"MPP Conversion Complete: Symbol={data['symbol']}, OrderType=SL-M->SL, "
-                    f"TriggerPrice={trigger_price}, LimitPrice={protected_price}"
-                )
-            except Exception as e:
-                logger.error(
-                    f"MPP Error: Failed to apply MPP for SL-M Symbol={data['symbol']}, "
-                    f"Exchange={data['exchange']}, Error={str(e)}. Proceeding with SL-M order."
-                )
-        else:
-            logger.warning(
-                f"MPP Warning: Trigger price is 0 for SL-M Symbol={data['symbol']}. "
-                f"Proceeding with SL-M order."
-            )
+    mp_value = _compute_mp(data, auth_token)
 
     # Basic mapping - ALL values must be strings for Kotak API
     transformed = {
@@ -160,7 +107,7 @@ def transform_data(data, token, auth_token=None):
         "dq": str(data.get("disclosed_quantity", "0")),
         "bc": "1",
         "es": reverse_map_exchange(data["exchange"]),
-        "mp": "0",
+        "mp": mp_value,
         "pc": data.get("product", "MIS"),
         "pf": "N",
         "pr": price,
@@ -184,7 +131,7 @@ def transform_modify_order_data(data, token):
         "tk": str(token),
         "dq": str(data.get("disclosed_quantity", "0")),
         "es": reverse_map_exchange(data["exchange"]),
-        "mp": "0",
+        "mp": _compute_mp(data, auth_token=None),
         "dd": "NA",
         "vd": "DAY",
         "pc": data.get("product", "MIS"),


### PR DESCRIPTION
… conversion

Kotak Neo now applies Market Price Protection natively when mp > 0 is passed, aligned with SEBI's post-April-1 no-market-order mandate. The earlier local MKT->L and SL-M->SL conversion (with quote fetch and tick-rounded protected price) is no longer needed and has been removed.

mp is now derived from the MPP slab:
 - MARKET: LTP-based lookup via BrokerData.get_quotes
 - SL-M:   trigger_price-based lookup (no quote call needed)
 - LIMIT/SL: mp=0 (price is specified; MPP is not applicable)

Slab percentages are ceil'd to Kotak's integer format (1, 2, 3, 5) with a minimum of 1. MARKET/SL-M fall back to mp=1 when slab lookup fails (no auth, bad LTP, missing trigger_price) so orders are never rejected for missing protection.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches to Kotak Neo’s native Market Price Protection by setting the `mp` parameter, removing local MARKET/SL-M to LIMIT/SL conversion. Aligns with SEBI’s no-market-order rule and keeps orders protected with safe fallbacks.

- **Refactors**
  - Compute `mp` from the MPP slab: MARKET uses LTP via `BrokerData.get_quotes`; SL-M uses `trigger_price`.
  - Remove local MKT->L and SL-M->SL conversions; send `mp=0` for LIMIT/SL and ceil slab to Kotak’s integer format with a minimum of 1.
  - Apply the same `mp` computation for modify orders.

- **Bug Fixes**
  - Pass `auth_token` into the modify flow so MARKET flips compute `mp` from the slab instead of defaulting to `1`.
  - Guard SL-M slab lookup with try/except and fallback to `mp=1` on errors.

<sup>Written for commit 2449745e982f2ecb6ac4536f3ea6f5d00ffdde48. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

