### PR TITLE
Add tooltips to icon-only buttons on OrderBook, Positions, Holdings a…

### DIFF
--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -31,6 +31,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 function formatPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
@@ -232,19 +233,36 @@ export default function Holdings() {
           <p className="text-muted-foreground">View your holdings portfolio</p>
         </div>
         <div className="flex items-center gap-2">
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchHoldings(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchHoldings(true)}
+                  disabled={isRefreshing}
+                >
+                  <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+                  Refresh
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh Holdings</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={exportToCSV}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export Holdings</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
+
         </div>
       </div>
 

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -54,6 +54,7 @@ import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Order, OrderStats } from '@/types/trading'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 // Sort configuration types
 type SortKey = 'timestamp' | 'symbol' | 'action' | 'order_status';
@@ -98,7 +99,7 @@ function formatTime(timestamp: string): string {
 
   const timeValue = parseTimestamp(timestamp)
   if (timeValue === 0) {
-     // Last resort: extract HH:MM:SS if embedded in the string
+    // Last resort: extract HH:MM:SS if embedded in the string
     const timeMatch = timestamp.match(/(\d{2}:\d{2}:\d{2})/)
     return timeMatch ? timeMatch[1] : timestamp
   }
@@ -154,8 +155,8 @@ export default function OrderBook() {
   // Filter and Sort orders
   const sortedAndFilteredOrders = useMemo(() => {
     // 1. Filter Logic
-    const filtered = statusFilter.length === 0 
-      ? orders 
+    const filtered = statusFilter.length === 0
+      ? orders
       : orders.filter((order) => statusFilter.includes(order.order_status))
 
     // 2. Sort Logic
@@ -410,62 +411,85 @@ export default function OrderBook() {
         <div className="flex items-center gap-2 flex-wrap">
           {/* Settings Button */}
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
-                size="sm"
-                className="relative"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Filters
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Order Filters</DialogTitle>
-                <DialogDescription>Filter orders by status</DialogDescription>
-              </DialogHeader>
+            <TooltipProvider>
+              <Tooltip>
+                <DialogTrigger asChild>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={hasActiveFilters ? 'default' : 'outline'}
+                      size="sm"
+                      className="relative"
+                    >
+                      <Settings2 className="h-4 w-4 mr-2" />
+                      Filters
+                      {hasActiveFilters && (
+                        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                      )}
+                    </Button>
 
-              <div className="space-y-6 py-4">
-                {/* Order Status */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Order Status
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip status="complete" label="Complete" />
-                    <FilterChip status="open" label="Open" />
-                    <FilterChip status="rejected" label="Rejected" />
-                    <FilterChip status="cancelled" label="Cancelled" />
+                  </TooltipTrigger>
+                </DialogTrigger>
+                <TooltipContent>Order Filters</TooltipContent>
+                <DialogContent className="max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>Order Filters</DialogTitle>
+                    <DialogDescription>Filter orders by status</DialogDescription>
+                  </DialogHeader>
+
+                  <div className="space-y-6 py-4">
+                    {/* Order Status */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Order Status
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        <FilterChip status="complete" label="Complete" />
+                        <FilterChip status="open" label="Open" />
+                        <FilterChip status="rejected" label="Rejected" />
+                        <FilterChip status="cancelled" label="Cancelled" />
+                      </div>
+                    </div>
                   </div>
-                </div>
-              </div>
 
-              <DialogFooter>
-                <Button variant="ghost" onClick={clearFilters}>
-                  Clear All
-                </Button>
-                <Button onClick={() => setSettingsOpen(false)}>Done</Button>
-              </DialogFooter>
-            </DialogContent>
+                  <DialogFooter>
+                    <Button variant="ghost" onClick={clearFilters}>
+                      Clear All
+                    </Button>
+                    <Button onClick={() => setSettingsOpen(false)}>Done</Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Tooltip>
+            </TooltipProvider>
           </Dialog>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchOrders(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchOrders(true)}
+                  disabled={isRefreshing}
+                >
+                  <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+                  Refresh
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh Orders</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={exportToCSV}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export Orders</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
           <AlertDialog>
             <AlertDialogTrigger asChild>
               <Button variant="destructive" size="sm" disabled={openOrders.length === 0}>
@@ -491,28 +515,30 @@ export default function OrderBook() {
       </div>
 
       {/* Active Filters Bar */}
-      {hasActiveFilters && (
-        <div className="flex flex-wrap items-center gap-3">
-          <span className="text-sm text-muted-foreground">Active Filters:</span>
-          {statusFilter.map((status) => (
-            <Badge
-              key={status}
-              variant="secondary"
-              className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+      {
+        hasActiveFilters && (
+          <div className="flex flex-wrap items-center gap-3">
+            <span className="text-sm text-muted-foreground">Active Filters:</span>
+            {statusFilter.map((status) => (
+              <Badge
+                key={status}
+                variant="secondary"
+                className="bg-pink-500/10 text-pink-600 border-pink-500/30"
+              >
+                {status}
+              </Badge>
+            ))}
+            <Button
+              variant="outline"
+              size="sm"
+              className="text-red-500 border-red-500/50 hover:bg-red-500/10"
+              onClick={clearFilters}
             >
-              {status}
-            </Badge>
-          ))}
-          <Button
-            variant="outline"
-            size="sm"
-            className="text-red-500 border-red-500/50 hover:bg-red-500/10"
-            onClick={clearFilters}
-          >
-            Clear All
-          </Button>
-        </div>
-      )}
+              Clear All
+            </Button>
+          </div>
+        )
+      }
 
       {/* Stats Cards */}
       <div className="grid gap-4 md:grid-cols-5">
@@ -581,7 +607,7 @@ export default function OrderBook() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead 
+                    <TableHead
                       className="w-[120px] cursor-pointer hover:bg-muted/50 transition-colors"
                       onClick={() => requestSort('symbol')}
                     >
@@ -593,7 +619,7 @@ export default function OrderBook() {
                       </div>
                     </TableHead>
                     <TableHead className="w-[80px]">Exchange</TableHead>
-                    <TableHead 
+                    <TableHead
                       className="w-[70px] cursor-pointer hover:bg-muted/50 transition-colors"
                       onClick={() => requestSort('action')}
                     >
@@ -610,7 +636,7 @@ export default function OrderBook() {
                     <TableHead className="w-[80px]">Type</TableHead>
                     {!isCrypto && <TableHead className="w-[70px]">Product</TableHead>}
                     <TableHead className="w-[140px]">Order ID</TableHead>
-                    <TableHead 
+                    <TableHead
                       className="w-[100px] cursor-pointer hover:bg-muted/50 transition-colors"
                       onClick={() => requestSort('order_status')}
                     >
@@ -621,7 +647,7 @@ export default function OrderBook() {
                         )}
                       </div>
                     </TableHead>
-                    <TableHead 
+                    <TableHead
                       className="w-[100px] cursor-pointer hover:bg-muted/50 transition-colors"
                       onClick={() => requestSort('timestamp')}
                     >
@@ -868,6 +894,6 @@ export default function OrderBook() {
           </DialogFooter>
         </DialogContent>
       </Dialog>
-    </div>
+    </div >
   )
 }

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -58,6 +58,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { onModeChange } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 const STORAGE_KEY = 'openalgo_positions_prefs'
 
@@ -622,130 +623,153 @@ export default function Positions() {
         <div className="flex items-center gap-2 flex-wrap">
           {/* Settings Button */}
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
-                size="sm"
-                className="relative"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Settings
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Position Settings</DialogTitle>
-                <DialogDescription>Configure grouping and filters</DialogDescription>
-              </DialogHeader>
+            <TooltipProvider>
+              <Tooltip>
+                <DialogTrigger asChild>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={hasActiveFilters ? 'default' : 'outline'}
+                      size="sm"
+                      className="relative"
+                    >
+                      <Settings2 className="h-4 w-4 mr-2" />
+                      Settings
+                      {hasActiveFilters && (
+                        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                      )}
+                    </Button>
 
-              <div className="space-y-6 py-4">
-                {/* Grouping */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Grouping
-                  </Label>
-                  <div className="space-y-2">
-                    {[
-                      { value: 'none', label: 'None' },
-                      { value: 'underlying', label: 'Underlying' },
-                      { value: 'underlying_expiry', label: 'Underlying & Expiry' },
-                    ].map((opt) => (
-                      <label
-                        key={opt.value}
-                        className={cn(
-                          'flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-muted',
-                          grouping === opt.value && 'bg-pink-500/10 border border-pink-500/30'
-                        )}
-                      >
-                        <input
-                          type="radio"
-                          name="grouping"
-                          checked={grouping === opt.value}
-                          onChange={() => {
-                            setGrouping(opt.value as GroupingType)
-                            setCollapsedGroups(new Set())
-                          }}
-                          className="accent-pink-500"
-                        />
-                        <span
-                          className={cn(grouping === opt.value && 'text-pink-500 font-semibold')}
-                        >
-                          {opt.label}
-                        </span>
-                      </label>
-                    ))}
+                  </TooltipTrigger>
+                </DialogTrigger>
+                <TooltipContent>Configure grouping and filters</TooltipContent>
+                <DialogContent className="max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>Position Settings</DialogTitle>
+                    <DialogDescription>Configure grouping and filters</DialogDescription>
+                  </DialogHeader>
+
+                  <div className="space-y-6 py-4">
+                    {/* Grouping */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Grouping
+                      </Label>
+                      <div className="space-y-2">
+                        {[
+                          { value: 'none', label: 'None' },
+                          { value: 'underlying', label: 'Underlying' },
+                          { value: 'underlying_expiry', label: 'Underlying & Expiry' },
+                        ].map((opt) => (
+                          <label
+                            key={opt.value}
+                            className={cn(
+                              'flex items-center gap-3 cursor-pointer p-2 rounded hover:bg-muted',
+                              grouping === opt.value && 'bg-pink-500/10 border border-pink-500/30'
+                            )}
+                          >
+                            <input
+                              type="radio"
+                              name="grouping"
+                              checked={grouping === opt.value}
+                              onChange={() => {
+                                setGrouping(opt.value as GroupingType)
+                                setCollapsedGroups(new Set())
+                              }}
+                              className="accent-pink-500"
+                            />
+                            <span
+                              className={cn(grouping === opt.value && 'text-pink-500 font-semibold')}
+                            >
+                              {opt.label}
+                            </span>
+                          </label>
+                        ))}
+                      </div>
+                    </div>
+
+                    <div className="border-t" />
+
+                    {/* Product Type */}
+                    {!isCrypto && (
+                      <div className="space-y-3">
+                        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                          Product Type
+                        </Label>
+                        <div className="flex flex-wrap gap-2">
+                          <FilterChip type="product" value="CNC" label="CNC" />
+                          <FilterChip type="product" value="MIS" label="MIS" />
+                          <FilterChip type="product" value="NRML" label="NRML" />
+                        </div>
+                      </div>
+                    )}
+
+                    {/* Direction */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Direction
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        <FilterChip type="direction" value="LONG" label="Long" />
+                        <FilterChip type="direction" value="SHORT" label="Short" />
+                      </div>
+                    </div>
+
+                    {/* Exchange */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Exchange
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        <FilterChip type="exchange" value="NSE" label="NSE" />
+                        <FilterChip type="exchange" value="BSE" label="BSE" />
+                        <FilterChip type="exchange" value="NFO" label="NFO" />
+                        <FilterChip type="exchange" value="BFO" label="BFO" />
+                        <FilterChip type="exchange" value="MCX" label="MCX" />
+                        <FilterChip type="exchange" value="CDS" label="CDS" />
+                      </div>
+                    </div>
                   </div>
-                </div>
 
-                <div className="border-t" />
-
-                {/* Product Type */}
-                {!isCrypto && (
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Product Type
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="product" value="CNC" label="CNC" />
-                    <FilterChip type="product" value="MIS" label="MIS" />
-                    <FilterChip type="product" value="NRML" label="NRML" />
-                  </div>
-                </div>
-                )}
-
-                {/* Direction */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Direction
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="direction" value="LONG" label="Long" />
-                    <FilterChip type="direction" value="SHORT" label="Short" />
-                  </div>
-                </div>
-
-                {/* Exchange */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Exchange
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="exchange" value="NSE" label="NSE" />
-                    <FilterChip type="exchange" value="BSE" label="BSE" />
-                    <FilterChip type="exchange" value="NFO" label="NFO" />
-                    <FilterChip type="exchange" value="BFO" label="BFO" />
-                    <FilterChip type="exchange" value="MCX" label="MCX" />
-                    <FilterChip type="exchange" value="CDS" label="CDS" />
-                  </div>
-                </div>
-              </div>
-
-              <DialogFooter>
-                <Button variant="ghost" onClick={clearFilters}>
-                  Clear All
-                </Button>
-                <Button onClick={() => setSettingsOpen(false)}>Done</Button>
-              </DialogFooter>
-            </DialogContent>
+                  <DialogFooter>
+                    <Button variant="ghost" onClick={clearFilters}>
+                      Clear All
+                    </Button>
+                    <Button onClick={() => setSettingsOpen(false)}>Done</Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Tooltip>
+            </TooltipProvider>
           </Dialog>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchPositions(true)}
+                  disabled={isRefreshing}
+                >
+                  <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+                  Refresh
+                </Button>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchPositions(true)}
-            disabled={isRefreshing}
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh Positions</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
-          <Button variant="outline" size="sm" onClick={exportToCSV}>
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={exportToCSV}>
+                  <Download className="h-4 w-4 mr-2" />
+                  Export
+                </Button>
+
+              </TooltipTrigger>
+              <TooltipContent>Export Positions</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
 
           <AlertDialog>
             <AlertDialogTrigger asChild>
@@ -952,14 +976,14 @@ export default function Positions() {
                                 </Badge>
                               </TableCell>
                               {!isCrypto && (
-                              <TableCell className="w-[80px]">
-                                <Badge
-                                  variant="outline"
-                                  className={PRODUCT_COLORS[position.product] || ''}
-                                >
-                                  {position.product}
-                                </Badge>
-                              </TableCell>
+                                <TableCell className="w-[80px]">
+                                  <Badge
+                                    variant="outline"
+                                    className={PRODUCT_COLORS[position.product] || ''}
+                                  >
+                                    {position.product}
+                                  </Badge>
+                                </TableCell>
                               )}
                               <TableCell
                                 className={cn(

--- a/frontend/src/pages/TradeBook.tsx
+++ b/frontend/src/pages/TradeBook.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, Download, Loader2, RefreshCw, Settings2, ToolCase, TrendingDown, TrendingUp } from 'lucide-react'
+import { ArrowDown, ArrowUp, Download, Loader2, RefreshCw, Settings2, TrendingDown, TrendingUp } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useOrderEventRefresh } from '@/hooks/useOrderEventRefresh'
 import { tradingApi } from '@/api/trading'

--- a/frontend/src/pages/TradeBook.tsx
+++ b/frontend/src/pages/TradeBook.tsx
@@ -1,4 +1,4 @@
-import { ArrowDown, ArrowUp, Download, Loader2, RefreshCw, Settings2, TrendingDown, TrendingUp } from 'lucide-react'
+import { ArrowDown, ArrowUp, Download, Loader2, RefreshCw, Settings2, ToolCase, TrendingDown, TrendingUp } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useState } from 'react'
 import { useOrderEventRefresh } from '@/hooks/useOrderEventRefresh'
 import { tradingApi } from '@/api/trading'
@@ -29,6 +29,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { onModeChange } from '@/stores/themeStore'
 import type { Trade } from '@/types/trading'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
 
 interface FilterState {
   action: string[]
@@ -76,7 +77,7 @@ function formatTime(timestamp: string): string {
 
   const timeValue = parseTimestamp(timestamp)
   if (timeValue === 0) {
-     // Last resort: extract HH:MM:SS if embedded in the string
+    // Last resort: extract HH:MM:SS if embedded in the string
     const timeMatch = timestamp.match(/(\d{2}:\d{2}:\d{2})/)
     return timeMatch ? timeMatch[1] : timestamp
   }
@@ -293,91 +294,114 @@ export default function TradeBook() {
         <div className="flex items-center gap-2 flex-wrap">
           {/* Settings Button */}
           <Dialog open={settingsOpen} onOpenChange={setSettingsOpen}>
-            <DialogTrigger asChild>
-              <Button
-                variant={hasActiveFilters ? 'default' : 'outline'}
-                size="sm"
-                className="relative"
-                aria-label="Open trade filters"
-              >
-                <Settings2 className="h-4 w-4 mr-2" />
-                Filters
-                {hasActiveFilters && (
-                  <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
-                )}
-              </Button>
-            </DialogTrigger>
-            <DialogContent className="max-w-md">
-              <DialogHeader>
-                <DialogTitle>Trade Filters</DialogTitle>
-                <DialogDescription>Filter trades by action, exchange, or product</DialogDescription>
-              </DialogHeader>
+            <TooltipProvider>
+              <Tooltip>
+                <DialogTrigger asChild>
+                  <TooltipTrigger asChild>
+                    <Button
+                      variant={hasActiveFilters ? 'default' : 'outline'}
+                      size="sm"
+                      className="relative"
+                      aria-label="Open trade filters"
+                    >
+                      <Settings2 className="h-4 w-4 mr-2" />
+                      Filters
+                      {hasActiveFilters && (
+                        <span className="absolute -top-1 -right-1 w-2.5 h-2.5 bg-red-500 rounded-full" />
+                      )}
+                    </Button>
+                  </TooltipTrigger>
+                </DialogTrigger>
+                <TooltipContent>Filter trades</TooltipContent>
+                <DialogContent className="max-w-md">
+                  <DialogHeader>
+                    <DialogTitle>Trade Filters</DialogTitle>
+                    <DialogDescription>Filter trades by action, exchange, or product</DialogDescription>
+                  </DialogHeader>
 
-              <div className="space-y-6 py-4">
-                {/* Action */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Action
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="action" value="BUY" label="Buy" />
-                    <FilterChip type="action" value="SELL" label="Sell" />
+                  <div className="space-y-6 py-4">
+                    {/* Action */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Action
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        <FilterChip type="action" value="BUY" label="Buy" />
+                        <FilterChip type="action" value="SELL" label="Sell" />
+                      </div>
+                    </div>
+
+                    {/* Exchange */}
+                    <div className="space-y-3">
+                      <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                        Exchange
+                      </Label>
+                      <div className="flex flex-wrap gap-2">
+                        <FilterChip type="exchange" value="NSE" label="NSE" />
+                        <FilterChip type="exchange" value="BSE" label="BSE" />
+                        <FilterChip type="exchange" value="NFO" label="NFO" />
+                        <FilterChip type="exchange" value="BFO" label="BFO" />
+                        <FilterChip type="exchange" value="MCX" label="MCX" />
+                        <FilterChip type="exchange" value="CDS" label="CDS" />
+                      </div>
+                    </div>
+
+                    {/* Product */}
+                    {!isCrypto && (
+                      <div className="space-y-3">
+                        <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+                          Product
+                        </Label>
+                        <div className="flex flex-wrap gap-2">
+                          <FilterChip type="product" value="CNC" label="CNC" />
+                          <FilterChip type="product" value="MIS" label="MIS" />
+                          <FilterChip type="product" value="NRML" label="NRML" />
+                        </div>
+                      </div>
+                    )}
                   </div>
-                </div>
 
-                {/* Exchange */}
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Exchange
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="exchange" value="NSE" label="NSE" />
-                    <FilterChip type="exchange" value="BSE" label="BSE" />
-                    <FilterChip type="exchange" value="NFO" label="NFO" />
-                    <FilterChip type="exchange" value="BFO" label="BFO" />
-                    <FilterChip type="exchange" value="MCX" label="MCX" />
-                    <FilterChip type="exchange" value="CDS" label="CDS" />
-                  </div>
-                </div>
-
-                {/* Product */}
-                {!isCrypto && (
-                <div className="space-y-3">
-                  <Label className="text-xs font-semibold uppercase tracking-wider text-muted-foreground">
-                    Product
-                  </Label>
-                  <div className="flex flex-wrap gap-2">
-                    <FilterChip type="product" value="CNC" label="CNC" />
-                    <FilterChip type="product" value="MIS" label="MIS" />
-                    <FilterChip type="product" value="NRML" label="NRML" />
-                  </div>
-                </div>
-                )}
-              </div>
-
-              <DialogFooter>
-                <Button variant="ghost" onClick={clearFilters}>
-                  Clear All
-                </Button>
-                <Button onClick={() => setSettingsOpen(false)}>Done</Button>
-              </DialogFooter>
-            </DialogContent>
+                  <DialogFooter>
+                    <Button variant="ghost" onClick={clearFilters}>
+                      Clear All
+                    </Button>
+                    <Button onClick={() => setSettingsOpen(false)}>Done</Button>
+                  </DialogFooter>
+                </DialogContent>
+              </Tooltip>
+            </TooltipProvider>
           </Dialog>
 
-          <Button
-            variant="outline"
-            size="sm"
-            onClick={() => fetchTrades(true)}
-            disabled={isRefreshing}
-            aria-label="Refresh tradebook"
-          >
-            <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
-            Refresh
-          </Button>
-          <Button variant="outline" size="sm" onClick={exportToCSV} aria-label="Export tradebook to CSV">
-            <Download className="h-4 w-4 mr-2" />
-            Export
-          </Button>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+
+                <Button
+                  variant="outline"
+                  size="sm"
+                  onClick={() => fetchTrades(true)}
+                  disabled={isRefreshing}
+                  aria-label="Refresh tradebook"
+                >
+                  <RefreshCw className={cn('h-4 w-4 mr-2', isRefreshing && 'animate-spin')} />
+                  Refresh
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Refresh trade data</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <TooltipProvider>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button variant="outline" size="sm" onClick={exportToCSV} aria-label="Export tradebook to CSV">
+                  <Download className="h-4 w-4 mr-2" />
+                  Export
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>Export tradebook to CSV</TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+
         </div>
       </div>
 
@@ -479,7 +503,7 @@ export default function TradeBook() {
               <Table>
                 <TableHeader>
                   <TableRow>
-                    <TableHead 
+                    <TableHead
                       onClick={() => requestSort('symbol')}
                       className="cursor-pointer hover:bg-muted/50 transition-colors"
                     >
@@ -492,7 +516,7 @@ export default function TradeBook() {
                     </TableHead>
                     <TableHead>Exchange</TableHead>
                     {!isCrypto && <TableHead>Product</TableHead>}
-                    <TableHead 
+                    <TableHead
                       onClick={() => requestSort('action')}
                       className="cursor-pointer hover:bg-muted/50 transition-colors"
                     >
@@ -507,7 +531,7 @@ export default function TradeBook() {
                     <TableHead className="text-right">Price</TableHead>
                     <TableHead className="text-right">Trade Value</TableHead>
                     <TableHead>Order ID</TableHead>
-                    <TableHead 
+                    <TableHead
                       onClick={() => requestSort('timestamp')}
                       className="cursor-pointer hover:bg-muted/50 transition-colors"
                     >
@@ -528,9 +552,9 @@ export default function TradeBook() {
                         <Badge variant="outline">{trade.exchange}</Badge>
                       </TableCell>
                       {!isCrypto && (
-                      <TableCell>
-                        <Badge variant="secondary">{trade.product}</Badge>
-                      </TableCell>
+                        <TableCell>
+                          <Badge variant="secondary">{trade.product}</Badge>
+                        </TableCell>
                       )}
                       <TableCell>
                         <Badge


### PR DESCRIPTION
## Description
Several pages have icon-only buttons (filter, settings, sort) that are unclear to new users. Adding tooltips would improve discoverability.
This PR  improves discoverability by adding tooltips to these buttons using the existing shadcn/ui Tooltip component.

## Affected Files
 - frontend/src/pages/OrderBook.tsx
 - frontend/src/pages/Positions.tsx 
 - frontend/src/pages/Holdings.tsx
- frontend/src/pages/TradeBook.tsx

## What i did
 - Used the existing Tooltip component from shadcn/ui
 - Wrapped icon-only buttons with tooltip provider

closes #1011 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds tooltips to key action buttons on OrderBook, Positions, Holdings, and TradeBook to improve discoverability and accessibility. Uses `@/components/ui/tooltip` and closes #1011.

- **New Features**
  - Tooltips added for Settings/Filters (where present), Refresh, and Export; settings dialog triggers are now wrapped with `TooltipProvider`, `Tooltip`, `TooltipTrigger`, and `TooltipContent`.
  - Page-specific copy and a11y improvements: e.g., “Order Filters”, “Configure grouping and filters”, “Filter trades”, “Refresh Orders/Positions/trade data”, and “Export … to CSV” (TradeBook also adds aria-labels).

<sup>Written for commit 308f4afe5124ae587d25e5178da2916c2ff17ce4. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

