### PR TITLE
 fix(iiflcapital): broker hardening, reliability fixes, and option-chain perf

### DIFF
--- a/broker/iiflcapital/api/auth_api.py
+++ b/broker/iiflcapital/api/auth_api.py
@@ -4,6 +4,9 @@ from urllib.parse import quote_plus
 
 from broker.iiflcapital.baseurl import BASE_URL, LOGIN_URL
 from utils.httpx_client import get_httpx_client
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 def _generate_checksum(client_id: str, auth_code: str, app_secret: str) -> str:
@@ -71,4 +74,7 @@ def authenticate_broker(auth_code: str, client_id: str):
         return None, message
 
     except Exception as exc:
-        return None, f"Error during authentication: {exc}"
+        # Log the full exception for diagnostics; return a generic message
+        # so internal paths/host details don't leak to the API client.
+        logger.exception("IIFL Capital authentication failed")
+        return None, f"Authentication error: {type(exc).__name__}"

--- a/broker/iiflcapital/api/data.py
+++ b/broker/iiflcapital/api/data.py
@@ -12,6 +12,12 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# IIFL exposes OI on a separate single-mode endpoint, so an option chain
+# pull does N HTTP roundtrips. The shared httpx client allows up to 100
+# concurrent connections; cap fanout at 32 so a 60-leg chain finishes in
+# ~2 batches (~400 ms) instead of the previous 8-worker loop (~1.6 s).
+_OI_MAX_WORKERS = 32
+
 
 def _try_json(value: Any) -> Any:
     if not isinstance(value, str):
@@ -504,13 +510,13 @@ class BrokerData:
         """
         Concurrently fetch OI for many instruments. Keyed by 'exchange:instrumentId'.
         IIFL doesn't support batch OI, so option chains require one HTTP call per
-        leg — capped at 8 in-flight to stay under typical broker rate limits.
+        leg — fanout capped at _OI_MAX_WORKERS.
         """
         if not instruments:
             return {}
 
         oi_map: dict[str, int] = {}
-        with ThreadPoolExecutor(max_workers=min(8, len(instruments))) as pool:
+        with ThreadPoolExecutor(max_workers=min(_OI_MAX_WORKERS, len(instruments))) as pool:
             futures = {
                 pool.submit(self._fetch_openinterest, inst): (
                     f"{str(inst['exchange']).upper()}:{inst['instrumentId']}"

--- a/broker/iiflcapital/api/data.py
+++ b/broker/iiflcapital/api/data.py
@@ -1,9 +1,11 @@
 import json
+from concurrent.futures import ThreadPoolExecutor
 from typing import Any
 
 import pandas as pd
 
 from broker.iiflcapital.baseurl import BASE_URL
+from broker.iiflcapital.streaming.iiflcapital_mapping import supports_open_interest
 from database.token_db import get_brexchange, get_token
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
@@ -472,6 +474,56 @@ class BrokerData:
 
         raise Exception("No quote rows in broker response")
 
+    def _fetch_openinterest(self, instrument: dict) -> int:
+        """
+        Fetch open interest for one F&O instrument.
+
+        IIFL's /marketdata/openinterest is single-mode only and lives on a
+        separate endpoint from marketquotes (which never returns OI). Best
+        effort — returns 0 on any failure so a flaky OI call never blocks
+        the quote/option-chain response.
+        """
+        try:
+            response = self._post("/marketdata/openinterest", instrument)
+        except Exception as exc:
+            logger.debug(f"IIFL OI fetch failed for {instrument}: {exc}")
+            return 0
+
+        if not isinstance(response, dict):
+            return 0
+
+        result = response.get("result", response)
+        if isinstance(result, list) and result:
+            result = result[0]
+        if not isinstance(result, dict):
+            return 0
+
+        return _to_int(_first(result, ("openInterest", "oi"), 0))
+
+    def _fetch_openinterest_map(self, instruments: list[dict]) -> dict[str, int]:
+        """
+        Concurrently fetch OI for many instruments. Keyed by 'exchange:instrumentId'.
+        IIFL doesn't support batch OI, so option chains require one HTTP call per
+        leg — capped at 8 in-flight to stay under typical broker rate limits.
+        """
+        if not instruments:
+            return {}
+
+        oi_map: dict[str, int] = {}
+        with ThreadPoolExecutor(max_workers=min(8, len(instruments))) as pool:
+            futures = {
+                pool.submit(self._fetch_openinterest, inst): (
+                    f"{str(inst['exchange']).upper()}:{inst['instrumentId']}"
+                )
+                for inst in instruments
+            }
+            for future, key in futures.items():
+                try:
+                    oi_map[key] = future.result()
+                except Exception:
+                    oi_map[key] = 0
+        return oi_map
+
     def _resolve_token(self, symbol: str, exchange: str) -> str:
         token = get_token(symbol, exchange)
         if token is None:
@@ -489,7 +541,8 @@ class BrokerData:
         }
 
     def get_quotes(self, symbol: str, exchange: str) -> dict:
-        rows = self._fetch_marketquote_rows([self._instrument(symbol, exchange)])
+        instrument = self._instrument(symbol, exchange)
+        rows = self._fetch_marketquote_rows([instrument])
         if not rows:
             raise Exception("No quote data received from broker")
 
@@ -504,7 +557,10 @@ class BrokerData:
         if not _looks_like_market_row(row):
             raise Exception("No quote data received from broker")
 
-        return _parse_quote_row(row)
+        parsed = _parse_quote_row(row)
+        if supports_open_interest(str(exchange).upper()):
+            parsed["oi"] = self._fetch_openinterest(instrument)
+        return parsed
 
     def get_multiquotes(self, symbols: list) -> list:
         instruments = []
@@ -549,6 +605,15 @@ class BrokerData:
             return skipped
 
         rows = self._fetch_marketquote_rows(instruments)
+
+        # IIFL OI lives on a separate single-mode endpoint. Fetch concurrently
+        # for F&O legs only (cash equities have no OI) and merge by identity.
+        oi_instruments = [
+            v["instrument"]
+            for v in valid_symbols
+            if supports_open_interest(str(v["exchange"]).upper())
+        ]
+        oi_map = self._fetch_openinterest_map(oi_instruments)
 
         parsed_rows = []
         rows_by_identity: dict[str, dict] = {}
@@ -601,18 +666,24 @@ class BrokerData:
                 )
                 continue
 
+            parsed = _parse_quote_row(row)
+            oi_key = f"{str(instrument['exchange']).upper()}:{instrument['instrumentId']}"
+            if oi_key in oi_map:
+                parsed["oi"] = oi_map[oi_key]
+
             results.append(
                 {
                     "symbol": original["symbol"],
                     "exchange": original["exchange"],
-                    "data": _parse_quote_row(row),
+                    "data": parsed,
                 }
             )
 
         return skipped + results
 
     def get_depth(self, symbol: str, exchange: str) -> dict:
-        payload = self._instrument(symbol, exchange)
+        instrument = self._instrument(symbol, exchange)
+        payload = instrument
         response = self._post("/marketdata/marketdepth", payload)
 
         rows = _extract_rows(response)
@@ -637,6 +708,8 @@ class BrokerData:
         prev_close = _to_float(_first(row, ("close", "previousClose"), 0))
         volume = _to_int(_first(row, ("volume", "tradedVolume"), 0))
         oi = _to_int(_first(row, ("oi", "openInterest"), 0))
+        if oi == 0 and supports_open_interest(str(exchange).upper()):
+            oi = self._fetch_openinterest(instrument)
         total_buy_qty = _to_int(
             _first(
                 row,

--- a/broker/iiflcapital/api/funds.py
+++ b/broker/iiflcapital/api/funds.py
@@ -42,7 +42,8 @@ def _fetch_limits(client, endpoint, auth_token):
         return {}
 
     logger.info(f"IIFL Capital limits API response status [{endpoint}]: {response.status_code}")
-    logger.info(f"IIFL Capital limits API raw response [{endpoint}]: {response.text}")
+    # Raw body may carry account IDs / token echoes — debug only.
+    logger.debug(f"IIFL Capital limits API raw response [{endpoint}]: {response.text}")
 
     if response.status_code != 200:
         return {}

--- a/broker/iiflcapital/api/margin_api.py
+++ b/broker/iiflcapital/api/margin_api.py
@@ -57,14 +57,16 @@ def calculate_margin_api(positions, auth):
             logger.error(f"Failed to parse IIFL Capital margin response: {response.text}")
             return response, {"status": "error", "message": "Invalid response from broker API"}
 
-        logger.info(f"IIFL Capital margin calculation response: {response_data}")
+        # Raw response may include account context — debug only.
+        logger.debug(f"IIFL Capital margin calculation response: {response_data}")
 
         standardized_response = parse_margin_response(response_data)
         return response, standardized_response
 
     except Exception as error:
-        logger.error(f"Error calling IIFL Capital margin API: {error}")
+        # Log full diagnostics internally; return a generic message externally.
+        logger.exception("Error calling IIFL Capital margin API")
         return _mock_response(500), {
             "status": "error",
-            "message": f"Failed to calculate margin: {error}",
+            "message": f"Failed to calculate margin: {type(error).__name__}",
         }

--- a/broker/iiflcapital/api/order_api.py
+++ b/broker/iiflcapital/api/order_api.py
@@ -1,3 +1,4 @@
+import re
 from types import SimpleNamespace
 from typing import Any
 
@@ -16,6 +17,19 @@ logger = get_logger(__name__)
 
 _DIRECT_ORDER_KEYS = {"instrumentId", "exchange", "transactionType", "quantity"}
 _SUCCESS_STATUSES = {"success", "ok"}
+_ORDER_ID_PATTERN = re.compile(r"^[A-Za-z0-9_-]+$")
+
+
+def _safe_order_id(orderid: Any) -> str:
+    """Validate orderid for inclusion in a URL path.
+
+    Rejects values containing '/', '?', '..', whitespace, etc. that could
+    pivot the request to a different endpoint.
+    """
+    candidate = str(orderid or "").strip()
+    if not candidate or not _ORDER_ID_PATTERN.match(candidate):
+        raise ValueError(f"Invalid orderid: {candidate!r}")
+    return candidate
 
 _OPEN_STATUSES = {
     "OPEN",
@@ -251,7 +265,8 @@ def place_order_api(data, auth):
     logger.debug(f"IIFL Capital place order payload: {payload}")
     response, response_data = _request("/orders", auth, method="POST", payload=payload)
     logger.info(f"IIFL Capital place order response status: {response.status_code}")
-    logger.info(f"IIFL Capital place order raw response: {response_data}")
+    # Raw body may include broker order IDs / account context — debug only.
+    logger.debug(f"IIFL Capital place order raw response: {response_data}")
 
     result = _first_result(response_data)
     order_id = result.get("brokerOrderId")
@@ -360,12 +375,17 @@ def close_all_positions(current_api_key, auth):
 
 
 def cancel_order(orderid, auth):
-    logger.debug(f"IIFL Capital cancel order request for {orderid}")
-    response, response_data = _request(f"/orders/{orderid}", auth, method="DELETE")
-    logger.debug(f"IIFL Capital cancel order response for {orderid}: {response_data}")
+    try:
+        safe_id = _safe_order_id(orderid)
+    except ValueError as exc:
+        return {"status": "error", "message": str(exc)}, 400
+
+    logger.debug(f"IIFL Capital cancel order request for {safe_id}")
+    response, response_data = _request(f"/orders/{safe_id}", auth, method="DELETE")
+    logger.debug(f"IIFL Capital cancel order response for {safe_id}: {response_data}")
 
     if response.status_code == 200 and _ok(response_data):
-        return {"status": "success", "orderid": str(orderid)}, 200
+        return {"status": "success", "orderid": safe_id}, 200
 
     return {
         "status": "error",
@@ -374,15 +394,19 @@ def cancel_order(orderid, auth):
 
 
 def modify_order(data, auth):
-    order_id = data.get("orderid")
+    try:
+        safe_id = _safe_order_id(data.get("orderid"))
+    except ValueError as exc:
+        return {"status": "error", "message": str(exc)}, 400
+
     payload = transform_modify_order_data(data)
 
-    logger.debug(f"IIFL Capital modify order payload for {order_id}: {payload}")
-    response, response_data = _request(f"/orders/{order_id}", auth, method="PUT", payload=payload)
-    logger.debug(f"IIFL Capital modify order response for {order_id}: {response_data}")
+    logger.debug(f"IIFL Capital modify order payload for {safe_id}: {payload}")
+    response, response_data = _request(f"/orders/{safe_id}", auth, method="PUT", payload=payload)
+    logger.debug(f"IIFL Capital modify order response for {safe_id}: {response_data}")
 
     if response.status_code == 200 and _ok(response_data):
-        return {"status": "success", "orderid": str(order_id)}, 200
+        return {"status": "success", "orderid": safe_id}, 200
 
     return {
         "status": "error",

--- a/broker/iiflcapital/database/master_contract_db.py
+++ b/broker/iiflcapital/database/master_contract_db.py
@@ -1,6 +1,7 @@
 # database/master_contract_db.py
 
 import os
+import time
 
 import pandas as pd
 from sqlalchemy import Column, Float, Index, Integer, Sequence, String, create_engine
@@ -13,6 +14,16 @@ from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# IIFL contract files are static CSV blobs served from a CDN-fronted
+# endpoint. Larger files (NSEFO, BSEFO) routinely take 10–20s to land and
+# occasionally surface as 502/503/connection reset under load. Retry each
+# segment a few times with backoff before giving up — without this, a single
+# transient failure silently leaves the symtoken table missing a whole
+# segment.
+_DOWNLOAD_ATTEMPTS = 4
+_DOWNLOAD_BACKOFF_SECONDS = 2.0
+_DOWNLOAD_TIMEOUT_SECONDS = 60.0
 
 DATABASE_URL = os.getenv("DATABASE_URL")
 engine = create_engine(DATABASE_URL)
@@ -164,23 +175,68 @@ def copy_from_dataframe(df):
 # ---------------------------------------------------------------------------
 # Download helpers
 # ---------------------------------------------------------------------------
-def download_csv_iiflcapital_data(output_path):
-    """Download all IIFL Capital master contract CSV files to output_path."""
-    logger.info("Downloading IIFL Capital Master Contract CSV Files")
-    client = get_httpx_client()
+def _download_segment(client, segment, url, file_path):
+    """Download one segment CSV with retries + exponential backoff.
 
-    for segment, url in SEGMENT_URLS.items():
+    Raises on final failure so the caller can surface a partial-download
+    error instead of silently writing an incomplete symtoken table.
+    """
+    last_error = None
+    for attempt in range(1, _DOWNLOAD_ATTEMPTS + 1):
         try:
-            response = client.get(url, timeout=30)
+            response = client.get(url, timeout=_DOWNLOAD_TIMEOUT_SECONDS)
             response.raise_for_status()
 
-            file_path = f"{output_path}/{segment}.csv"
+            # Sanity check — empty body means the CDN handed us a stub.
+            if not response.content:
+                raise ValueError("Empty response body")
+
             with open(file_path, "wb") as f:
                 f.write(response.content)
 
-            logger.info(f"Successfully downloaded {segment} master contract")
+            logger.info(
+                f"Successfully downloaded {segment} master contract "
+                f"({len(response.content):,} bytes, attempt {attempt})"
+            )
+            return
         except Exception as e:
-            logger.warning(f"Failed to download {segment} from {url}. Error: {e}")
+            last_error = e
+            if attempt < _DOWNLOAD_ATTEMPTS:
+                delay = _DOWNLOAD_BACKOFF_SECONDS * (2 ** (attempt - 1))
+                logger.warning(
+                    f"Download {segment} failed (attempt {attempt}/{_DOWNLOAD_ATTEMPTS}): "
+                    f"{e}. Retrying in {delay:.1f}s"
+                )
+                time.sleep(delay)
+            else:
+                logger.error(
+                    f"Download {segment} failed after {_DOWNLOAD_ATTEMPTS} attempts: {e}"
+                )
+
+    raise RuntimeError(f"Failed to download {segment} from {url}: {last_error}")
+
+
+def download_csv_iiflcapital_data(output_path):
+    """Download all IIFL Capital master contract CSV files to output_path.
+
+    Returns the list of segments that failed even after retries. An empty
+    list means every segment downloaded cleanly. The caller is expected to
+    abort the contract refresh if any segment failed, since partial data
+    leaves the user with missing instruments.
+    """
+    logger.info("Downloading IIFL Capital Master Contract CSV Files")
+    client = get_httpx_client()
+
+    failed_segments = []
+    for segment, url in SEGMENT_URLS.items():
+        file_path = f"{output_path}/{segment}.csv"
+        try:
+            _download_segment(client, segment, url, file_path)
+        except Exception as e:
+            logger.error(f"Giving up on {segment}: {e}")
+            failed_segments.append(segment)
+
+    return failed_segments
 
 
 def delete_iiflcapital_temp_data(output_path):
@@ -435,9 +491,24 @@ def process_iiflcapital_indices_csv(path):
 def master_contract_download():
     logger.info("Downloading IIFL Capital Master Contract")
 
-    output_path = "tmp"
+    # Use an absolute path under the repo root rather than a CWD-relative "tmp"
+    # so master-contract downloads land in a predictable location regardless
+    # of how the process was launched.
+    output_path = os.path.join(
+        os.path.dirname(os.path.abspath(__file__)), "..", "..", "..", "tmp"
+    )
+    output_path = os.path.normpath(output_path)
+    os.makedirs(output_path, exist_ok=True)
     try:
-        download_csv_iiflcapital_data(output_path)
+        failed = download_csv_iiflcapital_data(output_path)
+        if failed:
+            # Refuse to wipe + reload the symtoken table when downloads
+            # were incomplete — better to keep the previous contract data
+            # than to publish a half-populated one.
+            raise RuntimeError(
+                f"IIFL Capital contract download incomplete. Failed segments: "
+                f"{', '.join(failed)}. Existing symtoken data left untouched."
+            )
         delete_symtoken_table()
 
         # Process equity segments
@@ -481,6 +552,15 @@ def master_contract_download():
 
 
 def search_symbols(symbol, exchange):
+    # Escape LIKE wildcards so caller-supplied % / _ can't broaden the match
+    # (or trigger CPU-bound full-table scans).
+    escaped = (
+        str(symbol or "")
+        .replace("\\", "\\\\")
+        .replace("%", "\\%")
+        .replace("_", "\\_")
+    )
     return SymToken.query.filter(
-        SymToken.symbol.like(f"%{symbol}%"), SymToken.exchange == exchange
+        SymToken.symbol.like(f"%{escaped}%", escape="\\"),
+        SymToken.exchange == exchange,
     ).all()

--- a/broker/iiflcapital/mapping/order_data.py
+++ b/broker/iiflcapital/mapping/order_data.py
@@ -5,27 +5,56 @@ from broker.iiflcapital.mapping.transform_data import (
 from database.token_db import get_symbol
 
 
+# Fields that indicate a dict is an actual order/trade/position/holding row,
+# not a status/metadata wrapper. Used to avoid fabricating phantom UI rows
+# when IIFL returns an empty book wrapped as `{"result": {...wrapper...}}`.
+_ROW_FIELDS = (
+    "instrumentId",
+    "tradingSymbol",
+    "brokerOrderId",
+    "exchangeOrderId",
+    "netQuantity",
+    "filledQuantity",
+    "transactionType",
+    "nseTradingSymbol",
+    "bseTradingSymbol",
+)
+
+
+def _looks_like_row(item) -> bool:
+    """True if a dict carries at least one identifying field of a real row."""
+    return isinstance(item, dict) and any(item.get(field) for field in _ROW_FIELDS)
+
+
 def _extract_rows(payload):
     if isinstance(payload, list):
-        return payload
+        # Some IIFL endpoints emit a single status-wrapper element when the
+        # book is empty (e.g. `[{"status": "ok"}]`); strip those so the
+        # downstream transforms don't render them as phantom rows.
+        return [item for item in payload if _looks_like_row(item)]
 
     if not isinstance(payload, dict):
         return []
 
     result = payload.get("result")
     if isinstance(result, list):
-        return result
+        return [item for item in result if _looks_like_row(item)]
     if isinstance(result, dict):
         for key in ("orders", "trades", "positions", "holdings", "data", "positionList"):
             value = result.get(key)
             if isinstance(value, list):
-                return value
-        return [result]
+                return [item for item in value if _looks_like_row(item)]
+        # Only treat a result-dict as a single row when it actually looks
+        # like one. Empty/metadata-only `result` wrappers were previously
+        # rendered as phantom blank rows in the orderbook UI.
+        if _looks_like_row(result):
+            return [result]
+        return []
 
     for key in ("data", "orders", "trades", "positions", "holdings"):
         value = payload.get(key)
         if isinstance(value, list):
-            return value
+            return [item for item in value if _looks_like_row(item)]
 
     return []
 

--- a/broker/iiflcapital/mapping/order_data.py
+++ b/broker/iiflcapital/mapping/order_data.py
@@ -100,59 +100,22 @@ def _resolve_order_quantity(row: dict) -> int:
 
 def _resolve_holding_quantity(row: dict) -> float:
     """
-    Resolve holding quantity without inflating totals.
+    Resolve holding quantity preferring settled DP balance.
 
-    IIFL holdings payload can include aggregate fields like `totalQuantity` alongside
-    component quantities (`quantity`, `dpQuantity`, `t1Quantity`). In some accounts,
-    using only `totalQuantity` can overstate effective holdings. Prefer explicit
-    quantity fields first, then fall back to totalQuantity.
+    Per IIFL spec: totalQuantity = dpQuantity + collateralQuantity + t1Quantity
+    + authorizedQuantity. dpQuantity is what the broker UI shows as "settled".
     """
-    # Prefer settled DP quantity first (matches broker holdings page more closely)
-    # before generic quantity fields that may include aggregate values.
-    for key in ("dpQuantity", "dpQty", "availableQuantity", "dpquantity", "dp_qty"):
+    for key in ("dpQuantity", "dpQty", "availableQuantity"):
         dp_qty = _to_float(row.get(key))
         if dp_qty > 0:
             return dp_qty
 
-    qty = 0.0
-    for key in ("quantity", "holdingQuantity", "qty"):
+    for key in ("totalQuantity", "totalQty", "quantity", "holdingQuantity"):
         qty = _to_float(row.get(key))
         if qty > 0:
-            break
+            return qty
 
-    total_qty = 0.0
-    for key in ("totalQuantity", "totalQty", "holdingTotalQuantity"):
-        total_qty = _to_float(row.get(key))
-        if total_qty > 0:
-            break
-
-    t1_qty = 0.0
-    for key in ("t1Quantity", "t1Qty", "t1_quantity", "unsettledQuantity"):
-        t1_qty = _to_float(row.get(key))
-        if t1_qty > 0:
-            break
-
-    # If aggregate quantity appears to include T1, value only settled quantity.
-    if qty > 0 and t1_qty > 0 and qty >= t1_qty:
-        settled = qty - t1_qty
-        if settled >= 0:
-            return settled
-
-    if total_qty > 0 and t1_qty > 0 and total_qty >= t1_qty:
-        settled = total_qty - t1_qty
-        if settled >= 0:
-            return settled
-
-    if qty > 0:
-        return qty
-
-    if total_qty > 0:
-        return total_qty
-
-    if t1_qty > 0:
-        return t1_qty
-
-    return 0.0
+    return _to_float(row.get("t1Quantity"))
 
 
 def map_order_data(order_data):
@@ -279,7 +242,17 @@ def transform_positions_data(positions_data):
         exchange = _map_exchange(broker_exchange)
 
         quantity = int(float(row.get("netQuantity", row.get("quantity", 0)) or 0))
-        average_price = float(row.get("netAveragePrice", row.get("averagePrice", 0)) or 0)
+        average_price = _to_float(row.get("netAveragePrice", row.get("averagePrice", 0)))
+
+        # IIFL position spec exposes only `previousDayClose`; fall back to it when
+        # an upstream LTP isn't injected into the payload.
+        ltp = _to_float(_first_present(row, "ltp", "lastPrice", "previousDayClose"))
+
+        # Spec exposes `realizedPnl` only. Compute MTM unrealized from netQuantity
+        # and netAveragePrice so OpenAlgo's `pnl` field reflects total P&L.
+        realized_pnl = _to_float(row.get("realizedPnl"))
+        unrealized_pnl = (ltp - average_price) * quantity if quantity else 0.0
+        pnl = realized_pnl + unrealized_pnl
 
         transformed.append(
             {
@@ -288,8 +261,8 @@ def transform_positions_data(positions_data):
                 "product": reverse_map_product_type(row.get("product", "NORMAL")),
                 "quantity": quantity,
                 "average_price": f"{average_price:.2f}",
-                "ltp": float(row.get("ltp", row.get("lastPrice", row.get("previousDayClose", 0))) or 0),
-                "pnl": float(row.get("pnl", row.get("mtm", 0)) or 0),
+                "ltp": round(ltp, 2),
+                "pnl": round(pnl, 2),
             }
         )
 
@@ -338,11 +311,24 @@ def transform_holdings_data(holdings_data):
     transformed = []
 
     for row in rows:
-        # Prefer NSE instrument symbol if present
-        symbol = row.get("nseTradingSymbol") or row.get("tradingSymbol") or row.get("symbol") or ""
-        exchange = "NSE"
-
         quantity = int(_resolve_holding_quantity(row))
+
+        # IIFL holdings expose nse* and bse* pairs. Pick the populated side so
+        # BSE-only scrips aren't mislabeled as NSE with an empty symbol.
+        nse_symbol = row.get("nseTradingSymbol")
+        bse_symbol = row.get("bseTradingSymbol")
+        if nse_symbol:
+            symbol, exchange = nse_symbol, "NSE"
+        elif bse_symbol:
+            symbol, exchange = bse_symbol, "BSE"
+        else:
+            symbol = row.get("tradingSymbol") or row.get("formattedInstrumentName") or row.get("symbol") or ""
+            exchange = "NSE"
+
+        # Skip empty placeholder rows IIFL returns when the account has no
+        # settled holdings (avg=0, qty=0, no trading symbol).
+        if quantity <= 0:
+            continue
         avg_price = _to_float(row.get("averageTradedPrice", row.get("averagePrice", 0)))
         ltp = _to_float(row.get("ltp", row.get("previousDayClose", avg_price)), avg_price)
 

--- a/broker/iiflcapital/mapping/order_data.py
+++ b/broker/iiflcapital/mapping/order_data.py
@@ -8,22 +8,49 @@ from database.token_db import get_symbol
 # Fields that indicate a dict is an actual order/trade/position/holding row,
 # not a status/metadata wrapper. Used to avoid fabricating phantom UI rows
 # when IIFL returns an empty book wrapped as `{"result": {...wrapper...}}`.
+# Covers the canonical field names plus the variants the per-section
+# transforms accept as fallbacks (orderId, formattedInstrumentName,
+# tradedPrice, etc.) so a record with any of those still passes.
 _ROW_FIELDS = (
-    "instrumentId",
-    "tradingSymbol",
+    # Order / trade identifiers
     "brokerOrderId",
     "exchangeOrderId",
-    "netQuantity",
-    "filledQuantity",
-    "transactionType",
+    "orderId",
+    # Instrument identifiers
+    "instrumentId",
+    "token",
+    "exchangeInstrumentID",
+    "tradingSymbol",
+    "symbol",
+    "formattedInstrumentName",
     "nseTradingSymbol",
     "bseTradingSymbol",
+    # Quantity-bearing fields (any of these implies a real record)
+    "netQuantity",
+    "filledQuantity",
+    "pendingQuantity",
+    "cancelledQuantity",
+    "dpQuantity",
+    "totalQuantity",
+    # Action / price fields specific to real records
+    "transactionType",
+    "tradedPrice",
+    "averageTradedPrice",
 )
 
 
 def _looks_like_row(item) -> bool:
     """True if a dict carries at least one identifying field of a real row."""
-    return isinstance(item, dict) and any(item.get(field) for field in _ROW_FIELDS)
+    if not isinstance(item, dict):
+        return False
+    for field in _ROW_FIELDS:
+        value = item.get(field)
+        # `value not in (None, "")` rather than truthy so legitimate `0` /
+        # `"0"` quantity / netQuantity values on closed positions still
+        # qualify the row.
+        if value not in (None, ""):
+            return True
+    return False
 
 
 def _extract_rows(payload):
@@ -278,9 +305,14 @@ def transform_positions_data(positions_data):
         ltp = _to_float(_first_present(row, "ltp", "lastPrice", "previousDayClose"))
 
         # Spec exposes `realizedPnl` only. Compute MTM unrealized from netQuantity
-        # and netAveragePrice so OpenAlgo's `pnl` field reflects total P&L.
+        # and netAveragePrice so OpenAlgo's `pnl` field reflects total P&L —
+        # but only when LTP is genuinely populated. A missing LTP defaulting
+        # to 0 would otherwise fabricate a (-average_price * quantity) loss.
         realized_pnl = _to_float(row.get("realizedPnl"))
-        unrealized_pnl = (ltp - average_price) * quantity if quantity else 0.0
+        if quantity and ltp > 0:
+            unrealized_pnl = (ltp - average_price) * quantity
+        else:
+            unrealized_pnl = 0.0
         pnl = realized_pnl + unrealized_pnl
 
         transformed.append(

--- a/broker/iiflcapital/mapping/transform_data.py
+++ b/broker/iiflcapital/mapping/transform_data.py
@@ -69,6 +69,17 @@ def _to_float(value: Any, default: float = 0.0) -> float:
         return default
 
 
+def _to_int_or_zero(value: Any) -> int:
+    """Coerce arbitrary input to an int, returning 0 on any failure.
+    Catches NaN/inf (which `int()` raises on) along with the usual
+    type/value errors so a malformed numeric field never aborts order
+    transformation. Caller is expected to apply its own `> 0` guard."""
+    try:
+        return int(_to_float(value, 0.0) or 0)
+    except (TypeError, ValueError, OverflowError):
+        return 0
+
+
 def transform_data(data: dict, token: str) -> dict:
     """Transform OpenAlgo order request to IIFL Capital format."""
     transformed = {
@@ -91,8 +102,9 @@ def transform_data(data: dict, token: str) -> dict:
 
     # Coerce to int via float so zero-equivalent strings ("0", "0.0", " ")
     # don't slip through and surface as a meaningless `disclosedQuantity: 0`
-    # field to the broker.
-    disclosed_qty = int(_to_float(data.get("disclosed_quantity"), 0.0) or 0)
+    # field to the broker. NaN / inf / bad input fall back to 0 cleanly
+    # instead of raising and aborting the whole order.
+    disclosed_qty = _to_int_or_zero(data.get("disclosed_quantity"))
     if disclosed_qty > 0:
         transformed["disclosedQuantity"] = str(disclosed_qty)
 
@@ -125,8 +137,9 @@ def transform_modify_order_data(data: dict) -> dict:
 
     # Coerce to int via float so zero-equivalent strings ("0", "0.0", " ")
     # don't slip through and surface as a meaningless `disclosedQuantity: 0`
-    # field to the broker.
-    disclosed_qty = int(_to_float(data.get("disclosed_quantity"), 0.0) or 0)
+    # field to the broker. NaN / inf / bad input fall back to 0 cleanly
+    # instead of raising and aborting the whole order.
+    disclosed_qty = _to_int_or_zero(data.get("disclosed_quantity"))
     if disclosed_qty > 0:
         transformed["disclosedQuantity"] = str(disclosed_qty)
 

--- a/broker/iiflcapital/mapping/transform_data.py
+++ b/broker/iiflcapital/mapping/transform_data.py
@@ -75,7 +75,7 @@ def transform_data(data: dict, token: str) -> dict:
         "instrumentId": str(token),
         "exchange": map_exchange(data.get("exchange", "")),
         "transactionType": (data.get("action") or "").upper(),
-        "quantity": str(int(float(data.get("quantity", 0)))),
+        "quantity": str(data.get("quantity", "0")),
         "orderComplexity": data.get("order_complexity", "REGULAR"),
         "product": map_product_type(data.get("product", "MIS")),
         "orderType": map_order_type(data.get("pricetype", "MARKET")),
@@ -89,9 +89,9 @@ def transform_data(data: dict, token: str) -> dict:
     if transformed["orderType"] in ("SL", "SLM"):
         transformed["slTriggerPrice"] = _to_float(data.get("trigger_price", 0.0))
 
-    disclosed_qty = int(float(data.get("disclosed_quantity", 0) or 0))
-    if disclosed_qty > 0:
-        transformed["disclosedQuantity"] = str(disclosed_qty)
+    disclosed = data.get("disclosed_quantity")
+    if disclosed not in (None, "", 0, "0"):
+        transformed["disclosedQuantity"] = str(disclosed)
 
     if data.get("strategy"):
         transformed["orderTag"] = str(data["strategy"])[:50]
@@ -103,9 +103,8 @@ def transform_modify_order_data(data: dict) -> dict:
     """Transform OpenAlgo modify request to IIFL Capital format."""
     transformed = {}
 
-    quantity = data.get("quantity")
-    if quantity is not None:
-        transformed["quantity"] = str(int(float(data.get("quantity", 0))))
+    if data.get("quantity") is not None:
+        transformed["quantity"] = str(data.get("quantity"))
 
     pricetype = data.get("pricetype")
     if pricetype:
@@ -121,10 +120,8 @@ def transform_modify_order_data(data: dict) -> dict:
     if "validity" in data:
         transformed["validity"] = map_validity(data.get("validity", "DAY"))
 
-    disclosed_qty = data.get("disclosed_quantity")
-    if disclosed_qty is not None:
-        disclosed_qty = int(float(disclosed_qty or 0))
-        if disclosed_qty > 0:
-            transformed["disclosedQuantity"] = str(disclosed_qty)
+    disclosed = data.get("disclosed_quantity")
+    if disclosed not in (None, "", 0, "0"):
+        transformed["disclosedQuantity"] = str(disclosed)
 
     return transformed

--- a/broker/iiflcapital/mapping/transform_data.py
+++ b/broker/iiflcapital/mapping/transform_data.py
@@ -89,9 +89,12 @@ def transform_data(data: dict, token: str) -> dict:
     if transformed["orderType"] in ("SL", "SLM"):
         transformed["slTriggerPrice"] = _to_float(data.get("trigger_price", 0.0))
 
-    disclosed = data.get("disclosed_quantity")
-    if disclosed not in (None, "", 0, "0"):
-        transformed["disclosedQuantity"] = str(disclosed)
+    # Coerce to int via float so zero-equivalent strings ("0", "0.0", " ")
+    # don't slip through and surface as a meaningless `disclosedQuantity: 0`
+    # field to the broker.
+    disclosed_qty = int(_to_float(data.get("disclosed_quantity"), 0.0) or 0)
+    if disclosed_qty > 0:
+        transformed["disclosedQuantity"] = str(disclosed_qty)
 
     if data.get("strategy"):
         transformed["orderTag"] = str(data["strategy"])[:50]
@@ -120,8 +123,11 @@ def transform_modify_order_data(data: dict) -> dict:
     if "validity" in data:
         transformed["validity"] = map_validity(data.get("validity", "DAY"))
 
-    disclosed = data.get("disclosed_quantity")
-    if disclosed not in (None, "", 0, "0"):
-        transformed["disclosedQuantity"] = str(disclosed)
+    # Coerce to int via float so zero-equivalent strings ("0", "0.0", " ")
+    # don't slip through and surface as a meaningless `disclosedQuantity: 0`
+    # field to the broker.
+    disclosed_qty = int(_to_float(data.get("disclosed_quantity"), 0.0) or 0)
+    if disclosed_qty > 0:
+        transformed["disclosedQuantity"] = str(disclosed_qty)
 
     return transformed

--- a/broker/iiflcapital/streaming/iiflcapital_mqtt.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mqtt.py
@@ -383,7 +383,15 @@ class IiflMqttClient:
         chunks: list[bytes] = []
         remaining = n
         while remaining > 0:
-            chunk = sock.recv(min(remaining, self._RECV_BUF))
+            try:
+                chunk = sock.recv(min(remaining, self._RECV_BUF))
+            except (InterruptedError, OSError) as e:
+                # Socket closed from another thread (typically our own
+                # disconnect) or recv interrupted. On Windows this surfaces
+                # as WSACancelBlockingCall (WinError 10004); on POSIX as
+                # EBADF/ECONNRESET. Treat as clean close so the reader loop
+                # exits via its MqttError handler instead of crashing.
+                raise MqttError(f"Socket recv interrupted: {e}") from e
             if not chunk:
                 return b""
             chunks.append(chunk)

--- a/broker/iiflcapital/streaming/iiflcapital_mqtt.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mqtt.py
@@ -16,9 +16,8 @@ No QoS 1/2 inflight tracking, no retained messages, no will message, no
 session resumption — the IIFL broker only publishes QoS 0 to subscribers and
 expects clean_session=True clients.
 
-The transport is a single TLS socket (TLSv1.2, cert verification disabled —
-the IIFL broker presents a self-signed cert in production, matching bridgePy
-behaviour). A background reader thread parses frames off the wire and
+The transport is a single TLS socket (TLSv1.2 minimum) verified against the
+system trust store. A background reader thread parses frames off the wire and
 dispatches to user callbacks; a second thread sends PINGREQ inside the
 keepalive window so the broker does not drop us.
 """
@@ -167,9 +166,8 @@ class IiflMqttClient:
 
         raw = socket.create_connection((self.host, self.port), timeout=timeout)
         try:
-            ctx = ssl.SSLContext(self.tls_version)
-            ctx.check_hostname = False
-            ctx.verify_mode = ssl.CERT_NONE
+            ctx = ssl.create_default_context()
+            ctx.minimum_version = ssl.TLSVersion.TLSv1_2
             self._sock = ctx.wrap_socket(raw, server_hostname=self.host)
         except Exception:
             raw.close()

--- a/broker/iiflcapital/streaming/iiflcapital_mqtt.py
+++ b/broker/iiflcapital/streaming/iiflcapital_mqtt.py
@@ -119,7 +119,6 @@ class IiflMqttClient:
         username: str,
         password: str,
         keepalive: int = 20,
-        tls_version: int = ssl.PROTOCOL_TLSv1_2,
     ) -> None:
         self.host = host
         self.port = port
@@ -127,7 +126,6 @@ class IiflMqttClient:
         self.username = username
         self.password = password
         self.keepalive = max(5, int(keepalive))
-        self.tls_version = tls_version
 
         self.logger = get_logger("iifl_mqtt")
         self._sock: ssl.SSLSocket | None = None

--- a/broker/iiflcapital/streaming/iiflcapital_websocket.py
+++ b/broker/iiflcapital/streaming/iiflcapital_websocket.py
@@ -28,6 +28,7 @@ from __future__ import annotations
 import base64
 import ctypes
 import json
+import os
 import struct
 import threading
 import time
@@ -107,6 +108,10 @@ def _decode_jwt_username(token: str) -> str:
     Extract `preferred_username` from a JWT (matches bridgePy's
     __get_user_name). The JWT payload (middle segment) is URL-safe base64
     without padding, so we pad it before decoding.
+
+    Raises ValueError on malformed/expired tokens — the previous "tester"
+    fallback silently masqueraded as a hardcoded username and masked
+    misconfiguration.
     """
     try:
         payload_segment = token.split(".")[1]
@@ -114,9 +119,13 @@ def _decode_jwt_username(token: str) -> str:
         padded = payload_segment + ("=" * padding_needed)
         decoded = base64.urlsafe_b64decode(padded)
         claims = json.loads(decoded)
-        return str(claims.get("preferred_username", "tester"))
-    except Exception:
-        return "tester"
+    except Exception as exc:
+        raise ValueError(f"Invalid IIFL user_session JWT: {type(exc).__name__}") from exc
+
+    username = claims.get("preferred_username")
+    if not username:
+        raise ValueError("IIFL JWT missing 'preferred_username' claim")
+    return str(username)
 
 
 def _decode_market_feed(payload: bytes) -> dict | None:
@@ -243,7 +252,14 @@ class IiflcapitalWebSocket:
         self.on_ticks = on_ticks
         self.logger = get_logger("iiflcapital_websocket")
 
-        self.client_id = "openalgo" + datetime.now().strftime("%d%m%y%H%M%S%f")
+        # Microsecond timestamp + 4 bytes entropy avoids client_id collisions
+        # when two reconnects fire on the same host within the same microsecond
+        # (broker drops the older session with CONNACK rc=2 on collision).
+        self.client_id = (
+            "openalgo"
+            + datetime.now().strftime("%d%m%y%H%M%S%f")
+            + os.urandom(4).hex()
+        )
         self.username = _decode_jwt_username(user_session)
         self.password = f"OPENID~~{user_session}~"  # bridgePy format
 


### PR DESCRIPTION
 fix(iiflcapital): broker hardening, reliability fixes, and option-chain perf

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the `iiflcapital` broker for security and reliability, removes phantom/placeholder data, and adds concurrent open‑interest fetching to speed up option‑chain queries with accurate OI. Also makes master‑contract downloads robust with retries and prevents partial symbol tables.

- **Bug Fixes**
  - Remove phantom rows in order/trade/position/holding lists by filtering wrapper-only payloads; keep genuine rows even when qty=0.
  - Holdings: pick `nseTradingSymbol`/`bseTradingSymbol`, skip zero-qty rows. Positions: PnL = realized + MTM with `previousDayClose` fallback; skip MTM when LTP ≤ 0.
  - Return correct OI for F&O in quotes/multiquotes/depth via the single‑mode OI endpoint (only when supported).
  - Retry contract CSVs with backoff and abort on partial downloads; use a stable repo‑root `tmp` path; escape LIKE wildcards in `search_symbols`.
  - Security: verify TLS for MQTT (no insecure toggle), strict JWT username decode, validate `orderid` before cancel/modify, generic error messages with raw bodies moved to debug, cleaner planned MQTT disconnects; drop the unused `tls_version` knob.
  - Orders API transforms: pass `quantity` through; include `disclosedQuantity` only when > 0 and treat "0.0"/" 0 "/NaN/inf/malformed values as 0 to avoid errors.

- **Performance**
  - Concurrent OI fanout (up to 32 workers) for option chains, cutting chain latency from ~1.6s to ~400 ms.

<sup>Written for commit 8b940098bd42cc796401fd0e7070763d4dc29eec. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1430?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

