### PR TITLE
Feat : IIFLcapital websockets integrated and fix(iiflcapital/ws): close file-descriptor leaks across reconnect cycles 

### DIFF
--- a/broker/iiflcapital/streaming/iiflcapital_adapter.py
+++ b/broker/iiflcapital/streaming/iiflcapital_adapter.py
@@ -1,271 +1,376 @@
-import os
+"""
+IIFL Capital WebSocket adapter — connects OpenAlgo's WebSocket proxy to the
+IIFL Capital market-data feed over MQTT v3.1.1 (TLS port 8883).
+
+Replaces the earlier REST-polling stub. The on-wire protocol is implemented
+in-tree (`iiflcapital_mqtt.py`, `iiflcapital_websocket.py`) — no external SDK
+dependency on `bridgePy` or `paho-mqtt`.
+
+Shape mirrors the Zerodha adapter (broker/zerodha/streaming/zerodha_adapter.py)
+so it plugs into the same ConnectionPool / BaseBrokerWebSocketAdapter
+plumbing without special-casing.
+"""
+
+from __future__ import annotations
+
 import threading
 import time
 from typing import Any
 
-from broker.iiflcapital.api.data import BrokerData
+from database.token_db import get_brexchange, get_token
+from utils.logging import get_logger
 from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
+
+from .iiflcapital_mapping import (
+    is_index_exchange,
+    normalize_segment,
+    supports_open_interest,
+)
+from .iiflcapital_websocket import (
+    MODE_FULL,
+    MODE_LTP,
+    MODE_QUOTE,
+    IiflcapitalWebSocket,
+)
+
+logger = get_logger(__name__)
 
 
 class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """
-    IIFL Capital WebSocket adapter.
+    OpenAlgo broker adapter for IIFL Capital's MQTT market-data feed.
 
-    The broker currently exposes reliable REST market-data APIs, so this adapter
-    provides WebSocket compatibility by polling quote/depth endpoints and
-    publishing updates to the existing ZeroMQ pipeline.
+    Mode contract (mirrors Zerodha):
+        1 → LTP   (publish only `ltp` and `ltt`)
+        2 → Quote (OHLC + LTP + bid/ask totals)
+        3 → Depth (Quote + L5 depth)
+
+    The IIFL broker only emits one packet shape per stream (188-byte
+    MWBOCombined), so we subscribe once at the broker layer and slice the
+    decoded dict into three OpenAlgo-shaped payloads on the way out, exactly
+    like Zerodha's `full` → `ltp/quote/full` fan-out.
     """
 
-    MODE_LTP = 1
-    MODE_QUOTE = 2
-    MODE_DEPTH = 3
+    # OpenAlgo mode ints → internal IIFL feed mode strings.
+    _MODE_OA_TO_IIFL = {1: MODE_LTP, 2: MODE_QUOTE, 3: MODE_FULL}
 
-    def __init__(self):
+    def __init__(self) -> None:
         super().__init__()
+        self.logger = get_logger("iiflcapital_websocket")
         self.broker_name = "iiflcapital"
-        self.user_id = None
-        self.auth_token = None
-        self.data_handler = None
+
+        self.user_id: str | None = None
+        self.auth_token: str | None = None
+        self.ws_client: IiflcapitalWebSocket | None = None
+
+        self.running = False
         self.connected = False
+        self.lock = threading.Lock()
 
-        self.poll_interval = float(os.getenv("IIFLCAPITAL_POLL_INTERVAL", "0.8"))
-        self._stop_event = threading.Event()
-        self._poll_thread = None
-        self._sub_lock = threading.Lock()
-        self.subscriptions = {}
+        # Subscription tracking, keyed by f"{exchange}:{symbol}":
+        # {
+        #   "exchange": str,           # OpenAlgo exchange (e.g. NSE_INDEX)
+        #   "symbol": str,
+        #   "segment": str,            # IIFL brexchange (NSEEQ, NSEFO, …)
+        #   "token": str,
+        #   "mode": int,               # OpenAlgo mode int (1/2/3)
+        #   "is_index": bool,
+        # }
+        self.subscribed_symbols: dict[str, dict] = {}
 
-    def initialize(self, broker_name, user_id, auth_data=None, force=False):
+        # Reverse lookup: f"{segment}/{token}" → (symbol, exchange) — used to
+        # rebuild the OpenAlgo topic when a tick comes back from the broker.
+        self._key_to_symbol: dict[str, tuple[str, str]] = {}
+
+    # ----------------------------------------------------------------- lifecycle
+    def initialize(
+        self,
+        broker_name: str,
+        user_id: str,
+        auth_data: dict[str, str] | None = None,
+        force: bool = False,
+    ) -> dict[str, Any]:
+        """Pull the user's IIFL session token and wire up the feed client."""
+        if broker_name and broker_name.lower() != self.broker_name:
+            return {"status": "error", "message": f"Invalid broker name: {broker_name}"}
+
         self.user_id = user_id
-        self.broker_name = broker_name or self.broker_name
 
+        # auth_data wins if supplied; otherwise pull from the DB. `force`
+        # bypasses the cache so a stale daily-rolled token is not reused.
         auth_token = None
         if auth_data:
             auth_token = auth_data.get("auth_token")
-
         if force or not auth_token:
             auth_token = self.get_auth_token_for_user(user_id, bypass_cache=force)
 
         if not auth_token:
-            return self._create_error_response(
-                "AUTHENTICATION_ERROR", f"No authentication token found for user {user_id}"
-            )
+            return {
+                "status": "error",
+                "code": "AUTHENTICATION_ERROR",
+                "message": f"No authentication token found for user {user_id}",
+            }
 
         self.auth_token = auth_token
-        self.data_handler = BrokerData(auth_token=auth_token, user_id=user_id)
-        self._stop_event.clear()
-        return self._create_success_response("IIFL Capital adapter initialized")
 
-    def connect(self):
-        if not self.data_handler:
-            return self._create_error_response(
-                "NOT_INITIALIZED", "Adapter not initialized. Call initialize() first."
+        try:
+            self.ws_client = IiflcapitalWebSocket(
+                user_session=auth_token,
+                on_ticks=self._handle_ticks,
             )
+            self.ws_client.on_connect = self._on_connect
+            self.ws_client.on_disconnect = self._on_disconnect
+            self.ws_client.on_error = self._on_error
+        except Exception as e:
+            self.logger.exception(f"Failed to create IIFL feed client: {e}")
+            return {"status": "error", "message": str(e)}
 
-        if self.connected:
-            return self._create_success_response("Already connected")
+        self.logger.info(f"IIFL Capital adapter initialized for user {user_id}")
+        return {"status": "success", "message": "Adapter initialized successfully"}
 
-        self.connected = True
-        self._stop_event.clear()
+    def connect(self) -> dict[str, Any]:
+        if not self.ws_client:
+            return {"status": "error", "message": "Adapter not initialized — call initialize() first"}
 
-        if not self._poll_thread or not self._poll_thread.is_alive():
-            self._poll_thread = threading.Thread(target=self._poll_market_data, daemon=True)
-            self._poll_thread.start()
+        with self.lock:
+            if self.running and self.connected:
+                return {"status": "success", "message": "Already connected"}
 
-        return self._create_success_response("Connected")
+            started = self.ws_client.start()
+            self.running = True
 
-    def subscribe(self, symbol, exchange, mode=2, depth_level=5):
-        if mode not in (self.MODE_LTP, self.MODE_QUOTE, self.MODE_DEPTH):
-            return self._create_error_response(
-                "INVALID_MODE",
-                f"Invalid mode {mode}. Must be 1 (LTP), 2 (Quote), or 3 (Depth)",
+            if started and self.ws_client.wait_for_connection(timeout=15.0):
+                self.connected = True
+                return {"status": "success", "message": "Connected"}
+
+            if self.ws_client._fatal_error:  # noqa: SLF001 — surface auth failure quickly
+                return {
+                    "status": "error",
+                    "message": f"IIFL auth failed: {self.ws_client._fatal_error_message}",  # noqa: SLF001
+                }
+
+            return {"status": "error", "message": "Connection timeout"}
+
+    def disconnect(self) -> dict[str, Any]:
+        try:
+            with self.lock:
+                if self.ws_client is not None:
+                    try:
+                        self.ws_client.stop()
+                    except Exception as e:
+                        self.logger.debug(f"Error stopping IIFL feed client: {e}")
+                    self.ws_client = None
+
+                self.running = False
+                self.connected = False
+                self.subscribed_symbols.clear()
+                self._key_to_symbol.clear()
+
+            self.cleanup_zmq()
+            return {"status": "success", "message": "Disconnected"}
+        except Exception as e:
+            self.logger.exception(f"Error during disconnect: {e}")
+            try:
+                self.cleanup_zmq()
+            except Exception:
+                pass
+            return {"status": "error", "message": str(e)}
+
+    # ----------------------------------------------------------------- subscribe
+    def subscribe(
+        self,
+        symbol: str,
+        exchange: str,
+        mode: int = 2,
+        depth_level: int = 5,
+    ) -> dict[str, Any]:
+        """
+        Subscribe a (symbol, exchange) at the requested mode.
+
+        IIFL emits L5 depth natively; depth_level=20 is not supported and is
+        clamped to 5 (we still echo `actual_depth: 5` in the response).
+        """
+        if mode not in self._MODE_OA_TO_IIFL:
+            return {
+                "status": "error",
+                "code": "INVALID_MODE",
+                "message": f"Invalid mode {mode}. Must be 1 (LTP), 2 (Quote), or 3 (Depth)",
+            }
+
+        if not self.ws_client or not self.running:
+            return {"status": "error", "message": "WebSocket not connected. Call connect() first."}
+
+        # Resolve the broker-side segment and token via the master contract DB.
+        token = get_token(symbol, exchange)
+        brexchange = get_brexchange(symbol, exchange)
+        if not token or not brexchange:
+            return {
+                "status": "error",
+                "message": f"Token / brexchange not found for {exchange}:{symbol}",
+            }
+
+        token = str(token).strip()
+        segment = brexchange.strip()  # store uppercase; lower-casing happens in the feed client
+
+        is_index = is_index_exchange(exchange)
+        feed_mode = self._MODE_OA_TO_IIFL[mode]
+        # OI is only meaningful for derivatives — see iiflcapital_mapping.
+        include_oi = mode != 1 and supports_open_interest(exchange) and not is_index
+
+        key = f"{exchange}:{symbol}"
+        topic_suffix = f"{normalize_segment(segment)}/{token}"
+
+        with self.lock:
+            self.subscribed_symbols[key] = {
+                "exchange": exchange,
+                "symbol": symbol,
+                "segment": segment,
+                "token": token,
+                "mode": mode,
+                "is_index": is_index,
+            }
+            self._key_to_symbol[topic_suffix] = (symbol, exchange)
+
+        try:
+            self.ws_client.subscribe_instruments(
+                instruments=[(segment, token)],
+                mode=feed_mode,
+                is_index=is_index,
+                include_oi=include_oi,
             )
+        except Exception as e:
+            self.logger.exception(f"IIFL subscribe failed for {exchange}:{symbol}: {e}")
+            return {"status": "error", "message": str(e)}
 
-        if mode == self.MODE_DEPTH and depth_level not in (5, 20):
-            return self._create_error_response(
-                "INVALID_DEPTH", f"Invalid depth level {depth_level}. Must be 5 or 20"
-            )
+        self.logger.info(f"Subscribed to IIFL {exchange}:{symbol} (segment={segment} token=[REDACTED] mode={mode})")
+        return {
+            "status": "success",
+            "symbol": symbol,
+            "exchange": exchange,
+            "mode": mode,
+            "actual_depth": 5,
+            "message": f"Subscribed to {symbol}",
+        }
 
-        with self._sub_lock:
-            key = f"{exchange}:{symbol}"
-            subscription = self.subscriptions.get(
-                key,
-                {
-                    "symbol": symbol,
-                    "exchange": exchange,
-                    "modes": set(),
-                    "depth_level": 5,
-                },
-            )
-            subscription["modes"].add(mode)
-            subscription["depth_level"] = depth_level if mode == self.MODE_DEPTH else 5
-            self.subscriptions[key] = subscription
+    def unsubscribe(
+        self,
+        symbol: str,
+        exchange: str,
+        mode: int | None = None,
+        depth_level: int | None = None,
+    ) -> dict[str, Any]:
+        key = f"{exchange}:{symbol}"
+        with self.lock:
+            sub = self.subscribed_symbols.pop(key, None)
+        if sub is None:
+            return {"status": "error", "message": f"Not subscribed to {symbol}"}
 
-        return self._create_success_response(
-            f"Subscribed to {symbol} on {exchange}",
-            symbol=symbol,
-            exchange=exchange,
-            mode=mode,
-            actual_depth=depth_level if mode == self.MODE_DEPTH else 5,
-        )
+        topic_suffix = f"{normalize_segment(sub['segment'])}/{sub['token']}"
+        with self.lock:
+            self._key_to_symbol.pop(topic_suffix, None)
 
-    def unsubscribe(self, symbol, exchange, mode=2):
-        with self._sub_lock:
-            key = f"{exchange}:{symbol}"
-            if key not in self.subscriptions:
-                return self._create_success_response(
-                    f"No active subscription for {symbol} on {exchange}",
-                    symbol=symbol,
-                    exchange=exchange,
-                    mode=mode,
-                )
+        if self.ws_client:
+            try:
+                self.ws_client.unsubscribe_instruments([(sub["segment"], sub["token"])])
+            except Exception as e:
+                self.logger.exception(f"IIFL unsubscribe failed for {exchange}:{symbol}: {e}")
+                return {"status": "error", "message": str(e)}
 
-            subscription = self.subscriptions[key]
-            subscription["modes"].discard(mode)
-            if not subscription["modes"]:
-                del self.subscriptions[key]
-            else:
-                self.subscriptions[key] = subscription
+        return {"status": "success", "message": f"Unsubscribed from {symbol}"}
 
-        return self._create_success_response(
-            f"Unsubscribed from {symbol} on {exchange}",
-            symbol=symbol,
-            exchange=exchange,
-            mode=mode,
-        )
+    # ----------------------------------------------------------------- ticks
+    def _handle_ticks(self, ticks: list[dict]) -> None:
+        """
+        Receive decoded ticks from the IIFL feed client and fan them out to
+        the OpenAlgo ZeroMQ bus, slicing the single broker packet into LTP /
+        Quote / Depth topics as needed.
+        """
+        if not ticks:
+            return
 
-    def unsubscribe_all(self):
-        with self._sub_lock:
-            self.subscriptions.clear()
-        return self._create_success_response("Unsubscribed from all symbols")
+        for tick in ticks:
+            try:
+                segment = tick.get("segment", "")
+                token = tick.get("token", "")
+                suffix = f"{segment}/{token}"
 
-    def disconnect(self):
-        self.connected = False
-        self._stop_event.set()
+                with self.lock:
+                    symbol_info = self._key_to_symbol.get(suffix)
+                    sub_info = None
+                    if symbol_info:
+                        key = f"{symbol_info[1]}:{symbol_info[0]}"
+                        sub_info = self.subscribed_symbols.get(key)
 
-        if self._poll_thread and self._poll_thread.is_alive():
-            self._poll_thread.join(timeout=2)
-
-        self.cleanup_zmq()
-        return self._create_success_response("Disconnected")
-
-    def _poll_market_data(self):
-        while not self._stop_event.is_set():
-            if not self.connected or not self.data_handler:
-                self._stop_event.wait(self.poll_interval)
-                continue
-
-            with self._sub_lock:
-                subscriptions_snapshot = [
-                    {
-                        "symbol": item["symbol"],
-                        "exchange": item["exchange"],
-                        "modes": set(item["modes"]),
-                    }
-                    for item in self.subscriptions.values()
-                ]
-
-            for sub in subscriptions_snapshot:
-                symbol = sub["symbol"]
-                exchange = sub["exchange"]
-                modes = sub["modes"]
-
-                quote_data = None
-                depth_data = None
-
-                try:
-                    if self.MODE_LTP in modes or self.MODE_QUOTE in modes:
-                        quote_data = self.data_handler.get_quotes(symbol, exchange)
-
-                    if self.MODE_DEPTH in modes:
-                        depth_data = self.data_handler.get_depth(symbol, exchange)
-                except Exception as exc:
-                    self.logger.debug(f"IIFL Capital poll failed for {exchange}:{symbol}: {exc}")
+                if not symbol_info or not sub_info:
+                    self.logger.debug(f"No active subscription for IIFL tick {suffix}")
                     continue
 
-                if self.MODE_LTP in modes and quote_data:
-                    self._publish(symbol, exchange, self.MODE_LTP, self._as_ltp_payload(quote_data))
+                symbol, exchange = symbol_info
+                sub_mode = sub_info["mode"]
 
-                if self.MODE_QUOTE in modes and quote_data:
-                    self._publish(
-                        symbol,
-                        exchange,
-                        self.MODE_QUOTE,
-                        self._as_quote_payload(quote_data),
-                    )
+                # The feed client always returns the full decoded packet; we
+                # produce per-mode payloads from the same source dict.
+                base = {
+                    "symbol": symbol,
+                    "exchange": exchange,
+                    "ltp": tick.get("ltp", 0),
+                    "ltt": tick.get("ltt", 0),
+                    "timestamp": tick.get("timestamp", int(time.time() * 1000)),
+                }
 
-                if self.MODE_DEPTH in modes and depth_data:
-                    self._publish(
-                        symbol,
-                        exchange,
-                        self.MODE_DEPTH,
-                        self._as_depth_payload(depth_data),
-                    )
+                if sub_mode == 1:
+                    payload = {**base, "mode": "ltp"}
+                    self._publish(symbol, exchange, "LTP", payload)
+                    continue
 
-            self._stop_event.wait(self.poll_interval)
+                # Quote / Depth share the OHLC + bid/ask + volume block.
+                payload = {
+                    **base,
+                    "open": tick.get("open", 0),
+                    "high": tick.get("high", 0),
+                    "low": tick.get("low", 0),
+                    "close": tick.get("close", 0),
+                    "volume": tick.get("volume", 0),
+                    "last_quantity": tick.get("last_traded_quantity", 0),
+                    "average_price": tick.get("average_price", 0),
+                    "total_buy_quantity": tick.get("total_buy_quantity", 0),
+                    "total_sell_quantity": tick.get("total_sell_quantity", 0),
+                    "bid": tick.get("best_bid_price", 0),
+                    "ask": tick.get("best_ask_price", 0),
+                    "bid_quantity": tick.get("best_bid_quantity", 0),
+                    "ask_quantity": tick.get("best_ask_quantity", 0),
+                }
 
-    def _publish(self, symbol: str, exchange: str, mode: int, data: dict[str, Any]):
-        mode_str = {1: "LTP", 2: "QUOTE", 3: "DEPTH"}.get(mode, "QUOTE")
+                # Open interest is only carried on the tick when the feed
+                # client merged it in (derivatives, non-LTP modes). Surfaced
+                # as both `oi` and `open_interest` for client compatibility.
+                if "open_interest" in tick:
+                    payload["oi"] = tick["open_interest"]
+                    payload["open_interest"] = tick["open_interest"]
+
+                if sub_mode == 2:
+                    payload["mode"] = "quote"
+                    self._publish(symbol, exchange, "QUOTE", payload)
+                else:  # mode 3 — depth
+                    payload["mode"] = "full"
+                    payload["depth"] = tick.get("depth", {"buy": [], "sell": []})
+                    self._publish(symbol, exchange, "DEPTH", payload)
+
+            except Exception as e:
+                self.logger.exception(f"Error processing IIFL tick: {e}")
+
+    def _publish(self, symbol: str, exchange: str, mode_str: str, data: dict) -> None:
         topic = f"{exchange}_{symbol}_{mode_str}"
         self.publish_market_data(topic, data)
 
-    def _as_ltp_payload(self, quote: dict[str, Any]) -> dict[str, Any]:
-        return {
-            "ltp": quote.get("ltp", 0),
-            "volume": quote.get("volume", 0),
-            "timestamp": int(time.time()),
-        }
+    # ----------------------------------------------------------------- callbacks
+    def _on_connect(self) -> None:
+        self.connected = True
+        self.logger.info("IIFL Capital MQTT connection established")
 
-    def _as_quote_payload(self, quote: dict[str, Any]) -> dict[str, Any]:
-        prev_close = quote.get("prev_close", 0) or 0
-        ltp = quote.get("ltp", 0) or 0
-        change = float(ltp) - float(prev_close) if prev_close else 0
-        change_pct = (change / float(prev_close) * 100) if prev_close else 0
-        return {
-            "open": quote.get("open", 0),
-            "high": quote.get("high", 0),
-            "low": quote.get("low", 0),
-            "close": prev_close,
-            "ltp": ltp,
-            "volume": quote.get("volume", 0),
-            "bid": quote.get("bid", 0),
-            "ask": quote.get("ask", 0),
-            "oi": quote.get("oi", 0),
-            "change": change,
-            "change_percent": change_pct,
-            "timestamp": int(time.time()),
-        }
+    def _on_disconnect(self) -> None:
+        self.connected = False
+        self.logger.warning("IIFL Capital MQTT connection dropped")
 
-    def _as_depth_payload(self, depth: dict[str, Any]) -> dict[str, Any]:
-        buy = depth.get("buy") or depth.get("bids") or []
-        sell = depth.get("sell") or depth.get("asks") or []
-
-        # Convert bids/asks to market-data-service compatible buy/sell levels.
-        buy_levels = [
-            {
-                "price": level.get("price", 0),
-                "quantity": level.get("quantity", 0),
-                "orders": level.get("orders", 0),
-            }
-            for level in buy[:20]
-            if isinstance(level, dict)
-        ]
-        sell_levels = [
-            {
-                "price": level.get("price", 0),
-                "quantity": level.get("quantity", 0),
-                "orders": level.get("orders", 0),
-            }
-            for level in sell[:20]
-            if isinstance(level, dict)
-        ]
-
-        return {
-            "ltp": depth.get("ltp", 0),
-            "open": depth.get("open", 0),
-            "high": depth.get("high", 0),
-            "low": depth.get("low", 0),
-            "close": depth.get("prev_close", depth.get("close", 0)),
-            "volume": depth.get("volume", 0),
-            "depth": {"buy": buy_levels, "sell": sell_levels},
-            "timestamp": int(time.time()),
-        }
+    def _on_error(self, error: Exception) -> None:
+        self.logger.error(f"IIFL Capital MQTT error: {error}")

--- a/broker/iiflcapital/streaming/iiflcapital_adapter.py
+++ b/broker/iiflcapital/streaming/iiflcapital_adapter.py
@@ -113,6 +113,18 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
         self.auth_token = auth_token
 
+        # If initialize() is called a second time (e.g. issue #765 force re-init
+        # after a token refresh) we must stop the previous feed client first.
+        # Just dropping the reference is not enough: its reader/keepalive
+        # threads hold a back-reference to the IiflMqttClient via `self`,
+        # which would keep the old TLS socket and threads alive indefinitely.
+        if self.ws_client is not None:
+            try:
+                self.ws_client.stop()
+            except Exception as e:
+                self.logger.debug(f"Error stopping previous IIFL feed client: {e}")
+            self.ws_client = None
+
         try:
             self.ws_client = IiflcapitalWebSocket(
                 user_session=auth_token,

--- a/broker/iiflcapital/streaming/iiflcapital_adapter.py
+++ b/broker/iiflcapital/streaming/iiflcapital_adapter.py
@@ -149,11 +149,27 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 return {"status": "success", "message": "Already connected"}
 
             started = self.ws_client.start()
-            self.running = True
 
             if started and self.ws_client.wait_for_connection(timeout=15.0):
+                # Only flip running/connected once we know the broker
+                # session is live. Leaving running=True on failure would
+                # let subscribe() — which only checks self.running — push
+                # work into a dead client and return success to the caller.
+                self.running = True
                 self.connected = True
                 return {"status": "success", "message": "Connected"}
+
+            # Connection failed: make sure no half-started state survives,
+            # so the next subscribe() correctly rejects with "not connected".
+            self.running = False
+            self.connected = False
+            # Best-effort teardown of any threads start() may have spawned
+            # (reader/keepalive run only on accepted CONNACK, but reconnect
+            # workers can be running after a transient timeout).
+            try:
+                self.ws_client.stop()
+            except Exception as e:
+                self.logger.debug(f"Error stopping ws_client after failed connect: {e}")
 
             if self.ws_client._fatal_error:  # noqa: SLF001 — surface auth failure quickly
                 return {

--- a/broker/iiflcapital/streaming/iiflcapital_mapping.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mapping.py
@@ -1,0 +1,49 @@
+"""
+Helpers for translating between OpenAlgo's market-data conventions and the
+IIFL Capital feed's segment/topic conventions.
+
+The contract-master loader (broker/iiflcapital/database/master_contract_db.py)
+already stores the IIFL segment in the `brexchange` column of `SymToken`:
+
+    OpenAlgo exchange  →  brexchange
+    -----------------     ----------
+    NSE                  NSEEQ
+    BSE                  BSEEQ
+    NFO                  NSEFO
+    BFO                  BSEFO
+    CDS                  NSECURR
+    BCD                  BSECURR
+    MCX                  NSECOMM | MCXCOMM | NCDEXCOMM
+    NSE_INDEX            NSEEQ        (CSV column stored verbatim)
+    BSE_INDEX            BSEEQ        (CSV column stored verbatim)
+
+The IIFL MQTT topic suffix is just `{brexchange.lower()}/{token}` — see
+bridgePy/connector.py subscribe_feed/subscribe_index docstrings.
+"""
+
+from __future__ import annotations
+
+# OpenAlgo exchanges that are routed to the index MQTT topic prefix
+# (prod/marketfeed/index/v1/...) rather than the market feed prefix.
+INDEX_EXCHANGES: frozenset[str] = frozenset(
+    {"NSE_INDEX", "BSE_INDEX", "MCX_INDEX", "GLOBAL_INDEX"}
+)
+
+# OpenAlgo exchanges that support open-interest data. Anything outside this
+# set has no OI stream — saves a wasted SUBSCRIBE frame.
+OI_ELIGIBLE_EXCHANGES: frozenset[str] = frozenset({"NFO", "BFO", "CDS", "BCD", "MCX"})
+
+
+def is_index_exchange(exchange: str) -> bool:
+    return exchange in INDEX_EXCHANGES
+
+
+def supports_open_interest(exchange: str) -> bool:
+    return exchange in OI_ELIGIBLE_EXCHANGES
+
+
+def normalize_segment(brexchange: str | None) -> str:
+    """Lower-case the brexchange string for use in MQTT topic suffixes."""
+    if not brexchange:
+        return ""
+    return brexchange.strip().lower()

--- a/broker/iiflcapital/streaming/iiflcapital_mqtt.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mqtt.py
@@ -1,0 +1,518 @@
+"""
+Minimal MQTT v3.1.1 client used by the IIFL Capital streaming adapter.
+
+This is a hand-rolled, stdlib-only implementation modelled after the subset of
+paho-mqtt that the official IIFL bridgePy SDK exercises. Only the control
+packets required by IIFL's market-data broker are supported:
+
+    CONNECT / CONNACK
+    SUBSCRIBE / SUBACK
+    UNSUBSCRIBE / UNSUBACK
+    PUBLISH (QoS 0 only — incoming)
+    PINGREQ / PINGRESP
+    DISCONNECT
+
+No QoS 1/2 inflight tracking, no retained messages, no will message, no
+session resumption — the IIFL broker only publishes QoS 0 to subscribers and
+expects clean_session=True clients.
+
+The transport is a single TLS socket (TLSv1.2, cert verification disabled —
+the IIFL broker presents a self-signed cert in production, matching bridgePy
+behaviour). A background reader thread parses frames off the wire and
+dispatches to user callbacks; a second thread sends PINGREQ inside the
+keepalive window so the broker does not drop us.
+"""
+
+from __future__ import annotations
+
+import socket
+import ssl
+import struct
+import threading
+import time
+from collections.abc import Callable
+from typing import Optional
+
+from utils.logging import get_logger
+
+# Control packet types (high nibble of fixed-header byte 1)
+_CONNECT = 0x10
+_CONNACK = 0x20
+_PUBLISH = 0x30
+_SUBSCRIBE = 0x82  # type=8, flags=0010 (reserved bits required by spec)
+_SUBACK = 0x90
+_UNSUBSCRIBE = 0xA2  # type=10, flags=0010
+_UNSUBACK = 0xB0
+_PINGREQ = 0xC0
+_PINGRESP = 0xD0
+_DISCONNECT = 0xE0
+
+_MQTT_PROTOCOL_NAME = b"MQTT"
+_MQTT_PROTOCOL_LEVEL = 0x04  # MQTT v3.1.1
+
+# CONNACK return codes (MQTT v3.1.1 §3.2.2.3)
+CONNACK_ACCEPTED = 0
+CONNACK_REASONS = {
+    0: "Connection Accepted",
+    1: "Connection Refused: unacceptable protocol version",
+    2: "Connection Refused: identifier rejected",
+    3: "Connection Refused: server unavailable",
+    4: "Connection Refused: bad user name or password",
+    5: "Connection Refused: not authorized",
+}
+
+
+def _encode_remaining_length(length: int) -> bytes:
+    """Encode an MQTT variable-byte integer (1–4 bytes)."""
+    if length < 0 or length > 268_435_455:
+        raise ValueError(f"Remaining length out of range: {length}")
+    out = bytearray()
+    while True:
+        byte = length & 0x7F
+        length >>= 7
+        if length:
+            byte |= 0x80
+            out.append(byte)
+        else:
+            out.append(byte)
+            break
+    return bytes(out)
+
+
+def _encode_string(value: str) -> bytes:
+    """Encode a UTF-8 string with a 2-byte big-endian length prefix."""
+    data = value.encode("utf-8")
+    return struct.pack(">H", len(data)) + data
+
+
+class MqttError(Exception):
+    """Raised for MQTT-level protocol failures."""
+
+
+class IiflMqttClient:
+    """
+    Synchronous MQTT v3.1.1 client tailored for IIFL Capital's bridge.
+
+    Usage:
+        client = IiflMqttClient(host="bridge.iiflcapital.com", port=8883,
+                                client_id="...", username="...", password="...",
+                                keepalive=20)
+        client.on_message = lambda topic, payload: ...
+        client.on_connect = lambda rc, reason: ...
+        client.connect()
+        client.subscribe(["prod/marketfeed/mw/v1/nseeq/2885"])
+
+    The client owns one TLS socket and two daemon threads (reader + keepalive).
+    All sends are serialised by an internal lock so subscribe/unsubscribe calls
+    from the adapter layer are thread-safe.
+    """
+
+    # Reader keeps grabbing packets until it sees stop_event or the socket dies.
+    # We never timeout the socket; PINGREQ keeps the broker happy and a dead
+    # socket surfaces as a read returning b"".
+    _RECV_BUF = 65536
+
+    def __init__(
+        self,
+        host: str,
+        port: int,
+        client_id: str,
+        username: str,
+        password: str,
+        keepalive: int = 20,
+        tls_version: int = ssl.PROTOCOL_TLSv1_2,
+    ) -> None:
+        self.host = host
+        self.port = port
+        self.client_id = client_id
+        self.username = username
+        self.password = password
+        self.keepalive = max(5, int(keepalive))
+        self.tls_version = tls_version
+
+        self.logger = get_logger("iifl_mqtt")
+        self._sock: ssl.SSLSocket | None = None
+        self._send_lock = threading.Lock()
+        self._stop_event = threading.Event()
+        self._connected = threading.Event()
+        self._reader_thread: threading.Thread | None = None
+        self._keepalive_thread: threading.Thread | None = None
+
+        # Packet identifier for SUBSCRIBE/UNSUBSCRIBE (1..65535, wraps).
+        self._packet_id = 0
+        self._packet_id_lock = threading.Lock()
+
+        # Callbacks. All are optional; missing ones are simply skipped.
+        self.on_connect: Callable[[int, str], None] | None = None
+        self.on_disconnect: Callable[[Optional[Exception]], None] | None = None
+        self.on_message: Callable[[str, bytes], None] | None = None
+        self.on_subscribe: Callable[[int, list[int]], None] | None = None
+        self.on_unsubscribe: Callable[[int], None] | None = None
+        self.on_error: Callable[[Exception], None] | None = None
+
+    # ------------------------------------------------------------------ public
+    def is_connected(self) -> bool:
+        return self._connected.is_set() and self._sock is not None
+
+    def connect(self, timeout: float = 15.0) -> int:
+        """
+        Open the TLS socket, send CONNECT, wait for CONNACK.
+
+        Returns the CONNACK return code (0 = accepted). Raises on socket or
+        TLS failure before the MQTT layer is reached.
+        """
+        # Defensive cleanup if the caller is reusing the instance.
+        self._stop_event.clear()
+        self._connected.clear()
+
+        raw = socket.create_connection((self.host, self.port), timeout=timeout)
+        try:
+            ctx = ssl.SSLContext(self.tls_version)
+            ctx.check_hostname = False
+            ctx.verify_mode = ssl.CERT_NONE
+            self._sock = ctx.wrap_socket(raw, server_hostname=self.host)
+        except Exception:
+            raw.close()
+            raise
+
+        # Now switch to blocking with no read deadline — reader thread blocks.
+        self._sock.settimeout(None)
+
+        self._send_connect()
+
+        # Read CONNACK inline; we need its return code before we start the
+        # reader thread. Use a temporary deadline so a broker that hangs at
+        # this stage does not block the caller forever.
+        self._sock.settimeout(timeout)
+        try:
+            packet_type, _flags, body = self._read_packet()
+        finally:
+            self._sock.settimeout(None)
+
+        if packet_type != _CONNACK >> 4:
+            raise MqttError(f"Expected CONNACK, got packet type {packet_type}")
+        if len(body) < 2:
+            raise MqttError("Truncated CONNACK")
+
+        # Byte 0: session present flag (ignored — we use clean_session)
+        # Byte 1: return code
+        rc = body[1]
+        reason = CONNACK_REASONS.get(rc, f"Unknown CONNACK code {rc}")
+
+        if rc != CONNACK_ACCEPTED:
+            # Surface the auth failure to the caller; close the socket.
+            try:
+                self._sock.close()
+            finally:
+                self._sock = None
+            if self.on_connect:
+                try:
+                    self.on_connect(rc, reason)
+                except Exception:
+                    pass
+            return rc
+
+        # Reader and keepalive threads come up only after we know the broker
+        # accepted us — avoids spurious "connection closed" callbacks on a
+        # rejected handshake.
+        self._connected.set()
+        self._reader_thread = threading.Thread(
+            target=self._reader_loop, daemon=True, name="IiflMqttReader"
+        )
+        self._reader_thread.start()
+        self._keepalive_thread = threading.Thread(
+            target=self._keepalive_loop, daemon=True, name="IiflMqttKeepalive"
+        )
+        self._keepalive_thread.start()
+
+        if self.on_connect:
+            try:
+                self.on_connect(rc, reason)
+            except Exception as e:
+                self.logger.exception(f"on_connect callback raised: {e}")
+
+        return rc
+
+    def disconnect(self) -> None:
+        """Send DISCONNECT (best-effort), close socket, stop threads."""
+        self._stop_event.set()
+        self._connected.clear()
+
+        sock = self._sock
+        self._sock = None
+        if sock is not None:
+            # MQTT DISCONNECT is 0xE0 0x00 — try to send it, but tolerate
+            # the broker having already dropped the socket.
+            try:
+                sock.sendall(bytes([_DISCONNECT, 0x00]))
+            except OSError:
+                pass
+            try:
+                sock.shutdown(socket.SHUT_RDWR)
+            except OSError:
+                pass
+            try:
+                sock.close()
+            except OSError:
+                pass
+
+        # Daemon threads exit on their own when stop_event is set; we do not
+        # join them here to keep teardown non-blocking under eventlet.
+
+    def subscribe(self, topics: list[str], qos: int = 0) -> int:
+        """
+        Send SUBSCRIBE for a list of topic filters. Returns the packet id
+        used, so callers can correlate with on_subscribe(packet_id, granted_qos).
+        """
+        if not topics:
+            return 0
+        if not self.is_connected():
+            raise MqttError("Cannot subscribe — not connected")
+
+        pkt_id = self._next_packet_id()
+
+        # Variable header: packet identifier (u16)
+        # Payload: for each topic, (u16 len + utf-8) + u8 requested QoS
+        body = struct.pack(">H", pkt_id)
+        for topic in topics:
+            body += _encode_string(topic)
+            body += bytes([qos & 0x03])
+
+        self._send_packet(_SUBSCRIBE, body)
+        return pkt_id
+
+    def unsubscribe(self, topics: list[str]) -> int:
+        if not topics:
+            return 0
+        if not self.is_connected():
+            raise MqttError("Cannot unsubscribe — not connected")
+
+        pkt_id = self._next_packet_id()
+        body = struct.pack(">H", pkt_id)
+        for topic in topics:
+            body += _encode_string(topic)
+
+        self._send_packet(_UNSUBSCRIBE, body)
+        return pkt_id
+
+    # ------------------------------------------------------------------ private
+    def _next_packet_id(self) -> int:
+        with self._packet_id_lock:
+            self._packet_id = (self._packet_id % 65535) + 1
+            return self._packet_id
+
+    def _send_connect(self) -> None:
+        """
+        Build & send the MQTT CONNECT packet matching bridgePy's parameters:
+          - Protocol name "MQTT", level 0x04 (v3.1.1)
+          - Connect flags: clean_session | username | password (no will)
+          - Keep alive: self.keepalive
+          - Payload: client_id, username, password
+        """
+        # Variable header
+        var_header = _encode_string(_MQTT_PROTOCOL_NAME.decode())  # "MQTT"
+        var_header += bytes([_MQTT_PROTOCOL_LEVEL])
+        # Connect flags:
+        #   bit 7 username, bit 6 password, bit 1 clean_session.
+        connect_flags = 0b11000010
+        var_header += bytes([connect_flags])
+        var_header += struct.pack(">H", self.keepalive)
+
+        # Payload
+        payload = _encode_string(self.client_id)
+        payload += _encode_string(self.username)
+        payload += _encode_string(self.password)
+
+        body = var_header + payload
+        frame = bytes([_CONNECT]) + _encode_remaining_length(len(body)) + body
+
+        # CONNECT bypasses the send lock — there is no reader running yet, and
+        # nothing else writes to the socket before CONNACK comes back.
+        assert self._sock is not None
+        self._sock.sendall(frame)
+
+    def _send_packet(self, fixed_header_byte: int, body: bytes) -> None:
+        """
+        Serialise outbound traffic on the socket. Reader thread never writes,
+        but subscribe/unsubscribe and PINGREQ can race each other.
+        """
+        frame = bytes([fixed_header_byte]) + _encode_remaining_length(len(body)) + body
+        with self._send_lock:
+            sock = self._sock
+            if sock is None:
+                raise MqttError("Socket closed")
+            sock.sendall(frame)
+
+    def _send_pingreq(self) -> None:
+        # PINGREQ has no variable header or payload — just 0xC0 0x00.
+        with self._send_lock:
+            sock = self._sock
+            if sock is None:
+                return
+            try:
+                sock.sendall(bytes([_PINGREQ, 0x00]))
+            except OSError as e:
+                self.logger.debug(f"PINGREQ send failed: {e}")
+
+    def _read_exact(self, n: int) -> bytes:
+        """Read exactly n bytes from the socket; b"" if the peer closed."""
+        sock = self._sock
+        if sock is None:
+            return b""
+        chunks: list[bytes] = []
+        remaining = n
+        while remaining > 0:
+            chunk = sock.recv(min(remaining, self._RECV_BUF))
+            if not chunk:
+                return b""
+            chunks.append(chunk)
+            remaining -= len(chunk)
+        return b"".join(chunks)
+
+    def _read_remaining_length(self) -> int:
+        """
+        Decode the MQTT variable-byte integer that follows the fixed-header
+        first byte. Up to 4 continuation bytes.
+        """
+        multiplier = 1
+        value = 0
+        for _ in range(4):
+            byte = self._read_exact(1)
+            if not byte:
+                raise MqttError("Socket closed while reading remaining length")
+            digit = byte[0]
+            value += (digit & 0x7F) * multiplier
+            if (digit & 0x80) == 0:
+                return value
+            multiplier *= 128
+        raise MqttError("Malformed remaining length (more than 4 bytes)")
+
+    def _read_packet(self) -> tuple[int, int, bytes]:
+        """
+        Read one MQTT control packet. Returns (packet_type_nibble, flags_nibble, body_bytes).
+        Raises MqttError if the stream is closed.
+        """
+        header = self._read_exact(1)
+        if not header:
+            raise MqttError("Socket closed")
+        first = header[0]
+        packet_type = (first & 0xF0) >> 4
+        flags = first & 0x0F
+
+        remaining = self._read_remaining_length()
+        body = self._read_exact(remaining) if remaining else b""
+        if remaining and len(body) != remaining:
+            raise MqttError("Truncated MQTT body")
+        return packet_type, flags, body
+
+    def _reader_loop(self) -> None:
+        """
+        Background reader. Decodes inbound packets and dispatches callbacks.
+        Exits when the socket is closed or stop_event is set.
+        """
+        try:
+            while not self._stop_event.is_set():
+                try:
+                    packet_type, flags, body = self._read_packet()
+                except MqttError:
+                    # Clean close — peer hung up or we shut down.
+                    break
+
+                if packet_type == _PUBLISH >> 4:
+                    self._handle_publish(flags, body)
+                elif packet_type == _SUBACK >> 4:
+                    self._handle_suback(body)
+                elif packet_type == _UNSUBACK >> 4:
+                    self._handle_unsuback(body)
+                elif packet_type == _PINGRESP >> 4:
+                    # No-op; the keepalive thread does not currently check
+                    # for pong arrival — broker drop surfaces as recv == b"".
+                    pass
+                else:
+                    self.logger.debug(
+                        f"Unexpected MQTT packet type {packet_type} (flags={flags}, len={len(body)})"
+                    )
+        except Exception as e:  # noqa: BLE001 — surface to on_error callback
+            self.logger.exception(f"Reader loop crashed: {e}")
+            if self.on_error:
+                try:
+                    self.on_error(e)
+                except Exception:
+                    pass
+        finally:
+            self._connected.clear()
+            if self.on_disconnect:
+                try:
+                    self.on_disconnect(None)
+                except Exception as e:
+                    self.logger.exception(f"on_disconnect callback raised: {e}")
+
+    def _handle_publish(self, flags: int, body: bytes) -> None:
+        """
+        PUBLISH variable header:
+            Topic Name (u16 len + utf-8)
+            [Packet Identifier (u16) — only if QoS > 0; we only see QoS 0]
+        Payload:
+            remaining bytes after the variable header
+        """
+        if len(body) < 2:
+            self.logger.debug("PUBLISH too short to contain topic length")
+            return
+
+        topic_len = struct.unpack(">H", body[0:2])[0]
+        if len(body) < 2 + topic_len:
+            self.logger.debug("PUBLISH truncated topic")
+            return
+
+        topic = body[2:2 + topic_len].decode("utf-8", errors="replace")
+        qos = (flags & 0x06) >> 1
+
+        # We negotiated QoS 0 on subscribe, so the broker should never send
+        # us QoS 1/2. If it does, skip the packet identifier defensively so
+        # we don't mis-parse the payload.
+        offset = 2 + topic_len
+        if qos > 0:
+            offset += 2
+
+        payload = body[offset:]
+
+        if self.on_message:
+            try:
+                self.on_message(topic, payload)
+            except Exception as e:
+                self.logger.exception(f"on_message callback raised: {e}")
+
+    def _handle_suback(self, body: bytes) -> None:
+        if len(body) < 3:
+            return
+        packet_id = struct.unpack(">H", body[0:2])[0]
+        granted = list(body[2:])
+        if self.on_subscribe:
+            try:
+                self.on_subscribe(packet_id, granted)
+            except Exception as e:
+                self.logger.exception(f"on_subscribe callback raised: {e}")
+
+    def _handle_unsuback(self, body: bytes) -> None:
+        if len(body) < 2:
+            return
+        packet_id = struct.unpack(">H", body[0:2])[0]
+        if self.on_unsubscribe:
+            try:
+                self.on_unsubscribe(packet_id)
+            except Exception as e:
+                self.logger.exception(f"on_unsubscribe callback raised: {e}")
+
+    def _keepalive_loop(self) -> None:
+        """
+        Send PINGREQ every keepalive/2 seconds while connected. This is a
+        defensive interval — the broker disconnects after 1.5 × keepalive
+        with no traffic, so pinging at the half-period gives us slack.
+        """
+        interval = max(2, self.keepalive // 2)
+        while not self._stop_event.is_set():
+            if self._stop_event.wait(interval):
+                break
+            if not self.is_connected():
+                break
+            self._send_pingreq()

--- a/broker/iiflcapital/streaming/iiflcapital_mqtt.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mqtt.py
@@ -175,24 +175,45 @@ class IiflMqttClient:
             raw.close()
             raise
 
-        # Now switch to blocking with no read deadline — reader thread blocks.
-        self._sock.settimeout(None)
-
-        self._send_connect()
-
-        # Read CONNACK inline; we need its return code before we start the
-        # reader thread. Use a temporary deadline so a broker that hangs at
-        # this stage does not block the caller forever.
-        self._sock.settimeout(timeout)
+        # Anything below here happens AFTER we own a live TLS FD — any
+        # exception in send_connect / read_packet / CONNACK parsing must
+        # close that FD before propagating, otherwise we leak a socket on
+        # every failed handshake (caller will just create a new client and
+        # retry — the abandoned socket sits in CLOSE_WAIT until GC).
         try:
-            packet_type, _flags, body = self._read_packet()
-        finally:
+            # Now switch to blocking with no read deadline — reader thread blocks.
             self._sock.settimeout(None)
 
-        if packet_type != _CONNACK >> 4:
-            raise MqttError(f"Expected CONNACK, got packet type {packet_type}")
-        if len(body) < 2:
-            raise MqttError("Truncated CONNACK")
+            self._send_connect()
+
+            # Read CONNACK inline; we need its return code before we start the
+            # reader thread. Use a temporary deadline so a broker that hangs at
+            # this stage does not block the caller forever.
+            self._sock.settimeout(timeout)
+            try:
+                packet_type, _flags, body = self._read_packet()
+            finally:
+                # Restore blocking mode only if we still own the socket; the
+                # close-on-failure branch below nulls it out.
+                if self._sock is not None:
+                    self._sock.settimeout(None)
+
+            if packet_type != _CONNACK >> 4:
+                raise MqttError(f"Expected CONNACK, got packet type {packet_type}")
+            if len(body) < 2:
+                raise MqttError("Truncated CONNACK")
+        except BaseException:
+            # Cover both regular exceptions and bare control-flow exits
+            # (timeouts, KeyboardInterrupt) — we must not leave a TLS FD
+            # behind regardless of how we got here.
+            sock = self._sock
+            self._sock = None
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+            raise
 
         # Byte 0: session present flag (ignored — we use clean_session)
         # Byte 1: return code
@@ -441,6 +462,28 @@ class IiflMqttClient:
                     pass
         finally:
             self._connected.clear()
+            # Close the FD here, not in disconnect(), because the broker
+            # FIN path (or any reader-side exception) gets us here without
+            # any external code knowing the socket is dead. Without this
+            # explicit close, the FD sits in CLOSE_WAIT until garbage
+            # collection — one leaked FD per reconnect cycle. disconnect()
+            # remains idempotent because it nulls _sock and tolerates a
+            # None value.
+            sock = self._sock
+            self._sock = None
+            if sock is not None:
+                try:
+                    sock.close()
+                except OSError:
+                    pass
+
+            # Wake the keepalive thread so it exits promptly instead of
+            # blocking on its next wait(keepalive/2) tick. `_stop_event`
+            # is per-instance, so signalling here only affects this
+            # client; a fresh IiflMqttClient on reconnect has its own
+            # event and is unaffected.
+            self._stop_event.set()
+
             if self.on_disconnect:
                 try:
                     self.on_disconnect(None)

--- a/broker/iiflcapital/streaming/iiflcapital_websocket.py
+++ b/broker/iiflcapital/streaming/iiflcapital_websocket.py
@@ -620,7 +620,16 @@ class IiflcapitalWebSocket:
             if self._stop_event.wait(delay):
                 return
 
-            if self._fatal_error:
+            # Re-check liveness *after* the backoff wakes. stop() can flip
+            # `running` or set `_fatal_error` between the wait and the
+            # connect call; without this guard we would open a new TLS
+            # socket the caller is actively trying to tear down — leaking
+            # both the FD and the reader/keepalive threads tied to it.
+            if (
+                not self.running
+                or self._stop_event.is_set()
+                or self._fatal_error
+            ):
                 return
 
             if self._do_connect():

--- a/broker/iiflcapital/streaming/iiflcapital_websocket.py
+++ b/broker/iiflcapital/streaming/iiflcapital_websocket.py
@@ -1,0 +1,627 @@
+"""
+High-level IIFL Capital market-data feed client.
+
+Sits on top of `iiflcapital_mqtt.IiflMqttClient` and exposes the same
+broker-feed surface that other OpenAlgo adapters consume (Zerodha-style):
+
+    client = IiflcapitalWebSocket(user_session=<jwt>)
+    client.on_ticks = lambda ticks: ...
+    client.start()
+    client.subscribe(brexchange="NSEEQ", token="2885", mode="full")
+
+The IIFL feed publishes a single 188-byte "MWBOCombined" packet per market
+update — it always contains LTP + OHLC + L5 depth + bid/ask totals + timestamp.
+OpenAlgo's WebSocket proxy still wants three distinct modes (LTP/Quote/Depth),
+so we subscribe ONCE per (segment, token) at the MQTT layer and let the
+adapter slice the decoded dict into the right shape for each subscribed mode.
+That is the same trade-off the Zerodha adapter makes with its `full` mode.
+
+Stream coverage:
+    * Market Feed (prod/marketfeed/mw/v1/) — primary, 188-byte structure
+    * Index Feed  (prod/marketfeed/index/v1/) — same structure, separate prefix
+    * Open Interest (prod/marketfeed/oi/v1/) — 16-byte OI packet, surfaced as
+      the `oi`/`open_interest` field on the next Quote/Depth tick
+"""
+
+from __future__ import annotations
+
+import base64
+import ctypes
+import json
+import struct
+import threading
+import time
+from collections import deque
+from collections.abc import Callable
+from datetime import datetime
+
+from utils.logging import get_logger
+
+from .iiflcapital_mqtt import CONNACK_ACCEPTED, CONNACK_REASONS, IiflMqttClient
+
+# MQTT topic prefixes mirrored from bridgePy/connector.py.
+TOPIC_MARKET_FEED = "prod/marketfeed/mw/v1/"
+TOPIC_INDEX_FEED = "prod/marketfeed/index/v1/"
+TOPIC_OPEN_INTEREST = "prod/marketfeed/oi/v1/"
+
+# Modes are local to the IIFL client. They DO NOT correspond 1:1 with
+# OpenAlgo's mode ints — the adapter layer translates 1/2/3 → "ltp"/"quote"/"full".
+MODE_LTP = "ltp"
+MODE_QUOTE = "quote"
+MODE_FULL = "full"
+
+# Conservative subscribe batching. The IIFL broker tolerates up to 1024 topics
+# in a single SUBSCRIBE per the bridgePy validation; 100 keeps individual
+# frames under the typical broker buffer and yields fast feedback.
+MAX_TOKENS_PER_SUBSCRIBE = 100
+
+# IIFL caps a single client at 6000 subscriptions (per docs). We keep some
+# headroom below that to avoid edge-case rejections.
+MAX_INSTRUMENTS_PER_CONNECTION = 5800
+
+
+# ---------------------------------------------------------------------------
+# Binary packet structures — mirrored from bridgePy/examples/main.py.
+# IIFL's MWBOCombined packet is laid out for a C# struct with Pack=2 and
+# native little-endian byte order. We reproduce it with ctypes so the layout
+# stays in sync with the broker's wire format.
+# ---------------------------------------------------------------------------
+class _Depth(ctypes.Structure):
+    _fields_ = [
+        ("quantity", ctypes.c_uint32),
+        ("price", ctypes.c_int32),
+        ("orders", ctypes.c_int16),
+        ("transactionType", ctypes.c_int16),  # 1 = bid, 2 = ask (per IIFL)
+    ]
+
+
+class _MWBOCombined(ctypes.Structure):
+    _pack_ = 2
+    _fields_ = [
+        ("ltp", ctypes.c_int32),
+        ("lastTradedQuantity", ctypes.c_uint32),
+        ("tradedVolume", ctypes.c_uint32),
+        ("high", ctypes.c_int32),
+        ("low", ctypes.c_int32),
+        ("open", ctypes.c_int32),
+        ("close", ctypes.c_int32),
+        ("averageTradedPrice", ctypes.c_int32),
+        ("reserved", ctypes.c_uint16),
+        ("bestBidQuantity", ctypes.c_uint32),
+        ("bestBidPrice", ctypes.c_int32),
+        ("bestAskQuantity", ctypes.c_uint32),
+        ("bestAskPrice", ctypes.c_int32),
+        ("totalBidQuantity", ctypes.c_uint32),
+        ("totalAskQuantity", ctypes.c_uint32),
+        ("priceDivisor", ctypes.c_int32),
+        ("lastTradedTime", ctypes.c_int32),
+        ("marketDepth", _Depth * 10),
+    ]
+
+
+_MWBOCombined_SIZE = ctypes.sizeof(_MWBOCombined)  # 186 bytes with _pack_=2
+
+
+def _decode_jwt_username(token: str) -> str:
+    """
+    Extract `preferred_username` from a JWT (matches bridgePy's
+    __get_user_name). The JWT payload (middle segment) is URL-safe base64
+    without padding, so we pad it before decoding.
+    """
+    try:
+        payload_segment = token.split(".")[1]
+        padding_needed = (4 - len(payload_segment) % 4) % 4
+        padded = payload_segment + ("=" * padding_needed)
+        decoded = base64.urlsafe_b64decode(padded)
+        claims = json.loads(decoded)
+        return str(claims.get("preferred_username", "tester"))
+    except Exception:
+        return "tester"
+
+
+def _decode_market_feed(payload: bytes) -> dict | None:
+    """
+    Decode an MWBOCombined packet to a flat dict. Returns None if the
+    payload is shorter than the expected structure size.
+
+    Prices are integer-paise / priceDivisor; we apply the divisor here so
+    downstream consumers always see floats in rupees.
+    """
+    if len(payload) < _MWBOCombined_SIZE:
+        return None
+
+    # IIFL's MWBOCombined is 186 bytes but the broker publishes 188-byte
+    # frames in production (2 trailing bytes are slack). Slice to size.
+    pkt = _MWBOCombined.from_buffer_copy(payload[:_MWBOCombined_SIZE])
+
+    divisor = pkt.priceDivisor or 100  # never divide by zero
+    inv = 1.0 / divisor
+
+    # IIFL doc: "Bytes 66-185 contain: 5 bid levels - 5 ask levels". The
+    # `transactionType` field in each Depth entry is informational and not a
+    # reliable side selector (it stays 0 on many segments — MCX FUT, indices,
+    # certain commodity futures), so we slice positionally instead.
+    levels = pkt.marketDepth
+    depth_buy = [
+        {
+            "quantity": int(level.quantity),
+            "price": float(level.price) * inv,
+            "orders": int(level.orders),
+        }
+        for level in levels[:5]
+    ]
+    depth_sell = [
+        {
+            "quantity": int(level.quantity),
+            "price": float(level.price) * inv,
+            "orders": int(level.orders),
+        }
+        for level in levels[5:10]
+    ]
+
+    ltt_unix = int(pkt.lastTradedTime) if pkt.lastTradedTime else 0
+
+    return {
+        "ltp": float(pkt.ltp) * inv,
+        "last_traded_quantity": int(pkt.lastTradedQuantity),
+        "volume": int(pkt.tradedVolume),
+        "high": float(pkt.high) * inv,
+        "low": float(pkt.low) * inv,
+        "open": float(pkt.open) * inv,
+        "close": float(pkt.close) * inv,
+        "average_price": float(pkt.averageTradedPrice) * inv,
+        "best_bid_quantity": int(pkt.bestBidQuantity),
+        "best_bid_price": float(pkt.bestBidPrice) * inv,
+        "best_ask_quantity": int(pkt.bestAskQuantity),
+        "best_ask_price": float(pkt.bestAskPrice) * inv,
+        "total_buy_quantity": int(pkt.totalBidQuantity),
+        "total_sell_quantity": int(pkt.totalAskQuantity),
+        "ltt": ltt_unix,
+        "timestamp": int(time.time() * 1000),
+        "depth": {"buy": depth_buy, "sell": depth_sell},
+    }
+
+
+def _decode_open_interest(payload: bytes) -> dict | None:
+    """
+    16-byte OI packet — four signed 32-bit integers in native byte order.
+    Matches the `format = "iiii"` decode in bridgePy's example handler.
+    """
+    if len(payload) < 16:
+        return None
+    oi, day_high_oi, day_low_oi, prev_oi = struct.unpack("iiii", payload[:16])
+    return {
+        "open_interest": oi,
+        "day_high_oi": day_high_oi,
+        "day_low_oi": day_low_oi,
+        "previous_oi": prev_oi,
+    }
+
+
+def _topic_key(segment: str, token: str | int) -> str:
+    """Lowercase segment/token, e.g. ('NSEEQ', 2885) → 'nseeq/2885'."""
+    return f"{segment.lower()}/{token}"
+
+
+class IiflcapitalWebSocket:
+    """
+    Subscriber-side IIFL Capital market-data client.
+
+    Public callbacks:
+        on_ticks(list[dict])   — receives decoded ticks; each dict carries
+                                  segment, token, mode, and the merged
+                                  feed/OI fields.
+        on_connect()           — fired after a successful broker handshake.
+        on_disconnect()        — fired when the socket drops.
+        on_error(Exception)    — surfaced reader/transport failures.
+    """
+
+    # Topic-payload size hint for OI vs market feed routing — used only by
+    # the message dispatcher to skip OI decoding on undersized payloads.
+    _OI_TOPIC_PREFIX = TOPIC_OPEN_INTEREST
+    _MW_TOPIC_PREFIX = TOPIC_MARKET_FEED
+    _IDX_TOPIC_PREFIX = TOPIC_INDEX_FEED
+
+    # Reconnection settings (mirror the Zerodha client for parity).
+    RECONNECT_MAX_DELAY = 60
+    RECONNECT_MAX_TRIES = 50
+    SUBSCRIPTION_DELAY = 0.3  # seconds between successive subscribe batches
+
+    def __init__(
+        self,
+        user_session: str,
+        host: str = "bridge.iiflcapital.com",
+        port: int = 8883,
+        on_ticks: Callable[[list[dict]], None] | None = None,
+    ) -> None:
+        if not user_session:
+            raise ValueError("user_session is required")
+
+        self.user_session = user_session
+        self.host = host
+        self.port = port
+        self.on_ticks = on_ticks
+        self.logger = get_logger("iiflcapital_websocket")
+
+        self.client_id = "openalgo" + datetime.now().strftime("%d%m%y%H%M%S%f")
+        self.username = _decode_jwt_username(user_session)
+        self.password = f"OPENID~~{user_session}~"  # bridgePy format
+
+        self._mqtt: IiflMqttClient | None = None
+        self._lock = threading.Lock()
+        self.running = False
+        self.connected = False
+
+        # Subscription state, keyed by `segment/token` (the topic suffix).
+        # Each entry: {"mode": "full"|"quote"|"ltp", "is_index": bool, "oi": bool}
+        self._subscriptions: dict[str, dict] = {}
+
+        # Cache the most recent OI per (segment, token) so we can merge it
+        # into outbound market-feed ticks without round-trip latency.
+        self._oi_cache: dict[str, dict] = {}
+
+        # Pending subscribe queue (drained on a worker thread to batch large
+        # bursts, same pattern as the Zerodha client).
+        self._pending: deque = deque()
+        self._sub_thread: threading.Thread | None = None
+        self._stop_event = threading.Event()
+
+        # Lifecycle callbacks for the adapter layer.
+        self.on_connect: Callable[[], None] | None = None
+        self.on_disconnect: Callable[[], None] | None = None
+        self.on_error: Callable[[Exception], None] | None = None
+
+        # Reconnect state.
+        self._reconnect_attempts = 0
+        self._reconnect_thread: threading.Thread | None = None
+
+        # Fatal-error short-circuit — set on CONNACK auth rejections so the
+        # reconnect loop bails out rather than hammering a known-bad token.
+        self._fatal_error = False
+        self._fatal_error_message = ""
+
+    # ----------------------------------------------------------------- lifecycle
+    def start(self) -> bool:
+        """Open the MQTT connection. Returns True on accepted CONNACK."""
+        if self.running and self.connected:
+            return True
+
+        self.running = True
+        self._stop_event.clear()
+        self._fatal_error = False
+        self._fatal_error_message = ""
+
+        return self._do_connect()
+
+    def _do_connect(self) -> bool:
+        try:
+            self._mqtt = IiflMqttClient(
+                host=self.host,
+                port=self.port,
+                client_id=self.client_id,
+                username=self.username,
+                password=self.password,
+                keepalive=20,
+            )
+            self._mqtt.on_message = self._on_mqtt_message
+            self._mqtt.on_disconnect = self._on_mqtt_disconnect
+            self._mqtt.on_error = self._on_mqtt_error
+
+            rc = self._mqtt.connect(timeout=15.0)
+            if rc != CONNACK_ACCEPTED:
+                reason = CONNACK_REASONS.get(rc, f"CONNACK rc={rc}")
+                self.logger.error(f"IIFL CONNACK refused: {reason}")
+                # rc 4/5 are auth failures — token is bad, do not retry.
+                if rc in (4, 5):
+                    self._fatal_error = True
+                    self._fatal_error_message = reason
+                    self.running = False
+                return False
+
+            self.connected = True
+            self._reconnect_attempts = 0
+            self.logger.info(
+                f"IIFL Capital MQTT connected (client_id={self.client_id}, user={self.username})"
+            )
+
+            if self.on_connect:
+                try:
+                    self.on_connect()
+                except Exception as e:
+                    self.logger.exception(f"on_connect callback raised: {e}")
+
+            # Re-subscribe to anything that survived a reconnect.
+            self._resubscribe_all()
+            return True
+
+        except Exception as e:
+            self.logger.exception(f"IIFL Capital MQTT connect failed: {e}")
+            return False
+
+    def stop(self) -> None:
+        """Cleanly tear down the connection and worker threads."""
+        self.running = False
+        self._stop_event.set()
+        if self._mqtt is not None:
+            try:
+                self._mqtt.disconnect()
+            except Exception as e:
+                self.logger.debug(f"Error during MQTT disconnect: {e}")
+            self._mqtt = None
+        self.connected = False
+
+    def wait_for_connection(self, timeout: float = 15.0) -> bool:
+        deadline = time.time() + timeout
+        while time.time() < deadline:
+            if self.connected:
+                return True
+            if self._fatal_error:
+                return False
+            time.sleep(0.05)
+        return self.connected
+
+    def is_connected(self) -> bool:
+        return self.connected and self._mqtt is not None and self._mqtt.is_connected()
+
+    # ----------------------------------------------------------------- subscribe
+    def subscribe_instruments(
+        self,
+        instruments: list[tuple[str, str | int]],
+        mode: str = MODE_FULL,
+        is_index: bool = False,
+        include_oi: bool = False,
+    ) -> None:
+        """
+        Queue a batch of (segment, token) pairs for subscription.
+
+        Args:
+            instruments: list of (segment, token) tuples. Segment is the
+                IIFL brexchange ('NSEEQ', 'NSEFO', 'BSEEQ', ...).
+            mode: "ltp" / "quote" / "full" — affects which OpenAlgo modes the
+                adapter will publish, not which broker topic we hit (the
+                broker only has one packet shape per stream).
+            is_index: True for NSE_INDEX/BSE_INDEX symbols; routes to the
+                index topic prefix instead of the market-feed prefix.
+            include_oi: subscribe to the OI stream alongside the market feed
+                (only meaningful for derivatives).
+        """
+        if not instruments:
+            return
+
+        total_after = len(self._subscriptions) + len(instruments)
+        if total_after > MAX_INSTRUMENTS_PER_CONNECTION:
+            self.logger.error(
+                f"Cannot subscribe to {len(instruments)} — would exceed "
+                f"{MAX_INSTRUMENTS_PER_CONNECTION} per-connection cap"
+            )
+            return
+
+        with self._lock:
+            for segment, token in instruments:
+                key = _topic_key(segment, token)
+                self._subscriptions[key] = {
+                    "mode": mode,
+                    "is_index": is_index,
+                    "oi": include_oi,
+                    "segment": segment.lower(),
+                    "token": str(token),
+                }
+                # Queue both feed and OI topics for sending in a batch.
+                prefix = self._IDX_TOPIC_PREFIX if is_index else self._MW_TOPIC_PREFIX
+                self._pending.append(prefix + key)
+                if include_oi and not is_index:
+                    self._pending.append(self._OI_TOPIC_PREFIX + key)
+
+        if not self._sub_thread or not self._sub_thread.is_alive():
+            self._sub_thread = threading.Thread(
+                target=self._drain_pending, daemon=True, name="IiflSubscribeDrain"
+            )
+            self._sub_thread.start()
+
+    def unsubscribe_instruments(self, instruments: list[tuple[str, str | int]]) -> None:
+        """Send UNSUBSCRIBE for each (segment, token) and drop local state."""
+        if not instruments:
+            return
+        if not self.is_connected():
+            return
+
+        topics_to_drop: list[str] = []
+        with self._lock:
+            for segment, token in instruments:
+                key = _topic_key(segment, token)
+                sub = self._subscriptions.pop(key, None)
+                self._oi_cache.pop(key, None)
+                if sub is None:
+                    continue
+                prefix = self._IDX_TOPIC_PREFIX if sub["is_index"] else self._MW_TOPIC_PREFIX
+                topics_to_drop.append(prefix + key)
+                if sub.get("oi"):
+                    topics_to_drop.append(self._OI_TOPIC_PREFIX + key)
+
+        if topics_to_drop and self._mqtt is not None:
+            try:
+                self._mqtt.unsubscribe(topics_to_drop)
+            except Exception as e:
+                self.logger.exception(f"Unsubscribe failed: {e}")
+
+    def _drain_pending(self) -> None:
+        """Send queued subscribes in batches with light pacing."""
+        consecutive_failures = 0
+        while self._pending and self.running:
+            if not self.is_connected():
+                consecutive_failures += 1
+                if consecutive_failures > 5:
+                    self.logger.error(
+                        "MQTT not connected — abandoning pending subscriptions"
+                    )
+                    with self._lock:
+                        self._pending.clear()
+                    break
+                if self._stop_event.wait(min(2 * consecutive_failures, 10)):
+                    break
+                continue
+            consecutive_failures = 0
+
+            with self._lock:
+                batch: list[str] = []
+                while self._pending and len(batch) < MAX_TOKENS_PER_SUBSCRIBE:
+                    batch.append(self._pending.popleft())
+
+            if not batch:
+                break
+
+            try:
+                self._mqtt.subscribe(batch, qos=0)
+                self.logger.debug(f"Subscribed batch of {len(batch)} IIFL topics")
+            except Exception as e:
+                self.logger.exception(f"IIFL subscribe failed: {e}")
+                # Re-queue and back off so we don't tight-loop on broker errors.
+                with self._lock:
+                    for t in batch:
+                        self._pending.appendleft(t)
+                if self._stop_event.wait(5):
+                    break
+                continue
+
+            if self._pending and self._stop_event.wait(self.SUBSCRIPTION_DELAY):
+                break
+
+    def _resubscribe_all(self) -> None:
+        """Rebuild MQTT-level subscriptions from local state after a reconnect."""
+        with self._lock:
+            if not self._subscriptions:
+                return
+            self._pending.clear()
+            for key, sub in self._subscriptions.items():
+                prefix = self._IDX_TOPIC_PREFIX if sub["is_index"] else self._MW_TOPIC_PREFIX
+                self._pending.append(prefix + key)
+                if sub.get("oi"):
+                    self._pending.append(self._OI_TOPIC_PREFIX + key)
+
+        if not self._sub_thread or not self._sub_thread.is_alive():
+            self._sub_thread = threading.Thread(
+                target=self._drain_pending, daemon=True, name="IiflSubscribeDrain"
+            )
+            self._sub_thread.start()
+
+    # ----------------------------------------------------------------- callbacks
+    def _on_mqtt_message(self, topic: str, payload: bytes) -> None:
+        """
+        Route an inbound PUBLISH to the right decoder. We accept three
+        prefixes: market feed (mw/v1/), index feed (index/v1/), and open
+        interest (oi/v1/). Anything else gets logged and dropped.
+        """
+        try:
+            if topic.startswith(self._MW_TOPIC_PREFIX):
+                key = topic[len(self._MW_TOPIC_PREFIX):]
+                self._dispatch_feed(key, payload, is_index=False)
+            elif topic.startswith(self._IDX_TOPIC_PREFIX):
+                key = topic[len(self._IDX_TOPIC_PREFIX):]
+                self._dispatch_feed(key, payload, is_index=True)
+            elif topic.startswith(self._OI_TOPIC_PREFIX):
+                key = topic[len(self._OI_TOPIC_PREFIX):]
+                self._dispatch_oi(key, payload)
+            else:
+                self.logger.debug(f"Unhandled IIFL topic: {topic}")
+        except Exception as e:
+            self.logger.exception(f"Error handling IIFL message on {topic}: {e}")
+
+    def _dispatch_feed(self, key: str, payload: bytes, is_index: bool) -> None:
+        with self._lock:
+            sub = self._subscriptions.get(key)
+        if sub is None:
+            # Late delivery for an instrument we just unsubscribed.
+            return
+
+        decoded = _decode_market_feed(payload)
+        if decoded is None:
+            self.logger.debug(f"Short IIFL market feed payload for {key}: {len(payload)} bytes")
+            return
+
+        # Merge cached OI into the tick if the user subscribed to OI on this
+        # instrument. This keeps the consumer-facing payload self-contained.
+        if sub.get("oi"):
+            cached = self._oi_cache.get(key)
+            if cached:
+                decoded["open_interest"] = cached["open_interest"]
+                decoded["oi"] = cached["open_interest"]
+                decoded["day_high_oi"] = cached["day_high_oi"]
+                decoded["day_low_oi"] = cached["day_low_oi"]
+                decoded["previous_oi"] = cached["previous_oi"]
+
+        # Attach routing fields the adapter needs for ZeroMQ topic generation.
+        decoded["segment"] = sub["segment"]
+        decoded["token"] = sub["token"]
+        decoded["mode"] = sub["mode"]
+        decoded["is_index"] = is_index
+
+        if self.on_ticks:
+            try:
+                self.on_ticks([decoded])
+            except Exception as e:
+                self.logger.exception(f"on_ticks callback raised: {e}")
+
+    def _dispatch_oi(self, key: str, payload: bytes) -> None:
+        decoded = _decode_open_interest(payload)
+        if decoded is None:
+            return
+        self._oi_cache[key] = decoded
+        # We deliberately do not push an OI-only tick — OI is merged into the
+        # next market-feed tick (which is publishing constantly during market
+        # hours). This keeps the OpenAlgo proxy's mode set simple.
+
+    def _on_mqtt_disconnect(self, _exc: Exception | None) -> None:
+        was_connected = self.connected
+        self.connected = False
+
+        if self.on_disconnect:
+            try:
+                self.on_disconnect()
+            except Exception as e:
+                self.logger.exception(f"on_disconnect callback raised: {e}")
+
+        # If we shut down deliberately, do nothing further.
+        if not self.running or self._stop_event.is_set() or self._fatal_error:
+            return
+
+        if was_connected:
+            self.logger.warning("IIFL Capital MQTT disconnected — scheduling reconnect")
+            self._schedule_reconnect()
+
+    def _on_mqtt_error(self, exc: Exception) -> None:
+        self.logger.error(f"IIFL Capital MQTT error: {exc}")
+        if self.on_error:
+            try:
+                self.on_error(exc)
+            except Exception:
+                pass
+
+    # ----------------------------------------------------------------- reconnect
+    def _schedule_reconnect(self) -> None:
+        if self._reconnect_thread and self._reconnect_thread.is_alive():
+            return
+        self._reconnect_thread = threading.Thread(
+            target=self._reconnect_loop, daemon=True, name="IiflReconnect"
+        )
+        self._reconnect_thread.start()
+
+    def _reconnect_loop(self) -> None:
+        while self.running and not self._stop_event.is_set():
+            self._reconnect_attempts += 1
+            if self._reconnect_attempts > self.RECONNECT_MAX_TRIES:
+                self.logger.error("IIFL reconnect attempts exhausted")
+                self.running = False
+                return
+
+            delay = min(2 * (1.5 ** self._reconnect_attempts), self.RECONNECT_MAX_DELAY)
+            self.logger.info(
+                f"IIFL reconnect in {delay:.0f}s (attempt {self._reconnect_attempts})"
+            )
+            if self._stop_event.wait(delay):
+                return
+
+            if self._fatal_error:
+                return
+
+            if self._do_connect():
+                return

--- a/broker/iiflcapital/streaming/iiflcapital_websocket.py
+++ b/broker/iiflcapital/streaming/iiflcapital_websocket.py
@@ -388,15 +388,23 @@ class IiflcapitalWebSocket:
         if not instruments:
             return
 
-        total_after = len(self._subscriptions) + len(instruments)
-        if total_after > MAX_INSTRUMENTS_PER_CONNECTION:
-            self.logger.error(
-                f"Cannot subscribe to {len(instruments)} — would exceed "
-                f"{MAX_INSTRUMENTS_PER_CONNECTION} per-connection cap"
-            )
-            return
+        # Cap check must count only NEW keys — duplicates within the call or
+        # symbols already in _subscriptions are re-subscribes (no new broker
+        # slot consumed). Computing this under the lock keeps the count
+        # consistent with the dict update that follows.
+        incoming_keys = {_topic_key(seg, tok) for seg, tok in instruments}
 
         with self._lock:
+            new_keys = incoming_keys - self._subscriptions.keys()
+            total_after = len(self._subscriptions) + len(new_keys)
+            if total_after > MAX_INSTRUMENTS_PER_CONNECTION:
+                self.logger.error(
+                    f"Cannot subscribe to {len(new_keys)} new instruments — "
+                    f"would exceed {MAX_INSTRUMENTS_PER_CONNECTION} per-connection cap "
+                    f"(currently {len(self._subscriptions)})"
+                )
+                return
+
             for segment, token in instruments:
                 key = _topic_key(segment, token)
                 self._subscriptions[key] = {
@@ -419,10 +427,15 @@ class IiflcapitalWebSocket:
             self._sub_thread.start()
 
     def unsubscribe_instruments(self, instruments: list[tuple[str, str | int]]) -> None:
-        """Send UNSUBSCRIBE for each (segment, token) and drop local state."""
+        """Send UNSUBSCRIBE for each (segment, token) and drop local state.
+
+        Local state is cleared even when the socket is down — otherwise the
+        next reconnect would re-subscribe to symbols the caller already
+        dropped via _resubscribe_all(). The network UNSUBSCRIBE is best-
+        effort and skipped when disconnected; the broker drops our
+        subscriptions on reconnect anyway because we use clean_session=True.
+        """
         if not instruments:
-            return
-        if not self.is_connected():
             return
 
         topics_to_drop: list[str] = []
@@ -438,7 +451,10 @@ class IiflcapitalWebSocket:
                 if sub.get("oi"):
                     topics_to_drop.append(self._OI_TOPIC_PREFIX + key)
 
-        if topics_to_drop and self._mqtt is not None:
+        # Network UNSUBSCRIBE only when we have a live broker session. When
+        # offline we have already updated local state above; the broker will
+        # not redeliver these topics on reconnect (clean_session=True).
+        if topics_to_drop and self._mqtt is not None and self.is_connected():
             try:
                 self._mqtt.unsubscribe(topics_to_drop)
             except Exception as e:

--- a/websocket_proxy/__init__.py
+++ b/websocket_proxy/__init__.py
@@ -57,6 +57,9 @@ from broker.ibulls.streaming.ibulls_adapter import IbullsWebSocketAdapter
 # Import the iifl_adapter
 from broker.iifl.streaming.iifl_adapter import IiflWebSocketAdapter
 
+# Import the iiflcapital_adapter
+from broker.iiflcapital.streaming.iiflcapital_adapter import IiflcapitalWebSocketAdapter
+
 # Import the indmoney_adapter
 from broker.indmoney.streaming.indmoney_adapter import IndmoneyWebSocketAdapter
 
@@ -112,6 +115,7 @@ register_adapter("compositedge", CompositedgeWebSocketAdapter)
 register_adapter("fivepaisa", FivepaisaWebSocketAdapter)
 register_adapter("fivepaisaxts", FivepaisaXTSWebSocketAdapter)
 register_adapter("iifl", IiflWebSocketAdapter)
+register_adapter("iiflcapital", IiflcapitalWebSocketAdapter)
 register_adapter("wisdom", WisdomWebSocketAdapter)
 register_adapter("upstox", UpstoxWebSocketAdapter)
 register_adapter("kotak", KotakWebSocketAdapter)
@@ -160,6 +164,7 @@ __all__ = [
     "FivepaisaWebSocketAdapter",
     "FivepaisaXTSWebSocketAdapter",
     "IiflWebSocketAdapter",
+    "IiflcapitalWebSocketAdapter",
     "JainamWebSocketAdapter",
     "TrustlineWebSocketAdapter",
     "WisdomWebSocketAdapter",


### PR DESCRIPTION
Feat : IIFLcapital websockets integrated and fix(iiflcapital/ws): close file-descriptor leaks across reconnect cycles 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Integrated native IIFL Capital streaming over MQTT v3.1.1/TLS, replacing the REST-polling stub. Hardened reconnect/subscribe/unsubscribe paths and fixed FD/thread leaks for stable long-running sessions.

- **New Features**
  - Added in-tree MQTT client (`broker/iiflcapital/streaming/iiflcapital_mqtt.py`) using only stdlib; no `paho-mqtt` or `bridgePy`.
  - Added feed client (`iiflcapital_websocket.py`) with JWT auth, batched subscribes, reconnect with state recovery, and decoding of the 188-byte market packet plus 16-byte OI packet.
  - Adapter rewritten (`iiflcapital_adapter.py`) to publish LTP/Quote/Depth by fanning out a single broker tick; depth fixed to L5; OI merged for derivatives.
  - Index routing and OI eligibility helpers (`iiflcapital_mapping.py`); registered `iiflcapital` in `websocket_proxy`.

- **Bug Fixes**
  - Closed TLS socket on any CONNECT/CONNACK failure to prevent FD leaks.
  - Reader now closes the socket on broker FIN and wakes keepalive to avoid lingering handles.
  - Reconnect loop re-checks state after backoff to avoid opening new sockets during shutdown.
  - Adapter re-init stops the previous client to prevent orphaned sockets and threads.
  - Unsubscribe clears local state even when offline to avoid unintended re-subscribes on reconnect.
  - Adapter connect marks running/connected only after a confirmed session; stops the client on failure.
  - Subscription cap counts only new instruments; check runs inside the lock for race-free accounting.

<sup>Written for commit 7a04225f402b2e23d3c05131d3855381782fa398. Summary will update on new commits.</sup>

<!-- End of auto-generated description by cubic. -->

