### PR TITLE
iifl capital order api and margin api update

### DIFF
--- a/broker/iiflcapital/api/margin_api.py
+++ b/broker/iiflcapital/api/margin_api.py
@@ -1,29 +1,38 @@
 from types import SimpleNamespace
 
 from broker.iiflcapital.baseurl import BASE_URL
-from broker.iiflcapital.mapping.transform_data import transform_data
-from database.token_db import get_token
+from broker.iiflcapital.mapping.margin_data import (
+    parse_margin_response,
+    transform_margin_positions,
+)
 from utils.httpx_client import get_httpx_client
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _mock_response(status_code):
+    return SimpleNamespace(status=status_code, status_code=status_code)
 
 
 def calculate_margin_api(positions, auth):
-    """Calculate margin using IIFL Capital span/exposure endpoint."""
-    transformed_positions = []
+    """
+    Calculate margin requirement for a basket of positions using IIFL Capital API.
 
-    for position in positions:
-        token = get_token(position.get("symbol"), position.get("exchange"))
-        if not token:
-            continue
-        transformed_positions.append(transform_data(position, token))
+    Args:
+        positions: List of positions in OpenAlgo format
+        auth: Authentication token for IIFL Capital
+
+    Returns:
+        Tuple of (response, response_data)
+    """
+    transformed_positions = transform_margin_positions(positions)
 
     if not transformed_positions:
-        return (
-            SimpleNamespace(status=400, status_code=400),
-            {
-                "status": "error",
-                "message": "No valid positions for margin calculation",
-            },
-        )
+        return _mock_response(400), {
+            "status": "error",
+            "message": "No valid positions to calculate margin. Check if symbols are valid.",
+        }
 
     client = get_httpx_client()
     headers = {
@@ -32,31 +41,30 @@ def calculate_margin_api(positions, auth):
         "Accept": "application/json",
     }
 
-    response = client.post(f"{BASE_URL}/spanexposure", headers=headers, json=transformed_positions)
+    logger.info(f"IIFL Capital margin calculation payload: {transformed_positions}")
 
     try:
-        payload = response.json()
-    except Exception:
-        payload = {"status": "error", "message": "Invalid broker response"}
-
-    response_wrapper = SimpleNamespace(status=response.status_code, status_code=response.status_code)
-
-    if response.status_code == 200:
-        result = payload.get("result", payload)
-        return (
-            response_wrapper,
-            {
-                "status": "success",
-                "data": {
-                    "span": result.get("span", 0),
-                    "exposure_margin": result.get("exposureMargin", 0),
-                    "total_margin": result.get("totalMargin", 0),
-                    "buy_premium": result.get("buyPremium", 0),
-                },
-            },
+        response = client.post(
+            f"{BASE_URL}/spanexposure",
+            headers=headers,
+            json=transformed_positions,
         )
+        response.status = response.status_code
 
-    return response_wrapper, {
-        "status": "error",
-        "message": payload.get("message", "Failed to calculate margin"),
-    }
+        try:
+            response_data = response.json()
+        except Exception:
+            logger.error(f"Failed to parse IIFL Capital margin response: {response.text}")
+            return response, {"status": "error", "message": "Invalid response from broker API"}
+
+        logger.info(f"IIFL Capital margin calculation response: {response_data}")
+
+        standardized_response = parse_margin_response(response_data)
+        return response, standardized_response
+
+    except Exception as error:
+        logger.error(f"Error calling IIFL Capital margin API: {error}")
+        return _mock_response(500), {
+            "status": "error",
+            "message": f"Failed to calculate margin: {error}",
+        }

--- a/broker/iiflcapital/api/order_api.py
+++ b/broker/iiflcapital/api/order_api.py
@@ -27,6 +27,22 @@ _OPEN_STATUSES = {
 }
 
 
+def _log_rejected_orders(rows: list[dict[str, Any]]) -> None:
+    for row in rows:
+        if str(row.get("orderStatus", "")).upper() != "REJECTED":
+            continue
+
+        broker_order_id = row.get("brokerOrderId") or row.get("exchangeOrderId") or "unknown"
+        symbol = row.get("tradingSymbol") or row.get("formattedInstrumentName") or "unknown"
+        rejection_reason = row.get("rejectionReason") or "No rejection reason provided by broker"
+        logger.warning(
+            "IIFL Capital rejected order %s for %s: %s",
+            broker_order_id,
+            symbol,
+            rejection_reason,
+        )
+
+
 def _headers(auth: str) -> dict:
     return {
         "Authorization": f"Bearer {auth}",
@@ -85,17 +101,17 @@ def _extract_rows(payload):
 
 def _ok(payload: dict) -> bool:
     status = str(payload.get("status", "")).lower()
-    if status == "ok":
+    if status in _SUCCESS_STATUSES:
         return True
 
     result = payload.get("result")
     if isinstance(result, dict):
         nested_status = str(result.get("status", "")).lower()
-        if nested_status in ("success", "ok"):
+        if nested_status in _SUCCESS_STATUSES:
             return True
     if isinstance(result, list) and result:
         nested_status = str(result[0].get("status", "")).lower()
-        if nested_status in ("success", "ok"):
+        if nested_status in _SUCCESS_STATUSES:
             return True
 
     return False
@@ -152,13 +168,36 @@ def _is_success_result(result: dict) -> bool:
 
 
 def get_order_book(auth):
-    _, data = _request("/orders", auth)
-    return data
+    response, data = _request("/orders", auth)
+
+    if response.status_code == 200:
+        rows = data if isinstance(data, list) else _extract_rows(data)
+        if rows:
+            _log_rejected_orders(rows)
+        if isinstance(data, list):
+            return data
+        if rows or _ok(data):
+            return data
+
+    return {
+        "status": "error",
+        "message": _extract_message(data, "Failed to fetch order book"),
+    }
 
 
 def get_trade_book(auth):
-    _, data = _request("/trades", auth)
-    return data
+    response, data = _request("/trades", auth)
+
+    if response.status_code == 200:
+        if isinstance(data, list):
+            return data
+        if _extract_rows(data) or _ok(data):
+            return data
+
+    return {
+        "status": "error",
+        "message": _extract_message(data, "Failed to fetch trade book"),
+    }
 
 
 def get_positions(auth):
@@ -211,7 +250,8 @@ def place_order_api(data, auth):
     payload = order_payload if isinstance(order_payload, list) else [order_payload]
     logger.debug(f"IIFL Capital place order payload: {payload}")
     response, response_data = _request("/orders", auth, method="POST", payload=payload)
-    logger.debug(f"IIFL Capital place order response: {response_data}")
+    logger.info(f"IIFL Capital place order response status: {response.status_code}")
+    logger.info(f"IIFL Capital place order raw response: {response_data}")
 
     result = _first_result(response_data)
     order_id = result.get("brokerOrderId")
@@ -220,9 +260,11 @@ def place_order_api(data, auth):
         return _status_wrapper(200), response_data, order_id
 
     error_status = response.status_code if response.status_code != 200 else 400
+    error_message = _extract_message(response_data, "Failed to place order")
+    logger.warning(f"IIFL Capital place order failed: {error_message}")
     error_response = {
         "status": "error",
-        "message": _extract_message(response_data, "Failed to place order"),
+        "message": error_message,
     }
     return _status_wrapper(error_status), error_response, None
 
@@ -318,14 +360,16 @@ def close_all_positions(current_api_key, auth):
 
 
 def cancel_order(orderid, auth):
+    logger.debug(f"IIFL Capital cancel order request for {orderid}")
     response, response_data = _request(f"/orders/{orderid}", auth, method="DELETE")
+    logger.debug(f"IIFL Capital cancel order response for {orderid}: {response_data}")
 
     if response.status_code == 200 and _ok(response_data):
         return {"status": "success", "orderid": str(orderid)}, 200
 
     return {
         "status": "error",
-        "message": response_data.get("message", "Failed to cancel order"),
+        "message": _extract_message(response_data, "Failed to cancel order"),
     }, response.status_code
 
 
@@ -333,14 +377,16 @@ def modify_order(data, auth):
     order_id = data.get("orderid")
     payload = transform_modify_order_data(data)
 
-    response, response_data = _request(f"/orders/{order_id}", auth, method="PUT", payload=[payload])
+    logger.debug(f"IIFL Capital modify order payload for {order_id}: {payload}")
+    response, response_data = _request(f"/orders/{order_id}", auth, method="PUT", payload=payload)
+    logger.debug(f"IIFL Capital modify order response for {order_id}: {response_data}")
 
     if response.status_code == 200 and _ok(response_data):
         return {"status": "success", "orderid": str(order_id)}, 200
 
     return {
         "status": "error",
-        "message": response_data.get("message", "Failed to modify order"),
+        "message": _extract_message(response_data, "Failed to modify order"),
     }, response.status_code
 
 

--- a/broker/iiflcapital/mapping/margin_data.py
+++ b/broker/iiflcapital/mapping/margin_data.py
@@ -1,0 +1,131 @@
+# Mapping OpenAlgo API Request https://openalgo.in/docs
+# Mapping IIFL Capital SPAN and Exposure Margin API
+
+from broker.iiflcapital.mapping.transform_data import map_exchange
+from database.token_db import get_token
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def transform_margin_positions(positions):
+    """
+    Transform OpenAlgo margin positions to IIFL Capital span/exposure format.
+
+    Args:
+        positions: List of positions in OpenAlgo format
+
+    Returns:
+        List of positions in IIFL Capital format
+    """
+    transformed_positions = []
+    skipped_positions = []
+
+    for position in positions:
+        try:
+            symbol = position["symbol"]
+            exchange = position["exchange"]
+            action = str(position["action"]).upper()
+            quantity = int(float(position["quantity"]))
+
+            token = get_token(symbol, exchange)
+            if token in (None, "", "None"):
+                logger.warning(f"Token not found for symbol: {symbol} on exchange: {exchange}")
+                skipped_positions.append(f"{symbol} ({exchange})")
+                continue
+
+            if action not in {"BUY", "SELL"}:
+                logger.warning(f"Invalid action for margin position {symbol} ({exchange}): {action}")
+                skipped_positions.append(f"{symbol} ({exchange}) - invalid action: {action}")
+                continue
+
+            if quantity <= 0:
+                logger.warning(f"Invalid quantity for margin position {symbol} ({exchange}): {quantity}")
+                skipped_positions.append(f"{symbol} ({exchange}) - invalid quantity: {quantity}")
+                continue
+
+            transformed_positions.append(
+                {
+                    "instrumentId": str(token),
+                    "exchange": map_exchange(exchange),
+                    "transactionType": action,
+                    "quantity": quantity,
+                }
+            )
+
+        except Exception as error:
+            logger.error(f"Error transforming margin position: {position}, Error: {error}")
+            skipped_positions.append(
+                f"{position.get('symbol', 'unknown')} ({position.get('exchange', 'unknown')})"
+            )
+
+    if skipped_positions:
+        logger.warning(
+            "Skipped %s margin position(s): %s",
+            len(skipped_positions),
+            ", ".join(skipped_positions),
+        )
+
+    if transformed_positions:
+        logger.info(
+            "Successfully transformed %s position(s) for IIFL Capital margin calculation",
+            len(transformed_positions),
+        )
+
+    return transformed_positions
+
+
+def parse_margin_response(response_data):
+    """
+    Parse IIFL Capital span/exposure response to OpenAlgo standard format.
+
+    Args:
+        response_data: Raw response from IIFL Capital margin API
+
+    Returns:
+        Standardized margin response matching OpenAlgo format
+    """
+    try:
+        if not response_data or not isinstance(response_data, dict):
+            return {"status": "error", "message": "Invalid response from broker"}
+
+        status = str(response_data.get("status", "")).lower()
+        if status == "error":
+            return {
+                "status": "error",
+                "message": response_data.get("message", "Failed to calculate margin"),
+            }
+
+        result = response_data.get("result", response_data)
+        if not isinstance(result, dict):
+            return {"status": "error", "message": "Invalid margin payload from broker"}
+
+        span_margin = _safe_float(result.get("span", 0))
+        exposure_margin = _safe_float(result.get("exposureMargin", 0))
+        total_margin_required = _safe_float(
+            result.get("totalMargin", span_margin + exposure_margin)
+        )
+
+        return {
+            "status": "success",
+            "data": {
+                "total_margin_required": total_margin_required,
+                "span_margin": span_margin,
+                "exposure_margin": exposure_margin,
+                "margin_benefit": 0.0,
+            },
+        }
+
+    except Exception as error:
+        logger.error(f"Error parsing IIFL Capital margin response: {error}")
+        return {"status": "error", "message": f"Failed to parse margin response: {error}"}
+
+
+def _safe_float(value, default=0.0):
+    """Convert broker values to float safely."""
+    if value in (None, ""):
+        return default
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default

--- a/broker/iiflcapital/mapping/order_data.py
+++ b/broker/iiflcapital/mapping/order_data.py
@@ -1,6 +1,8 @@
+from broker.iiflcapital.mapping.transform_data import (
+    reverse_map_order_type,
+    reverse_map_product_type,
+)
 from database.token_db import get_symbol
-
-from broker.iiflcapital.mapping.transform_data import reverse_map_order_type, reverse_map_product_type
 
 
 def _extract_rows(payload):
@@ -51,8 +53,10 @@ def _map_status(status: str) -> str:
         return "rejected"
     if normalized in {"CANCELLED", "CANCELED"}:
         return "cancelled"
-    if normalized in {"TRIGGER_PENDING"}:
+    if normalized == "TRIGGER_PENDING":
         return "trigger pending"
+    if normalized in {"OPEN", "PENDING", "PARTIALLY_FILLED", "NEW", "PUT ORDER REQ RECEIVED"}:
+        return "open"
     return "open"
 
 
@@ -73,6 +77,25 @@ def _to_float(value, default=0.0):
         return float(value or 0)
     except (TypeError, ValueError):
         return default
+
+
+def _first_present(row: dict, *keys: str):
+    for key in keys:
+        value = row.get(key)
+        if value not in (None, ""):
+            return value
+    return None
+
+
+def _resolve_order_quantity(row: dict) -> int:
+    quantity = _first_present(row, "quantity", "orderQuantity")
+    if quantity not in (None, ""):
+        return int(float(quantity or 0))
+
+    filled_qty = _to_float(row.get("filledQuantity"))
+    pending_qty = _to_float(row.get("pendingQuantity"))
+    cancelled_qty = _to_float(row.get("cancelledQuantity"))
+    return int(filled_qty + pending_qty + cancelled_qty)
 
 
 def _resolve_holding_quantity(row: dict) -> float:
@@ -183,16 +206,20 @@ def transform_order_data(orders):
                 "symbol": _resolve_symbol(row, exchange),
                 "exchange": exchange,
                 "action": (row.get("transactionType") or "").upper(),
-                "quantity": int(float(row.get("quantity", 0) or 0)),
-                "price": float(row.get("price", 0) or 0),
-                "trigger_price": float(row.get("slTriggerPrice", 0) or 0),
-                "pricetype": reverse_map_order_type(row.get("orderType", "MARKET")),
-                "product": reverse_map_product_type(row.get("product", "INTRADAY")),
-                "orderid": str(row.get("brokerOrderId", "")),
-                "order_status": _map_status(row.get("orderStatus", "")),
-                "timestamp": row.get("exchangeTimestamp")
-                or row.get("exchangeUpdateTime")
-                or row.get("brokerUpdateTime")
+                "quantity": _resolve_order_quantity(row),
+                "price": _to_float(row.get("price")),
+                "trigger_price": _to_float(_first_present(row, "slTriggerPrice", "triggerPrice")),
+                "pricetype": reverse_map_order_type(str(row.get("orderType", "MARKET"))),
+                "product": reverse_map_product_type(str(row.get("product", "INTRADAY"))),
+                "orderid": str(_first_present(row, "brokerOrderId", "exchangeOrderId", "orderId") or ""),
+                "order_status": _map_status(str(row.get("orderStatus", ""))),
+                "rejection_reason": str(row.get("rejectionReason", "") or ""),
+                "timestamp": _first_present(
+                    row,
+                    "exchangeTimestamp",
+                    "exchangeUpdateTime",
+                    "brokerUpdateTime",
+                )
                 or "",
             }
         )
@@ -212,20 +239,27 @@ def transform_tradebook_data(tradebook_data):
         broker_exchange = row.get("exchange", "")
         exchange = _map_exchange(broker_exchange)
 
-        qty = int(float(row.get("filledQuantity", row.get("quantity", 0)) or 0))
-        avg_price = float(row.get("tradedPrice", row.get("averageTradedPrice", 0)) or 0)
+        qty = int(float(_first_present(row, "filledQuantity", "quantity", "filledQty") or 0))
+        avg_price = _to_float(_first_present(row, "tradedPrice", "averageTradedPrice", "price"))
 
         transformed.append(
             {
                 "symbol": _resolve_symbol(row, exchange),
                 "exchange": exchange,
-                "product": reverse_map_product_type(row.get("product", "INTRADAY")),
+                "product": reverse_map_product_type(str(row.get("product", "INTRADAY"))),
                 "action": (row.get("transactionType") or "").upper(),
                 "quantity": qty,
                 "average_price": avg_price,
                 "trade_value": qty * avg_price,
-                "orderid": str(row.get("brokerOrderId", "")),
-                "timestamp": row.get("fillTimestamp") or row.get("exchangeTimestamp") or "",
+                "orderid": str(_first_present(row, "brokerOrderId", "exchangeOrderId", "orderId") or ""),
+                "timestamp": _first_present(
+                    row,
+                    "fillTimestamp",
+                    "exchangeTimestamp",
+                    "exchangeUpdateTime",
+                    "brokerUpdateTime",
+                )
+                or "",
             }
         )
 

--- a/broker/iiflcapital/mapping/transform_data.py
+++ b/broker/iiflcapital/mapping/transform_data.py
@@ -103,11 +103,13 @@ def transform_modify_order_data(data: dict) -> dict:
     """Transform OpenAlgo modify request to IIFL Capital format."""
     transformed = {}
 
-    if "quantity" in data:
+    quantity = data.get("quantity")
+    if quantity is not None:
         transformed["quantity"] = str(int(float(data.get("quantity", 0))))
 
-    if "pricetype" in data:
-        order_type = map_order_type(data.get("pricetype", "MARKET"))
+    pricetype = data.get("pricetype")
+    if pricetype:
+        order_type = map_order_type(pricetype)
         transformed["orderType"] = order_type
 
         if order_type in ("LIMIT", "SL"):


### PR DESCRIPTION
iifl capital order api and margin api update

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardized the IIFL Capital margin and order APIs with robust mapping, clearer errors, and better logging. Adds margin payload/response transformers, logs rejected orders, and fixes modify/cancel request handling.

- **New Features**
  - Margin: added `transform_margin_positions` with validation and `parse_margin_response` returning standardized fields (total_margin_required, span_margin, exposure_margin).
  - Improved error handling and logs across margin and orders (including graceful 4xx/5xx and invalid payloads).
  - Order/trade book: return structured error on failure and log rejected orders with reason.
  - place/modify/cancel: unified error messages via extractor, detailed request/response logs, and corrected modify payload shape.
  - Mapping: stronger order/trade mappings (quantity resolution, better timestamps/order IDs, status coverage, and `rejection_reason`).

- **Migration**
  - Margin API now returns standardized keys: use data.total_margin_required, data.span_margin, and data.exposure_margin instead of broker-specific names.

<sup>Written for commit c171548a318918b8dcc4e8b4b197931bba556ba9. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1319?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

