### PR TITLE
fix(python_strategy): clean up stale RUNNING_STRATEGIES and surface scheduled-start failures

### DIFF
--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -101,6 +101,43 @@ IS_WINDOWS = OS_TYPE == "windows"
 IS_MAC = OS_TYPE == "darwin"
 IS_LINUX = OS_TYPE == "linux"
 
+# Aliased ``time`` module: the top-level ``from datetime import ... time``
+# import shadows the stdlib ``time`` module, so we re-import under a
+# distinct name for sleep/monotonic helpers.
+import time as time_mod  # noqa: E402  (intentional late import for clarity)
+
+
+def _wait_for_pid_exit(pid, timeout=5.0, poll_interval=0.1):
+    """Eventlet-safe wait for a PID to exit.
+
+    ``psutil.Process.wait()`` and ``psutil.wait_procs()`` ultimately call
+    ``select.poll()`` inside ``psutil._psposix.wait_pid_pidfd_open``. Under
+    gunicorn ``--worker-class eventlet`` (OpenAlgo's default), eventlet's
+    monkey-patching strips ``select.poll`` and the call raises
+    ``AttributeError: module 'select' has no attribute 'poll'`` -- which
+    breaks both manual and scheduled strategy stops.
+
+    This helper polls with ``psutil.pid_exists`` (a simple ``os.stat`` call)
+    and ``time.sleep`` (eventlet-aware), and reaps zombie children if we
+    own them. Returns True if the process has exited within the timeout.
+    """
+    deadline = time_mod.monotonic() + max(0.0, timeout)
+    while time_mod.monotonic() < deadline:
+        if not psutil.pid_exists(pid):
+            return True
+        try:
+            p = psutil.Process(pid)
+            if p.status() == psutil.STATUS_ZOMBIE:
+                try:
+                    os.waitpid(pid, os.WNOHANG)
+                except (ChildProcessError, OSError):
+                    pass
+                return True
+        except psutil.NoSuchProcess:
+            return True
+        time_mod.sleep(poll_interval)
+    return not psutil.pid_exists(pid)
+
 
 def init_scheduler():
     """Initialize the APScheduler with IST timezone"""
@@ -694,13 +731,18 @@ def stop_strategy_process(strategy_id):
                         except ProcessLookupError:
                             pass  # Process already dead
             elif hasattr(process, "terminate"):
-                # For psutil.Process objects
+                # For psutil.Process objects (typically restored after a
+                # gunicorn worker restart). We MUST NOT call process.wait()
+                # here -- under eventlet it raises AttributeError on
+                # ``select.poll``. See _wait_for_pid_exit() for context.
                 try:
                     process.terminate()
-                    process.wait(timeout=5)
-                except psutil.TimeoutExpired:
-                    process.kill()
-                    process.wait(timeout=2)
+                    if not _wait_for_pid_exit(pid, timeout=5):
+                        try:
+                            process.kill()
+                        except (psutil.NoSuchProcess, psutil.AccessDenied):
+                            pass
+                        _wait_for_pid_exit(pid, timeout=2)
                 except (psutil.NoSuchProcess, psutil.AccessDenied):
                     pass  # Process already dead or no permission
             else:
@@ -742,12 +784,19 @@ def stop_strategy_process(strategy_id):
 
 
 def terminate_process_cross_platform(pid):
-    """Terminate a process in a cross-platform way"""
+    """Terminate a process in a cross-platform way.
+
+    Avoids ``psutil.wait_procs`` / ``psutil.Process.wait`` because those
+    call ``select.poll`` under the hood, which eventlet (gunicorn worker
+    class on this deployment) monkey-patches away. Uses an eventlet-safe
+    polling loop instead.
+    """
     try:
         process = psutil.Process(pid)
 
-        # Terminate child processes first
+        # Snapshot children before terminate so we can poll them by PID
         children = process.children(recursive=True)
+        child_pids = [c.pid for c in children]
         for child in children:
             try:
                 child.terminate()
@@ -757,13 +806,21 @@ def terminate_process_cross_platform(pid):
         # Terminate main process
         process.terminate()
 
-        # Wait and kill if necessary
-        gone, alive = psutil.wait_procs([process] + children, timeout=3)
-        for p in alive:
-            try:
-                p.kill()
-            except psutil.NoSuchProcess:
-                pass
+        # Wait for everything to die, eventlet-safely
+        all_pids = [pid] + child_pids
+        deadline = time_mod.monotonic() + 3.0
+        while time_mod.monotonic() < deadline and any(
+            psutil.pid_exists(p) for p in all_pids
+        ):
+            time_mod.sleep(0.1)
+
+        # Force-kill any survivors
+        for p_pid in all_pids:
+            if psutil.pid_exists(p_pid):
+                try:
+                    psutil.Process(p_pid).kill()
+                except psutil.NoSuchProcess:
+                    pass
 
     except psutil.NoSuchProcess:
         pass  # Process already dead

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -421,7 +421,36 @@ def start_strategy_process(strategy_id):
     """Start a strategy in a new process - cross-platform implementation"""
     with PROCESS_LOCK:  # Thread-safe operation
         if strategy_id in RUNNING_STRATEGIES:
-            return False, "Strategy already running"
+            # Validate that the tracked process is actually still alive.
+            # A stale entry can survive natural exit, SIGTERM from a scheduled
+            # stop that wasn't followed by a UI Stop click, or any path that
+            # bypasses stop_strategy_process(). Without this check, the next
+            # scheduled/manual start silently fails with "already running"
+            # forever (until the worker is restarted).
+            existing = RUNNING_STRATEGIES[strategy_id]
+            existing_proc = existing.get("process")
+            is_alive = True
+            try:
+                if isinstance(existing_proc, subprocess.Popen):
+                    is_alive = existing_proc.poll() is None
+                elif hasattr(existing_proc, "is_running"):
+                    is_alive = bool(existing_proc.is_running())
+                else:
+                    pid = existing.get("pid")
+                    is_alive = bool(pid and psutil.pid_exists(pid))
+            except (psutil.NoSuchProcess, psutil.AccessDenied, OSError):
+                is_alive = False
+
+            if is_alive:
+                return False, "Strategy already running"
+
+            # Stale entry — clean it up and fall through to start a fresh process.
+            logger.warning(
+                f"Removing stale RUNNING_STRATEGIES entry for {strategy_id} "
+                f"(tracked process is no longer alive); starting fresh"
+            )
+            close_log_handle_safely(existing)
+            RUNNING_STRATEGIES.pop(strategy_id, None)
 
         config = STRATEGY_CONFIGS.get(strategy_id)
         if not config:
@@ -1072,7 +1101,26 @@ def scheduled_start_strategy(strategy_id: str):
     logger.info(
         f"Strategy {strategy_id} ({exch}) - all checks passed, starting"
     )
-    start_strategy_process(strategy_id)
+    success, message = start_strategy_process(strategy_id)
+    if not success:
+        # Surface the failure - otherwise the scheduler swallows it silently
+        # and the user sees nothing in the logs (no log file is created
+        # because start_strategy_process bailed before opening one).
+        logger.error(
+            f"Scheduled start FAILED for strategy {strategy_id} ({exch}): {message}"
+        )
+        if strategy_id in STRATEGY_CONFIGS:
+            STRATEGY_CONFIGS[strategy_id]["last_error"] = (
+                f"Scheduled start failed: {message}"
+            )
+            save_configs()
+        try:
+            broadcast_status_update(strategy_id, "error", message)
+        except Exception as broadcast_err:  # pragma: no cover - defensive
+            logger.debug(
+                f"Could not broadcast scheduled-start failure for "
+                f"{strategy_id}: {broadcast_err}"
+            )
 
 
 def scheduled_stop_strategy(strategy_id: str):

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -1102,7 +1102,7 @@ def scheduled_start_strategy(strategy_id: str):
         f"Strategy {strategy_id} ({exch}) - all checks passed, starting"
     )
     success, message = start_strategy_process(strategy_id)
-    if not success:
+    if not success and message != "Strategy already running":
         # Surface the failure - otherwise the scheduler swallows it silently
         # and the user sees nothing in the logs (no log file is created
         # because start_strategy_process bailed before opening one).

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -128,10 +128,15 @@ def _wait_for_pid_exit(pid, timeout=5.0, poll_interval=0.1):
         try:
             p = psutil.Process(pid)
             if p.status() == psutil.STATUS_ZOMBIE:
-                try:
-                    os.waitpid(pid, os.WNOHANG)
-                except (ChildProcessError, OSError):
-                    pass
+                # ``os.WNOHANG`` is Unix-only. Windows processes never enter
+                # ``STATUS_ZOMBIE`` in practice, so this branch is unreachable
+                # on Windows today, but guard explicitly to keep this
+                # cross-platform-safe if the entry condition ever widens.
+                if not IS_WINDOWS:
+                    try:
+                        os.waitpid(pid, os.WNOHANG)
+                    except (ChildProcessError, OSError):
+                        pass
                 return True
         except psutil.NoSuchProcess:
             return True


### PR DESCRIPTION
## Summary

Two related bugs cause scheduled Python strategies to silently fail to start the day after a successful run.

### Bug 1 — `start_strategy_process` does not validate stale in-memory entries

```python
if strategy_id in RUNNING_STRATEGIES:
    return False, "Strategy already running"
```

The `RUNNING_STRATEGIES` dict is only cleaned by `stop_strategy_process()`. Any code path that bypasses that — natural exit, internal squareoff, scheduled stop that did not fire, container hiccup — leaves a stale entry that blocks **every** future start until the worker is restarted.

### Bug 2 — `scheduled_start_strategy` discards the failure

```python
logger.info(f"... all checks passed, starting")
start_strategy_process(strategy_id)   # return value thrown away
```

When Bug 1 fires, there is no log line, no `last_error` on the config, no SSE broadcast. No log file is ever created (`start_strategy_process` bails before opening one), making this very hard to diagnose. From the user side it looks like the scheduler simply did not fire.

## Reproduction

1. Schedule a strategy to start at 09:00 and stop at 16:00.
2. Let the strategy self-terminate before 16:00 (e.g. internal squareoff that calls `sys.exit`) so the child process exits **without** going through `stop_strategy_process()`.
3. Next morning at 09:00 the scheduler ticks — strategy silently does not start, no new log file is created, and the strategy card still shows yesterday's stop time.

## Fix

- **`start_strategy_process`**: when a `RUNNING_STRATEGIES` entry already exists, validate liveness via `Popen.poll()` / `psutil.is_running()` / `psutil.pid_exists()` depending on the stored object type. If the process is dead, log a warning, close the log handle, drop the stale entry, and fall through to start a fresh one. If the process is alive, behaviour is unchanged.
- **`scheduled_start_strategy`**: capture `(success, message)` and on failure log an error, set `last_error` on the config, and broadcast an `error` status update via SSE so the UI reflects reality.

Both changes are surgical (50 + / 2 −) and live entirely inside the existing `PROCESS_LOCK` critical section, so concurrency semantics are unchanged.

## Testing

- Verified hot-patched on a production deployment (v2.0.0.2) that hit this exact bug today; restart was clean and the patch loads without error.
- `python -m py_compile blueprints/python_strategy.py` passes.
- Existing callers of `start_strategy_process` (`stop_strategy_process`, the manual start route at line 1653, the post-login restoration paths at 2589/2654) are unaffected — they all pass through the same gateway and now also benefit from the stale-entry cleanup.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes silent no-starts for scheduled Python strategies and prevents stop crashes under `eventlet` workers. Cleans stale `RUNNING_STRATEGIES`, surfaces scheduled-start failures, and switches to eventlet-safe stop logic.

- **Bug Fixes**
  - `start_strategy_process`: validate tracked process (poll/is_running/pid_exists); if dead, warn, close log handle, drop stale entry, then start fresh.
  - `scheduled_start_strategy`: handle `(success, message)`; on failure log an error, set and persist `last_error`, and broadcast an SSE `error`.
  - Stop logic: replace `psutil.wait`/`wait_procs` with `_wait_for_pid_exit` polling (`psutil.pid_exists` + sleep) in `stop_strategy_process` and `terminate_process_cross_platform` to avoid `select.poll` errors under `gunicorn` `eventlet`.

<sup>Written for commit a24a2c3ee767ae286977bbf1d2bba27a56038be6. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1297?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

