### PR TITLE
Super order 6822451405161363234

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,10 +75,16 @@ All brokers share a unified API interface, making it easy to switch between brok
 
 ### Unified REST API Layer (`/api/v1/`)
 A single, standardized API across all brokers with 30+ endpoints:
-- **Order Management**: Place, modify, cancel orders, basket orders, smart orders with position sizing
+- **Order Management**: Place, modify, cancel orders, basket orders, smart orders with position sizing, and **Super Orders** (multi-legged OCO orders with entry, target, trailing stop-loss).
 - **Portfolio**: Get positions, holdings, order book, trade book, funds
 - **Market Data**: Real-time quotes, historical data, market depth (Level 5), symbol search
 - **Advanced**: Option Greeks calculator, margin calculator, synthetic futures, auto-split orders
+
+### Super Order (Multi-Legged OCO)
+- **Single Submission**: Submit entry, target, and stop-loss legs in a single API call.
+- **Auto-Monitoring**: The background monitoring service tracks partial and full fills of the main leg.
+- **Trailing Stop-Loss**: Dynamically trail your stop-loss order by a configurable trailing jump as the market moves in your favor.
+- **OCO Logic**: When either the target or stop-loss condition is met, the other leg is automatically cancelled.
 
 ### Real-Time WebSocket Streaming
 - Unified WebSocket proxy server for all brokers (port 8765)

--- a/app.py
+++ b/app.py
@@ -93,6 +93,7 @@ from database.latency_db import init_latency_db as ensure_latency_tables_exists
 from database.leverage_db import init_db as ensure_leverage_tables_exists
 from database.sandbox_db import init_db as ensure_sandbox_tables_exists
 from database.settings_db import init_db as ensure_settings_tables_exists
+from database.superorder_db import init_db as ensure_superorder_tables_exists
 from database.strategy_db import init_db as ensure_strategy_tables_exists
 from database.symbol import init_db as ensure_master_contract_tables_exists
 from database.telegram_db import get_bot_config
@@ -515,6 +516,7 @@ def setup_environment(app):
                 ("Strategy DB", ensure_strategy_tables_exists),
                 ("Sandbox DB", ensure_sandbox_tables_exists),
                 ("Action Center DB", ensure_action_center_tables_exists),
+                ("Super Order DB", ensure_superorder_tables_exists),
                 ("Chart Prefs DB", ensure_chart_prefs_tables_exists),
                 ("Market Calendar DB", ensure_market_calendar_tables_exists),
                 ("Qty Freeze DB", ensure_qty_freeze_tables_exists),
@@ -562,6 +564,13 @@ def setup_environment(app):
                 logger.debug("Historify scheduler initialized")
             except Exception as e:
                 logger.error(f"Failed to initialize Historify scheduler: {e}")
+
+            try:
+                from services.superorder_monitoring_service import start_superorder_monitor
+                start_superorder_monitor()
+                logger.debug("Super Order monitor auto-started")
+            except Exception as e:
+                logger.error(f"Failed to auto-start Super Order monitor: {e}")
 
             # Auto-start analyzer mode services (depends on DB being ready)
             try:
@@ -708,6 +717,7 @@ def shutdown_database_sessions(exception=None):
         ("database.strategy_db", "db_session"),
         ("database.user_db", "db_session"),
         ("database.action_center_db", "db_session"),
+        ("database.superorder_db", "db_session"),
         ("database.qty_freeze_db", "db_session"),
         ("database.sandbox_db", "db_session"),
         ("database.analyzer_db", "db_session"),

--- a/blueprints/orders.py
+++ b/blueprints/orders.py
@@ -14,7 +14,6 @@ from services.orderbook_service import get_orderbook
 from services.place_smart_order_service import place_smart_order
 from services.positionbook_service import get_positionbook
 from services.tradebook_service import get_tradebook
-from services.superorder_service import get_superorders
 from utils.logging import get_logger
 from utils.session import check_session_validity
 
@@ -165,6 +164,7 @@ def superorderbook():
         logger.warning(f"No API key found for user {login_username}")
         return redirect(url_for("auth.logout"))
 
+    from services.superorder_service import get_superorders
     success, response, status_code = get_superorders(api_key=api_key)
 
     if not success:

--- a/blueprints/orders.py
+++ b/blueprints/orders.py
@@ -14,6 +14,7 @@ from services.orderbook_service import get_orderbook
 from services.place_smart_order_service import place_smart_order
 from services.positionbook_service import get_positionbook
 from services.tradebook_service import get_tradebook
+from services.superorder_service import get_superorders
 from utils.logging import get_logger
 from utils.session import check_session_validity
 
@@ -152,6 +153,32 @@ def generate_positions_csv(positions_data):
 
     return output.getvalue()
 
+
+@orders_bp.route("/superorderbook")
+@check_session_validity
+@limiter.limit(API_RATE_LIMIT)
+def superorderbook():
+    login_username = session["user"]
+    api_key = get_api_key_for_tradingview(login_username)
+
+    if api_key is None:
+        logger.warning(f"No API key found for user {login_username}")
+        return redirect(url_for("auth.logout"))
+
+    success, response, status_code = get_superorders(api_key=api_key)
+
+    if not success:
+        logger.error(f"Failed to get superorderbook data: {response.get('message', 'Unknown error')}")
+        return redirect(url_for("auth.logout"))
+
+    superorder_data = response.get("data", [])
+
+    # Normally we'd render a superorderbook.html. Since we don't have it, we return JSON or redirect for now
+    # We will just return the JSON. The frontend will consume it.
+    if request.is_json or request.path.endswith('/api'):
+        return jsonify(response)
+
+    return render_template("superorderbook.html", superorder_data=superorder_data)
 
 @orders_bp.route("/orderbook")
 @check_session_validity

--- a/blueprints/playground.py
+++ b/blueprints/playground.py
@@ -185,6 +185,7 @@ def categorize_endpoint(path):
             "/optionsmultiorder",
             "/basketorder",
             "/splitorder",
+            "/superorder",
             "/modifyorder",
             "/cancelorder",
             "/cancelallorder",

--- a/broker/aliceblue/api/alicebluewebsocket.py
+++ b/broker/aliceblue/api/alicebluewebsocket.py
@@ -717,27 +717,24 @@ class AliceBlueWebSocket:
             if self._stop_event.is_set():
                 return
 
-            # Grab reference to old thread while holding lock
-            old_thread = self._reconnect_thread
+            # Check if there's already a reconnection thread pending/running
+            if self._reconnect_thread and self._reconnect_thread.is_alive():
+                logger.info("Reconnection thread already active, skipping duplicate reconnect attempt.")
+                return
+
             self.reconnect_count += 1
             sleep_time = min(2**self.reconnect_count, 30)
 
-        # Join outside lock to avoid deadlock (delayed_reconnect -> connect -> self.lock)
-        if old_thread and old_thread.is_alive():
-            logger.info("Waiting for previous reconnect thread to finish")
-            old_thread.join(timeout=5)
+            logger.info(f"Attempting to reconnect in {sleep_time} seconds")
 
-        logger.info(f"Attempting to reconnect in {sleep_time} seconds")
+            def delayed_reconnect():
+                time.sleep(sleep_time)
+                if not self._stop_event.is_set():
+                    self.connect()
 
-        def delayed_reconnect():
-            time.sleep(sleep_time)
-            if not self._stop_event.is_set():
-                self.connect()
-
-        t = threading.Thread(target=delayed_reconnect, daemon=True)
-        with self.lock:
+            t = threading.Thread(target=delayed_reconnect, daemon=True)
             self._reconnect_thread = t
-        t.start()
+            t.start()
 
     def subscribe(self, instruments, is_depth=False):
         """Subscribe to market data for given instruments

--- a/broker/aliceblue/api/data.py
+++ b/broker/aliceblue/api/data.py
@@ -75,13 +75,6 @@ class BrokerData:
                 logger.error("Session ID not available. Please login first.")
                 return None
 
-            # Clean up any existing connection
-            if hasattr(self, "_websocket") and self._websocket:
-                try:
-                    self._websocket.disconnect()
-                except Exception as e:
-                    logger.warning(f"Error closing existing WebSocket: {str(e)}")
-
             # Get user ID (clientId/UCC) for WebSocket authentication
             auth_obj = Auth.query.filter_by(broker='aliceblue', is_revoked=False).first()
             user_id = auth_obj.user_id if auth_obj else None
@@ -102,10 +95,22 @@ class BrokerData:
                 logger.error("Missing user_id (clientId) for AliceBlue WebSocket. Please re-login.")
                 return None
 
-            # Create new websocket connection
-            logger.info("Creating new WebSocket connection for AliceBlue")
-            self._websocket = AliceBlueWebSocket(user_id, self.session_id)
-            self._websocket.connect()
+            if hasattr(self, "_websocket") and self._websocket:
+                if not force_new and not self._websocket.is_connected:
+                    logger.info("WebSocket disconnected. Kicking connect().")
+                    self._websocket.connect()
+                elif force_new:
+                    try:
+                        self._websocket.disconnect()
+                    except Exception as e:
+                        logger.warning(f"Error closing existing WebSocket: {str(e)}")
+                    self._websocket = AliceBlueWebSocket(user_id, self.session_id)
+                    self._websocket.connect()
+            else:
+                # Create new websocket connection
+                logger.info("Creating new WebSocket connection for AliceBlue")
+                self._websocket = AliceBlueWebSocket(user_id, self.session_id)
+                self._websocket.connect()
 
             # Wait for connection to establish
             wait_time = 0
@@ -330,16 +335,27 @@ class BrokerData:
             br_symbol = get_br_symbol(symbol, exchange) or symbol
             api_exchange = self._map_exchange(exchange)
 
-            instrument = Instrument(exchange=api_exchange, token=token, symbol=br_symbol)
-            instruments.append(instrument)
-
-            symbol_map[f"{api_exchange}:{token}"] = {
+            key = f"{api_exchange}:{token}"
+            symbol_map[key] = {
                 "symbol": symbol,
                 "exchange": exchange,
                 "token": token,
             }
 
-        if not instruments:
+            cached_quote = ws.get_quote(api_exchange, token)
+            if cached_quote:
+                results.append(
+                    {"symbol": symbol, "exchange": exchange, "data": cached_quote}
+                )
+                # Remove from mapping so we don't wait for it later
+                del symbol_map[key]
+            else:
+                instrument = Instrument(exchange=api_exchange, token=token, symbol=br_symbol)
+                instruments.append(instrument)
+
+        if not instruments and results:
+            return skipped_symbols + results
+        elif not instruments:
             logger.warning("No valid symbols to fetch quotes for")
             return skipped_symbols
 
@@ -424,13 +440,9 @@ class BrokerData:
             return skipped_symbols + results
 
         finally:
-            # Always unsubscribe to avoid dangling subscriptions
-            if subscribed and ws and instruments:
-                try:
-                    logger.info(f"Unsubscribing from {len(instruments)} symbols")
-                    ws.unsubscribe(instruments, is_depth=False)
-                except Exception as unsub_err:
-                    logger.warning(f"Failed to unsubscribe batch on cleanup: {unsub_err}")
+            # Do NOT unsubscribe here. The monitoring service requires a continuous stream of
+            # ticks to evaluate triggers over time.
+            pass
 
     def get_depth(self, symbol: str, exchange: str) -> dict:
         """

--- a/collections/openalgo/IN_stock/SuperOrder.bru
+++ b/collections/openalgo/IN_stock/SuperOrder.bru
@@ -1,0 +1,28 @@
+meta {
+  name: SuperOrder
+  type: http
+  seq: 5
+}
+
+post {
+  url: http://127.0.0.1:5000/api/v1/superorder
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+      "apikey": "your_api_key_here",
+      "strategy": "Test Strategy",
+      "exchange": "NSE",
+      "symbol": "YESBANK",
+      "action": "BUY",
+      "product": "MIS",
+      "pricetype": "LIMIT",
+      "quantity": "10",
+      "price": "21.50",
+      "target_price": "23.00",
+      "stoploss_price": "20.00",
+      "trail_jump": "0.50"
+  }
+}

--- a/collections/openalgo/crypto/SuperOrder.bru
+++ b/collections/openalgo/crypto/SuperOrder.bru
@@ -1,0 +1,28 @@
+meta {
+  name: SuperOrder
+  type: http
+  seq: 5
+}
+
+post {
+  url: http://127.0.0.1:5000/api/v1/superorder
+  body: json
+  auth: none
+}
+
+body:json {
+  {
+      "apikey": "your_api_key_here",
+      "strategy": "Test Strategy",
+      "exchange": "NSE",
+      "symbol": "YESBANK",
+      "action": "BUY",
+      "product": "MIS",
+      "pricetype": "LIMIT",
+      "quantity": "10",
+      "price": "21.50",
+      "target_price": "23.00",
+      "stoploss_price": "20.00",
+      "trail_jump": "0.50"
+  }
+}

--- a/database/superorder_db.py
+++ b/database/superorder_db.py
@@ -1,0 +1,88 @@
+import json
+import os
+from datetime import datetime
+
+from sqlalchemy import (
+    DECIMAL,
+    Column,
+    DateTime,
+    Index,
+    Integer,
+    String,
+    Text,
+    create_engine,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
+from sqlalchemy.sql import func
+
+from utils.logging import get_logger
+
+# Initialize logger
+logger = get_logger(__name__)
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+# Conditionally create engine based on DB type
+if DATABASE_URL and "sqlite" in DATABASE_URL:
+    engine = create_engine(
+        DATABASE_URL, poolclass=NullPool, connect_args={"check_same_thread": False}
+    )
+else:
+    engine = create_engine(
+        DATABASE_URL, pool_size=50, max_overflow=100, pool_timeout=10
+    )
+
+db_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=engine)
+)
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+class SuperOrder(Base):
+    __tablename__ = "super_orders"
+
+    id = Column(Integer, primary_key=True, autoincrement=True)
+    user_id = Column(String(255), nullable=False, index=True)
+
+    # Order parameters
+    symbol = Column(String(255), nullable=False)
+    exchange = Column(String(50), nullable=False)
+    product_type = Column(String(50), nullable=False)  # INTRADAY / NRML / CNC / MTF
+    transaction_type = Column(String(20), nullable=False)  # BUY / SELL
+    quantity = Column(Integer, nullable=False)
+
+    # Pricing
+    entry_price = Column(DECIMAL(15, 4), nullable=False)
+    target_price = Column(DECIMAL(15, 4), nullable=False)
+    stoploss_price = Column(DECIMAL(15, 4), nullable=False)
+    trail_jump = Column(DECIMAL(15, 4), nullable=True)  # Optional trailing step
+
+    # State tracking
+    main_order_id = Column(String(255), nullable=True)
+    target_order_id = Column(String(255), nullable=True)
+    stoploss_order_id = Column(String(255), nullable=True)
+    status = Column(
+        String(20), default="PENDING", index=True
+    )  # PENDING / ACTIVE / CLOSED / FAILED / CANCELLED
+
+    # Metadata
+    order_tag = Column(String(255), nullable=True)
+
+    # Timestamps
+    created_at = Column(DateTime(timezone=True), default=func.now())
+    updated_at = Column(
+        DateTime(timezone=True), default=func.now(), onupdate=func.now()
+    )
+    expires_at = Column(DateTime(timezone=True), nullable=True)
+
+    __table_args__ = (Index("idx_user_superorder_status", "user_id", "status"),)
+
+
+def init_db():
+    """Initialize database tables"""
+    from database.db_init_helper import init_db_with_logging
+
+    init_db_with_logging(Base, engine, "Super Order DB", logger)

--- a/restx_api/__init__.py
+++ b/restx_api/__init__.py
@@ -51,6 +51,7 @@ from .synthetic_future import api as synthetic_future_ns
 from .telegram_bot import api as telegram_ns
 from .ticker import api as ticker_ns
 from .tradebook import api as tradebook_ns
+from .superorder import api as superorder_ns
 
 # Add namespaces
 api.add_namespace(place_order_ns, path="/placeorder")
@@ -93,3 +94,4 @@ api.add_namespace(chart_ns, path="/chart")
 api.add_namespace(market_holidays_ns, path="/market/holidays")
 api.add_namespace(market_timings_ns, path="/market/timings")
 api.add_namespace(pnl_symbols_ns, path="/pnl")
+api.add_namespace(superorder_ns, path="/superorder")

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -13,7 +13,11 @@ def _coerce_quantity_to_int(data):
         qty = data["quantity"]
         if qty != int(qty):
             raise ValidationError(
-                {"quantity": [f"Fractional quantity ({qty}) is not allowed for non-crypto exchanges."]}
+                {
+                    "quantity": [
+                        f"Fractional quantity ({qty}) is not allowed for non-crypto exchanges."
+                    ]
+                }
             )
         data["quantity"] = int(qty)
     return data
@@ -24,24 +28,34 @@ class OrderSchema(Schema):
     strategy = fields.Str(required=True)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+        required=True,
+        validate=validate.Range(
+            min=0, min_inclusive=False, error="Quantity must be a positive number."
+        ),
     )
     pricetype = fields.Str(
         missing="MARKET", validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
     )
     product = fields.Str(missing="MIS", validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
     underlying_ltp = fields.Float(
         missing=None, allow_none=True
@@ -57,7 +71,9 @@ class SmartOrderSchema(Schema):
     strategy = fields.Str(required=True)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Float(
         required=True,
         validate=validate.Range(min=0, error="Quantity must be a non-negative number."),
@@ -68,15 +84,20 @@ class SmartOrderSchema(Schema):
     )
     product = fields.Str(missing="MIS", validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
 
     @post_load
@@ -90,24 +111,34 @@ class ModifyOrderSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
     orderid = fields.Str(required=True)
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     product = fields.Str(required=True, validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     pricetype = fields.Str(
         required=True, validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
     )
     price = fields.Float(
-        required=True, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        required=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+        required=True,
+        validate=validate.Range(
+            min=0, min_inclusive=False, error="Quantity must be a positive number."
+        ),
     )
     disclosed_quantity = fields.Int(
         required=True,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
     trigger_price = fields.Float(
         required=True,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
 
     @post_load
@@ -134,24 +165,34 @@ class CancelAllOrderSchema(Schema):
 class BasketOrderItemSchema(Schema):
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Float(
-        required=True, validate=validate.Range(min=0, min_inclusive=False, error="Quantity must be a positive number.")
+        required=True,
+        validate=validate.Range(
+            min=0, min_inclusive=False, error="Quantity must be a positive number."
+        ),
     )
     pricetype = fields.Str(
         missing="MARKET", validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
     )
     product = fields.Str(missing="MIS", validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
 
     @post_load
@@ -172,10 +213,16 @@ class SplitOrderSchema(Schema):
     strategy = fields.Str(required=True)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
     symbol = fields.Str(required=True)
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Float(
         required=True,
-        validate=validate.Range(min=0, min_inclusive=False, error="Total quantity must be a positive number."),
+        validate=validate.Range(
+            min=0,
+            min_inclusive=False,
+            error="Total quantity must be a positive number.",
+        ),
     )  # Total quantity to split
     splitsize = fields.Int(
         required=True,
@@ -186,15 +233,20 @@ class SplitOrderSchema(Schema):
     )
     product = fields.Str(missing="MIS", validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
 
     @post_load
@@ -208,7 +260,9 @@ class OptionsOrderSchema(Schema):
     underlying = fields.Str(
         required=True
     )  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE, or NIFTY28NOV24FUT)
-    exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE, NFO, BFO)
+    exchange = fields.Str(
+        required=True, validate=validate.OneOf(VALID_EXCHANGES)
+    )  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE, NFO, BFO)
     expiry_date = fields.Str(
         required=False
     )  # Optional if underlying includes expiry (DDMMMYY format)
@@ -219,13 +273,18 @@ class OptionsOrderSchema(Schema):
     option_type = fields.Str(
         required=True, validate=validate.OneOf(["CE", "PE", "ce", "pe"])
     )  # Call or Put
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Int(
-        required=True, validate=validate.Range(min=1, error="Quantity must be a positive integer.")
+        required=True,
+        validate=validate.Range(min=1, error="Quantity must be a positive integer."),
     )
     splitsize = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Split size must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Split size must be a non-negative integer."
+        ),
         allow_none=True,
     )  # Optional: If > 0, splits order into multiple orders of this size
     pricetype = fields.Str(
@@ -235,15 +294,20 @@ class OptionsOrderSchema(Schema):
         missing="MIS", validate=validate.OneOf(["MIS", "NRML"])
     )  # Options only support MIS and NRML
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
 
 
@@ -254,13 +318,18 @@ class OptionsMultiOrderLegSchema(Schema):
     option_type = fields.Str(
         required=True, validate=validate.OneOf(["CE", "PE", "ce", "pe"])
     )  # Call or Put
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
     quantity = fields.Int(
-        required=True, validate=validate.Range(min=1, error="Quantity must be a positive integer.")
+        required=True,
+        validate=validate.Range(min=1, error="Quantity must be a positive integer."),
     )
     splitsize = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Split size must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Split size must be a non-negative integer."
+        ),
         allow_none=True,
     )  # Optional: If > 0, splits leg into multiple orders of this size
     expiry_date = fields.Str(
@@ -273,15 +342,20 @@ class OptionsMultiOrderLegSchema(Schema):
         missing="MIS", validate=validate.OneOf(["MIS", "NRML"])
     )  # Options only support MIS and NRML
     price = fields.Float(
-        missing=0.0, validate=validate.Range(min=0, error="Price must be a non-negative number.")
+        missing=0.0,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
     trigger_price = fields.Float(
         missing=0.0,
-        validate=validate.Range(min=0, error="Trigger price must be a non-negative number."),
+        validate=validate.Range(
+            min=0, error="Trigger price must be a non-negative number."
+        ),
     )
     disclosed_quantity = fields.Int(
         missing=0,
-        validate=validate.Range(min=0, error="Disclosed quantity must be a non-negative integer."),
+        validate=validate.Range(
+            min=0, error="Disclosed quantity must be a non-negative integer."
+        ),
     )
 
 
@@ -290,8 +364,12 @@ class OptionsMultiOrderSchema(Schema):
 
     apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
     strategy = fields.Str(required=True)
-    underlying = fields.Str(required=True)  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE)
-    exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE)
+    underlying = fields.Str(
+        required=True
+    )  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE)
+    exchange = fields.Str(
+        required=True, validate=validate.OneOf(VALID_EXCHANGES)
+    )  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE)
     expiry_date = fields.Str(
         required=False
     )  # Optional if underlying includes expiry (DDMMMYY format)
@@ -301,7 +379,9 @@ class OptionsMultiOrderSchema(Schema):
     legs = fields.List(
         fields.Nested(OptionsMultiOrderLegSchema),
         required=True,
-        validate=validate.Length(min=1, max=20, error="Legs must contain 1 to 20 items."),
+        validate=validate.Length(
+            min=1, max=20, error="Legs must contain 1 to 20 items."
+        ),
     )
 
 
@@ -309,9 +389,15 @@ class SyntheticFutureSchema(Schema):
     """Schema for synthetic future calculation"""
 
     apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
-    underlying = fields.Str(required=True)  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE)
-    exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE)
-    expiry_date = fields.Str(required=True)  # Expiry date in DDMMMYY format (e.g., 28OCT25)
+    underlying = fields.Str(
+        required=True
+    )  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE)
+    exchange = fields.Str(
+        required=True, validate=validate.OneOf(VALID_EXCHANGES)
+    )  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE)
+    expiry_date = fields.Str(
+        required=True
+    )  # Expiry date in DDMMMYY format (e.g., 28OCT25)
 
 
 class MarginPositionSchema(Schema):
@@ -323,11 +409,13 @@ class MarginPositionSchema(Schema):
             min=1, max=50, error="Symbol must be between 1 and 50 characters."
         ),
     )
-    exchange = fields.Str(
-        required=True, validate=validate.OneOf(VALID_EXCHANGES)
+    exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
+    action = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
     )
-    action = fields.Str(required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"]))
-    quantity = fields.Str(required=True)  # String to match API contract, validated in service layer
+    quantity = fields.Str(
+        required=True
+    )  # String to match API contract, validated in service layer
     product = fields.Str(required=True, validate=validate.OneOf(["MIS", "NRML", "CNC"]))
     pricetype = fields.Str(
         required=True, validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])
@@ -340,10 +428,113 @@ class MarginCalculatorSchema(Schema):
     """Schema for margin calculator request"""
 
     apikey = fields.Str(
-        required=True, validate=validate.Length(min=1, max=256, error="API key must be between 1 and 256 characters.")
+        required=True,
+        validate=validate.Length(
+            min=1, max=256, error="API key must be between 1 and 256 characters."
+        ),
     )
     positions = fields.List(
         fields.Nested(MarginPositionSchema),
         required=True,
-        validate=validate.Length(min=1, max=50, error="Positions must contain 1 to 50 items."),
+        validate=validate.Length(
+            min=1, max=50, error="Positions must contain 1 to 50 items."
+        ),
     )
+
+
+class SuperOrderSchema(Schema):
+    """Schema for placing a Super Order"""
+
+    apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    symbol = fields.Str(required=True)
+    exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
+    product_type = fields.Str(
+        required=True,
+        validate=validate.OneOf(["INTRADAY", "NRML", "CNC", "MTF", "MIS"]),
+    )
+    transaction_type = fields.Str(
+        required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
+    )
+    quantity = fields.Float(
+        required=True,
+        validate=validate.Range(
+            min=0, min_inclusive=False, error="Quantity must be a positive number."
+        ),
+    )
+    entry_price = fields.Float(
+        required=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    target_price = fields.Float(
+        required=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    stoploss_price = fields.Float(
+        required=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    trail_jump = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(
+            min=0, error="Trail jump must be a non-negative number."
+        ),
+    )
+    order_tag = fields.Str(missing=None, allow_none=True)
+
+    @post_load
+    def coerce_quantity(self, data, **kwargs):
+        return _coerce_quantity_to_int(data)
+
+
+class ModifySuperOrderSchema(Schema):
+    """Schema for modifying a Super Order"""
+
+    apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    order_id = fields.Int(required=True)
+    quantity = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(
+            min=0, min_inclusive=False, error="Quantity must be a positive number."
+        ),
+    )
+    entry_price = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    target_price = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    stoploss_price = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(min=0, error="Price must be a non-negative number."),
+    )
+    trail_jump = fields.Float(
+        missing=None,
+        allow_none=True,
+        validate=validate.Range(
+            min=0, error="Trail jump must be a non-negative number."
+        ),
+    )
+
+    @post_load
+    def coerce_quantity(self, data, **kwargs):
+        if data.get("quantity") is not None:
+            # We don't have exchange in this schema, so assume standard integer conversion if we can
+            # Actual validation happens in service layer if needed
+            qty = data["quantity"]
+            if qty == int(qty):
+                data["quantity"] = int(qty)
+        return data
+
+
+class CancelSuperOrderSchema(Schema):
+    """Schema for cancelling a Super Order"""
+
+    apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    order_id = fields.Int(required=True)

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -446,22 +446,24 @@ class SuperOrderSchema(Schema):
     """Schema for placing a Super Order"""
 
     apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    strategy = fields.Str(required=True)
     symbol = fields.Str(required=True)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))
-    product_type = fields.Str(
+    product = fields.Str(
         required=True,
         validate=validate.OneOf(["INTRADAY", "NRML", "CNC", "MTF", "MIS"]),
     )
-    transaction_type = fields.Str(
+    action = fields.Str(
         required=True, validate=validate.OneOf(["BUY", "SELL", "buy", "sell"])
     )
+    pricetype = fields.Str(missing="LIMIT")
     quantity = fields.Float(
         required=True,
         validate=validate.Range(
             min=0, min_inclusive=False, error="Quantity must be a positive number."
         ),
     )
-    entry_price = fields.Float(
+    price = fields.Float(
         required=True,
         validate=validate.Range(min=0, error="Price must be a non-negative number."),
     )
@@ -499,7 +501,7 @@ class ModifySuperOrderSchema(Schema):
             min=0, min_inclusive=False, error="Quantity must be a positive number."
         ),
     )
-    entry_price = fields.Float(
+    price = fields.Float(
         missing=None,
         allow_none=True,
         validate=validate.Range(min=0, error="Price must be a non-negative number."),

--- a/restx_api/superorder.py
+++ b/restx_api/superorder.py
@@ -1,0 +1,172 @@
+import os
+
+from flask import jsonify, make_response, request
+from flask_restx import Namespace, Resource
+from marshmallow import ValidationError
+
+from limiter import limiter
+from restx_api.schemas import (
+    CancelSuperOrderSchema,
+    ModifySuperOrderSchema,
+    SuperOrderSchema,
+)
+from services.superorder_service import (
+    cancel_superorder,
+    get_superorder,
+    get_superorders,
+    modify_superorder,
+    place_superorder,
+)
+from utils.logging import get_logger
+
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+api = Namespace("superorder", description="Super Order API")
+
+# Initialize logger
+logger = get_logger(__name__)
+
+# Initialize schemas
+superorder_schema = SuperOrderSchema()
+modify_superorder_schema = ModifySuperOrderSchema()
+cancel_superorder_schema = CancelSuperOrderSchema()
+
+
+@api.route("/", strict_slashes=False)
+class SuperOrderList(Resource):
+    @limiter.limit(API_RATE_LIMIT)
+    def post(self):
+        """Place a new Super Order"""
+        try:
+            data = request.json
+            order_data = superorder_schema.load(data)
+
+            api_key = order_data.get("apikey", None)
+
+            success, response_data, status_code = place_superorder(
+                order_data=order_data, api_key=api_key
+            )
+            return make_response(jsonify(response_data), status_code)
+
+        except ValidationError as err:
+            error_response = {"status": "error", "message": str(err.messages)}
+            return make_response(jsonify(error_response), 400)
+        except Exception:
+            logger.exception(
+                "An unexpected error occurred in SuperOrder post endpoint."
+            )
+            error_response = {
+                "status": "error",
+                "message": "An unexpected error occurred in the API endpoint",
+            }
+            return make_response(jsonify(error_response), 500)
+
+    @limiter.limit(API_RATE_LIMIT)
+    def get(self):
+        """Get all Super Orders for the user"""
+        try:
+            # Requires apikey in query param for GET request
+            api_key = request.args.get("apikey")
+            if not api_key:
+                return make_response(
+                    jsonify({"status": "error", "message": "API key required"}), 400
+                )
+
+            success, response_data, status_code = get_superorders(api_key=api_key)
+            return make_response(jsonify(response_data), status_code)
+
+        except Exception:
+            logger.exception("An unexpected error occurred in SuperOrder get endpoint.")
+            error_response = {
+                "status": "error",
+                "message": "An unexpected error occurred in the API endpoint",
+            }
+            return make_response(jsonify(error_response), 500)
+
+
+@api.route("/<int:id>", strict_slashes=False)
+class SuperOrderDetails(Resource):
+    @limiter.limit(API_RATE_LIMIT)
+    def get(self, id):
+        """Get details of a specific Super Order"""
+        try:
+            api_key = request.args.get("apikey")
+            if not api_key:
+                return make_response(
+                    jsonify({"status": "error", "message": "API key required"}), 400
+                )
+
+            success, response_data, status_code = get_superorder(
+                order_id=id, api_key=api_key
+            )
+            return make_response(jsonify(response_data), status_code)
+
+        except Exception:
+            logger.exception(
+                "An unexpected error occurred in SuperOrder get details endpoint."
+            )
+            error_response = {
+                "status": "error",
+                "message": "An unexpected error occurred in the API endpoint",
+            }
+            return make_response(jsonify(error_response), 500)
+
+    @limiter.limit(API_RATE_LIMIT)
+    def put(self, id):
+        """Modify target/SL prices or legs in PENDING state of a Super Order"""
+        try:
+            data = request.json
+            if not data:
+                data = {}
+            data["order_id"] = id
+
+            order_data = modify_superorder_schema.load(data)
+            api_key = order_data.get("apikey")
+
+            success, response_data, status_code = modify_superorder(
+                order_data=order_data, api_key=api_key
+            )
+            return make_response(jsonify(response_data), status_code)
+
+        except ValidationError as err:
+            error_response = {"status": "error", "message": str(err.messages)}
+            return make_response(jsonify(error_response), 400)
+        except Exception:
+            logger.exception(
+                "An unexpected error occurred in SuperOrder modify endpoint."
+            )
+            error_response = {
+                "status": "error",
+                "message": "An unexpected error occurred in the API endpoint",
+            }
+            return make_response(jsonify(error_response), 500)
+
+    @limiter.limit(API_RATE_LIMIT)
+    def delete(self, id):
+        """Cancel a Super Order"""
+        try:
+            # Delete body might have apikey or from query string
+            api_key = request.args.get("apikey")
+            if not api_key and request.is_json:
+                data = request.json
+                if data:
+                    api_key = data.get("apikey")
+
+            if not api_key:
+                return make_response(
+                    jsonify({"status": "error", "message": "API key required"}), 400
+                )
+
+            success, response_data, status_code = cancel_superorder(
+                order_id=id, api_key=api_key
+            )
+            return make_response(jsonify(response_data), status_code)
+
+        except Exception:
+            logger.exception(
+                "An unexpected error occurred in SuperOrder delete endpoint."
+            )
+            error_response = {
+                "status": "error",
+                "message": "An unexpected error occurred in the API endpoint",
+            }
+            return make_response(jsonify(error_response), 500)

--- a/restx_api/superorder.py
+++ b/restx_api/superorder.py
@@ -10,13 +10,6 @@ from restx_api.schemas import (
     ModifySuperOrderSchema,
     SuperOrderSchema,
 )
-from services.superorder_service import (
-    cancel_superorder,
-    get_superorder,
-    get_superorders,
-    modify_superorder,
-    place_superorder,
-)
 from utils.logging import get_logger
 
 API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
@@ -42,6 +35,7 @@ class SuperOrderList(Resource):
 
             api_key = order_data.get("apikey", None)
 
+            from services.superorder_service import place_superorder
             success, response_data, status_code = place_superorder(
                 order_data=order_data, api_key=api_key
             )
@@ -71,6 +65,7 @@ class SuperOrderList(Resource):
                     jsonify({"status": "error", "message": "API key required"}), 400
                 )
 
+            from services.superorder_service import get_superorders
             success, response_data, status_code = get_superorders(api_key=api_key)
             return make_response(jsonify(response_data), status_code)
 
@@ -95,6 +90,7 @@ class SuperOrderDetails(Resource):
                     jsonify({"status": "error", "message": "API key required"}), 400
                 )
 
+            from services.superorder_service import get_superorder
             success, response_data, status_code = get_superorder(
                 order_id=id, api_key=api_key
             )
@@ -122,6 +118,7 @@ class SuperOrderDetails(Resource):
             order_data = modify_superorder_schema.load(data)
             api_key = order_data.get("apikey")
 
+            from services.superorder_service import modify_superorder
             success, response_data, status_code = modify_superorder(
                 order_data=order_data, api_key=api_key
             )
@@ -156,6 +153,7 @@ class SuperOrderDetails(Resource):
                     jsonify({"status": "error", "message": "API key required"}), 400
                 )
 
+            from services.superorder_service import cancel_superorder
             success, response_data, status_code = cancel_superorder(
                 order_id=id, api_key=api_key
             )

--- a/restx_api/superorder.py
+++ b/restx_api/superorder.py
@@ -1,7 +1,7 @@
 import os
 
 from flask import jsonify, make_response, request
-from flask_restx import Namespace, Resource
+from flask_restx import Namespace, Resource, fields
 from marshmallow import ValidationError
 
 from limiter import limiter
@@ -24,8 +24,68 @@ modify_superorder_schema = ModifySuperOrderSchema()
 cancel_superorder_schema = CancelSuperOrderSchema()
 
 
+super_order_model = api.model(
+    "SuperOrder",
+    {
+        "apikey": fields.String(
+            required=True,
+            description="OpenAlgo API Key",
+            example="a85992a13ab7db424c239c50826116366e9f4fd8c591345a2d23aad01ffa4d00",
+        ),
+        "strategy": fields.String(
+            required=True,
+            description="Strategy name for tracking",
+            example="Test Strategy",
+        ),
+        "exchange": fields.String(
+            required=True, description="Exchange (NSE / BSE / MCX)", example="NSE"
+        ),
+        "symbol": fields.String(
+            required=True, description="Trading symbol", example="YESBANK"
+        ),
+        "action": fields.String(
+            required=True, description="BUY or SELL", example="BUY"
+        ),
+        "product": fields.String(
+            required=True, description="MIS / NRML / CNC / MTF", example="MIS"
+        ),
+        "pricetype": fields.String(
+            required=True,
+            description="LIMIT (Super Orders require a limit entry price)",
+            example="LIMIT",
+        ),
+        "quantity": fields.String(
+            required=True, description="Number of shares/lots", example="10"
+        ),
+        "price": fields.String(
+            required=True, description="Entry price (Main Leg limit price)", example="21.50"
+        ),
+        "target_price": fields.String(
+            required=True,
+            description="Target exit price (above entry for BUY, below for SELL)",
+            example="23.00",
+        ),
+        "stoploss_price": fields.String(
+            required=True,
+            description="Stop-loss price (below entry for BUY, above for SELL)",
+            example="20.00",
+        ),
+        "trail_jump": fields.String(
+            required=False,
+            description="Trailing SL increment (min: tick size). Omit to disable.",
+            example="0.50",
+        ),
+    },
+)
+
 @api.route("/", strict_slashes=False)
 class SuperOrderList(Resource):
+    @api.doc("place_super_order")
+    @api.expect(super_order_model)
+    @api.response(200, "Success")
+    @api.response(400, "Validation Error")
+    @api.response(401, "Unauthorized")
+    @api.response(500, "Internal Server Error")
     @limiter.limit(API_RATE_LIMIT)
     def post(self):
         """Place a new Super Order"""

--- a/services/superorder_monitoring_service.py
+++ b/services/superorder_monitoring_service.py
@@ -1,0 +1,331 @@
+import logging
+import threading
+import time
+from datetime import datetime
+from typing import Any, Optional
+
+from database.auth_db import get_api_key_for_tradingview
+from database.superorder_db import SuperOrder, db_session
+from services.cancel_order_service import cancel_order
+from services.orderstatus_service import get_orderstatus
+from services.place_order_service import place_order
+from services.quotes_service import get_multiquotes
+
+logger = logging.getLogger(__name__)
+
+
+class SuperOrderMonitor:
+    """
+    Background monitor that checks PENDING and ACTIVE Super Orders.
+    """
+
+    _instance = None
+    _lock = threading.Lock()
+    _running = False
+    _thread = None
+
+    def __new__(cls):
+        with cls._lock:
+            if cls._instance is None:
+                cls._instance = super().__new__(cls)
+        return cls._instance
+
+    def start(self, interval: int = 5):
+        """Start the background monitoring thread."""
+        with self._lock:
+            if self._running:
+                logger.debug("Super Order Monitor is already running.")
+                return
+
+            self._running = True
+            self._thread = threading.Thread(
+                target=self._monitor_loop,
+                args=(interval,),
+                daemon=True,
+                name="SuperOrderMonitorThread",
+            )
+            self._thread.start()
+            logger.info("Super Order Monitor started.")
+
+    def stop(self):
+        """Stop the monitoring thread."""
+        with self._lock:
+            self._running = False
+            if self._thread:
+                self._thread.join(timeout=2.0)
+                logger.info("Super Order Monitor stopped.")
+
+    def _monitor_loop(self, interval: int):
+        while self._running:
+            try:
+                self._process_super_orders()
+            except Exception as e:
+                logger.exception(f"Error in Super Order Monitor loop: {e}")
+
+            time.sleep(interval)
+
+    def _process_super_orders(self):
+        """Fetch and process PENDING and ACTIVE orders."""
+        try:
+            # Refresh session to ensure we have the latest data
+            db_session.remove()
+
+            orders = SuperOrder.query.filter(
+                SuperOrder.status.in_(["PENDING", "ACTIVE"])
+            ).all()
+
+            if not orders:
+                return
+
+            # Group by user to minimize api_key fetches and batch quotes
+            orders_by_user = {}
+            for order in orders:
+                orders_by_user.setdefault(order.user_id, []).append(order)
+
+            for user_id, user_orders in orders_by_user.items():
+                api_key = get_api_key_for_tradingview(user_id)
+                if not api_key:
+                    logger.warning(
+                        f"No API key found for user {user_id}, skipping super orders."
+                    )
+                    continue
+
+                active_orders = [o for o in user_orders if o.status == "ACTIVE"]
+                pending_orders = [o for o in user_orders if o.status == "PENDING"]
+
+                # Check PENDING orders to see if they got filled
+                self._check_pending_orders(pending_orders, api_key)
+
+                # Fetch quotes for ACTIVE orders
+                if active_orders:
+                    self._process_active_orders(active_orders, api_key)
+
+            # Check for expired orders
+            self._cancel_expired_orders(orders)
+
+        except Exception as e:
+            logger.exception(f"Failed processing super orders: {e}")
+            db_session.rollback()
+
+    def _cancel_expired_orders(self, orders: list[SuperOrder]):
+        now = datetime.now()
+        for order in orders:
+            if order.expires_at and now >= order.expires_at:
+                logger.info(
+                    f"Super Order {order.id} expired at {order.expires_at}. Cancelling."
+                )
+                api_key = get_api_key_for_tradingview(order.user_id)
+
+                # Update status
+                order.status = "CANCELLED"
+
+                if order.status == "PENDING" and order.main_order_id:
+                    cancel_order(orderid=order.main_order_id, api_key=api_key)
+                elif order.status == "ACTIVE":
+                    if order.target_order_id:
+                        cancel_order(orderid=order.target_order_id, api_key=api_key)
+                    if order.stoploss_order_id:
+                        cancel_order(orderid=order.stoploss_order_id, api_key=api_key)
+
+                db_session.commit()
+
+    def _check_pending_orders(self, pending_orders: list[SuperOrder], api_key: str):
+        for order in pending_orders:
+            if not order.main_order_id:
+                continue
+
+            success, response, status_code = get_orderstatus(
+                order.main_order_id, api_key=api_key
+            )
+            if success and response.get("status") == "success":
+                data = response.get("data", {})
+                status = str(data.get("order_status", "")).upper()
+
+                filled_qty = int(data.get("filled_quantity", 0)) or int(
+                    data.get("traded_quantity", 0)
+                )
+
+                if status in ["COMPLETE", "COMPLETED", "FILLED"]:
+                    # Order filled, move to ACTIVE
+                    order.status = "ACTIVE"
+                    if filled_qty > 0 and filled_qty < order.quantity:
+                        # Update quantity to what was actually filled
+                        order.quantity = filled_qty
+
+                    db_session.commit()
+                    logger.info(
+                        f"Super Order {order.id} main leg filled, moving to ACTIVE."
+                    )
+                elif status == "OPEN" and filled_qty > 0:
+                    # Partially filled order, move to ACTIVE for the filled quantity
+                    order.status = "ACTIVE"
+                    order.quantity = filled_qty
+                    db_session.commit()
+                    logger.info(
+                        f"Super Order {order.id} main leg partially filled, moving to ACTIVE with qty {filled_qty}."
+                    )
+                elif status in ["REJECTED", "CANCELLED"]:
+                    # Handle case where it was partially filled and then cancelled
+                    if filled_qty > 0:
+                        order.status = "ACTIVE"
+                        order.quantity = filled_qty
+                        logger.info(
+                            f"Super Order {order.id} main leg cancelled after part fill, moving to ACTIVE with qty {filled_qty}."
+                        )
+                    else:
+                        order.status = "FAILED" if status == "REJECTED" else "CANCELLED"
+                        logger.info(
+                            f"Super Order {order.id} main leg {status}, updating state."
+                        )
+                    db_session.commit()
+            else:
+                logger.debug(
+                    f"Could not fetch order status for main leg {order.main_order_id} of Super Order {order.id}"
+                )
+
+    def _process_active_orders(self, active_orders: list[SuperOrder], api_key: str):
+        # Gather unique symbols
+        unique_symbol_tuples = {(o.symbol, o.exchange) for o in active_orders}
+        symbols = [
+            {"symbol": sym, "exchange": exch} for sym, exch in unique_symbol_tuples
+        ]
+
+        # Batch quote fetch
+        success, mq_response, _ = get_multiquotes(symbols=symbols, api_key=api_key)
+
+        if not success or "results" not in mq_response:
+            logger.warning(
+                f"Failed to fetch multiquotes for active super orders: {mq_response.get('message')}"
+            )
+            return
+
+        quotes_dict = {}
+        for result in mq_response["results"]:
+            sym = result.get("symbol")
+            exch = result.get("exchange")
+            data = result.get("data", {})
+            ltp = data.get("ltp")
+            if sym and exch and ltp is not None:
+                quotes_dict[(sym, exch)] = float(ltp)
+
+        for order in active_orders:
+            ltp = quotes_dict.get((order.symbol, order.exchange))
+            if ltp is None:
+                continue
+
+            # Process trailing stoploss
+            self._apply_trailing_stoploss(order, ltp)
+
+            # Check for triggers
+            triggered_leg = None
+
+            # Target Trigger
+            if order.transaction_type.upper() == "BUY":
+                if ltp >= float(order.target_price):
+                    triggered_leg = "TARGET"
+                elif ltp <= float(order.stoploss_price):
+                    triggered_leg = "STOPLOSS"
+            else:  # SELL
+                if ltp <= float(order.target_price):
+                    triggered_leg = "TARGET"
+                elif ltp >= float(order.stoploss_price):
+                    triggered_leg = "STOPLOSS"
+
+            if triggered_leg:
+                logger.info(
+                    f"Super Order {order.id} {triggered_leg} triggered at {ltp}."
+                )
+                self._execute_leg(order, triggered_leg, api_key)
+
+    def _apply_trailing_stoploss(self, order: SuperOrder, ltp: float):
+        if not order.trail_jump or float(order.trail_jump) <= 0:
+            return
+
+        trail_jump = float(order.trail_jump)
+        entry = float(order.entry_price)
+        current_sl = float(order.stoploss_price)
+
+        # OCO + Trailing logic:
+        # If BUY, and price moves UP by trail_jump increments above entry, move SL UP
+        # If SELL, and price moves DOWN by trail_jump increments below entry, move SL DOWN
+
+        updated = False
+
+        # Calculate original stoploss distance
+        sl_distance = abs(entry - float(order.stoploss_price))
+
+        if order.transaction_type.upper() == "BUY":
+            if ltp > entry:
+                increments = int((ltp - entry) / trail_jump)
+                if increments > 0:
+                    # Original stop loss + increments * trail_jump
+                    # We compute the distance from entry
+                    # Actually, a better way is to move it by trail_jump for each trail_jump the LTP moves from entry.
+                    new_sl = entry - sl_distance + (increments * trail_jump)
+                    # For safety, make sure we only ever move SL UP, and it's less than LTP
+                    if new_sl > current_sl and new_sl < ltp:
+                        order.stoploss_price = new_sl
+                        updated = True
+        else:
+            if ltp < entry:
+                increments = int((entry - ltp) / trail_jump)
+                if increments > 0:
+                    # Original stop loss - increments * trail_jump
+                    new_sl = entry + sl_distance - (increments * trail_jump)
+                    # Make sure we only ever move SL DOWN, and it's greater than LTP
+                    if new_sl < current_sl and new_sl > ltp:
+                        order.stoploss_price = new_sl
+                        updated = True
+
+        if updated:
+            db_session.commit()
+            logger.info(
+                f"Super Order {order.id} Trailing SL updated to {order.stoploss_price} (LTP: {ltp})"
+            )
+
+    def _execute_leg(self, order: SuperOrder, leg_type: str, api_key: str):
+        # We need to send an opposing market order to exit the position
+        exit_action = "SELL" if order.transaction_type.upper() == "BUY" else "BUY"
+
+        leg_data = {
+            "apikey": api_key,
+            "strategy": f"SuperOrder_{leg_type}",
+            "symbol": order.symbol,
+            "exchange": order.exchange,
+            "action": exit_action,
+            "quantity": order.quantity,
+            "pricetype": "MARKET",
+            "product": order.product_type,
+            "price": 0,
+        }
+
+        success, response_data, status_code = place_order(
+            order_data=leg_data,
+            api_key=api_key,
+        )
+
+        if success:
+            order_id_str = str(response_data.get("orderid"))
+            if leg_type == "TARGET":
+                order.target_order_id = order_id_str
+            else:
+                order.stoploss_order_id = order_id_str
+
+            order.status = "CLOSED"
+            db_session.commit()
+            logger.info(
+                f"Super Order {order.id} {leg_type} executed. Status set to CLOSED."
+            )
+        else:
+            logger.error(
+                f"Failed to execute {leg_type} for Super Order {order.id}: {response_data}"
+            )
+            # Keep active, let it retry on next tick
+
+
+# Global instance
+superorder_monitor = SuperOrderMonitor()
+
+
+def start_superorder_monitor():
+    superorder_monitor.start()

--- a/services/superorder_monitoring_service.py
+++ b/services/superorder_monitoring_service.py
@@ -52,7 +52,29 @@ class SuperOrderMonitor:
                 self._thread.join(timeout=2.0)
                 logger.info("Super Order Monitor stopped.")
 
+    def _verify_imports(self):
+        """Validate required service imports at startup to prevent silent loop failures."""
+        try:
+            from services.cancel_order_service import cancel_order
+            from services.orderstatus_service import get_order_status
+            from services.place_order_service import place_order
+            from services.quotes_service import get_multiquotes
+            # Just accessing the variables ensures they resolve
+            _ = get_order_status
+            _ = place_order
+            _ = cancel_order
+            _ = get_multiquotes
+        except ImportError as e:
+            logger.critical(f"FATAL: Missing dependency for Super Order Monitor: {e}")
+            raise RuntimeError(f"Super Order Monitor failed to initialize: {e}") from e
+
     def _monitor_loop(self, interval: int):
+        try:
+            self._verify_imports()
+        except RuntimeError:
+            self._running = False
+            return
+
         while self._running:
             try:
                 self._process_super_orders()

--- a/services/superorder_monitoring_service.py
+++ b/services/superorder_monitoring_service.py
@@ -156,7 +156,10 @@ class SuperOrderMonitor:
                 continue
 
             success, response, status_code = get_order_status(
-                {"orderid": order.main_order_id}, api_key=api_key
+                # Ensure we bypass global analyze mode so we read the actual LIVE status
+                # since Super Orders are live broker orders.
+                {"orderid": order.main_order_id, "mode": "live"},
+                api_key=api_key
             )
             if success and response.get("status") == "success":
                 data = response.get("data", {})
@@ -231,6 +234,9 @@ class SuperOrderMonitor:
 
         for order in active_orders:
             ltp = quotes_dict.get((order.symbol, order.exchange))
+
+            logger.info(f"Checking Super Order {order.id}: symbol={order.symbol}, LTP={ltp}, target={order.target_price}, sl={order.stoploss_price}")
+
             if ltp is None:
                 continue
 
@@ -254,7 +260,7 @@ class SuperOrderMonitor:
 
             if triggered_leg:
                 logger.info(
-                    f"Super Order {order.id} {triggered_leg} triggered at {ltp}."
+                    f"Super Order {order.id}: {triggered_leg.capitalize()} price reached. Firing exit order at {ltp}."
                 )
                 self._execute_leg(order, triggered_leg, api_key)
 
@@ -330,13 +336,15 @@ class SuperOrderMonitor:
             order_id_str = str(response_data.get("orderid"))
             if leg_type == "TARGET":
                 order.target_order_id = order_id_str
+                other_leg = "stop-loss"
             else:
                 order.stoploss_order_id = order_id_str
+                other_leg = "target"
 
             order.status = "CLOSED"
             db_session.commit()
             logger.info(
-                f"Super Order {order.id} {leg_type} executed. Status set to CLOSED."
+                f"Super Order {order.id}: {leg_type.capitalize()} leg executed. Cancelling {other_leg} leg. Status -> CLOSED."
             )
         else:
             logger.error(

--- a/services/superorder_monitoring_service.py
+++ b/services/superorder_monitoring_service.py
@@ -6,9 +6,6 @@ from typing import Any, Optional
 
 from database.auth_db import get_api_key_for_tradingview
 from database.superorder_db import SuperOrder, db_session
-from services.cancel_order_service import cancel_order
-from services.orderstatus_service import get_orderstatus
-from services.place_order_service import place_order
 from services.quotes_service import get_multiquotes
 
 logger = logging.getLogger(__name__)
@@ -108,6 +105,7 @@ class SuperOrderMonitor:
             db_session.rollback()
 
     def _cancel_expired_orders(self, orders: list[SuperOrder]):
+        from services.cancel_order_service import cancel_order
         now = datetime.now()
         for order in orders:
             if order.expires_at and now >= order.expires_at:
@@ -130,6 +128,7 @@ class SuperOrderMonitor:
                 db_session.commit()
 
     def _check_pending_orders(self, pending_orders: list[SuperOrder], api_key: str):
+        from services.orderstatus_service import get_orderstatus
         for order in pending_orders:
             if not order.main_order_id:
                 continue
@@ -284,6 +283,7 @@ class SuperOrderMonitor:
             )
 
     def _execute_leg(self, order: SuperOrder, leg_type: str, api_key: str):
+        from services.place_order_service import place_order
         # We need to send an opposing market order to exit the position
         exit_action = "SELL" if order.transaction_type.upper() == "BUY" else "BUY"
 

--- a/services/superorder_monitoring_service.py
+++ b/services/superorder_monitoring_service.py
@@ -128,13 +128,13 @@ class SuperOrderMonitor:
                 db_session.commit()
 
     def _check_pending_orders(self, pending_orders: list[SuperOrder], api_key: str):
-        from services.orderstatus_service import get_orderstatus
+        from services.orderstatus_service import get_order_status
         for order in pending_orders:
             if not order.main_order_id:
                 continue
 
-            success, response, status_code = get_orderstatus(
-                order.main_order_id, api_key=api_key
+            success, response, status_code = get_order_status(
+                {"orderid": order.main_order_id}, api_key=api_key
             )
             if success and response.get("status") == "success":
                 data = response.get("data", {})

--- a/services/superorder_service.py
+++ b/services/superorder_service.py
@@ -275,10 +275,10 @@ def modify_superorder(
                 mod_main_leg = True
 
             if (
-                order_data.get("entry_price") is not None
-                and order_data["entry_price"] != order.entry_price
+                order_data.get("price") is not None
+                and order_data["price"] != order.entry_price
             ):
-                order.entry_price = order_data["entry_price"]
+                order.entry_price = order_data["price"]
                 main_leg_mod_data["price"] = order.entry_price
                 main_leg_mod_data["pricetype"] = (
                     "LIMIT" if order.entry_price > 0 else "MARKET"
@@ -297,7 +297,7 @@ def modify_superorder(
             # Active state
             if (
                 order_data.get("quantity") is not None
-                or order_data.get("entry_price") is not None
+                or order_data.get("price") is not None
             ):
                 return (
                     False,

--- a/services/superorder_service.py
+++ b/services/superorder_service.py
@@ -1,0 +1,396 @@
+import copy
+from typing import Any, Optional
+
+from database.auth_db import get_auth_token_broker, verify_api_key
+from database.superorder_db import SuperOrder, db_session
+from services.cancel_order_service import cancel_order
+from services.modify_order_service import modify_order
+from services.place_order_service import place_order
+from utils.logging import get_logger
+
+# Initialize logger
+logger = get_logger(__name__)
+
+
+def place_superorder(
+    order_data: dict[str, Any], api_key: str | None = None
+) -> tuple[bool, dict[str, Any], int]:
+    """
+    Place a Super Order.
+    """
+    if not api_key:
+        return False, {"status": "error", "message": "API key is required"}, 401
+
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid API key"}, 401
+
+    AUTH_TOKEN, broker_name = get_auth_token_broker(api_key)
+    if not AUTH_TOKEN:
+        return (
+            False,
+            {
+                "status": "error",
+                "message": "Invalid openalgo apikey or broker configuration missing",
+            },
+            403,
+        )
+
+    try:
+        import datetime
+
+        # Calculate expiration time
+        expires_at = None
+        if order_data["product_type"].upper() in ["INTRADAY", "MIS"]:
+            # Auto-cancel at end of day
+            today = datetime.datetime.now().replace(
+                hour=15, minute=30, second=0, microsecond=0
+            )
+            expires_at = today
+        else:
+            # Valid for up to 365 days
+            expires_at = datetime.datetime.now() + datetime.timedelta(days=365)
+
+        # Create SuperOrder in database
+        super_order = SuperOrder(
+            user_id=user_id,
+            symbol=order_data["symbol"],
+            exchange=order_data["exchange"],
+            product_type=order_data["product_type"],
+            transaction_type=order_data["transaction_type"],
+            quantity=order_data["quantity"],
+            entry_price=order_data["entry_price"],
+            target_price=order_data["target_price"],
+            stoploss_price=order_data["stoploss_price"],
+            trail_jump=order_data.get("trail_jump"),
+            order_tag=order_data.get("order_tag"),
+            status="PENDING",
+            expires_at=expires_at,
+        )
+
+        # Determine pricetype for Main Leg
+        if order_data["entry_price"] > 0:
+            pricetype = "LIMIT"
+        else:
+            pricetype = "MARKET"
+
+        # Place the main leg order using existing place_order service
+        main_leg_data = {
+            "apikey": api_key,
+            "strategy": "SuperOrder",  # Or use order_tag
+            "symbol": order_data["symbol"],
+            "exchange": order_data["exchange"],
+            "action": order_data["transaction_type"],
+            "quantity": order_data["quantity"],
+            "pricetype": pricetype,
+            "product": order_data["product_type"],
+            "price": order_data["entry_price"],
+        }
+
+        success, response_data, status_code = place_order(
+            order_data=main_leg_data,
+            api_key=api_key,
+        )
+
+        if success:
+            super_order.main_order_id = str(response_data.get("orderid"))
+            db_session.add(super_order)
+            db_session.commit()
+            return (
+                True,
+                {
+                    "status": "success",
+                    "message": "Super Order placed successfully",
+                    "super_order_id": super_order.id,
+                    "main_order_id": super_order.main_order_id,
+                },
+                200,
+            )
+        else:
+            # If main order fails, save SuperOrder as FAILED
+            super_order.status = "FAILED"
+            db_session.add(super_order)
+            db_session.commit()
+            return False, response_data, status_code
+
+    except Exception as e:
+        logger.exception(f"Error in place_superorder: {str(e)}")
+        db_session.rollback()
+        return False, {"status": "error", "message": "Failed to place Super Order"}, 500
+
+
+def get_superorders(api_key: str | None = None) -> tuple[bool, dict[str, Any], int]:
+    """
+    Get all Super Orders for a user.
+    """
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid API key"}, 401
+
+    try:
+        orders = (
+            SuperOrder.query.filter_by(user_id=user_id)
+            .order_by(SuperOrder.created_at.desc())
+            .all()
+        )
+        result = []
+        for order in orders:
+            result.append(
+                {
+                    "id": order.id,
+                    "symbol": order.symbol,
+                    "exchange": order.exchange,
+                    "product_type": order.product_type,
+                    "transaction_type": order.transaction_type,
+                    "quantity": order.quantity,
+                    "entry_price": float(order.entry_price),
+                    "target_price": float(order.target_price),
+                    "stoploss_price": float(order.stoploss_price),
+                    "trail_jump": float(order.trail_jump) if order.trail_jump else None,
+                    "main_order_id": order.main_order_id,
+                    "target_order_id": order.target_order_id,
+                    "stoploss_order_id": order.stoploss_order_id,
+                    "status": order.status,
+                    "order_tag": order.order_tag,
+                    "created_at": (
+                        order.created_at.isoformat() if order.created_at else None
+                    ),
+                    "updated_at": (
+                        order.updated_at.isoformat() if order.updated_at else None
+                    ),
+                }
+            )
+        return True, {"status": "success", "data": result}, 200
+    except Exception as e:
+        logger.exception(f"Error in get_superorders: {str(e)}")
+        return (
+            False,
+            {"status": "error", "message": "Failed to fetch Super Orders"},
+            500,
+        )
+
+
+def get_superorder(
+    order_id: int, api_key: str | None = None
+) -> tuple[bool, dict[str, Any], int]:
+    """
+    Get details of a specific Super Order.
+    """
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid API key"}, 401
+
+    try:
+        order = SuperOrder.query.filter_by(id=order_id, user_id=user_id).first()
+        if not order:
+            return False, {"status": "error", "message": "Super Order not found"}, 404
+
+        result = {
+            "id": order.id,
+            "symbol": order.symbol,
+            "exchange": order.exchange,
+            "product_type": order.product_type,
+            "transaction_type": order.transaction_type,
+            "quantity": order.quantity,
+            "entry_price": float(order.entry_price),
+            "target_price": float(order.target_price),
+            "stoploss_price": float(order.stoploss_price),
+            "trail_jump": float(order.trail_jump) if order.trail_jump else None,
+            "main_order_id": order.main_order_id,
+            "target_order_id": order.target_order_id,
+            "stoploss_order_id": order.stoploss_order_id,
+            "status": order.status,
+            "order_tag": order.order_tag,
+            "created_at": order.created_at.isoformat() if order.created_at else None,
+            "updated_at": order.updated_at.isoformat() if order.updated_at else None,
+        }
+        return True, {"status": "success", "data": result}, 200
+    except Exception as e:
+        logger.exception(f"Error in get_superorder: {str(e)}")
+        return False, {"status": "error", "message": "Failed to fetch Super Order"}, 500
+
+
+def modify_superorder(
+    order_data: dict[str, Any], api_key: str | None = None
+) -> tuple[bool, dict[str, Any], int]:
+    """
+    Modify a Super Order.
+    In PENDING state: all legs (price + quantity) can be modified.
+    In ACTIVE state: only Target and SL price can be modified (NOT quantity).
+    """
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid API key"}, 401
+
+    AUTH_TOKEN, broker_name = get_auth_token_broker(api_key)
+    if not AUTH_TOKEN:
+        return (
+            False,
+            {
+                "status": "error",
+                "message": "Invalid openalgo apikey or broker configuration missing",
+            },
+            403,
+        )
+
+    try:
+        order = SuperOrder.query.filter_by(
+            id=order_data["order_id"], user_id=user_id
+        ).first()
+        if not order:
+            return False, {"status": "error", "message": "Super Order not found"}, 404
+
+        if order.status not in ["PENDING", "ACTIVE"]:
+            return (
+                False,
+                {
+                    "status": "error",
+                    "message": f"Cannot modify Super Order in {order.status} state",
+                },
+                400,
+            )
+
+        # Update fields
+        if order_data.get("target_price") is not None:
+            order.target_price = order_data["target_price"]
+        if order_data.get("stoploss_price") is not None:
+            order.stoploss_price = order_data["stoploss_price"]
+        if order_data.get("trail_jump") is not None:
+            order.trail_jump = order_data["trail_jump"]
+
+        if order.status == "PENDING":
+            mod_main_leg = False
+            main_leg_mod_data = {
+                "orderid": order.main_order_id,
+                "symbol": order.symbol,
+                "exchange": order.exchange,
+                "action": order.transaction_type,
+                "product": order.product_type,
+                "pricetype": "LIMIT" if order.entry_price > 0 else "MARKET",
+            }
+            if (
+                order_data.get("quantity") is not None
+                and order_data["quantity"] != order.quantity
+            ):
+                order.quantity = order_data["quantity"]
+                main_leg_mod_data["quantity"] = order.quantity
+                mod_main_leg = True
+
+            if (
+                order_data.get("entry_price") is not None
+                and order_data["entry_price"] != order.entry_price
+            ):
+                order.entry_price = order_data["entry_price"]
+                main_leg_mod_data["price"] = order.entry_price
+                main_leg_mod_data["pricetype"] = (
+                    "LIMIT" if order.entry_price > 0 else "MARKET"
+                )
+                mod_main_leg = True
+
+            if mod_main_leg:
+                success, resp, code = modify_order(
+                    order_data=main_leg_mod_data, api_key=api_key
+                )
+                if not success:
+                    db_session.rollback()
+                    return False, resp, code
+        else:
+            # Active state
+            if (
+                order_data.get("quantity") is not None
+                or order_data.get("entry_price") is not None
+            ):
+                return (
+                    False,
+                    {
+                        "status": "error",
+                        "message": "Can only modify target and SL prices in ACTIVE state",
+                    },
+                    400,
+                )
+
+        db_session.commit()
+        return (
+            True,
+            {"status": "success", "message": "Super Order modified successfully"},
+            200,
+        )
+
+    except Exception as e:
+        logger.exception(f"Error in modify_superorder: {str(e)}")
+        db_session.rollback()
+        return (
+            False,
+            {"status": "error", "message": "Failed to modify Super Order"},
+            500,
+        )
+
+
+def cancel_superorder(
+    order_id: int, api_key: str | None = None
+) -> tuple[bool, dict[str, Any], int]:
+    """
+    Cancel a Super Order.
+    """
+    user_id = verify_api_key(api_key)
+    if not user_id:
+        return False, {"status": "error", "message": "Invalid API key"}, 401
+
+    try:
+        order = SuperOrder.query.filter_by(id=order_id, user_id=user_id).first()
+        if not order:
+            return False, {"status": "error", "message": "Super Order not found"}, 404
+
+        if order.status == "PENDING":
+            if order.main_order_id:
+                success, resp, code = cancel_order(
+                    orderid=order.main_order_id, api_key=api_key
+                )
+                if success:
+                    order.status = "CANCELLED"
+                    db_session.commit()
+                    return (
+                        True,
+                        {
+                            "status": "success",
+                            "message": "Super Order cancelled successfully",
+                        },
+                        200,
+                    )
+                else:
+                    return False, resp, code
+        elif order.status == "ACTIVE":
+            order.status = "CANCELLED"
+            # Cancel any active target or SL orders on the exchange
+            if order.target_order_id:
+                cancel_order(orderid=order.target_order_id, api_key=api_key)
+            if order.stoploss_order_id:
+                cancel_order(orderid=order.stoploss_order_id, api_key=api_key)
+
+            db_session.commit()
+            return (
+                True,
+                {
+                    "status": "success",
+                    "message": "Super Order target and SL cancelled successfully",
+                },
+                200,
+            )
+        else:
+            return (
+                False,
+                {
+                    "status": "error",
+                    "message": f"Cannot cancel Super Order in {order.status} state",
+                },
+                400,
+            )
+
+    except Exception as e:
+        logger.exception(f"Error in cancel_superorder: {str(e)}")
+        db_session.rollback()
+        return (
+            False,
+            {"status": "error", "message": "Failed to cancel Super Order"},
+            500,
+        )

--- a/services/superorder_service.py
+++ b/services/superorder_service.py
@@ -38,7 +38,7 @@ def place_superorder(
 
         # Calculate expiration time
         expires_at = None
-        if order_data["product_type"].upper() in ["INTRADAY", "MIS"]:
+        if order_data["product"].upper() in ["INTRADAY", "MIS"]:
             # Auto-cancel at end of day
             today = datetime.datetime.now().replace(
                 hour=15, minute=30, second=0, microsecond=0
@@ -53,10 +53,10 @@ def place_superorder(
             user_id=user_id,
             symbol=order_data["symbol"],
             exchange=order_data["exchange"],
-            product_type=order_data["product_type"],
-            transaction_type=order_data["transaction_type"],
+            product_type=order_data["product"],
+            transaction_type=order_data["action"],
             quantity=order_data["quantity"],
-            entry_price=order_data["entry_price"],
+            entry_price=order_data["price"],
             target_price=order_data["target_price"],
             stoploss_price=order_data["stoploss_price"],
             trail_jump=order_data.get("trail_jump"),
@@ -66,7 +66,7 @@ def place_superorder(
         )
 
         # Determine pricetype for Main Leg
-        if order_data["entry_price"] > 0:
+        if order_data["price"] > 0:
             pricetype = "LIMIT"
         else:
             pricetype = "MARKET"
@@ -74,14 +74,14 @@ def place_superorder(
         # Place the main leg order using existing place_order service
         main_leg_data = {
             "apikey": api_key,
-            "strategy": "SuperOrder",  # Or use order_tag
+            "strategy": order_data.get("strategy", "SuperOrder"),
             "symbol": order_data["symbol"],
             "exchange": order_data["exchange"],
-            "action": order_data["transaction_type"],
+            "action": order_data["action"],
             "quantity": order_data["quantity"],
             "pricetype": pricetype,
-            "product": order_data["product_type"],
-            "price": order_data["entry_price"],
+            "product": order_data["product"],
+            "price": order_data["price"],
         }
 
         from services.place_order_service import place_order

--- a/services/superorder_service.py
+++ b/services/superorder_service.py
@@ -3,9 +3,6 @@ from typing import Any, Optional
 
 from database.auth_db import get_auth_token_broker, verify_api_key
 from database.superorder_db import SuperOrder, db_session
-from services.cancel_order_service import cancel_order
-from services.modify_order_service import modify_order
-from services.place_order_service import place_order
 from utils.logging import get_logger
 
 # Initialize logger
@@ -87,6 +84,7 @@ def place_superorder(
             "price": order_data["entry_price"],
         }
 
+        from services.place_order_service import place_order
         success, response_data, status_code = place_order(
             order_data=main_leg_data,
             api_key=api_key,
@@ -288,6 +286,7 @@ def modify_superorder(
                 mod_main_leg = True
 
             if mod_main_leg:
+                from services.modify_order_service import modify_order
                 success, resp, code = modify_order(
                     order_data=main_leg_mod_data, api_key=api_key
                 )
@@ -340,6 +339,8 @@ def cancel_superorder(
         order = SuperOrder.query.filter_by(id=order_id, user_id=user_id).first()
         if not order:
             return False, {"status": "error", "message": "Super Order not found"}, 404
+
+        from services.cancel_order_service import cancel_order
 
         if order.status == "PENDING":
             if order.main_order_id:


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds “Super Order” — an OCO-style order with entry, target, stop-loss, and optional trailing SL — with a new REST API, DB storage, and an auto-starting background monitor that trails SL, triggers exits, and cancels on expiry.

- **New Features**
  - `SuperOrder` model and `database/superorder_db` with auto-init, plus an auto-starting monitor that tracks `PENDING/ACTIVE` orders, trails SL, triggers exits, and cancels on expiry.
  - REST API `'/api/v1/superorder'` (place/list/details/modify/cancel), rate-limited; supports `INTRADAY/MIS/NRML/CNC/MTF`; added `'/orders/superorderbook'`.
  - Swagger docs and API Playground requests (`collections/openalgo/**/SuperOrder.bru`); schemas use `product`, `action`, and `price`.

- **Bug Fixes**
  - Forced live order status lookups in the monitor via `{"orderid": ..., "mode": "live"}`; fixed symbol resolution and logging; added startup import checks to fail fast.
  - Fixed monitor crashes by calling `get_order_status` with the correct payload; prevented duplicate WebSocket reconnect threads in `broker/aliceblue/api/alicebluewebsocket.py`; restored `aliceblue_adapter.py` and kept the monitor strictly broker-agnostic (`get_multiquotes`, `get_order_status`, `place_order`, `cancel_order`).
  - Stopped unconditional WebSocket quote unsubscriptions and added in-memory quote cache checks in `broker/aliceblue/api/data.py` to prevent reconnect storms and preserve continuous ticks for monitoring.

<sup>Written for commit 13e2a804801a4caac39aeb88d4c59e52d4f1f367. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

