### PR TITLE
fix(paytm): normalize NSE_INDEX and BSE_INDEX symbols, ws: close file-descriptor leaks in streaming layer and fix(paytm): option chain, OI tracker, historical-data graceful empty, batch ws subscribe

### DIFF
--- a/broker/paytm/api/data.py
+++ b/broker/paytm/api/data.py
@@ -147,8 +147,12 @@ class BrokerData:
             # Paytm expects the symbol to be in the format "exchange:token:opt_type" E.g: NSE:335:EQUITY
             encoded_symbol = urllib.parse.quote(f"{request_exchange}:{token}:{opt_type}")
 
+            # Use mode=FULL so the response carries `oi` and `change_oi`
+            # (per Paytm doc 10-02, QUOTE mode omits them). The OI tracker,
+            # IV smile and similar tooling read these fields. FULL is a
+            # strict superset of QUOTE — we just ignore the depth array.
             response = get_api_response(
-                f"/data/v1/price/live?mode=QUOTE&pref={encoded_symbol}", self.auth_token
+                f"/data/v1/price/live?mode=FULL&pref={encoded_symbol}", self.auth_token
             )
 
             if not response or not response.get("data", []):
@@ -172,6 +176,7 @@ class BrokerData:
                 "open": quote.get("ohlc", {}).get("open", 0),
                 "prev_close": quote.get("ohlc", {}).get("close", 0),
                 "volume": quote.get("volume_traded", 0),
+                "oi": quote.get("oi", 0),
             }
 
         except Exception as e:
@@ -299,8 +304,11 @@ class BrokerData:
             encoded_pref = urllib.parse.quote(",".join(pref_list))
             logger.info(f"Fetching {len(pref_list)} quotes via REST API")
 
+            # mode=FULL so each quote carries `oi` / `change_oi` for the
+            # OI tracker, IV smile, etc. QUOTE mode omits OI per the Paytm
+            # API spec (10-02).
             response = get_api_response(
-                f"/data/v1/price/live?mode=QUOTE&pref={encoded_pref}", self.auth_token
+                f"/data/v1/price/live?mode=FULL&pref={encoded_pref}", self.auth_token
             )
 
             if not response or not response.get("data", []):
@@ -335,7 +343,7 @@ class BrokerData:
                                 "ltp": quote.get("last_price", 0),
                                 "prev_close": quote.get("ohlc", {}).get("close", 0),
                                 "volume": quote.get("volume_traded", 0),
-                                "oi": 0,
+                                "oi": quote.get("oi", 0),
                             },
                         }
                     )
@@ -462,22 +470,20 @@ class BrokerData:
         self, symbol: str, exchange: str, timeframe: str, from_date: str, to_date: str
     ) -> pd.DataFrame:
         """
-        Get historical data for given symbol and timeframe
-        Args:
-            symbol: Trading symbol
-            exchange: Exchange (e.g., NSE, BSE)
-            timeframe: Timeframe (e.g., 1m, 5m, 15m, 60m, D)
-            from_date: Start date in format YYYY-MM-DD
-            to_date: End date in format YYYY-MM-DD
-        Returns:
-            pd.DataFrame: Historical data with OHLCV
+        Historical data is not provided by the Paytm Money API.
+
+        Return an empty OHLCV DataFrame instead of raising, so downstream
+        consumers (history_service, option_greeks_service, straddle chart,
+        IV charts, etc.) can render a "no data" state gracefully rather
+        than surfacing a 500. Mirrors the Kotak Neo handling.
         """
-        raise NotImplementedError("Paytm does not support historical data API")
+        logger.warning("Paytm does not provide historical data API")
+        return pd.DataFrame(columns=["timestamp", "open", "high", "low", "close", "volume"])
 
     def get_intervals(self) -> list:
-        """Get available intervals/timeframes for historical data
-
-        Returns:
-            list: List of available intervals
         """
-        raise NotImplementedError("Paytm does not support historical data API")
+        Paytm does not provide historical data; return an empty list so
+        callers that probe interval support don't see an exception.
+        """
+        logger.warning("Paytm does not provide historical data API intervals")
+        return []

--- a/broker/paytm/database/master_contract_db.py
+++ b/broker/paytm/database/master_contract_db.py
@@ -188,6 +188,29 @@ def reformat_symbol(row):
         return symbol
 
 
+def _paytm_option_ce_pe(row):
+    """
+    Derive the OpenAlgo option instrumenttype ("CE" or "PE") from the
+    Paytm row's `name` field (e.g. "NIFTY 12 MAY 17850 CALL" -> "CE").
+
+    The shared option lookup services (services/option_symbol_service.py
+    and services/option_chain_service.py) filter SymToken rows by
+    `instrumenttype == "CE"` / `"PE"`. If we stored "OPT" here, those
+    queries would return zero rows and the option chain page would
+    render empty for Paytm users.
+    """
+    name_upper = str(row["name"]).upper()
+    if "CALL" in name_upper:
+        return "CE"
+    if "PUT" in name_upper:
+        return "PE"
+    # Some rows may carry CE/PE explicitly as the last whitespace-token.
+    parts = str(row["name"]).split()
+    if parts and parts[-1].upper() in ("CE", "PE"):
+        return parts[-1].upper()
+    return "OPT"
+
+
 # Define the function to apply conditions
 def assign_values(row):
     # Paytm Exchange Mappings are simply NSE and BSE. No other complications
@@ -213,11 +236,12 @@ def assign_values(row):
     elif row["exchange"] == "BSE" and row["instrument_type"] in ["FUTIDX", "FUTSTK"]:
         return "BFO", "BSE", "FUT"
 
-    # Handle options
+    # Handle options — write CE/PE so the shared option lookup services
+    # match. Storing "OPT" here breaks /optionchain and tools pages.
     elif row["exchange"] == "NSE" and row["instrument_type"] in ["OPTIDX", "OPTSTK"]:
-        return "NFO", "NSE", "OPT"
+        return "NFO", "NSE", _paytm_option_ce_pe(row)
     elif row["exchange"] == "BSE" and row["instrument_type"] in ["OPTIDX", "OPTSTK"]:
-        return "BFO", "BSE", "OPT"
+        return "BFO", "BSE", _paytm_option_ce_pe(row)
 
     # Handle unknown cases
     else:
@@ -358,9 +382,18 @@ def master_contract_download():
         token_df = process_paytm_csv(output_path)
         copy_from_dataframe(token_df)
         delete_paytm_temp_data(output_path)
-        # token_df['token'] = pd.to_numeric(token_df['token'], errors='coerce').fillna(-1).astype(int)
 
-        # token_df = token_df.drop_duplicates(subset='symbol', keep='first')
+        # Invalidate the in-process strikes cache in option_symbol_service.
+        # Without this, an empty result cached before refresh (e.g. when
+        # instrumenttype was still stored as "OPT") survives the rebuild
+        # and the option chain / tools pages keep rendering empty until
+        # the Flask process is restarted.
+        try:
+            from services.option_symbol_service import clear_strikes_cache
+
+            clear_strikes_cache()
+        except Exception as cache_err:
+            logger.warning(f"Could not clear strikes cache after master refresh: {cache_err}")
 
         return socketio.emit(
             "master_contract_download", {"status": "success", "message": "Successfully Downloaded"}

--- a/broker/paytm/database/master_contract_db.py
+++ b/broker/paytm/database/master_contract_db.py
@@ -146,9 +146,11 @@ def reformat_symbol(row):
     if instrument_type in ["ES"]:
         return symbol
 
-    # For index instruments, use name without spaces and set it as both symbol and brsymbol
+    # For index instruments, use name without spaces (uppercased) and set it
+    # as both symbol and brsymbol. Index normalization to OpenAlgo's standard
+    # naming happens later in process_paytm_csv via INDEX_SYMBOL_MAP_*.
     elif instrument_type in ["I"]:
-        symbol = "".join(row["name"].split())
+        symbol = "".join(row["name"].split()).upper()
         row["symbol"] = symbol  # Set the symbol in the row
         return symbol
 
@@ -251,7 +253,7 @@ def process_paytm_csv(path):
     # For indices, set brsymbol to be the same as the formatted symbol
     indices_mask = df["instrument_type"] == "I"
     df.loc[indices_mask, "brsymbol"] = df.loc[indices_mask, "name"].apply(
-        lambda x: "".join(x.split())
+        lambda x: "".join(x.split()).upper()
     )
 
     # Apply the function to get exchange mappings
@@ -284,10 +286,52 @@ def process_paytm_csv(path):
     # Removing the specified columns
     token_df = df.drop(columns=columns_to_remove)
 
-    # Common Index Symbol Formats
+    # Normalize index symbols to OpenAlgo's standard naming (see symbol_Openalgo.md).
+    # Mapping is scoped per exchange to avoid colliding with equity symbols that
+    # happen to share short BSE-index codes (e.g. AUTO, METAL, POWER, REALTY).
+    # Only Paytm names listed in OpenAlgo's standard index list are rewritten;
+    # unlisted indices keep their uppercased joined-name form.
+    nse_index_map = {
+        "NIFTYNEXT50": "NIFTYNXT50",
+        "NIFTYMCAP50": "NIFTYMIDCAP50",
+        "NIFTYSMALLCAP250": "NIFTYSMLCAP250",
+        "NIFTYMIDSELECT": "MIDCPNIFTY",
+    }
+    bse_index_map = {
+        "SNSX50": "SENSEX50",
+        "SNXT50": "BSESENSEXNEXT50",
+        "AUTO": "BSEAUTO",
+        "BSECD": "BSECONSUMERDURABLES",
+        "BSECG": "BSECAPITALGOODS",
+        "BSEFMC": "BSEFASTMOVINGCONSUMERGOODS",
+        "BSEHC": "BSEHEALTHCARE",
+        "BSEIT": "BSEINFORMATIONTECHNOLOGY",
+        "ENERGY": "BSEENERGY",
+        "FINSER": "BSEFINANCIALSERVICES",
+        "INDSTR": "BSEINDUSTRIALS",
+        "LMI250": "BSE250LARGEMIDCAPINDEX",
+        "LRGCAP": "BSELARGECAP",
+        "METAL": "BSEMETAL",
+        "MID150": "BSE150MIDCAPINDEX",
+        "MIDCAP": "BSEMIDCAP",
+        "MIDSEL": "BSEMIDCAPSELECTINDEX",
+        "MSL400": "BSE400MIDSMALLCAPINDEX",
+        "OILGAS": "BSEOIL&GAS",
+        "POWER": "BSEPOWER",
+        "REALTY": "BSEREALTY",
+        "SMLCAP": "BSESMALLCAP",
+        "SMLSEL": "BSESMALLCAPSELECTINDEX",
+        "TECK": "BSETECK",
+        "TELCOM": "BSETELECOM",
+    }
 
-    token_df["symbol"] = token_df["symbol"].replace(
-        {"NIFTYNEXT50": "NIFTYNXT50", "NIFTYMIDCAP150": "MIDCPNIFTY", "SNSX50": "SENSEX50"}
+    nse_idx_mask = token_df["exchange"] == "NSE_INDEX"
+    bse_idx_mask = token_df["exchange"] == "BSE_INDEX"
+    token_df.loc[nse_idx_mask, "symbol"] = (
+        token_df.loc[nse_idx_mask, "symbol"].replace(nse_index_map)
+    )
+    token_df.loc[bse_idx_mask, "symbol"] = (
+        token_df.loc[bse_idx_mask, "symbol"].replace(bse_index_map)
     )
 
     return token_df

--- a/broker/paytm/streaming/paytm_adapter.py
+++ b/broker/paytm/streaming/paytm_adapter.py
@@ -1,3 +1,4 @@
+import atexit
 import json
 import logging
 import os
@@ -36,6 +37,24 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.lock = threading.Lock()
         # Map to track scripId -> (symbol, exchange) for reverse lookup
         self.token_map = {}
+        # Reconnect gate. Only one _connect_with_retry thread may exist
+        # at a time, otherwise multiple concurrent ws_client.connect()
+        # calls would each create a WebSocketApp and orphan the earlier
+        # one's socket. Both connect() and _on_close funnel through
+        # _start_reconnect, which respects this flag.
+        self._reconnecting = False
+        self._reconnect_thread: Optional[threading.Thread] = None
+        # Interruptible-sleep handle for the retry backoff. disconnect()
+        # sets this so we don't keep retrying for up to 60s after the
+        # adapter has been asked to shut down.
+        self._shutdown_event = threading.Event()
+        # Guards against double-disconnect: atexit may fire disconnect()
+        # after Flask has already called it, which would re-run
+        # cleanup_zmq() against already-closed sockets.
+        self._disconnected = False
+        # Track whether we've registered an atexit handler so repeated
+        # initialize() calls don't pile up duplicate callbacks.
+        self._atexit_registered = False
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -51,6 +70,16 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         Raises:
             ValueError: If required authentication tokens are not found
         """
+        # If re-initializing (e.g. account switch, re-auth), tear down the
+        # previous ws_client first so its WebSocketApp and reconnect thread
+        # don't outlive the new ws_client assignment below. We don't touch
+        # ZMQ here — that stays alive for the new lifecycle.
+        if self.ws_client is not None:
+            self._teardown_ws_client()
+            self._shutdown_event.clear()
+            self._reconnect_thread = None
+            self.reconnect_attempts = 0
+
         self.user_id = user_id
         self.broker_name = broker_name
 
@@ -75,10 +104,9 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.logger.error("Missing required public access token")
                 raise ValueError("Missing required public access token")
 
-        # Create PaytmWebSocket instance
-        self.ws_client = PaytmWebSocket(
-            public_access_token=public_access_token, max_retry_attempt=5
-        )
+        # Create PaytmWebSocket instance. Reconnect policy lives in this
+        # adapter (see _on_close), not in PaytmWebSocket itself.
+        self.ws_client = PaytmWebSocket(public_access_token=public_access_token)
 
         # Set callbacks
         self.ws_client.on_open = self._on_open
@@ -88,42 +116,128 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.ws_client.on_message = self._on_message
 
         self.running = True
+        self._disconnected = False
+
+        # Ensure ZMQ + WS cleanup runs even if the process exits without an
+        # explicit disconnect() call (e.g. unhandled exception, sys.exit()).
+        # disconnect() is idempotent so calling it twice is safe.
+        if not self._atexit_registered:
+            atexit.register(self.disconnect)
+            self._atexit_registered = True
 
     def connect(self) -> None:
         """Establish connection to Paytm WebSocket"""
         if not self.ws_client:
             self.logger.error("WebSocket client not initialized. Call initialize() first.")
             return
+        self._start_reconnect("initial connect")
 
-        threading.Thread(target=self._connect_with_retry, daemon=True).start()
+    def _start_reconnect(self, reason: str) -> None:
+        """
+        Spawn the single _connect_with_retry background thread if one isn't
+        already running. Both connect() (initial) and _on_close (reconnect)
+        funnel through here so we never have two threads racing to call
+        ws_client.connect() and overwriting self.ws_client.wsapp.
+        """
+        with self.lock:
+            if self._reconnecting:
+                self.logger.debug(f"Reconnect already in progress; skipping ({reason})")
+                return
+            self._reconnecting = True
+            self._shutdown_event.clear()
+            self._reconnect_thread = threading.Thread(
+                target=self._connect_with_retry, daemon=True
+            )
+        self._reconnect_thread.start()
 
     def _connect_with_retry(self) -> None:
-        """Connect to Paytm WebSocket with retry logic"""
-        while self.running and self.reconnect_attempts < self.max_reconnect_attempts:
-            try:
-                self.logger.info(
-                    f"Connecting to Paytm WebSocket (attempt {self.reconnect_attempts + 1})"
-                )
-                self.ws_client.connect()
-                self.reconnect_attempts = 0  # Reset attempts on successful connection
-                break
+        """
+        Single reconnect loop. Owns the lifecycle of ws_client.connect().
 
-            except Exception as e:
-                self.reconnect_attempts += 1
+        ws_client.connect() blocks inside run_forever() until the socket
+        closes; on return we either back off and reconnect (if still
+        running) or exit. _on_close does NOT spawn parallel threads;
+        otherwise concurrent connect() calls would orphan WebSocketApp
+        sockets.
+        """
+        try:
+            while self.running:
+                if self.reconnect_attempts >= self.max_reconnect_attempts:
+                    self.logger.error("Max reconnection attempts reached. Giving up.")
+                    break
+
+                connect_start = time.monotonic()
+                try:
+                    self.logger.info(
+                        f"Connecting to Paytm WebSocket (attempt {self.reconnect_attempts + 1})"
+                    )
+                    self.ws_client.connect()  # blocks until the socket closes
+                except Exception as e:
+                    self.logger.error(f"Connection error: {e}")
+
+                if not self.running:
+                    break
+
+                # If the connection stayed up for a meaningful period treat
+                # this return as a recovery (reset the backoff). Otherwise
+                # count it as a failed attempt and back off exponentially.
+                duration = time.monotonic() - connect_start
+                if duration >= 30:
+                    self.reconnect_attempts = 0
+                else:
+                    self.reconnect_attempts += 1
+
                 delay = min(
-                    self.reconnect_delay * (2**self.reconnect_attempts), self.max_reconnect_delay
+                    self.reconnect_delay * (2 ** max(0, self.reconnect_attempts - 1)),
+                    self.max_reconnect_delay,
                 )
-                self.logger.error(f"Connection failed: {e}. Retrying in {delay} seconds...")
-                time.sleep(delay)
+                self.logger.info(
+                    f"Paytm WS closed after {duration:.1f}s; reconnecting in {delay}s"
+                )
+                # Interruptible sleep: disconnect() sets the event so we
+                # don't keep retrying after shutdown.
+                if self._shutdown_event.wait(delay):
+                    break
+        finally:
+            with self.lock:
+                self._reconnecting = False
 
-        if self.reconnect_attempts >= self.max_reconnect_attempts:
-            self.logger.error("Max reconnection attempts reached. Giving up.")
-
-    def disconnect(self) -> None:
-        """Disconnect from Paytm WebSocket"""
+    def _teardown_ws_client(self) -> None:
+        """
+        Tear down only the WebSocket side: stop the retry loop, close the
+        socket, and wait for the reconnect thread to exit. Does NOT
+        release ZMQ resources — the caller decides whether to also call
+        cleanup_zmq() (e.g. disconnect() does, initialize() doesn't).
+        """
         self.running = False
+        # Wake the retry loop out of its backoff sleep before it spins up
+        # another connection.
+        self._shutdown_event.set()
         if hasattr(self, "ws_client") and self.ws_client:
             self.ws_client.close_connection()
+
+        # Wait for the reconnect thread to exit. It should die quickly:
+        # shutdown_event unblocks the sleep, and wsapp.close() unblocks
+        # run_forever().
+        thread = self._reconnect_thread
+        if thread and thread.is_alive():
+            thread.join(timeout=10)
+            if thread.is_alive():
+                self.logger.warning("Paytm reconnect thread did not exit within 10s")
+
+    def disconnect(self) -> None:
+        """
+        Disconnect from Paytm WebSocket and release resources.
+
+        Idempotent: safe to call multiple times. atexit may invoke this
+        after Flask has already torn the adapter down, and we don't want
+        cleanup_zmq() to run twice against the same socket.
+        """
+        if self._disconnected:
+            return
+        self._disconnected = True
+
+        self._teardown_ws_client()
 
         # Clean up ZeroMQ resources
         self.cleanup_zmq()
@@ -338,13 +452,17 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.error(f"Paytm WebSocket error: {error}")
 
     def _on_close(self, wsapp) -> None:
-        """Callback when connection is closed"""
+        """
+        Callback when connection is closed.
+
+        Reconnect is NOT spawned here. The single _connect_with_retry
+        loop (already alive on its own thread) will return from
+        ws_client.connect() now that the socket has closed, then back off
+        and reconnect on its own. Spawning another thread here would
+        race against that loop and orphan WebSocketApp sockets.
+        """
         self.logger.info("Paytm WebSocket connection closed")
         self.connected = False
-
-        # Attempt to reconnect if we're still running
-        if self.running:
-            threading.Thread(target=self._connect_with_retry, daemon=True).start()
 
     def _on_message(self, wsapp, message) -> None:
         """Callback for text messages from the WebSocket"""

--- a/broker/paytm/streaming/paytm_adapter.py
+++ b/broker/paytm/streaming/paytm_adapter.py
@@ -87,7 +87,17 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         if self.ws_client is not None:
             self._teardown_ws_client()
             self._shutdown_event.clear()
-            self._reconnect_thread = None
+            # Force-clear the reconnect gate. If _teardown_ws_client's
+            # join() timed out the orphan thread is still alive but
+            # unreachable; without this reset _reconnecting stays True
+            # and all subsequent connect() → _start_reconnect() calls
+            # are silently skipped, permanently breaking the adapter.
+            # The orphan's finally is gated by a thread-identity check
+            # (see _connect_with_retry) so it cannot later clobber a
+            # newly spawned thread's _reconnecting=True state.
+            with self.lock:
+                self._reconnecting = False
+                self._reconnect_thread = None
             self.reconnect_attempts = 0
 
         self.user_id = user_id
@@ -210,7 +220,15 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     break
         finally:
             with self.lock:
-                self._reconnecting = False
+                # Only clear the gate if we are still the active thread.
+                # If initialize() timed out joining us, it has already
+                # cleared _reconnect_thread (or replaced it with a new
+                # thread). In that case our finally must not clobber the
+                # new thread's _reconnecting=True state, otherwise a
+                # concurrent connect() could start a duplicate thread
+                # and orphan a WebSocketApp socket.
+                if self._reconnect_thread is threading.current_thread():
+                    self._reconnecting = False
 
     def _start_batch_timer(self) -> None:
         """

--- a/broker/paytm/streaming/paytm_adapter.py
+++ b/broker/paytm/streaming/paytm_adapter.py
@@ -56,6 +56,16 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # initialize() calls don't pile up duplicate callbacks.
         self._atexit_registered = False
 
+        # Batch subscription queueing. Modeled on the Zerodha adapter:
+        # subscribe() appends preferences to subscription_queue and arms a
+        # 500ms debounced Timer; the timer fires _process_batch_subscriptions
+        # which drains the queue and sends one JSON-array frame to Paytm.
+        # This cuts wire chatter when many symbols are subscribed in quick
+        # succession (e.g. a watchlist load).
+        self.subscription_queue: List[dict] = []
+        self.batch_timer: Optional[threading.Timer] = None
+        self.batch_delay = 0.5  # seconds
+
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
     ) -> None:
@@ -202,6 +212,52 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
             with self.lock:
                 self._reconnecting = False
 
+    def _start_batch_timer(self) -> None:
+        """
+        (Re)arm the batch-subscription debounce timer.
+
+        Must be called with self.lock held. Cancels any existing pending
+        timer so a fresh batch window starts cleanly.
+        """
+        if self.batch_timer:
+            self.batch_timer.cancel()
+        self.batch_timer = threading.Timer(
+            self.batch_delay, self._process_batch_subscriptions
+        )
+        self.batch_timer.daemon = True
+        self.batch_timer.start()
+
+    def _process_batch_subscriptions(self) -> None:
+        """
+        Drain the subscription queue and send all queued preferences in a
+        single JSON-array frame.
+
+        Paytm's WS protocol accepts mixed-mode preferences in one payload,
+        so we don't need Zerodha-style grouping by mode. If the socket
+        isn't connected yet, the queued items are dropped — the adapter's
+        existing on_open / paytm_websocket.resubscribe path will replay
+        from the stored subscription state on the next successful connect.
+        """
+        with self.lock:
+            if not self.subscription_queue:
+                return
+            preferences = list(self.subscription_queue)
+            self.subscription_queue.clear()
+            self.batch_timer = None  # timer has already fired
+
+        if not (self.connected and self.ws_client):
+            self.logger.debug(
+                f"Dropping {len(preferences)} queued subscription(s) — not connected; "
+                "they will be replayed on reconnect from stored subscriptions."
+            )
+            return
+
+        try:
+            self.ws_client.subscribe(preferences)
+            self.logger.info(f"Batch-subscribed {len(preferences)} preference(s)")
+        except Exception as e:
+            self.logger.error(f"Error sending batch subscription: {e}")
+
     def _teardown_ws_client(self) -> None:
         """
         Tear down only the WebSocket side: stop the retry loop, close the
@@ -209,6 +265,14 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         release ZMQ resources — the caller decides whether to also call
         cleanup_zmq() (e.g. disconnect() does, initialize() doesn't).
         """
+        # Cancel any pending batch flush so its Timer thread doesn't fire
+        # against a torn-down ws_client.
+        with self.lock:
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+            self.subscription_queue.clear()
+
         self.running = False
         # Wake the retry loop out of its backoff sleep before it spins up
         # another connection.
@@ -303,7 +367,11 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Generate unique correlation ID
         correlation_id = f"{symbol}_{exchange}_{mode}"
 
-        # Store subscription for reconnection and reverse lookup
+        # Store subscription for reconnection and reverse lookup, and
+        # enqueue the preference for the next batched send. The batch
+        # timer is (re)armed only when the queue transitions from empty
+        # to non-empty, giving us a stable 500ms collection window
+        # regardless of how many subscribes pile in.
         with self.lock:
             self.subscriptions[correlation_id] = {
                 "symbol": symbol,
@@ -316,17 +384,15 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
             }
             # Store token mapping for reverse lookup
             self.token_map[str(token)] = (symbol, exchange, mode)
-            self.logger.info(
-                f"Subscribed: token={token}, symbol={symbol}, exchange={exchange}, preference={preference}"
-            )
 
-        # Subscribe if connected
-        if self.connected and self.ws_client:
-            try:
-                self.ws_client.subscribe([preference])
-            except Exception as e:
-                self.logger.error(f"Error subscribing to {symbol}.{exchange}: {e}")
-                return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
+            self.subscription_queue.append(preference)
+            if len(self.subscription_queue) == 1:
+                self._start_batch_timer()
+
+            self.logger.info(
+                f"Queued subscribe: token={token}, symbol={symbol}, exchange={exchange}, "
+                f"queue_size={len(self.subscription_queue)}"
+            )
 
         # Return success
         return self._create_success_response(
@@ -370,17 +436,51 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     "NOT_SUBSCRIBED", f"Not subscribed to {symbol}.{exchange}"
                 )
 
-            # Create unsubscribe preference
-            preference = subscription["preference"].copy()
-            preference["actionType"] = PaytmWebSocket.REMOVE_ACTION
-
+            stored_pref = subscription["preference"]
             # Remove from subscriptions
             del self.subscriptions[correlation_id]
             # Remove from token map
             if str(token) in self.token_map:
                 del self.token_map[str(token)]
 
-        # Unsubscribe if connected
+            # If the corresponding ADD(s) are still sitting in the batch
+            # queue (subscribed within the last 500ms and not yet flushed),
+            # drop them in place — there's no wire ADD to undo and sending
+            # a REMOVE here would race the still-queued ADD, leaving the
+            # caller subscribed to a symbol they thought they cancelled.
+            # Remove ALL matching entries: duplicate subscribes for the
+            # same scrip+mode are idempotent, so one unsubscribe must
+            # fully cancel them — leaving any behind would re-subscribe
+            # the user post-flush.
+            had_pending_add = False
+            remaining = []
+            for p in self.subscription_queue:
+                if (
+                    p.get("actionType") == PaytmWebSocket.ADD_ACTION
+                    and p.get("scripId") == stored_pref["scripId"]
+                    and p.get("exchangeType") == stored_pref["exchangeType"]
+                    and p.get("modeType") == stored_pref["modeType"]
+                ):
+                    had_pending_add = True
+                    continue
+                remaining.append(p)
+            self.subscription_queue = remaining
+
+        # If the ADD was cancelled in-place, nothing was ever on the wire.
+        if had_pending_add:
+            self.logger.info(
+                f"Cancelled pending subscribe for {symbol}.{exchange} before flush"
+            )
+            return self._create_success_response(
+                f"Unsubscribed from {symbol}.{exchange}",
+                symbol=symbol,
+                exchange=exchange,
+                mode=mode,
+            )
+
+        # Otherwise the ADD already went out; send the REMOVE.
+        preference = stored_pref.copy()
+        preference["actionType"] = PaytmWebSocket.REMOVE_ACTION
         if self.connected and self.ws_client:
             try:
                 self.ws_client.unsubscribe([preference])
@@ -437,8 +537,17 @@ class PaytmWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info("Connected to Paytm WebSocket")
         self.connected = True
 
-        # Resubscribe to existing subscriptions if reconnecting
+        # Resubscribe to existing subscriptions if reconnecting. self.subscriptions
+        # is the authoritative source of truth — we replay everything from it in
+        # one shot. Any items still sitting in subscription_queue would otherwise
+        # cause a duplicate ADD on the wire 500ms later, so we drain the queue
+        # and cancel the pending batch timer here.
         with self.lock:
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+            self.subscription_queue.clear()
+
             if self.subscriptions:
                 preferences = [sub["preference"] for sub in self.subscriptions.values()]
                 try:

--- a/broker/paytm/streaming/paytm_websocket.py
+++ b/broker/paytm/streaming/paytm_websocket.py
@@ -18,7 +18,6 @@ class PaytmWebSocket:
     ROOT_URI = "wss://developer-ws.paytmmoney.com/broadcast/user/v1/data"
     HEART_BEAT_INTERVAL = 30  # Paytm sends ping every 30 seconds
     LITTLE_ENDIAN_BYTE_ORDER = "<"
-    RESUBSCRIBE_FLAG = False
 
     # Action types
     ADD_ACTION = "ADD"
@@ -48,31 +47,30 @@ class PaytmWebSocket:
     PACKET_CODE_INDEX_QUOTE = 65
     PACKET_CODE_INDEX_FULL = 66
 
-    wsapp = None
-    subscriptions = {}
-    current_retry_attempt = 0
-
-    def __init__(self, public_access_token, max_retry_attempt=5, retry_delay=5, retry_multiplier=2):
+    def __init__(self, public_access_token):
         """
-        Initialize the PaytmWebSocket instance
+        Initialize the PaytmWebSocket instance.
+
+        Reconnect / retry policy is owned by the consumer (e.g.
+        PaytmWebSocketAdapter), which observes on_close and decides when
+        to call connect() again. This class no longer self-reconnects.
 
         Parameters
         ----------
         public_access_token: string
             Public access token received from Paytm Money API
-        max_retry_attempt: int
-            Maximum number of retry attempts
-        retry_delay: int
-            Initial retry delay in seconds
-        retry_multiplier: int
-            Multiplier for exponential backoff
         """
         self.public_access_token = public_access_token
-        self.MAX_RETRY_ATTEMPT = max_retry_attempt
-        self.retry_delay = retry_delay
-        self.retry_multiplier = retry_multiplier
         self.DISCONNECT_FLAG = True
         self.last_pong_timestamp = None
+
+        # Per-instance state. These used to live as class attributes, which
+        # caused subscriptions to be shared across all PaytmWebSocket
+        # instances (one user's resubscribe would replay another user's
+        # tokens).
+        self.wsapp = None
+        self.subscriptions = {}
+        self.RESUBSCRIBE_FLAG = False
 
         if not self._sanity_check():
             logger.error("Invalid initialization parameters. Provide a valid public access token.")
@@ -119,27 +117,24 @@ class PaytmWebSocket:
             self.on_open(wsapp)
 
     def _on_error(self, wsapp, error):
-        """Handle WebSocket errors with retry logic"""
+        """
+        Log the WebSocket error and notify the user callback.
+
+        Reconnect is intentionally NOT performed here. The previous
+        implementation called close_connection() followed by connect()
+        from inside this callback, which runs on the WebSocketApp's own
+        thread inside run_forever(). That recursively re-entered
+        run_forever() and could leave the old WebSocketApp's socket
+        descriptor open while a new one was being created.
+
+        The websocket-client library will fire _on_close() naturally once
+        the socket terminates; the consumer (e.g. PaytmWebSocketAdapter)
+        owns the reconnect strategy in its on_close handler.
+        """
         logger.error(f"WebSocket error: {error}")
         self.RESUBSCRIBE_FLAG = True
-
-        if self.current_retry_attempt < self.MAX_RETRY_ATTEMPT:
-            logger.warning(f"Attempting to reconnect (Attempt {self.current_retry_attempt + 1})...")
-            self.current_retry_attempt += 1
-            delay = self.retry_delay * (self.retry_multiplier ** (self.current_retry_attempt - 1))
-            time.sleep(delay)
-
-            try:
-                self.close_connection()
-                self.connect()
-            except Exception as e:
-                logger.error(f"Error during reconnect: {e}")
-                if hasattr(self, "on_error"):
-                    self.on_error(wsapp, str(e) if str(e) else "Unknown error")
-        else:
-            self.close_connection()
-            if hasattr(self, "on_error"):
-                self.on_error(wsapp, "Max retry attempts reached")
+        if hasattr(self, "on_error"):
+            self.on_error(wsapp, error)
 
     def _on_close(self, wsapp, close_status_code=None, close_msg=None):
         """Callback when WebSocket connection is closed"""
@@ -248,9 +243,19 @@ class PaytmWebSocket:
                 on_pong=self._on_pong,
             )
 
-            # Run WebSocket in a separate thread to avoid blocking
+            # ping_timeout closes half-open sockets: if the server stops
+            # responding to pings, websocket-client tears the connection
+            # down instead of holding the FD forever. Must be strictly less
+            # than ping_interval.
+            #
+            # ssl.CERT_REQUIRED: Paytm's WSS endpoint serves a valid
+            # public-CA cert (DigiCert / GeoTrust, wildcard *.paytmmoney.com).
+            # The rest of the codebase still uses CERT_NONE on most brokers
+            # but there's no Paytm-specific reason to skip verification.
             self.wsapp.run_forever(
-                sslopt={"cert_reqs": ssl.CERT_NONE}, ping_interval=self.HEART_BEAT_INTERVAL
+                sslopt={"cert_reqs": ssl.CERT_REQUIRED},
+                ping_interval=self.HEART_BEAT_INTERVAL,
+                ping_timeout=10,
             )
 
         except Exception as e:
@@ -258,11 +263,27 @@ class PaytmWebSocket:
             raise e
 
     def close_connection(self):
-        """Close WebSocket connection"""
+        """
+        Close the WebSocket connection.
+
+        wsapp.close() can raise if the underlying socket is in a weird
+        state (e.g. already torn down by a parallel error path). Swallow
+        and log so the caller's shutdown sequence (event signaling,
+        thread joins, ZMQ cleanup) always runs to completion.
+
+        self.wsapp is nulled after close so subscribe/unsubscribe paths
+        don't try to send() on a stale, already-closed object — the next
+        connect() reassigns a fresh WebSocketApp.
+        """
         self.RESUBSCRIBE_FLAG = False
         self.DISCONNECT_FLAG = True
         if self.wsapp:
-            self.wsapp.close()
+            try:
+                self.wsapp.close()
+            except Exception as e:
+                logger.warning(f"Error during wsapp.close(): {e}")
+            finally:
+                self.wsapp = None
             logger.info("WebSocket connection closed")
 
     def _parse_binary_data(self, binary_data):


### PR DESCRIPTION
fix(paytm): normalize NSE_INDEX and BSE_INDEX symbols, ws: close file-descriptor leaks in streaming layer and fix(paytm): option chain, OI tracker, historical-data graceful empty, batch ws subscribe

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize Paytm index symbols to OpenAlgo names and fix option/OI data paths, while stabilizing the WebSocket client with a single reconnect loop and batched subscriptions. Also return empty historical data gracefully to avoid 500s.

- **Bug Fixes**
  - Normalize `NSE_INDEX`/`BSE_INDEX` symbols to OpenAlgo standard (uppercased, scoped maps; avoid collisions like AUTO/METAL/POWER/REALTY; `MIDCPNIFTY` now maps from “NIFTY MID SELECT”, `NIFTYMIDCAP150` kept intact).
  - Option tools: derive `CE`/`PE` from `name` instead of `OPT`; clear in-process strikes cache after master refresh so option chain and tools populate immediately.
  - Quotes: switch REST to `mode=FULL` and include `oi` in single and batch quotes to fix OI tracker/IV views.
  - Historical API: return empty DataFrame/intervals with warnings (Paytm has no history), preventing errors downstream.

- **Refactors**
  - Streaming adapter: single reconnect loop with interruptible backoff; no parallel reconnect threads; idempotent shutdown with `atexit`; force-clear reconnect gate if teardown join times out; finally guard so an orphan thread can’t clobber a new one.
  - Batched WS subscribe: 500ms debounce; unsubscribe drops pending ADDs to avoid race; on open, clear queue and resubscribe once.
  - WebSocket client: move state to instance (no cross-user bleed); remove self-reconnect from `_on_error`; add `ping_timeout=10`; use `ssl.CERT_REQUIRED`; safe `close()` handling.

<sup>Written for commit 26d90fad5b68682d54f3341450dc2941545ae797. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

