### PR TITLE
fix(zerodha): recover from daily Kite token expiry without restart (#765)

### DIFF
--- a/broker/zerodha/streaming/zerodha_adapter.py
+++ b/broker/zerodha/streaming/zerodha_adapter.py
@@ -709,6 +709,120 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Handle WebSocket errors"""
         self.logger.error(f"WebSocket error: {error}")
 
+        # Daily token-expiry recovery. When Kite returns 403/Authentication
+        # failed the underlying ZerodhaWebSocket flips its `auth_failed`
+        # flag and stops retrying. We here detect the same condition and
+        # rebuild the client end-to-end so the next subscribe attempt
+        # succeeds with a fresh access_token from the auth db.
+        #
+        # Without this, the broker WS adapter stays dead until the user
+        # restarts the OpenAlgo container, even if they re-log into Kite.
+        err_str = str(error)
+        if "403" in err_str or "Authentication failed" in err_str:
+            if getattr(self, "_token_refresh_in_progress", False):
+                # Re-init already running in another thread — don't pile up.
+                return
+            self._token_refresh_in_progress = True
+            try:
+                threading.Thread(
+                    target=self._refresh_token_and_reconnect,
+                    daemon=True,
+                    name="ZerodhaTokenRefresh",
+                ).start()
+            except Exception as e:
+                self.logger.error(f"Failed to spawn token refresh thread: {e}")
+                self._token_refresh_in_progress = False
+
+    def _refresh_token_and_reconnect(self):
+        """
+        Tear down the auth-failed WS client, re-fetch the access_token from
+        the auth db (which holds whatever token the user has after their
+        latest Kite login), and bring up a fresh WebSocket client. Resubs
+        are replayed from self.subscribed_symbols so the user doesn't
+        notice a daily disconnect.
+        """
+        try:
+            self.logger.warning("🔄 Refreshing Zerodha token + rebuilding WebSocket client")
+
+            # Snapshot subscriptions to replay after reconnect.
+            with self.lock:
+                subs_snapshot = list(self.subscribed_symbols.values())
+
+            # Stop and discard the dead WS client.
+            try:
+                if self.ws_client:
+                    self.ws_client.stop()
+            except Exception as e:
+                self.logger.debug(f"Error stopping old WS client: {e}")
+            self.ws_client = None
+            self.connected = False
+            self.running = False
+
+            # Re-read the access_token from the auth db. The user's most
+            # recent Kite login is recorded there; if they haven't re-
+            # logged this is the same expired token and we'll loop, but
+            # the loop is throttled by Kite's own rate-limiting and the
+            # user will see the failures in logs and act.
+            #
+            # bypass_cache=True is REQUIRED here: get_auth_token's default
+            # path returns a cached token that was populated with the now-
+            # expired credentials. Without bypassing, this refresh re-reads
+            # the same dead token forever even after the user re-logs and
+            # the DB has fresh credentials. See OpenAlgo issue #765.
+            if not self.user_id:
+                self.logger.error("Cannot refresh token: user_id is None")
+                return
+            auth_token = get_auth_token(self.user_id, bypass_cache=True)
+            if not auth_token:
+                self.logger.error("Cannot refresh token: auth db returned no token")
+                return
+            if ":" in auth_token:
+                parts = auth_token.split(":")
+                self.access_token = parts[1] if len(parts) >= 2 else auth_token
+            else:
+                self.access_token = auth_token
+            if not self.access_token:
+                self.logger.error("Cannot refresh token: empty access_token after parse")
+                return
+
+            # Rebuild the WS client with the fresh token.
+            self.ws_client = ZerodhaWebSocket(
+                api_key=self.api_key,
+                access_token=self.access_token,
+                on_ticks=self._handle_ticks,
+            )
+            self.ws_client.on_connect = self._on_connect
+            self.ws_client.on_disconnect = self._on_disconnect
+            self.ws_client.on_error = self._on_error
+
+            # Connect — same flow as the original adapter.connect().
+            if not self.ws_client.start():
+                self.logger.error("Token refresh: ws_client.start() returned False")
+                return
+            self.running = True
+            if self.ws_client.wait_for_connection(timeout=15.0):
+                self.connected = True
+                self.logger.info("✅ Token refresh: WebSocket reconnected with fresh token")
+            else:
+                self.logger.warning("Token refresh: connection still pending after 15s")
+
+            # Replay subscriptions so the upstream stream keeps flowing.
+            if subs_snapshot:
+                self.logger.info(f"Replaying {len(subs_snapshot)} subscriptions after token refresh")
+                for sub in subs_snapshot:
+                    try:
+                        self.subscribe(
+                            symbol=sub.get("symbol"),
+                            exchange=sub.get("exchange"),
+                            mode=sub.get("mode", 2),
+                        )
+                    except Exception as e:
+                        self.logger.error(f"Failed to replay subscription {sub}: {e}")
+        except Exception as e:
+            self.logger.error(f"Token refresh failed: {e}")
+        finally:
+            self._token_refresh_in_progress = False
+
     def cleanup(self):
         """Clean up all resources including WebSocket connection and ZMQ resources"""
         try:

--- a/broker/zerodha/streaming/zerodha_websocket.py
+++ b/broker/zerodha/streaming/zerodha_websocket.py
@@ -113,6 +113,15 @@ class ZerodhaWebSocket:
         self._connection_ready = threading.Event()
         self._stop_event = threading.Event()
 
+        # Auth failure tracking. Kite Connect access tokens expire daily
+        # at ~08:00 IST; when expired the WS handshake returns
+        # "Handshake status 403 Forbidden ... Authentication failed".
+        # Reconnecting with the same baked-in access_token will fail
+        # forever — there's no path for the WS thread to refresh the
+        # token. Flag the failure so the adapter (which CAN re-fetch
+        # from the auth db) tears this client down and rebuilds it.
+        self.auth_failed = False
+
         self.logger.info("Enhanced Zerodha WebSocket client initialized (sync)")
 
     def set_token_exchange_mapping(self, token_exchange_map: dict[int, str]):
@@ -167,6 +176,15 @@ class ZerodhaWebSocket:
                 self.logger.error(f"WebSocket run_forever error: {e}")
 
             self.connected = False
+
+            # Auth failure short-circuits the retry loop. The token is
+            # baked into self.ws_url so retrying achieves nothing — the
+            # adapter must rebuild this client with a fresh token.
+            if self.auth_failed:
+                self.logger.warning(
+                    "WebSocket thread exiting — auth failed, awaiting adapter re-init with fresh token"
+                )
+                break
 
             if not self.running or self._stop_event.is_set():
                 break
@@ -407,6 +425,23 @@ class ZerodhaWebSocket:
         self.logger.error(f"WebSocket error: {error}")
         self.connected = False
         self.error_count += 1
+
+        # Detect Kite Connect daily token expiry (08:00 IST). Errors look
+        # like: "Handshake status 403 Forbidden ... 'Authentication failed.'"
+        # When seen, flag and stop the reconnect loop — the adapter will
+        # rebuild this client with a freshly re-fetched access_token.
+        err_str = str(error)
+        if "403" in err_str or "Authentication failed" in err_str:
+            if not self.auth_failed:
+                self.logger.warning(
+                    "Kite WS auth failed — stopping reconnects so adapter can refresh access_token"
+                )
+            self.auth_failed = True
+            # Trip the run-loop's exit conditions so it doesn't waste
+            # 50 retries × exponential backoff on a guaranteed-fail token.
+            self.running = False
+            self._stop_event.set()
+
         if self.on_error:
             try:
                 self.on_error(error)

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -758,7 +758,12 @@ class WebSocketProxy:
                     should_retry = (
                         adapter.is_auth_error(error_msg) or
                         error_code in ("CONNECTION_FAILED", "CONNECTION_ERROR") or
-                        "failed to connect" in error_msg.lower()
+                        "failed to connect" in error_msg.lower() or
+                        # Stale pooled adapter: ws_client died (e.g. daily token
+                        # rotation) and ConnectionPool.initialize() early-returns
+                        # "Already initialized" so it never rebuilds. Treat as
+                        # retryable so the force=True re-init below recovers it.
+                        "not initialized" in error_msg.lower()
                     )
 
                     if should_retry:


### PR DESCRIPTION
## Summary

Kite Connect access tokens expire daily at ~08:00 IST. When that happens, the Zerodha WebSocket handshake returns `403 "Authentication failed"` and the existing reconnect loop spins forever on the baked-in dead token. Until now, the only recovery was an OpenAlgo container restart — even after the user re-logged into Kite and a fresh token landed in the auth db.

This PR makes the streaming adapter self-heal: detect the 403, tear down the auth-failed WS client, re-fetch the freshly-stored `access_token` from the auth db, and bring up a new WS client with live credentials. Existing subscriptions are snapshotted before teardown and replayed afterward, so downstream subscribers don't notice the daily disconnect.

## What's in here

**1. `broker/zerodha/streaming/zerodha_websocket.py`**

- New `auth_failed` flag, set when the `on_error` callback sees a `403` / `Authentication failed` string.
- Short-circuits the run-loop's exponential-backoff retry — prevents burning ~50 attempts on a guaranteed-fail token. The WS thread exits cleanly so the adapter can rebuild it with fresh credentials.

**2. `broker/zerodha/streaming/zerodha_adapter.py`**

- In `_on_error`, detect the same 403 condition and spawn a single `_refresh_token_and_reconnect` thread (guarded by a re-entry flag).
- The refresh re-reads the token from the auth db with **`bypass_cache=True`**. This is the critical fix from #765: the default cached read returns the now-expired token, so without `bypass_cache=True` the rebuild loops on the same dead token forever even after the user re-logs and the DB has fresh credentials.
- After reconnecting, replay the prior subscriptions so the upstream ZMQ stream keeps flowing.

## Why `bypass_cache=True` is non-negotiable

`get_auth_token()`'s own docstring already calls this case out:

```python
def get_auth_token(name, bypass_cache: bool = False):
    """
    bypass_cache: If True, skip the cache and query the database directly.
                  Use this when retrying after a 403 error to get fresh credentials.
                  See GitHub issue #765 for details.
    """
```

The token-refresh path is exactly that scenario. Without the flag, the cache returns yesterday's expired token even after `auth_db.upsert_auth(...)` has stored today's fresh one — so the WS rebuild authenticates with the dead token, gets 403 again, and we're back in the original retry loop.

## Test plan

- [x] Reproduced the original failure on a real OpenAlgo deployment after Kite's daily expiry: WS keeps 403'ing, user log-in stores a new token in `auth` table, but cached refresh keeps reading the expired one.
- [x] With this patch deployed, after Kite re-login the next 403 triggers `_refresh_token_and_reconnect`, `get_auth_token(user_id, bypass_cache=True)` returns the fresh token, the new WS client connects cleanly, and prior subscriptions replay automatically — verified via:
  - `[zerodha_adapter] ✅ Token refresh: WebSocket reconnected with fresh token`
  - downstream tick consumers (custom dashboard) seeing `First tick` events resume within ~5 s of OAuth callback.
- [x] Confirmed no regression on the cold-connect path (initial `initialize()` still uses cached `get_auth_token` since the cache is warm/correct at process start).

Closes #765

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically recover from daily Kite Connect token expiry and stale pooled adapters without restarting OpenAlgo. On 403 auth failures, the Zerodha streaming adapter refreshes the token from the auth DB and reconnects; the WebSocket proxy also force re-initializes on “not initialized” pool errors.

- **Bug Fixes**
  - Detect 403/"Authentication failed" in both `zerodha_websocket` and `zerodha_adapter`, stop the retry loop, and exit the WS thread.
  - Spawn a single refresh-and-reconnect flow that reads the token with `bypass_cache=True` to avoid stale credentials (fixes #765).
  - Rebuild the WebSocket with the fresh token and replay prior subscriptions.
  - Guard against concurrent refresh attempts with an in-progress flag.
  - In `websocket_proxy`, treat "not initialized" as retryable so the connection pool force-reinitializes the broker adapter and recovers the feed after token rotation (also fixes #765).

<sup>Written for commit 341c3c785bc8f15152bf6464c13b419630cc61d1. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1387?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

