### PR TITLE
fix(auth): /broker?reauth=1 escape hatch for stale broker tokens (closes #1400)

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -460,6 +460,13 @@ def two_factor_configure():
 @limiter.limit(LOGIN_RATE_LIMIT_MIN)
 @limiter.limit(LOGIN_RATE_LIMIT_HOUR)
 def broker_login():
+    # `?reauth=1` lets a logged-in user re-enter the broker OAuth flow without
+    # first having to /auth/logout. Recovery path for stale broker tokens that
+    # the platform does not auto-refresh — e.g. daily-expiring brokers like
+    # IIFL Capital, Zerodha, Upstox. See issue #1400.
+    if request.args.get("reauth", "").lower() in ("1", "true", "yes"):
+        session.pop("logged_in", None)
+
     if session.get("logged_in"):
         return redirect("/dashboard")
     if request.method == "GET":


### PR DESCRIPTION
Closes #1400.

## Problem

When a broker access token expires server-side (typical for daily-expiring brokers like IIFL Capital, Zerodha, Upstox), `session.logged_in` is never reset. The dashboard then shows `Failed to get margin data` with no UI path to re-authenticate, and `/auth/broker` redirects logged-in users back to `/dashboard` — so the only recovery is `/auth/logout` + `/login`. Most users never figure that out.

See #1400 for the full repro / root-cause writeup.

## Change

Adds a `?reauth=1` (also accepts `true`/`yes`) query parameter to the `/auth/broker` route. When present, it clears `session.logged_in` so the React broker selection page renders the OAuth flow.

```python
def broker_login():
    if request.args.get("reauth", "").lower() in ("1", "true", "yes"):
        session.pop("logged_in", None)

    if session.get("logged_in"):
        return redirect("/dashboard")
    ...
```

7-line patch, single file (`blueprints/auth.py`).

## Behaviour

- `GET /auth/broker` — unchanged: redirects logged-in users to `/dashboard`, sends not-yet-broker-authed users to `/broker`.
- `GET /auth/broker?reauth=1` — clears `session.logged_in`, then proceeds. The React `/broker` page sees `logged_in: false` from `/auth/session-status` and renders the broker selection UI for fresh OAuth.
- No effect on the broker callback path, no DB writes.

## Why minimal

This is the smallest patch that unsticks users who are otherwise trapped. It deliberately doesn't:

- Add mid-session token validation (would need a `before_request` hook + cached funds probe to avoid latency).
- Touch the dashboard React UI (the `Failed to get margin data` toast can be wired to link to `/auth/broker?reauth=1` in a follow-up).
- Mutate the DB `auth` row.

Happy to extend in either direction if maintainers prefer a heavier fix.

## Manual test

1. Login with a working broker session — `session.logged_in = True`, dashboard loads.
2. Invalidate the broker token (e.g. `UPDATE auth SET is_revoked=1 WHERE name=...` or wait for daily expiry).
3. Hit `/auth/broker` — old behaviour: bounce to `/dashboard`. New behaviour: same (unchanged when no query param).
4. Hit `/auth/broker?reauth=1` — `session.logged_in` is cleared, redirected to `/broker`, broker selection UI renders, OAuth flow completes, fresh token written.

---

Co-Authored-By: Claude Opus 4.7 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a `?reauth=1` escape hatch to `/auth/broker` that clears `session.logged_in`, letting users re-run the broker OAuth flow when tokens expire without logging out. Behavior is unchanged without the query param; fixes the re-auth dead end in #1400.

<sup>Written for commit f8047cd7a6b5a30ed5fe74466216fc909dbaaceb. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

