### PR TITLE
perf(flattrade/ws): batch-queue subscriptions like zerodha adapter

### DIFF
--- a/broker/flattrade/api/data.py
+++ b/broker/flattrade/api/data.py
@@ -1,6 +1,7 @@
 import asyncio
 import json
 import os
+import threading
 import time
 import urllib.parse
 from concurrent.futures import ThreadPoolExecutor, as_completed
@@ -26,11 +27,73 @@ USE_ASYNC = not _is_eventlet_patched()
 
 logger = get_logger(__name__)
 
+# Global rate limiter (ported from broker/dhan/api/data.py)
+# Flattrade caps data APIs at 200 req/min (docs); some accounts are lower
+# (observed 120/min). 0.55s/req ≈ 109/min keeps us under both ceilings.
+_last_api_call_time = 0.0
+_rate_limit_lock = threading.Lock()
+FLATTRADE_MIN_REQUEST_INTERVAL = 0.55
 
-def get_api_response(endpoint, auth, method="POST", payload=None):
+
+def _apply_rate_limit():
+    """Sync rate limiter - serializes Flattrade API calls across threads.
+
+    Reserves the slot inside the lock, sleeps outside it so concurrent
+    threads queue without blocking each other on the lock itself.
     """
-    Common function to make API calls to Flattrade using httpx with connection pooling
+    global _last_api_call_time
+    sleep_time = 0.0
+
+    with _rate_limit_lock:
+        current_time = time.time()
+        time_since_last_call = current_time - _last_api_call_time
+        if time_since_last_call < FLATTRADE_MIN_REQUEST_INTERVAL:
+            sleep_time = FLATTRADE_MIN_REQUEST_INTERVAL - time_since_last_call
+        # Reserve the slot atomically
+        _last_api_call_time = current_time + sleep_time
+
+    if sleep_time > 0:
+        logger.debug(f"Rate limiting: sleeping {sleep_time:.2f}s before Flattrade API call")
+        time.sleep(sleep_time)
+
+
+async def _apply_rate_limit_async():
+    """Async variant - same algorithm but awaits asyncio.sleep so the event loop is not blocked."""
+    global _last_api_call_time
+    sleep_time = 0.0
+
+    with _rate_limit_lock:
+        current_time = time.time()
+        time_since_last_call = current_time - _last_api_call_time
+        if time_since_last_call < FLATTRADE_MIN_REQUEST_INTERVAL:
+            sleep_time = FLATTRADE_MIN_REQUEST_INTERVAL - time_since_last_call
+        _last_api_call_time = current_time + sleep_time
+
+    if sleep_time > 0:
+        await asyncio.sleep(sleep_time)
+
+
+def _is_rate_limit_error(response: dict) -> bool:
+    """Return True when Flattrade's response indicates a rate-limit hit."""
+    if not isinstance(response, dict):
+        return False
+    if response.get("stat") != "Not_Ok":
+        return False
+    emsg = response.get("emsg", "")
+    return "exceeds Limit" in emsg or "exceeds limit" in emsg
+
+
+def get_api_response(endpoint, auth, method="POST", payload=None, retry_count=0):
     """
+    Common function to make API calls to Flattrade using httpx with connection pooling.
+    Applies global rate limiting and retries with exponential backoff on rate-limit errors.
+    """
+    MAX_RETRIES = 3
+    RETRY_DELAY = 2.0  # base seconds for exponential backoff
+
+    # Apply rate limiting before making the request
+    _apply_rate_limit()
+
     AUTH_TOKEN = auth
     full_api_key = os.getenv("BROKER_API_KEY")
     api_key = full_api_key.split(":::")[0]
@@ -57,11 +120,23 @@ def get_api_response(endpoint, auth, method="POST", payload=None):
     logger.info(f"Raw Response: {data}")
 
     try:
-        return json.loads(data)
+        parsed = json.loads(data)
     except json.JSONDecodeError as e:
         logger.error(f"Error decoding JSON: {e}")
         logger.info(f"Response data: {data}")
         raise
+
+    # Retry on rate-limit error with exponential backoff
+    if _is_rate_limit_error(parsed) and retry_count < MAX_RETRIES:
+        retry_delay = RETRY_DELAY * (2**retry_count)
+        logger.warning(
+            f"Flattrade rate limit hit ({parsed.get('emsg')}). "
+            f"Retrying in {retry_delay}s (attempt {retry_count + 1}/{MAX_RETRIES})"
+        )
+        time.sleep(retry_delay)
+        return get_api_response(endpoint, auth, method, payload, retry_count + 1)
+
+    return parsed
 
 
 class BrokerData:
@@ -178,12 +253,25 @@ class BrokerData:
             raise Exception(f"Error fetching multiquotes: {e}")
 
     def _fetch_single_quote_sync(
-        self, symbol: str, exchange: str, api_exchange: str, token: str, api_key: str
+        self,
+        symbol: str,
+        exchange: str,
+        api_exchange: str,
+        token: str,
+        api_key: str,
+        retry_count: int = 0,
     ) -> dict:
         """
-        Fetch quote for a single symbol synchronously (for ThreadPoolExecutor)
+        Fetch quote for a single symbol synchronously (for ThreadPoolExecutor).
+        Honors the global rate limiter and retries with exponential backoff on rate-limit errors.
         """
+        MAX_RETRIES = 3
+        RETRY_DELAY = 2.0
+
         try:
+            # Serialize through the shared rate limiter
+            _apply_rate_limit()
+
             data = {"uid": api_key, "actid": api_key, "exch": api_exchange, "token": token}
 
             payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
@@ -195,6 +283,17 @@ class BrokerData:
             response = http_response.json()
 
             if response.get("stat") != "Ok":
+                # Retry on rate-limit error
+                if _is_rate_limit_error(response) and retry_count < MAX_RETRIES:
+                    retry_delay = RETRY_DELAY * (2**retry_count)
+                    logger.warning(
+                        f"Flattrade rate limit hit for {symbol}@{exchange}. "
+                        f"Retrying in {retry_delay}s (attempt {retry_count + 1}/{MAX_RETRIES})"
+                    )
+                    time.sleep(retry_delay)
+                    return self._fetch_single_quote_sync(
+                        symbol, exchange, api_exchange, token, api_key, retry_count + 1
+                    )
                 return {
                     "symbol": symbol,
                     "exchange": exchange,
@@ -229,11 +328,19 @@ class BrokerData:
         api_exchange: str,
         token: str,
         api_key: str,
+        retry_count: int = 0,
     ) -> dict:
         """
-        Fetch quote for a single symbol asynchronously
+        Fetch quote for a single symbol asynchronously.
+        Honors the global rate limiter and retries with exponential backoff on rate-limit errors.
         """
+        MAX_RETRIES = 3
+        RETRY_DELAY = 2.0
+
         try:
+            # Serialize through the shared rate limiter (async-safe sleep)
+            await _apply_rate_limit_async()
+
             data = {"uid": api_key, "actid": api_key, "exch": api_exchange, "token": token}
 
             payload_str = "jData=" + json.dumps(data) + "&jKey=" + self.auth_token
@@ -245,6 +352,17 @@ class BrokerData:
             response = http_response.json()
 
             if response.get("stat") != "Ok":
+                # Retry on rate-limit error
+                if _is_rate_limit_error(response) and retry_count < MAX_RETRIES:
+                    retry_delay = RETRY_DELAY * (2**retry_count)
+                    logger.warning(
+                        f"Flattrade rate limit hit for {symbol}@{exchange}. "
+                        f"Retrying in {retry_delay}s (attempt {retry_count + 1}/{MAX_RETRIES})"
+                    )
+                    await asyncio.sleep(retry_delay)
+                    return await self._fetch_single_quote_async(
+                        client, symbol, exchange, api_exchange, token, api_key, retry_count + 1
+                    )
                 logger.warning(
                     f"Error fetching quote for {symbol}@{exchange}: {response.get('emsg', 'Unknown error')}"
                 )

--- a/broker/flattrade/streaming/flattrade_adapter.py
+++ b/broker/flattrade/streaming/flattrade_adapter.py
@@ -330,6 +330,12 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.reconnect_attempts = 0
         self._reconnect_timer = None  # Track reconnection timer for cleanup
 
+        # Batch subscription management - coalesce rapid subscribe calls into a
+        # single touchline/depth message to avoid hammering the WebSocket
+        self.subscription_queue = []
+        self.batch_timer = None
+        self.batch_delay = 0.5  # 500ms window to collect subscriptions before flushing
+
     def _setup_normalizers(self):
         """Initialize data normalizers"""
         self.normalizers = {
@@ -401,6 +407,12 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self._reconnect_timer.cancel()
                 self._reconnect_timer = None
                 self.logger.debug("Cancelled pending reconnection timer")
+
+            # Cancel any pending batch subscription timer and drop queued items
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+            self.subscription_queue.clear()
 
             if self.ws_client:
                 self.ws_client.stop()
@@ -585,7 +597,13 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
             )
 
     def _websocket_subscribe(self, subscription: dict) -> None:
-        """Handle WebSocket subscription with reference counting"""
+        """Handle WebSocket subscription with reference counting and batch queueing.
+
+        On the first reference (count 0 -> 1) the scrip is added to a batch queue
+        that flushes after self.batch_delay; subsequent references just bump the
+        counter so we never send a redundant subscribe to the server.
+        Caller must hold self.lock.
+        """
         scrip = subscription["scrip"]
         mode = subscription["mode"]
 
@@ -595,26 +613,87 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
         if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
             if self.ws_subscription_refs[scrip]["touchline_count"] == 0:
-                self.logger.info(f"First touchline subscription for {scrip}")
-                self.ws_client.subscribe_touchline(scrip)
-                self.ws_subscription_refs[scrip]["touchline_count"] = 1
-            else:
-                # Already subscribed, just increment the count
-                self.ws_subscription_refs[scrip]["touchline_count"] += 1
-                self.logger.info(
-                    f"Additional touchline subscription for {scrip}, count: {self.ws_subscription_refs[scrip]['touchline_count']}"
-                )
+                self.logger.info(f"First touchline subscription for {scrip}, queueing for batch")
+                self._queue_subscription(scrip, "touchline")
+            self.ws_subscription_refs[scrip]["touchline_count"] += 1
+            self.logger.debug(
+                f"touchline_count for {scrip}: {self.ws_subscription_refs[scrip]['touchline_count']}"
+            )
         elif mode == Config.MODE_DEPTH:
             if self.ws_subscription_refs[scrip]["depth_count"] == 0:
-                self.logger.info(f"First depth subscription for {scrip}")
-                self.ws_client.subscribe_depth(scrip)
-                self.ws_subscription_refs[scrip]["depth_count"] = 1
-            else:
-                # Already subscribed, just increment the count
-                self.ws_subscription_refs[scrip]["depth_count"] += 1
-                self.logger.info(
-                    f"Additional depth subscription for {scrip}, count: {self.ws_subscription_refs[scrip]['depth_count']}"
-                )
+                self.logger.info(f"First depth subscription for {scrip}, queueing for batch")
+                self._queue_subscription(scrip, "depth")
+            self.ws_subscription_refs[scrip]["depth_count"] += 1
+            self.logger.debug(
+                f"depth_count for {scrip}: {self.ws_subscription_refs[scrip]['depth_count']}"
+            )
+
+    def _queue_subscription(self, scrip: str, sub_type: str) -> None:
+        """Queue a scrip for batched subscription. Caller must hold self.lock."""
+        self.subscription_queue.append({"scrip": scrip, "type": sub_type})
+        if len(self.subscription_queue) == 1:
+            self._start_batch_timer()
+
+    def _start_batch_timer(self) -> None:
+        """(Re)start the timer that flushes queued subscriptions."""
+        if self.batch_timer:
+            self.batch_timer.cancel()
+
+        self.batch_timer = threading.Timer(self.batch_delay, self._process_batch_subscriptions)
+        self.batch_timer.daemon = True
+        self.batch_timer.start()
+
+    def _process_batch_subscriptions(self) -> None:
+        """Flush the queue: send one touchline and one depth message with all scrips joined by #."""
+        with self.lock:
+            self.batch_timer = None
+
+            if not self.subscription_queue:
+                return
+
+            # De-duplicate while preserving order in case the same scrip was queued twice
+            touchline_scrips: list[str] = []
+            depth_scrips: list[str] = []
+            seen_touchline: set[str] = set()
+            seen_depth: set[str] = set()
+
+            for sub in self.subscription_queue:
+                scrip = sub["scrip"]
+                if sub["type"] == "touchline":
+                    if scrip not in seen_touchline:
+                        seen_touchline.add(scrip)
+                        touchline_scrips.append(scrip)
+                else:
+                    if scrip not in seen_depth:
+                        seen_depth.add(scrip)
+                        depth_scrips.append(scrip)
+
+            self.subscription_queue.clear()
+
+            # Snapshot client; release the lock before doing network I/O
+            ws_client = self.ws_client
+            connected = self.connected
+
+        if not ws_client or not connected:
+            self.logger.warning(
+                "Skipping batch flush - WebSocket not connected; "
+                "_resubscribe_all() will handle these on reconnect"
+            )
+            return
+
+        if touchline_scrips:
+            try:
+                self.logger.info(f"Batch subscribing {len(touchline_scrips)} touchline scrips")
+                ws_client.subscribe_touchline("#".join(touchline_scrips))
+            except Exception as e:
+                self.logger.error(f"Batch touchline subscription failed: {e}")
+
+        if depth_scrips:
+            try:
+                self.logger.info(f"Batch subscribing {len(depth_scrips)} depth scrips")
+                ws_client.subscribe_depth("#".join(depth_scrips))
+            except Exception as e:
+                self.logger.error(f"Batch depth subscription failed: {e}")
 
     def _websocket_unsubscribe(self, subscription: dict) -> None:
         """Handle WebSocket unsubscription with reference counting"""
@@ -691,6 +770,14 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
             f"Flattrade WebSocket connection closed: {close_status_code} - {close_msg}"
         )
         self.connected = False
+
+        # Drop pending batch items - _resubscribe_all() will rebuild subscriptions
+        # from self.subscriptions on reconnect, so anything still queued is stale
+        with self.lock:
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+            self.subscription_queue.clear()
 
         if self.running:
             self._schedule_reconnection()
@@ -1007,6 +1094,13 @@ class FlattradeWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     scrip_list = "#".join(depth_scrips)
                     self.logger.info(f"Unsubscribing from {len(depth_scrips)} depth scrips")
                     self.ws_client.unsubscribe_depth(scrip_list)
+
+                # Cancel any pending batch subscription timer - the items would
+                # subscribe to scrips we just cleared
+                if self.batch_timer:
+                    self.batch_timer.cancel()
+                    self.batch_timer = None
+                self.subscription_queue.clear()
 
                 # Clear all subscription tracking but keep WebSocket connection alive
                 subscription_count = len(self.subscriptions)


### PR DESCRIPTION
Coalesce rapid subscribe() calls into one touchline and one depth WS message per 500ms window. Prevents per-symbol message bursts that hit broker rate limits, reduces lock contention on UI mount, and makes first-tick delivery hit all symbols at roughly the same epoch.

- Queue scrips on first ref (0->1); subsequent refs just bump counter
- Flush via threading.Timer; release lock before network I/O
- Cancel timer + clear queue on disconnect, _on_close, unsubscribe_all so _resubscribe_all on reconnect does not race stale queued items

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-queue WebSocket subscriptions in the Flattrade adapter to coalesce rapid subscribe() calls into one touchline and one depth message every 500ms. Add a global rate limiter + retry for Flattrade data APIs to prevent "exceeds limit" errors.

- **Refactors**
  - Queue scrips only on first ref; flush after 500ms with de-dupe; release lock before I/O; skip if disconnected.
  - Cancel timer and clear queue on disconnect, `_on_close`, and `unsubscribe_all` to avoid reconnect races.
  - Add 0.55s global API gate with retries (2/4/8s, max 3) on rate-limit errors; applied to `get_api_response` and sync/async multiquotes.

<sup>Written for commit f404a65c3d5eba78d05b44062e8294727e713058. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

