### PR TITLE
perf(shoonya/ws): batch-queue, auth-fail short-circuit, env-var tuning, interruptible sleeps and perf(shoonya/ws): cut cold-subscribe latency ~5x with leading-edge debounce

### DIFF
--- a/broker/shoonya/streaming/shoonya_adapter.py
+++ b/broker/shoonya/streaming/shoonya_adapter.py
@@ -25,10 +25,12 @@ from .shoonya_websocket import ShoonyaWebSocket
 
 
 # Configuration constants
+# Phase 7: reconnect timings tunable via env vars per issue #1101.
+# Defaults preserve Shoonya's known-good behavior.
 class Config:
-    MAX_RECONNECT_ATTEMPTS = 10
-    BASE_RECONNECT_DELAY = 5
-    MAX_RECONNECT_DELAY = 60
+    MAX_RECONNECT_ATTEMPTS = int(os.getenv("WS_RECONNECT_MAX_TRIES", "10"))
+    BASE_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_BASE_DELAY", "5"))
+    MAX_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_MAX_DELAY", "60"))
     CACHE_COMPLETENESS_THRESHOLD = 0.3
     WEBSOCKET_TIMEOUT = 30
 
@@ -296,6 +298,16 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self._reconnect_timer = None
         self._resub_thread = None
 
+        # Subscription batch debounce — coalesce rapid subscribe()/unsubscribe()
+        # calls into a single batched WS message. Pending entries are
+        # (scrip, ws_call) tuples where ws_call is "touchline" or "depth".
+        self._sub_queue: list[tuple[str, str]] = []
+        self._unsub_queue: list[tuple[str, str]] = []
+        self._sub_batch_timer: threading.Timer | None = None
+        self._unsub_batch_timer: threading.Timer | None = None
+        # Phase 7: tunable via env var per issue #1101
+        self._batch_delay = float(os.getenv("WS_BATCH_DEBOUNCE_DELAY", "0.5"))
+
     def _setup_normalizers(self):
         """Initialize data normalizers"""
         self.normalizers = {
@@ -375,6 +387,14 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self._reconnect_timer.cancel()
                 timer_to_join = self._reconnect_timer
                 self._reconnect_timer = None
+            if self._sub_batch_timer:
+                self._sub_batch_timer.cancel()
+                self._sub_batch_timer = None
+            if self._unsub_batch_timer:
+                self._unsub_batch_timer.cancel()
+                self._unsub_batch_timer = None
+            self._sub_queue.clear()
+            self._unsub_queue.clear()
             resub_to_join = self._resub_thread
             ws_to_stop = self.ws_client
             self.ws_client = None
@@ -597,15 +617,17 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         }
 
     def _websocket_subscribe(self, subscription: dict) -> None:
-        """Handle WebSocket subscription with lock-protected ref counting"""
+        """Update ref counts and enqueue scrip into the subscription batch.
+        Batched WS sends are flushed by _flush_subscription_batch on a short
+        debounce timer, then chunked further by the WS layer."""
         scrip = subscription["scrip"]
         mode = subscription["mode"]
 
+        ws_call = None
         with self.lock:
             if scrip not in self.ws_subscription_refs:
                 self.ws_subscription_refs[scrip] = {"touchline_count": 0, "depth_count": 0}
 
-            ws_call = None
             if mode in [Config.MODE_LTP, Config.MODE_QUOTE]:
                 if self.ws_subscription_refs[scrip]["touchline_count"] == 0:
                     ws_call = "touchline"
@@ -615,37 +637,84 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     ws_call = "depth"
                 self.ws_subscription_refs[scrip]["depth_count"] += 1
 
+            if ws_call:
+                self._sub_queue.append((scrip, ws_call))
+                self._start_sub_batch_timer_locked()
+
+    def _start_sub_batch_timer_locked(self) -> None:
+        """Start (or restart) the subscribe-batch timer. Caller must hold self.lock."""
+        if self._sub_batch_timer:
+            self._sub_batch_timer.cancel()
+        self._sub_batch_timer = threading.Timer(
+            self._batch_delay, self._flush_subscription_batch
+        )
+        self._sub_batch_timer.daemon = True
+        self._sub_batch_timer.start()
+
+    def _start_unsub_batch_timer_locked(self) -> None:
+        """Start (or restart) the unsubscribe-batch timer. Caller must hold self.lock."""
+        if self._unsub_batch_timer:
+            self._unsub_batch_timer.cancel()
+        self._unsub_batch_timer = threading.Timer(
+            self._batch_delay, self._flush_unsubscription_batch
+        )
+        self._unsub_batch_timer.daemon = True
+        self._unsub_batch_timer.start()
+
+    def _flush_subscription_batch(self) -> None:
+        """Drain _sub_queue, group by ws_call type, and hand off to the WS
+        layer's batched API which chunks and paces the actual sends."""
+        with self.lock:
+            self._sub_batch_timer = None
+            if not self._sub_queue:
+                return
+            queue_snapshot = self._sub_queue
+            self._sub_queue = []
             ws = self.ws_client
 
-        # Network I/O outside lock
-        if ws_call and ws:
-            try:
-                if ws_call == "touchline":
-                    ws.subscribe_touchline(scrip)
-                    self.logger.info(f"First touchline subscription for {scrip}")
-                else:
-                    ws.subscribe_depth(scrip)
-                    self.logger.info(f"First depth subscription for {scrip}")
-            except Exception as e:
-                # SA-R7-7 fix: Log that subscription is kept in dict for retry on reconnect
-                self.logger.error(
-                    f"Error subscribing {ws_call} for {scrip}: {e}; "
-                    f"subscription retained for retry on reconnect"
+        if not ws:
+            self.logger.warning(
+                f"[BATCH_SUBSCRIBE] No WS client; dropping {len(queue_snapshot)} pending subs "
+                f"(will be re-sent on reconnect via resubscribe_all)"
+            )
+            return
+
+        touchline_scrips: list[str] = []
+        depth_scrips: list[str] = []
+        seen_touchline: set[str] = set()
+        seen_depth: set[str] = set()
+
+        # Dedupe within the batch — multiple correlation IDs for the same
+        # scrip/mode collapse to one WS subscription.
+        for scrip, ws_call in queue_snapshot:
+            if ws_call == "touchline" and scrip not in seen_touchline:
+                seen_touchline.add(scrip)
+                touchline_scrips.append(scrip)
+            elif ws_call == "depth" and scrip not in seen_depth:
+                seen_depth.add(scrip)
+                depth_scrips.append(scrip)
+
+        try:
+            if touchline_scrips:
+                self.logger.info(
+                    f"[BATCH_SUBSCRIBE] Sending {len(touchline_scrips)} touchline scrips"
                 )
-                # SA-4 fix: Roll back ref count on failure so retry is possible
-                with self.lock:
-                    if scrip in self.ws_subscription_refs:
-                        if ws_call == "touchline":
-                            self.ws_subscription_refs[scrip]["touchline_count"] = max(
-                                0, self.ws_subscription_refs[scrip]["touchline_count"] - 1
-                            )
-                        else:
-                            self.ws_subscription_refs[scrip]["depth_count"] = max(
-                                0, self.ws_subscription_refs[scrip]["depth_count"] - 1
-                            )
+                ws.subscribe_touchline_scrips(touchline_scrips)
+            if depth_scrips:
+                self.logger.info(
+                    f"[BATCH_SUBSCRIBE] Sending {len(depth_scrips)} depth scrips"
+                )
+                ws.subscribe_depth_scrips(depth_scrips)
+        except Exception as e:
+            self.logger.error(
+                f"Error queueing batch subscription: {e}; subscriptions retained "
+                f"in adapter and will be re-sent on reconnect"
+            )
 
     def _websocket_unsubscribe(self, subscription: dict) -> None:
-        """Handle WebSocket unsubscription with lock-protected ref counting"""
+        """Update ref counts and enqueue scrip into the unsubscribe batch.
+        Actual WS sends are flushed by _flush_unsubscription_batch on a short
+        debounce timer."""
         scrip = subscription["scrip"]
         mode = subscription["mode"]
 
@@ -674,19 +743,49 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             if refs and refs["touchline_count"] <= 0 and refs["depth_count"] <= 0:
                 del self.ws_subscription_refs[scrip]
 
+            if ws_call:
+                self._unsub_queue.append((scrip, ws_call))
+                self._start_unsub_batch_timer_locked()
+
+    def _flush_unsubscription_batch(self) -> None:
+        """Drain _unsub_queue and hand off to the WS-layer batched API."""
+        with self.lock:
+            self._unsub_batch_timer = None
+            if not self._unsub_queue:
+                return
+            queue_snapshot = self._unsub_queue
+            self._unsub_queue = []
             ws = self.ws_client
 
-        # Network I/O outside lock
-        if ws_call and ws:
-            try:
-                if ws_call == "touchline":
-                    ws.unsubscribe_touchline(scrip)
-                    self.logger.info(f"Last touchline subscription for {scrip}")
-                else:
-                    ws.unsubscribe_depth(scrip)
-                    self.logger.info(f"Last depth subscription for {scrip}")
-            except Exception as e:
-                self.logger.error(f"Error unsubscribing {ws_call} for {scrip}: {e}")
+        if not ws:
+            return
+
+        touchline_scrips: list[str] = []
+        depth_scrips: list[str] = []
+        seen_touchline: set[str] = set()
+        seen_depth: set[str] = set()
+
+        for scrip, ws_call in queue_snapshot:
+            if ws_call == "touchline" and scrip not in seen_touchline:
+                seen_touchline.add(scrip)
+                touchline_scrips.append(scrip)
+            elif ws_call == "depth" and scrip not in seen_depth:
+                seen_depth.add(scrip)
+                depth_scrips.append(scrip)
+
+        try:
+            if touchline_scrips:
+                self.logger.info(
+                    f"[BATCH_UNSUBSCRIBE] Sending {len(touchline_scrips)} touchline scrips"
+                )
+                ws.unsubscribe_touchline_scrips(touchline_scrips)
+            if depth_scrips:
+                self.logger.info(
+                    f"[BATCH_UNSUBSCRIBE] Sending {len(depth_scrips)} depth scrips"
+                )
+                ws.unsubscribe_depth_scrips(depth_scrips)
+        except Exception as e:
+            self.logger.error(f"Error queueing batch unsubscription: {e}")
 
     # SA-1 fix: Don't reset _reconnecting here — let _attempt_reconnection own that flag
     # SA-7 fix: Move _resubscribe_all to background thread to avoid blocking WS message thread
@@ -712,13 +811,63 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             resub.start()
 
     def _on_error(self, ws, error):
-        """Handle WebSocket connection error — just log, close callback handles reconnection"""
+        """Handle WebSocket connection error.
+        Phase 4a: detect auth-failure error messages (401/403/"unauthorized"/
+        "session expired"/"invalid token") and stop the reconnect loop. The
+        close callback owns the actual reconnect scheduling — we just set the
+        running flag here so it short-circuits."""
         self.logger.error(f"Shoonya WebSocket error: {error}")
+
+        # is_auth_error() inherited from BaseBrokerWebSocketAdapter
+        if self.is_auth_error(error):
+            self.logger.error(
+                "Auth-failure error detected on Shoonya WS; stopping reconnect "
+                "loop to avoid hammering broker IP with dead-token requests"
+            )
+            with self.lock:
+                self.running = False
+                self._reconnecting = False
+                if self._reconnect_timer:
+                    self._reconnect_timer.cancel()
+                    self._reconnect_timer = None
 
     # M1 fix: connected=False inside lock block to prevent TOCTOU
     def _on_close(self, ws, close_status_code, close_msg):
-        """Handle WebSocket connection close with reconnection guard"""
+        """Handle WebSocket connection close with reconnection guard.
+        Phase 4a: short-circuit reconnect when the underlying close was caused
+        by an auth-failure ack (running=False already set by WS layer) or the
+        close-status text matches an auth-error pattern."""
         self.logger.info(f"Shoonya WebSocket connection closed: {close_status_code} - {close_msg}")
+
+        # Detect auth-failure paths before deciding to reconnect:
+        # 1. WS layer flagged auth_failed in _handle_auth_response (status != "OK")
+        # 2. Close message matches a generic auth-error pattern
+        ws_client = self.ws_client
+        ws_layer_auth_failed = bool(
+            ws_client is not None and getattr(ws_client, "auth_failed", False)
+        )
+        close_text_auth_failed = self.is_auth_error(close_msg) or self.is_auth_error(
+            str(close_status_code)
+        )
+
+        if ws_layer_auth_failed or close_text_auth_failed:
+            reason = (
+                getattr(ws_client, "auth_failure_reason", None)
+                if ws_layer_auth_failed
+                else f"{close_status_code} {close_msg}"
+            )
+            self.logger.error(
+                f"Auth failure on Shoonya WS ({reason}); stopping reconnect loop. "
+                f"User must re-login to refresh the auth token."
+            )
+            with self.lock:
+                self.connected = False
+                self.running = False
+                self._reconnecting = False
+                if self._reconnect_timer:
+                    self._reconnect_timer.cancel()
+                    self._reconnect_timer = None
+            return
 
         with self.lock:
             self.connected = False
@@ -843,9 +992,23 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     reconnect_succeeded = True
                     self.logger.info("Reconnected successfully")
             else:
-                self.logger.error("Reconnection failed")
-                self._schedule_reconnection()
-                scheduled_retry = True
+                # Phase 4a: distinguish "auth-rejected with fresh token" from
+                # transient TCP/timeout failures. If auth failed even with a
+                # freshly-fetched DB token, re-login is required — don't keep
+                # hammering the broker.
+                if getattr(new_client, "auth_failed", False):
+                    self.logger.error(
+                        f"Reconnection auth-rejected with fresh token "
+                        f"({new_client.auth_failure_reason}); stopping reconnect "
+                        f"loop. User must re-login."
+                    )
+                    with self.lock:
+                        self.running = False
+                        self._reconnecting = False
+                else:
+                    self.logger.error("Reconnection failed")
+                    self._schedule_reconnection()
+                    scheduled_retry = True
 
         except Exception as e:
             self.logger.error(f"Reconnection error: {e}")
@@ -898,17 +1061,18 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # Snapshot ws_client reference under lock
             ws = self.ws_client
 
-        # Network I/O outside lock
+        # Network I/O outside lock — use batched API so large scrip sets get
+        # chunked into MAX_SCRIPS_PER_BATCH-sized messages by the WS layer.
         if ws and touchline_scrips:
             try:
-                ws.subscribe_touchline("#".join(touchline_scrips))
+                ws.subscribe_touchline_scrips(list(touchline_scrips))
                 self.logger.info(f"Resubscribed to {len(touchline_scrips)} touchline scrips")
             except Exception as e:
                 self.logger.error(f"Error resubscribing touchline: {e}")
 
         if ws and depth_scrips:
             try:
-                ws.subscribe_depth("#".join(depth_scrips))
+                ws.subscribe_depth_scrips(list(depth_scrips))
                 self.logger.info(f"Resubscribed to {len(depth_scrips)} depth scrips")
             except Exception as e:
                 self.logger.error(f"Error resubscribing depth: {e}")
@@ -1072,21 +1236,19 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # SA-16 fix: Track partial failures in unsubscribe calls
             unsub_errors = []
 
-            # Network I/O outside lock
+            # Network I/O outside lock — batched API chunks per MAX_SCRIPS_PER_BATCH
             if ws and touchline_scrips:
                 try:
-                    scrip_list = "#".join(touchline_scrips)
                     self.logger.info(f"Unsubscribing from {len(touchline_scrips)} touchline scrips")
-                    ws.unsubscribe_touchline(scrip_list)
+                    ws.unsubscribe_touchline_scrips(list(touchline_scrips))
                 except Exception as e:
                     self.logger.error(f"Error unsubscribing touchline: {e}")
                     unsub_errors.append(f"touchline: {e}")
 
             if ws and depth_scrips:
                 try:
-                    scrip_list = "#".join(depth_scrips)
                     self.logger.info(f"Unsubscribing from {len(depth_scrips)} depth scrips")
-                    ws.unsubscribe_depth(scrip_list)
+                    ws.unsubscribe_depth_scrips(list(depth_scrips))
                 except Exception as e:
                     self.logger.error(f"Error unsubscribing depth: {e}")
                     unsub_errors.append(f"depth: {e}")
@@ -1136,6 +1298,14 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     self._reconnect_timer.cancel()
                     timer_to_join = self._reconnect_timer
                     self._reconnect_timer = None
+                if self._sub_batch_timer:
+                    self._sub_batch_timer.cancel()
+                    self._sub_batch_timer = None
+                if self._unsub_batch_timer:
+                    self._unsub_batch_timer.cancel()
+                    self._unsub_batch_timer = None
+                self._sub_queue.clear()
+                self._unsub_queue.clear()
                 resub_to_join = self._resub_thread
                 ws_to_stop = self.ws_client
                 self.ws_client = None

--- a/broker/shoonya/streaming/shoonya_adapter.py
+++ b/broker/shoonya/streaming/shoonya_adapter.py
@@ -10,6 +10,7 @@ import sys
 import threading
 import time
 import uuid
+from collections import Counter
 from typing import Any
 
 from database.auth_db import get_auth_token
@@ -695,11 +696,41 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self._unsub_batch_timer.start()
         return False
 
+    def _reconcile_queues_locked(self) -> None:
+        """Cancel matching (scrip, ws_call) pairs that appear in both
+        _sub_queue and _unsub_queue. A subscribe followed by an unsubscribe
+        within the same debounce window has no net effect on the broker;
+        sending the pair wastes a round trip and — since the two queues
+        drain on independent timers — risks leaking a broker subscription
+        with no local tracking if the unsub flushes before the sub.
+        Caller must hold self.lock."""
+        if not (self._sub_queue and self._unsub_queue):
+            return
+        cancel = Counter(self._sub_queue) & Counter(self._unsub_queue)
+        if not cancel:
+            return
+
+        def filter_queue(
+            queue: list[tuple[str, str]], to_cancel: Counter
+        ) -> list[tuple[str, str]]:
+            remaining = Counter(to_cancel)
+            out: list[tuple[str, str]] = []
+            for entry in queue:
+                if remaining.get(entry, 0) > 0:
+                    remaining[entry] -= 1
+                    continue
+                out.append(entry)
+            return out
+
+        self._sub_queue = filter_queue(self._sub_queue, cancel)
+        self._unsub_queue = filter_queue(self._unsub_queue, cancel)
+
     def _flush_subscription_batch(self) -> None:
         """Drain _sub_queue, group by ws_call type, and hand off to the WS
         layer's batched API which chunks and paces the actual sends."""
         with self.lock:
             self._sub_batch_timer = None
+            self._reconcile_queues_locked()
             if not self._sub_queue:
                 return
             queue_snapshot = self._sub_queue
@@ -789,6 +820,7 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Drain _unsub_queue and hand off to the WS-layer batched API."""
         with self.lock:
             self._unsub_batch_timer = None
+            self._reconcile_queues_locked()
             if not self._unsub_queue:
                 return
             queue_snapshot = self._unsub_queue

--- a/broker/shoonya/streaming/shoonya_adapter.py
+++ b/broker/shoonya/streaming/shoonya_adapter.py
@@ -25,12 +25,10 @@ from .shoonya_websocket import ShoonyaWebSocket
 
 
 # Configuration constants
-# Phase 7: reconnect timings tunable via env vars per issue #1101.
-# Defaults preserve Shoonya's known-good behavior.
 class Config:
-    MAX_RECONNECT_ATTEMPTS = int(os.getenv("WS_RECONNECT_MAX_TRIES", "10"))
-    BASE_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_BASE_DELAY", "5"))
-    MAX_RECONNECT_DELAY = int(os.getenv("WS_RECONNECT_MAX_DELAY", "60"))
+    MAX_RECONNECT_ATTEMPTS = 10
+    BASE_RECONNECT_DELAY = 5
+    MAX_RECONNECT_DELAY = 60
     CACHE_COMPLETENESS_THRESHOLD = 0.3
     WEBSOCKET_TIMEOUT = 30
 
@@ -301,12 +299,18 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Subscription batch debounce — coalesce rapid subscribe()/unsubscribe()
         # calls into a single batched WS message. Pending entries are
         # (scrip, ws_call) tuples where ws_call is "touchline" or "depth".
+        # Leading-edge debounce: the FIRST call after a quiet period flushes
+        # immediately (no debounce wait), so a single-symbol UI click pays
+        # ~0ms adapter overhead. Subsequent calls within `_batch_delay` of
+        # the last flush wait it out so they coalesce — that's how the
+        # /optionchain 42-symbol burst still hits a single WS frame.
         self._sub_queue: list[tuple[str, str]] = []
         self._unsub_queue: list[tuple[str, str]] = []
         self._sub_batch_timer: threading.Timer | None = None
         self._unsub_batch_timer: threading.Timer | None = None
-        # Phase 7: tunable via env var per issue #1101
-        self._batch_delay = float(os.getenv("WS_BATCH_DEBOUNCE_DELAY", "0.5"))
+        self._last_sub_flush_at: float = 0.0
+        self._last_unsub_flush_at: float = 0.0
+        self._batch_delay = 0.5
 
     def _setup_normalizers(self):
         """Initialize data normalizers"""
@@ -618,12 +622,16 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def _websocket_subscribe(self, subscription: dict) -> None:
         """Update ref counts and enqueue scrip into the subscription batch.
-        Batched WS sends are flushed by _flush_subscription_batch on a short
-        debounce timer, then chunked further by the WS layer."""
+        Leading-edge dispatch: if it's been at least `_batch_delay` since the
+        last flush, send the batch immediately so a single-symbol click pays
+        ~0ms of adapter overhead. Otherwise schedule a flush for the end of
+        the current debounce window so a burst of calls coalesces into one
+        WS frame."""
         scrip = subscription["scrip"]
         mode = subscription["mode"]
 
         ws_call = None
+        flush_now = False
         with self.lock:
             if scrip not in self.ws_subscription_refs:
                 self.ws_subscription_refs[scrip] = {"touchline_count": 0, "depth_count": 0}
@@ -639,27 +647,53 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
             if ws_call:
                 self._sub_queue.append((scrip, ws_call))
-                self._start_sub_batch_timer_locked()
+                flush_now = self._schedule_sub_flush_locked()
 
-    def _start_sub_batch_timer_locked(self) -> None:
-        """Start (or restart) the subscribe-batch timer. Caller must hold self.lock."""
-        if self._sub_batch_timer:
-            self._sub_batch_timer.cancel()
-        self._sub_batch_timer = threading.Timer(
-            self._batch_delay, self._flush_subscription_batch
-        )
-        self._sub_batch_timer.daemon = True
-        self._sub_batch_timer.start()
+        if flush_now:
+            # Outside the lock — _flush_subscription_batch reacquires it.
+            self._flush_subscription_batch()
 
-    def _start_unsub_batch_timer_locked(self) -> None:
-        """Start (or restart) the unsubscribe-batch timer. Caller must hold self.lock."""
-        if self._unsub_batch_timer:
-            self._unsub_batch_timer.cancel()
-        self._unsub_batch_timer = threading.Timer(
-            self._batch_delay, self._flush_unsubscription_batch
-        )
-        self._unsub_batch_timer.daemon = True
-        self._unsub_batch_timer.start()
+    def _schedule_sub_flush_locked(self) -> bool:
+        """Decide whether to flush the subscribe queue now (leading edge) or
+        schedule a timer for the end of the current debounce window.
+        Caller must hold self.lock. Returns True if the caller should call
+        _flush_subscription_batch synchronously after releasing the lock."""
+        elapsed = time.time() - self._last_sub_flush_at
+        if elapsed >= self._batch_delay:
+            # Quiet window — flush immediately. Mark the time now so any
+            # racing call within _batch_delay schedules a timer instead.
+            self._last_sub_flush_at = time.time()
+            if self._sub_batch_timer:
+                self._sub_batch_timer.cancel()
+                self._sub_batch_timer = None
+            return True
+        # In the debounce window — ensure a timer is scheduled to flush
+        # at the end of it. Don't restart an already-running timer (that
+        # would push the deadline back indefinitely under sustained load).
+        if self._sub_batch_timer is None:
+            delay = max(0.0, self._batch_delay - elapsed)
+            self._sub_batch_timer = threading.Timer(delay, self._flush_subscription_batch)
+            self._sub_batch_timer.daemon = True
+            self._sub_batch_timer.start()
+        return False
+
+    def _schedule_unsub_flush_locked(self) -> bool:
+        """Mirror of _schedule_sub_flush_locked for the unsubscribe queue."""
+        elapsed = time.time() - self._last_unsub_flush_at
+        if elapsed >= self._batch_delay:
+            self._last_unsub_flush_at = time.time()
+            if self._unsub_batch_timer:
+                self._unsub_batch_timer.cancel()
+                self._unsub_batch_timer = None
+            return True
+        if self._unsub_batch_timer is None:
+            delay = max(0.0, self._batch_delay - elapsed)
+            self._unsub_batch_timer = threading.Timer(
+                delay, self._flush_unsubscription_batch
+            )
+            self._unsub_batch_timer.daemon = True
+            self._unsub_batch_timer.start()
+        return False
 
     def _flush_subscription_batch(self) -> None:
         """Drain _sub_queue, group by ws_call type, and hand off to the WS
@@ -670,6 +704,7 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 return
             queue_snapshot = self._sub_queue
             self._sub_queue = []
+            self._last_sub_flush_at = time.time()
             ws = self.ws_client
 
         if not ws:
@@ -713,11 +748,11 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def _websocket_unsubscribe(self, subscription: dict) -> None:
         """Update ref counts and enqueue scrip into the unsubscribe batch.
-        Actual WS sends are flushed by _flush_unsubscription_batch on a short
-        debounce timer."""
+        Same leading-edge dispatch as _websocket_subscribe."""
         scrip = subscription["scrip"]
         mode = subscription["mode"]
 
+        flush_now = False
         with self.lock:
             if scrip not in self.ws_subscription_refs:
                 return
@@ -745,7 +780,10 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
             if ws_call:
                 self._unsub_queue.append((scrip, ws_call))
-                self._start_unsub_batch_timer_locked()
+                flush_now = self._schedule_unsub_flush_locked()
+
+        if flush_now:
+            self._flush_unsubscription_batch()
 
     def _flush_unsubscription_batch(self) -> None:
         """Drain _unsub_queue and hand off to the WS-layer batched API."""
@@ -755,6 +793,7 @@ class ShoonyaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 return
             queue_snapshot = self._unsub_queue
             self._unsub_queue = []
+            self._last_unsub_flush_at = time.time()
             ws = self.ws_client
 
         if not ws:

--- a/broker/shoonya/streaming/shoonya_websocket.py
+++ b/broker/shoonya/streaming/shoonya_websocket.py
@@ -660,9 +660,13 @@ class ShoonyaWebSocket:
             else:
                 # Re-queue at the front and back off; preserve ordering for the
                 # rest of the queue so different msg types stay grouped.
+                # Skip re-queue if shutting down — clear_pending_subscriptions()
+                # may have already drained, and re-adding here leaks stale
+                # entries into a later reconnect/reuse of this WS client.
                 with self._subscription_lock:
-                    for scrip in reversed(batch_scrips):
-                        self._pending_subscriptions.appendleft((batch_msg_type, scrip))
+                    if self.running and not self._shutdown_event.is_set():
+                        for scrip in reversed(batch_scrips):
+                            self._pending_subscriptions.appendleft((batch_msg_type, scrip))
                 self.logger.warning(
                     f"{operation_name} batch failed; retrying after backoff"
                 )

--- a/broker/shoonya/streaming/shoonya_websocket.py
+++ b/broker/shoonya/streaming/shoonya_websocket.py
@@ -5,7 +5,6 @@ Handles connection to Shoonya's market data streaming API
 
 import json
 import logging
-import os
 import threading
 import time
 from collections import deque
@@ -20,32 +19,29 @@ class ShoonyaWebSocket:
 
     # Connection constants
     WS_URL = "wss://api.shoonya.com/NorenWSAPI/"
-    # Phase 7: keepalive/reconnect timings are tunable via env vars
-    # (issue #1101). Defaults preserve Shoonya's known-good behavior.
-    CONNECTION_TIMEOUT = int(os.getenv("WS_CONNECTION_TIMEOUT", "15"))
+    CONNECTION_TIMEOUT = 15
     THREAD_JOIN_TIMEOUT = 5
 
-    # Heartbeat constants
-    HEARTBEAT_INTERVAL = int(os.getenv("WS_APP_HEARTBEAT_INTERVAL", "30"))
-    HEARTBEAT_TIMEOUT = int(os.getenv("WS_DATA_TIMEOUT", "120"))
-    PING_INTERVAL = int(os.getenv("WS_PING_INTERVAL", "30"))
-    PING_TIMEOUT = int(os.getenv("WS_PING_TIMEOUT", "10"))
-    # websocket-client strictly requires ping_interval > ping_timeout
-    # (ValueError: "Ensure ping_interval > ping_timeout"). If a deployment
-    # has inherited values from the proxy server's WS config (which is
-    # tolerated by the `websockets` library used there), bump interval
-    # above timeout so Shoonya doesn't fail to connect. We add 5s headroom
-    # so there's a meaningful pong-wait window.
-    if PING_INTERVAL <= PING_TIMEOUT:
-        PING_INTERVAL = PING_TIMEOUT + 5
+    # Heartbeat constants. websocket-client requires PING_INTERVAL strictly
+    # greater than PING_TIMEOUT, so they are pinned here rather than read
+    # from the platform-wide WS_PING_* env vars (which the proxy server
+    # tolerates being equal under the `websockets` library).
+    HEARTBEAT_INTERVAL = 30
+    HEARTBEAT_TIMEOUT = 120
+    PING_INTERVAL = 30
+    PING_TIMEOUT = 10
     HEARTBEAT_JOIN_TIMEOUT = 3
 
     # Subscription batching — Shoonya supports '#'-separated scrip lists in
     # a single message; chunk large lists so each WS send stays small and
     # add a small delay between chunks to avoid server-side rate limits.
-    MAX_SCRIPS_PER_BATCH = int(os.getenv("WS_MAX_SCRIPS_PER_BATCH", "100"))
-    SUBSCRIPTION_DELAY = float(os.getenv("WS_SUBSCRIPTION_DELAY", "0.5"))
-    SUBSCRIPTION_RETRY_DELAY = float(os.getenv("WS_SUBSCRIPTION_RETRY_DELAY", "2.0"))
+    # Empirically Shoonya tolerates much faster pacing than the original
+    # 0.5s/2.0s pair; 100ms / 500ms keeps headroom for very large bursts
+    # and is invisible to single-symbol UI clicks (which skip the delay
+    # entirely via the `if has_more` guard around the wait).
+    MAX_SCRIPS_PER_BATCH = 100
+    SUBSCRIPTION_DELAY = 0.1
+    SUBSCRIPTION_RETRY_DELAY = 0.5
 
     # Message types (OAuth WebSocket API)
     MSG_TYPE_CONNECT = "a"

--- a/broker/shoonya/streaming/shoonya_websocket.py
+++ b/broker/shoonya/streaming/shoonya_websocket.py
@@ -5,8 +5,10 @@ Handles connection to Shoonya's market data streaming API
 
 import json
 import logging
+import os
 import threading
 import time
+from collections import deque
 from collections.abc import Callable
 from typing import Any
 
@@ -18,15 +20,32 @@ class ShoonyaWebSocket:
 
     # Connection constants
     WS_URL = "wss://api.shoonya.com/NorenWSAPI/"
-    CONNECTION_TIMEOUT = 15
+    # Phase 7: keepalive/reconnect timings are tunable via env vars
+    # (issue #1101). Defaults preserve Shoonya's known-good behavior.
+    CONNECTION_TIMEOUT = int(os.getenv("WS_CONNECTION_TIMEOUT", "15"))
     THREAD_JOIN_TIMEOUT = 5
 
     # Heartbeat constants
-    HEARTBEAT_INTERVAL = 30
-    HEARTBEAT_TIMEOUT = 120
-    PING_INTERVAL = 30
-    PING_TIMEOUT = 10
+    HEARTBEAT_INTERVAL = int(os.getenv("WS_APP_HEARTBEAT_INTERVAL", "30"))
+    HEARTBEAT_TIMEOUT = int(os.getenv("WS_DATA_TIMEOUT", "120"))
+    PING_INTERVAL = int(os.getenv("WS_PING_INTERVAL", "30"))
+    PING_TIMEOUT = int(os.getenv("WS_PING_TIMEOUT", "10"))
+    # websocket-client strictly requires ping_interval > ping_timeout
+    # (ValueError: "Ensure ping_interval > ping_timeout"). If a deployment
+    # has inherited values from the proxy server's WS config (which is
+    # tolerated by the `websockets` library used there), bump interval
+    # above timeout so Shoonya doesn't fail to connect. We add 5s headroom
+    # so there's a meaningful pong-wait window.
+    if PING_INTERVAL <= PING_TIMEOUT:
+        PING_INTERVAL = PING_TIMEOUT + 5
     HEARTBEAT_JOIN_TIMEOUT = 3
+
+    # Subscription batching — Shoonya supports '#'-separated scrip lists in
+    # a single message; chunk large lists so each WS send stays small and
+    # add a small delay between chunks to avoid server-side rate limits.
+    MAX_SCRIPS_PER_BATCH = int(os.getenv("WS_MAX_SCRIPS_PER_BATCH", "100"))
+    SUBSCRIPTION_DELAY = float(os.getenv("WS_SUBSCRIPTION_DELAY", "0.5"))
+    SUBSCRIPTION_RETRY_DELAY = float(os.getenv("WS_SUBSCRIPTION_RETRY_DELAY", "2.0"))
 
     # Message types (OAuth WebSocket API)
     MSG_TYPE_CONNECT = "a"
@@ -73,6 +92,13 @@ class ShoonyaWebSocket:
         self.running = False
         self.connected = False
 
+        # Phase 4a: distinguishes auth-failure from transient network drops so
+        # the adapter can short-circuit the reconnect loop. Set True only when
+        # the broker explicitly rejects auth (status != "OK" in the auth-ack
+        # response). Persistent across the lifetime of this WS client.
+        self.auth_failed = False
+        self.auth_failure_reason: str | None = None
+
         # Callbacks
         self.on_message = on_message
         self.on_error = on_error
@@ -83,6 +109,18 @@ class ShoonyaWebSocket:
         self._heartbeat_thread = None
         self._last_message_time = None
         self._heartbeat_lock = threading.Lock()
+
+        # Subscription batching — separate queues per (msg_type) since
+        # touchline/depth use different message types but share one worker.
+        self._pending_subscriptions: deque[tuple[str, str]] = deque()
+        self._subscription_thread: threading.Thread | None = None
+        self._subscription_lock = threading.Lock()
+
+        # Phase 8: shutdown event lets every wait/sleep loop bail immediately
+        # when stop() is called, instead of blocking up to N seconds. Critical
+        # under gunicorn+eventlet where systemd graceful_timeout (30s) would
+        # otherwise SIGKILL the worker mid-sleep.
+        self._shutdown_event = threading.Event()
 
         # Logging
         self.logger = logging.getLogger("shoonya_websocket")
@@ -115,6 +153,13 @@ class ShoonyaWebSocket:
     def _initialize_connection(self) -> None:
         """Initialize WebSocket connection and start thread"""
         self.running = True
+        # Phase 8: clear shutdown event so wait()s block normally on this
+        # session even if the same client object was previously stopped.
+        self._shutdown_event.clear()
+        # Phase 4a: reset stale auth-failure state if this client object is
+        # being reused for a fresh connection attempt.
+        self.auth_failed = False
+        self.auth_failure_reason = None
 
         self.ws = websocket.WebSocketApp(
             self.WS_URL,
@@ -134,13 +179,16 @@ class ShoonyaWebSocket:
         Returns:
             bool: True if connected within timeout, False otherwise
         """
+        # Phase 8: interruptible poll. Bail immediately if shutdown is signaled.
         start_time = time.time()
 
         while self.running and time.time() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("WebSocket connected successfully")
                 return True
-            time.sleep(0.1)
+            if self._shutdown_event.wait(0.1):
+                self.logger.debug("Connection wait interrupted by shutdown")
+                return False
 
         self.logger.error("Connection timeout")
         self.stop()
@@ -168,6 +216,15 @@ class ShoonyaWebSocket:
 
         self.running = False
         self.connected = False
+
+        # Phase 8: signal every wait/sleep loop (heartbeat, connection-poll,
+        # subscription worker) to bail immediately instead of blocking up to
+        # HEARTBEAT_INTERVAL seconds.
+        self._shutdown_event.set()
+
+        # Drop any queued subscription batches; the worker exits when it
+        # sees running=False on its next loop iteration.
+        self.clear_pending_subscriptions()
 
         self._close_websocket()
         self._wait_for_thread_completion()
@@ -294,6 +351,11 @@ class ShoonyaWebSocket:
             # set it before auth completes
             self.connected = False
             self.running = False
+            # Phase 4a: flag this as an auth failure so the adapter can
+            # short-circuit its reconnect loop instead of hammering a dead
+            # token (e.g., 3am IST daily token expiry, weekend gap).
+            self.auth_failed = True
+            self.auth_failure_reason = str(data)
             self._close_websocket()
 
         return True
@@ -373,7 +435,9 @@ class ShoonyaWebSocket:
         """Heartbeat worker thread - sends periodic heartbeats and monitors connection"""
         while self.running and self.connected:
             try:
-                time.sleep(self.HEARTBEAT_INTERVAL)
+                # Phase 8: interruptible — exit immediately on shutdown signal
+                if self._shutdown_event.wait(self.HEARTBEAT_INTERVAL):
+                    break
 
                 if self.running and self.connected:
                     if not self._send_heartbeat():
@@ -489,6 +553,141 @@ class ShoonyaWebSocket:
         return self._send_subscription_message(
             self.MSG_TYPE_DEPTH_UNSUB, scrip_list, "depth unsubscription"
         )
+
+    # Batched subscription API — accepts a list of scrips, queues them, and
+    # drains the queue from a single worker thread that chunks large lists
+    # into MAX_SCRIPS_PER_BATCH-sized '#'-separated messages with a small
+    # SUBSCRIPTION_DELAY between sends.
+    def subscribe_touchline_scrips(self, scrips: list[str]) -> None:
+        """Queue touchline subscriptions for batched sending"""
+        self._enqueue_subscriptions(self.MSG_TYPE_TOUCHLINE_SUB, scrips)
+
+    def unsubscribe_touchline_scrips(self, scrips: list[str]) -> None:
+        """Queue touchline unsubscriptions for batched sending"""
+        self._enqueue_subscriptions(self.MSG_TYPE_TOUCHLINE_UNSUB, scrips)
+
+    def subscribe_depth_scrips(self, scrips: list[str]) -> None:
+        """Queue depth subscriptions for batched sending"""
+        self._enqueue_subscriptions(self.MSG_TYPE_DEPTH_SUB, scrips)
+
+    def unsubscribe_depth_scrips(self, scrips: list[str]) -> None:
+        """Queue depth unsubscriptions for batched sending"""
+        self._enqueue_subscriptions(self.MSG_TYPE_DEPTH_UNSUB, scrips)
+
+    def _enqueue_subscriptions(self, msg_type: str, scrips: list[str]) -> None:
+        """Append (msg_type, scrip) entries to the pending queue and ensure
+        the worker thread is running."""
+        if not scrips:
+            return
+
+        with self._subscription_lock:
+            for scrip in scrips:
+                if scrip:
+                    self._pending_subscriptions.append((msg_type, scrip))
+
+            if self._subscription_thread and self._subscription_thread.is_alive():
+                return
+
+            self._subscription_thread = threading.Thread(
+                target=self._process_pending_subscriptions,
+                daemon=True,
+                name="ShoonyaWSSubWorker",
+            )
+            self._subscription_thread.start()
+
+    def _process_pending_subscriptions(self) -> None:
+        """Drain the pending queue, grouping consecutive same-type entries
+        into batches of up to MAX_SCRIPS_PER_BATCH scrips, '#'-joined into
+        a single WS message. Sleeps SUBSCRIPTION_DELAY between batches."""
+        consecutive_failures = 0
+
+        while self.running:
+            # Wait until we have an authenticated, connected WS session
+            if not self.connected:
+                consecutive_failures += 1
+                if consecutive_failures > 6:
+                    self.logger.error(
+                        "Subscription worker giving up — no connection after retries; "
+                        "dropping pending subscription batch"
+                    )
+                    with self._subscription_lock:
+                        self._pending_subscriptions.clear()
+                    return
+                # Phase 8: interruptible wait
+                if self._shutdown_event.wait(
+                    min(self.SUBSCRIPTION_RETRY_DELAY * consecutive_failures, 10)
+                ):
+                    return
+                continue
+
+            consecutive_failures = 0
+
+            batch_msg_type: str | None = None
+            batch_scrips: list[str] = []
+
+            with self._subscription_lock:
+                if not self._pending_subscriptions:
+                    self._subscription_thread = None
+                    return
+
+                while (
+                    self._pending_subscriptions
+                    and len(batch_scrips) < self.MAX_SCRIPS_PER_BATCH
+                ):
+                    msg_type, scrip = self._pending_subscriptions[0]
+                    if batch_msg_type is None:
+                        batch_msg_type = msg_type
+                    elif msg_type != batch_msg_type:
+                        break
+                    self._pending_subscriptions.popleft()
+                    batch_scrips.append(scrip)
+
+            if not batch_scrips or batch_msg_type is None:
+                continue
+
+            scrip_list = "#".join(batch_scrips)
+            operation_name = self._operation_name_for_msg_type(batch_msg_type)
+            success = self._send_subscription_message(
+                batch_msg_type, scrip_list, operation_name
+            )
+
+            if success:
+                self.logger.info(
+                    f"Sent batch {operation_name} for {len(batch_scrips)} scrips"
+                )
+                # Pace consecutive batches so we don't flood the server
+                with self._subscription_lock:
+                    has_more = bool(self._pending_subscriptions)
+                # Phase 8: interruptible pacing
+                if has_more and self._shutdown_event.wait(self.SUBSCRIPTION_DELAY):
+                    return
+            else:
+                # Re-queue at the front and back off; preserve ordering for the
+                # rest of the queue so different msg types stay grouped.
+                with self._subscription_lock:
+                    for scrip in reversed(batch_scrips):
+                        self._pending_subscriptions.appendleft((batch_msg_type, scrip))
+                self.logger.warning(
+                    f"{operation_name} batch failed; retrying after backoff"
+                )
+                if self._shutdown_event.wait(self.SUBSCRIPTION_RETRY_DELAY):
+                    return
+
+    def _operation_name_for_msg_type(self, msg_type: str) -> str:
+        """Human-readable label for log messages."""
+        return {
+            self.MSG_TYPE_TOUCHLINE_SUB: "touchline subscription",
+            self.MSG_TYPE_TOUCHLINE_UNSUB: "touchline unsubscription",
+            self.MSG_TYPE_DEPTH_SUB: "depth subscription",
+            self.MSG_TYPE_DEPTH_UNSUB: "depth unsubscription",
+        }.get(msg_type, f"message {msg_type}")
+
+    def clear_pending_subscriptions(self) -> int:
+        """Clear any queued subscription batches. Returns the number cleared."""
+        with self._subscription_lock:
+            count = len(self._pending_subscriptions)
+            self._pending_subscriptions.clear()
+        return count
 
     def _send_subscription_message(
         self, msg_type: str, scrip_list: str, operation_name: str


### PR DESCRIPTION
perf(shoonya/ws): batch-queue, auth-fail short-circuit, env-var tuning, interruptible sleeps and perf(shoonya/ws): cut cold-subscribe latency ~5x with leading-edge debounce

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batch-queues Shoonya WS subscribe/unsubscribe with a leading-edge debounce and a chunked send worker, cutting cold-subscribe latency by ~5x and reducing WS load. Also short-circuits reconnect on auth failures, makes waits interruptible, and prevents stale broker subscriptions during bursty toggles.

- **Performance**
  - Adapter debounces sub/unsub with a 500 ms window; first call after quiet flushes immediately.
  - WS adds list-based sub/unsub APIs; chunks 100 scrips per message with 100 ms pacing; used by resubscribe/unsubscribe paths.
  - Batches are deduped per scrip/mode to avoid duplicate sends.

- **Reliability**
  - Detects auth failures (in error/close and during reconnect) and stops the reconnect loop until re-login.
  - Reconnect logic separates auth rejects from transient errors.
  - Reconciles sub/unsub queues before each flush and skips re-queue after shutdown to avoid stale broker subs across reconnects.
  - All sleeps are interruptible via a shutdown signal; disconnect/cleanup cancel timers and clear pending queues.

<sup>Written for commit 08a3004bb485ceb13671066d812f4a28f3bfd9e3. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

