### PR TITLE
fix(kotak): align place/modify order payload with official Neo spec

### DIFF
--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -148,7 +148,7 @@ def place_order_api(data, auth_token):
     client = get_httpx_client()
 
     token_id = get_token(data["symbol"], data["exchange"])
-    newdata = transform_data(data, token_id, auth_token)
+    newdata = transform_data(data, token_id)
 
     json_string = json.dumps(newdata)
     payload = f"jData={urllib.parse.quote(json_string)}"
@@ -166,6 +166,7 @@ def place_order_api(data, auth_token):
 
     try:
         response = client.post(url, headers=headers, content=payload)
+        logger.info(f"PLACE ORDER API Response: {response.status_code} {response.text}")
 
         # Add status attribute for compatibility with the existing codebase
         response.status = response.status_code
@@ -380,7 +381,7 @@ def modify_order(data, auth_token):
     client = get_httpx_client()
 
     token_id = get_token(data["symbol"], data["exchange"])
-    newdata = transform_modify_order_data(data, token_id, auth_token)
+    newdata = transform_modify_order_data(data, token_id)
 
     logger.info(f"MODIFY ORDER - Transformed data: {newdata}")
 

--- a/broker/kotak/mapping/transform_data.py
+++ b/broker/kotak/mapping/transform_data.py
@@ -1,150 +1,67 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Kotak Neo API Parameters
 
-import math
-
-from broker.kotak.api.data import BrokerData
 from database.token_db import get_br_symbol
 from utils.logging import get_logger
-from utils.mpp_slab import get_instrument_type_from_symbol, get_mpp_percentage
 
 logger = get_logger(__name__)
 
-# mp=0 means "no MPP" — correct for limit-priced orders (LIMIT/SL) where price is specified.
-NO_MPP = "0"
-# Minimum integer slab value; used only as a safe fallback for MARKET/SL-M when slab lookup fails.
-FALLBACK_MP = "1"
 
-
-def _mp_from_percentage(percentage):
-    """Kotak mp is an integer percentage; slabs < 1% floor to 1."""
-    return str(max(1, math.ceil(percentage)))
-
-
-def _compute_mp(data, auth_token):
-    """
-    Compute Kotak's mp (market protection %) from the MPP slab.
-
-    Only MARKET and SL-M orders need MPP — they execute at market price.
-    LIMIT/SL orders carry their own price, so mp is not applicable and is sent as 0.
-
-    Reference price for slab lookup:
-      - MARKET: LTP (fetched via quotes)
-      - SL-M:   trigger_price (the level at which the order converts to MARKET)
-    """
-    pricetype = data.get("pricetype")
-    symbol = data["symbol"]
-    exchange = data["exchange"]
-
-    if pricetype not in ("MARKET", "SL-M"):
-        return NO_MPP
-
-    instrument_type = get_instrument_type_from_symbol(symbol)
-
-    if pricetype == "MARKET":
-        if not auth_token:
-            return FALLBACK_MP
-        try:
-            quote_data = BrokerData(auth_token).get_quotes(symbol, exchange)
-            ltp = float(quote_data.get("ltp", 0)) if quote_data else 0.0
-            if ltp <= 0:
-                logger.warning(f"MPP: LTP invalid for {symbol}/{exchange}, using mp={FALLBACK_MP}")
-                return FALLBACK_MP
-            percentage = get_mpp_percentage(ltp, instrument_type)
-            mp_value = _mp_from_percentage(percentage)
-            logger.info(
-                f"MPP (MARKET): Symbol={symbol}, LTP={ltp}, InstrumentType={instrument_type}, "
-                f"SlabPct={percentage}%, mp={mp_value}"
-            )
-            return mp_value
-        except Exception as e:
-            logger.warning(f"MPP: Failed to compute mp for {symbol}/{exchange}: {e}. Using mp={FALLBACK_MP}")
-            return FALLBACK_MP
-
-    # SL-M
+def _fmt_price(value):
+    """Kotak rejects '0.0' on numeric fields — emit '0' for zero, otherwise stringified value."""
     try:
-        trigger_price = float(data.get("trigger_price", 0))
+        f = float(value)
     except (TypeError, ValueError):
-        trigger_price = 0.0
-    if trigger_price <= 0:
-        logger.warning(
-            f"MPP: trigger_price invalid for SL-M {symbol}/{exchange}, using mp={FALLBACK_MP}"
-        )
-        return FALLBACK_MP
-    try:
-        percentage = get_mpp_percentage(trigger_price, instrument_type)
-        mp_value = _mp_from_percentage(percentage)
-    except Exception as e:
-        logger.warning(
-            f"MPP: Failed to compute mp for SL-M {symbol}/{exchange}: {e}. Using mp={FALLBACK_MP}"
-        )
-        return FALLBACK_MP
-    logger.info(
-        f"MPP (SL-M): Symbol={symbol}, TriggerPrice={trigger_price}, "
-        f"InstrumentType={instrument_type}, SlabPct={percentage}%, mp={mp_value}"
-    )
-    return mp_value
+        return str(value) if value is not None else "0"
+    if f == 0:
+        return "0"
+    return str(value)
 
 
-def transform_data(data, token, auth_token=None):
+def transform_data(data, token):
     """
     Transforms the new API request structure to the current expected structure.
     ALL values must be strings for Kotak API.
-
-    Kotak Neo applies Market Price Protection natively when mp > 0 is passed.
-    For MARKET orders, mp is derived from the MPP slab based on LTP + instrument type.
-    MARKET/SL-M orders are forwarded as-is (no local MKT->L / SL-M->SL conversion).
-
-    Args:
-        data: Order data dictionary
-        token: Instrument token
-        auth_token: Authentication token used to fetch LTP for mp computation
     """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
 
-    price = str(data.get("price", "0"))
     order_type = map_order_type(data["pricetype"])
     action = data["action"].upper()
-    mp_value = _compute_mp(data, auth_token)
 
-    # Basic mapping - ALL values must be strings for Kotak API
     transformed = {
         "am": "NO",
         "dq": str(data.get("disclosed_quantity", "0")),
-        "bc": "1",
         "es": reverse_map_exchange(data["exchange"]),
-        "mp": mp_value,
+        "mp": "0",
         "pc": data.get("product", "MIS"),
         "pf": "N",
-        "pr": price,
+        "pr": _fmt_price(data.get("price", 0)),
         "pt": order_type,
         "qt": str(data["quantity"]),
         "rt": "DAY",
-        "tp": str(data.get("trigger_price", "0")),
+        "tp": _fmt_price(data.get("trigger_price", 0)),
         "ts": symbol,
         "tt": "B" if action == "BUY" else ("S" if action == "SELL" else "None"),
     }
 
-    # Log order data
     logger.info(f"Transformed order data: {transformed}")
     return transformed
 
 
-def transform_modify_order_data(data, token, auth_token=None):
+def transform_modify_order_data(data, token):
     symbol = get_br_symbol(data["symbol"], data["exchange"])
-    # Basic mapping - ALL values must be strings for Kotak API
     transformed = {
         "tk": str(token),
         "dq": str(data.get("disclosed_quantity", "0")),
         "es": reverse_map_exchange(data["exchange"]),
-        "mp": _compute_mp(data, auth_token),
+        "mp": "0",
         "dd": "NA",
         "vd": "DAY",
         "pc": data.get("product", "MIS"),
-        "pr": str(data.get("price", "0")),
+        "pr": _fmt_price(data.get("price", 0)),
         "pt": map_order_type(data["pricetype"]),
         "qt": str(data["quantity"]),
-        "tp": str(data.get("trigger_price", "0")),
+        "tp": _fmt_price(data.get("trigger_price", 0)),
         "ts": symbol,
         "no": str(data["orderid"]),
         "tt": "B" if data["action"] == "BUY" else ("S" if data["action"] == "SELL" else "None"),


### PR DESCRIPTION
fix(kotak): align place/modify order payload with official Neo spec

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns Kotak Neo place/modify order payloads to the official spec to reduce server rejections and simplify client logic. Also adds response logging for easier debugging.

- **Bug Fixes**
  - Removed client-side MPP slab logic; send `mp: "0"` for place/modify (Neo applies MPP server-side).
  - Dropped undocumented `bc` field from payloads.
  - Emit "0" (not "0.0") for `pr`/`tp` when zero to match Neo validation.
  - Simplified `transform_data`/`transform_modify_order_data` signatures (no `auth_token` or quote fetch).
  - Logged Place Order API responses to surface non-2xx errors (e.g., unauthorized/static IP).

<sup>Written for commit 9dea31986577e7b616a9966a8351150e3cb2496b. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

