### PR TITLE
fix(websocket): self-heal pool on stale auth-token failure (#1419) and fix(websocket): spawn WS proxy as subprocess under gunicorn+eventlet (#1421)

### DIFF
--- a/app.py
+++ b/app.py
@@ -864,7 +864,12 @@ if is_docker:
         "Running in Docker/standalone mode - WebSocket server started separately by start.sh"
     )
 else:
-    logger.debug("Running in local/integrated mode - Starting WebSocket proxy in Flask")
+    # Under gunicorn+eventlet, start_websocket_proxy() spawns a child *process*
+    # (not a thread) so the WS asyncio loop never shares an eventlet hub with
+    # gunicorn — closes the greenlet.error cross-thread crash class entirely
+    # (including GitHub issue #1421). Under the dev server (no eventlet) it
+    # still uses a real OS thread, as before.
+    logger.debug("Starting WebSocket proxy")
     start_websocket_proxy(app)
 
 # Start Flask development server with SocketIO support if directly executed

--- a/broker/fyers/streaming/fyers_adapter.py
+++ b/broker/fyers/streaming/fyers_adapter.py
@@ -50,6 +50,10 @@ class FyersAdapter:
         # Connection state
         self.connected = False
         self.connecting = False
+        # Last error from connect(), exposed so the outer adapter can surface
+        # the underlying auth/network failure rather than a generic message
+        # (issue #1419). Reset on each connect() attempt.
+        self.last_error: str | None = None
 
         # Threading
         self.lock = threading.Lock()
@@ -63,6 +67,10 @@ class FyersAdapter:
         """
         Connect to Fyers HSM WebSocket
 
+        On failure, ``self.last_error`` is populated with the underlying error
+        message so callers can surface it (issue #1419 — ConnectionPool needs
+        the real auth keyword to trigger token refresh, not a generic bool).
+
         Returns:
             True if connection successful, False otherwise
         """
@@ -72,10 +80,12 @@ class FyersAdapter:
 
         if self.connecting:
             self.logger.warning("Connection already in progress")
+            self.last_error = "Connection already in progress"
             return False
 
         try:
             self.connecting = True
+            self.last_error = None
             self.logger.info("Connecting to Fyers HSM WebSocket...")
 
             # Initialize WebSocket client
@@ -103,10 +113,12 @@ class FyersAdapter:
                 self.logger.info("✅ Connected to Fyers HSM WebSocket")
                 return True
             else:
-                self.logger.error("❌ Failed to authenticate with Fyers HSM WebSocket")
+                self.last_error = "Failed to authenticate with Fyers HSM WebSocket (timeout)"
+                self.logger.error(f"❌ {self.last_error}")
                 return False
 
         except Exception as e:
+            self.last_error = str(e)
             self.logger.error(f"❌ Connection error: {e}")
             return False
         finally:

--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -132,10 +132,24 @@ class FyersHSMWebSocket:
         self.access_token = access_token
         self.logger = logging.getLogger("fyers_hsm_websocket")
 
-        # Extract HSM key from token
+        # Initialize health-check stop event BEFORE the HSM key extraction so
+        # cleanup paths can reference it even when __init__ raises (the
+        # extraction call below). Without this the disconnect logged after a
+        # failed init crashes with "no attribute '_health_check_stop_event'".
+        self._health_check_stop_event = threading.Event()
+
+        # Extract HSM key from token. _extract_hsm_key returns None either when
+        # the JWT exp claim is in the past (logged as "Access token has
+        # expired") or when decoding fails. The most common cause in
+        # production is the daily token expiry, so the raised message includes
+        # auth keywords so the websocket_proxy ConnectionPool recovery (issue
+        # #1419) can detect it and rebuild the adapter with a fresh token.
         self.hsm_key = self._extract_hsm_key(access_token)
         if not self.hsm_key:
-            raise ValueError("Failed to extract HSM key from access token")
+            raise ValueError(
+                "Failed to extract HSM key from access token — "
+                "access token has expired or is invalid"
+            )
 
         self.logger.debug(f"HSM key extracted: {self.hsm_key[:20]}...")
 
@@ -150,10 +164,10 @@ class FyersHSMWebSocket:
         self.reconnect_enabled = True
         self.reconnect_attempts = 0
 
-        # Health check state
+        # Health check state. _health_check_stop_event is already initialized
+        # at the top of __init__ so cleanup-after-failed-init paths can use it.
         self._last_message_time = None
         self._health_check_thread = None
-        self._health_check_stop_event = threading.Event()  # Signal to stop health check thread
 
         # Data structures
         self.subscriptions = {}  # topic_id -> topic_name mapping

--- a/broker/fyers/streaming/fyers_websocket_adapter.py
+++ b/broker/fyers/streaming/fyers_websocket_adapter.py
@@ -154,10 +154,16 @@ class FyersWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
             # self.logger.info("Connecting to Fyers HSM WebSocket...")
 
-            # Connect to Fyers
+            # Connect to Fyers. On failure, propagate the underlying error
+            # message from FyersAdapter.last_error so the ConnectionPool can
+            # detect auth-token expiry via keyword match and rebuild this
+            # adapter with a fresh token from auth_db (issue #1419).
             success = self.fyers_adapter.connect()
             if not success:
-                raise ConnectionError("Failed to connect to Fyers WebSocket")
+                err = getattr(self.fyers_adapter, "last_error", None) or (
+                    "Failed to connect to Fyers WebSocket"
+                )
+                raise ConnectionError(err)
 
             self.connected = True
             self.running = True
@@ -253,21 +259,29 @@ class FyersWebSocketAdapter(BaseBrokerWebSocketAdapter):
             depth_level: Depth level for order book (not used in Fyers)
         """
         try:
-            # Auto-reconnect if disconnected
-            if not self.connected or not self.fyers_adapter:
+            # Auto-reconnect if disconnected. The two pre-existing branches
+            # (outer adapter missing vs inner FyersAdapter disconnected) are
+            # collapsed into a single connect() call: connect() recreates the
+            # inner adapter if absent and reuses it otherwise. On failure, the
+            # underlying error from connect_result["message"] is surfaced so
+            # the ConnectionPool's auth-recovery (issue #1419) can detect a
+            # stale token via keyword match and rebuild this adapter against
+            # a freshly-read auth_db token.
+            needs_reconnect = (
+                not self.connected
+                or not self.fyers_adapter
+                or not self.fyers_adapter.connected
+            )
+            if needs_reconnect:
                 self.logger.info("Not connected to Fyers - attempting to reconnect...")
                 connect_result = self.connect()
                 if not connect_result or connect_result.get("status") != "success":
-                    self.logger.error("Failed to reconnect to Fyers WebSocket")
-                    return {"status": "error", "message": "Failed to reconnect to Fyers WebSocket"}
+                    err = (connect_result or {}).get(
+                        "message"
+                    ) or "Failed to reconnect to Fyers WebSocket"
+                    self.logger.error(f"Failed to reconnect to Fyers WebSocket: {err}")
+                    return {"status": "error", "message": err}
                 self.logger.info("Successfully reconnected to Fyers WebSocket")
-
-            # Ensure adapter is properly connected
-            if self.fyers_adapter and not self.fyers_adapter.connected:
-                self.logger.info("Fyers adapter exists but not connected, reconnecting...")
-                if not self.fyers_adapter.connect():
-                    self.logger.error("Failed to reconnect Fyers adapter")
-                    return {"status": "error", "message": "Failed to reconnect Fyers adapter"}
 
             with self.lock:
                 # Convert to OpenAlgo format

--- a/websocket_proxy/app_integration.py
+++ b/websocket_proxy/app_integration.py
@@ -3,6 +3,7 @@ import atexit
 import os
 import platform
 import signal
+import subprocess
 import sys
 import threading
 
@@ -20,6 +21,16 @@ if "eventlet" in sys.modules:
 else:
     _original_threading = threading
 
+
+def _eventlet_active() -> bool:
+    """True when eventlet has monkey-patched the stdlib (gunicorn worker)."""
+    try:
+        from eventlet.patcher import is_monkey_patched
+        return bool(is_monkey_patched("socket"))
+    except Exception:
+        return False
+
+
 # Set the correct event loop policy for Windows to avoid ZeroMQ warnings
 if platform.system() == "Windows":
     asyncio.set_event_loop_policy(asyncio.WindowsSelectorEventLoopPolicy())
@@ -29,6 +40,7 @@ if platform.system() == "Windows":
 _websocket_server_started = False
 _websocket_proxy_instance = None
 _websocket_thread = None
+_websocket_subprocess = None  # set when running under eventlet (gunicorn)
 
 logger = get_logger(__name__)
 
@@ -58,6 +70,12 @@ def should_start_websocket():
 def cleanup_websocket_server():
     """Clean up WebSocket server resources - cross-platform compatible"""
     global _websocket_proxy_instance, _websocket_thread
+
+    # If we spawned the WS as a subprocess (gunicorn+eventlet path), there is
+    # no in-process thread or proxy instance to clean up — just kill the child.
+    if _websocket_subprocess is not None:
+        _terminate_websocket_subprocess()
+        return
 
     try:
         logger.info("Cleaning up WebSocket server...")
@@ -137,12 +155,102 @@ def signal_handler(signum, frame):
     os._exit(0)
 
 
+def _spawn_websocket_subprocess():
+    """
+    Spawn the WebSocket proxy as a child *process* (not a thread).
+
+    Required under gunicorn+eventlet: an in-process asyncio thread shares the
+    process with the eventlet hub, and any eventlet-monkey-patched semaphore
+    (stdlib logging RLock, socketio lock, broker adapter `threading.Lock`)
+    touched from both threads triggers `greenlet.error: Cannot switch to a
+    different thread` and silently corrupts WS state (GitHub issue #1421).
+
+    The child runs `python -m websocket_proxy.server` in a fresh interpreter
+    with no eventlet monkey-patching, so all the offending primitives are
+    real OS locks. Systemd's cgroup-based KillMode (default: control-group)
+    cleans up the child when the unit stops; our atexit handler covers
+    graceful gunicorn shutdown.
+    """
+    global _websocket_subprocess
+
+    if _websocket_subprocess is not None and _websocket_subprocess.poll() is None:
+        logger.debug("WebSocket subprocess already running, skipping spawn")
+        return
+
+    # Find the openalgo project root (parent of websocket_proxy/)
+    project_root = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+    cmd = [sys.executable, "-u", "-m", "websocket_proxy.server"]
+    logger.debug(f"Spawning WebSocket subprocess: {' '.join(cmd)} (cwd={project_root})")
+
+    try:
+        # Inherit stdout/stderr so the child's logging lands in the same
+        # systemd journal as gunicorn. The WS server already uses Python
+        # logging via utils.logging, so file/json log handlers fire too.
+        _websocket_subprocess = subprocess.Popen(
+            cmd,
+            cwd=project_root,
+            stdout=None,
+            stderr=None,
+            # Do NOT set start_new_session=True — staying in the gunicorn
+            # cgroup means systemd reaps the child if gunicorn dies hard.
+        )
+        logger.info(f"WebSocket subprocess started with PID {_websocket_subprocess.pid}")
+    except Exception as e:
+        logger.exception(f"Failed to spawn WebSocket subprocess: {e}")
+        _websocket_subprocess = None
+        return
+
+    # Graceful shutdown on clean gunicorn exit
+    atexit.register(_terminate_websocket_subprocess)
+
+
+def _terminate_websocket_subprocess():
+    """SIGTERM the WS child on shutdown; SIGKILL if it ignores TERM."""
+    global _websocket_subprocess
+    if _websocket_subprocess is None:
+        return
+    if _websocket_subprocess.poll() is not None:
+        _websocket_subprocess = None
+        return
+    try:
+        logger.info(f"Terminating WebSocket subprocess PID {_websocket_subprocess.pid}")
+        _websocket_subprocess.terminate()
+        try:
+            _websocket_subprocess.wait(timeout=10)
+        except subprocess.TimeoutExpired:
+            logger.warning("WebSocket subprocess did not exit on SIGTERM, sending SIGKILL")
+            _websocket_subprocess.kill()
+            _websocket_subprocess.wait(timeout=5)
+    except Exception as e:
+        logger.warning(f"Error terminating WebSocket subprocess: {e}")
+    finally:
+        _websocket_subprocess = None
+
+
 def start_websocket_server():
     """
-    Start the WebSocket proxy server in a separate thread.
-    This function should be called when the Flask app starts.
+    Start the WebSocket proxy server.
+
+    Under gunicorn+eventlet: spawned as a child process (avoids the
+    eventlet/asyncio cross-OS-thread greenlet crash class).
+
+    Under the dev server (no eventlet): run as a real OS thread inside the
+    Flask process, preserving the long-standing dev workflow.
     """
     global _websocket_proxy_instance, _websocket_thread
+
+    if _eventlet_active():
+        _spawn_websocket_subprocess()
+        # Register signal handlers so Ctrl+C in dev forwards cleanly. Under
+        # systemd these are typically replaced by the unit's signal handling.
+        try:
+            signal.signal(signal.SIGINT, signal_handler)
+            if hasattr(signal, "SIGTERM"):
+                signal.signal(signal.SIGTERM, signal_handler)
+        except Exception as e:
+            logger.warning(f"Could not register signal handlers: {e}")
+        return None
 
     logger.debug("Starting WebSocket proxy server in a separate thread")
 

--- a/websocket_proxy/connection_manager.py
+++ b/websocket_proxy/connection_manager.py
@@ -273,6 +273,9 @@ class ConnectionPool:
 
         # Subscription tracking: (symbol, exchange, mode) -> adapter_index
         self.subscription_map: dict[tuple[str, str, int], int] = {}
+        # Per-subscription depth_level so auth-recovery restore can re-issue
+        # mode=3 (Depth) at its originally requested depth, not the default.
+        self.subscription_depths: dict[tuple[str, str, int], int] = {}
 
         # Shared ZeroMQ publisher
         self.shared_publisher = SharedZmqPublisher()
@@ -417,6 +420,7 @@ class ConnectionPool:
                 self.adapters.clear()
                 self.adapter_symbol_counts.clear()
                 self.subscription_map.clear()
+                self.subscription_depths.clear()
                 self.connected = False
                 self.initialized = False
             try:
@@ -496,11 +500,13 @@ class ConnectionPool:
             f"Refreshing token and rebuilding pool."
         )
 
-        # Snapshot subscriptions before initialize(force=True) clears them.
-        # depth_level is not tracked in subscription_map, so mode=3 restores
-        # use the default depth.
+        # Snapshot (symbol, exchange, mode, depth_level) before
+        # initialize(force=True) clears subscription_map / subscription_depths.
         with self.lock:
-            prior_subs = list(self.subscription_map.keys())
+            prior_subs = [
+                (s, e, m, self.subscription_depths.get((s, e, m), 5))
+                for (s, e, m) in self.subscription_map
+            ]
 
         self._clear_auth_cache_for_user()
         reinit = self.initialize(force=True)
@@ -526,9 +532,9 @@ class ConnectionPool:
                 f"Restoring {len(prior_subs)} subscription(s) after auth refresh"
             )
             restored = 0
-            for symbol, exchange, mode in prior_subs:
+            for symbol, exchange, mode, depth in prior_subs:
                 try:
-                    sub_result = self._subscribe_inner(symbol, exchange, mode)
+                    sub_result = self._subscribe_inner(symbol, exchange, mode, depth)
                     if sub_result.get("status") == "success":
                         restored += 1
                     else:
@@ -681,6 +687,7 @@ class ConnectionPool:
                         result = adapter.subscribe(symbol, exchange, mode, depth_level)
                         if result.get("status") == "success":
                             self.subscription_map[sub_key] = adapter_idx
+                            self.subscription_depths[sub_key] = depth_level
                             # Don't increment adapter_symbol_counts — same symbol, already counted
                             result["connection"] = adapter_idx + 1
                             self.logger.info(
@@ -691,6 +698,7 @@ class ConnectionPool:
                     else:
                         # COVERED: higher mode already active — just track, skip broker call
                         self.subscription_map[sub_key] = adapter_idx
+                        self.subscription_depths[sub_key] = depth_level
                         # Don't increment adapter_symbol_counts — same symbol, already counted
                         self.logger.debug(
                             f"Tracked {symbol}.{exchange} mode {mode} "
@@ -708,6 +716,7 @@ class ConnectionPool:
 
                     if result.get("status") == "success":
                         self.subscription_map[sub_key] = adapter_idx
+                        self.subscription_depths[sub_key] = depth_level
                         self.adapter_symbol_counts[adapter_idx] += 1
                         symbols_on_conn = self.adapter_symbol_counts[adapter_idx]
                         total_symbols = sum(self.adapter_symbol_counts)
@@ -783,8 +792,11 @@ class ConnectionPool:
                 adapter_idx = self.subscription_map[sub_key]
                 adapter = self.adapters[adapter_idx]
 
-                # Remove tracking entry
+                # Remove tracking entry. Stash the prior depth so rollback paths
+                # below can restore both maps atomically if the broker call fails.
+                old_depth = self.subscription_depths.get(sub_key, 5)
                 del self.subscription_map[sub_key]
+                self.subscription_depths.pop(sub_key, None)
 
                 # Check what modes remain for this symbol
                 remaining_modes = self._get_existing_modes(symbol, exchange)
@@ -801,6 +813,7 @@ class ConnectionPool:
                     else:
                         # Rollback tracking on failure
                         self.subscription_map[sub_key] = adapter_idx
+                        self.subscription_depths[sub_key] = old_depth
                     return result
 
                 else:
@@ -827,7 +840,8 @@ class ConnectionPool:
                                 f"{new_highest}, rolling back: {result}"
                             )
                             self.subscription_map[sub_key] = adapter_idx
-                            adapter.subscribe(symbol, exchange, mode, 5)
+                            self.subscription_depths[sub_key] = old_depth
+                            adapter.subscribe(symbol, exchange, mode, old_depth)
                             return {
                                 "status": "error",
                                 "code": "DOWNGRADE_FAILED",
@@ -849,6 +863,7 @@ class ConnectionPool:
                 # Rollback tracking on exception
                 if sub_key not in self.subscription_map:
                     self.subscription_map[sub_key] = adapter_idx
+                    self.subscription_depths[sub_key] = old_depth
                 self.logger.exception(f"Error unsubscribing from {symbol}.{exchange}: {e}")
                 return {"status": "error", "code": "UNSUBSCRIPTION_ERROR", "message": str(e)}
 
@@ -875,6 +890,7 @@ class ConnectionPool:
                     adapter.unsubscribe_all()
 
             self.subscription_map.clear()
+            self.subscription_depths.clear()
             self.adapter_symbol_counts = [0] * len(self.adapters)
 
             self.logger.info("[POOL] Unsubscribed from all symbols")

--- a/websocket_proxy/connection_manager.py
+++ b/websocket_proxy/connection_manager.py
@@ -54,6 +54,35 @@ def get_max_websocket_connections() -> int:
     return int(os.getenv("MAX_WEBSOCKET_CONNECTIONS", DEFAULT_MAX_WEBSOCKET_CONNECTIONS))
 
 
+# Keywords used to recognize auth-related failures returned by broker adapters.
+# Matches 401/403 plus the common token-expiry phrasings emitted by broker REST
+# APIs and WS clients. Used by ConnectionPool to decide whether a connect or
+# subscribe failure is recoverable via a forced re-init that reads a fresh
+# token from auth_db. See issue #1419.
+_AUTH_ERROR_INDICATORS = (
+    "401",
+    "403",
+    "unauthorized",
+    "forbidden",
+    "authentication failed",
+    "auth failed",
+    "invalid token",
+    "token expired",
+    "access token has expired",
+    "access denied",
+    "invalid credentials",
+    "session expired",
+)
+
+
+def _is_auth_error(error_message: str) -> bool:
+    """True if ``error_message`` looks like an auth failure (401/403/expired)."""
+    if not error_message:
+        return False
+    msg = str(error_message).lower()
+    return any(indicator in msg for indicator in _AUTH_ERROR_INDICATORS)
+
+
 class SharedZmqPublisher:
     """
     Shared ZeroMQ publisher that can be used by multiple adapter instances.
@@ -425,6 +454,69 @@ class ConnectionPool:
                 self.logger.exception(f"Failed to initialize connection pool: {e}")
                 return {"success": False, "error": str(e)}
 
+    def _clear_auth_cache_for_user(self) -> None:
+        """Drop cached auth tokens for this pool's user.
+
+        The next ``initialize(force=True)`` then re-reads from ``auth_db`` and
+        constructs adapters with the fresh token. Called when an auth error is
+        detected on connect/subscribe (issue #1419).
+        """
+        try:
+            from database.auth_db import auth_cache, feed_token_cache
+
+            cleared = []
+            if f"auth-{self.user_id}" in auth_cache:
+                del auth_cache[f"auth-{self.user_id}"]
+                cleared.append("auth_cache")
+            if f"feed-{self.user_id}" in feed_token_cache:
+                del feed_token_cache[f"feed-{self.user_id}"]
+                cleared.append("feed_token_cache")
+            if cleared:
+                self.logger.info(
+                    f"Cleared auth caches for user {self.user_id}: {', '.join(cleared)}"
+                )
+        except Exception as e:
+            self.logger.warning(f"Error clearing auth cache for user {self.user_id}: {e}")
+
+    def _attempt_auth_recovery(self, error_msg: str) -> bool:
+        """Rebuild the pool with a fresh token after an auth failure.
+
+        Tears down the existing adapter (which was constructed with a stale
+        token), clears cached auth state, re-initializes the pool — which
+        re-reads the token from ``auth_db`` — and reconnects. Used to recover
+        from new-trading-day stale tokens without a container restart.
+
+        Does not recurse into ``self.connect()``; it calls the adapter's
+        ``connect()`` directly on the freshly rebuilt adapter. Returns ``True``
+        when the post-refresh reconnect succeeds.
+        """
+        self.logger.warning(
+            f"Auth error on {self.broker_name} (user={self.user_id}): {error_msg}. "
+            f"Refreshing token and rebuilding pool."
+        )
+        self._clear_auth_cache_for_user()
+        reinit = self.initialize(force=True)
+        if not reinit.get("success"):
+            self.logger.error(
+                f"Pool re-initialization after auth error failed: {reinit.get('error')}"
+            )
+            return False
+        if not self.adapters:
+            return False
+        result = self.adapters[0].connect()
+        is_error = (result and result.get("success") is False) or (
+            result and result.get("status") == "error"
+        )
+        if is_error:
+            err = result.get("message", result.get("error", "Connection failed"))
+            self.logger.error(f"Reconnect after auth refresh failed: {err}")
+            return False
+        self.connected = True
+        self.logger.info(
+            f"Auth recovery succeeded for {self.broker_name} (user={self.user_id})"
+        )
+        return True
+
     def connect(self) -> dict:
         """
         Connect the first adapter in the pool.
@@ -451,8 +543,19 @@ class ConnectionPool:
                         (result and result.get("status") == "error")
                     )
                     if is_error:
-                        # Convert to consistent format and return error
                         error_msg = result.get("message", result.get("error", "Connection failed"))
+                        # Issue #1419: try recovery once if this looks like a stale
+                        # auth token (new trading day, etc.) before surfacing the
+                        # error. _attempt_auth_recovery() does not call back into
+                        # self.connect(), so no recursion; _recovering guards against
+                        # repeat attempts on the same call.
+                        if _is_auth_error(error_msg) and not getattr(self, "_recovering", False):
+                            self._recovering = True
+                            try:
+                                if self._attempt_auth_recovery(error_msg):
+                                    return {"success": True, "message": "Connected after auth refresh"}
+                            finally:
+                                self._recovering = False
                         self.logger.error(f"Adapter connection failed: {error_msg}")
                         return {"success": False, "error": error_msg}
                     self.connected = True
@@ -461,8 +564,18 @@ class ConnectionPool:
                     return {"success": False, "error": "No adapters available"}
 
             except Exception as e:
+                err_str = str(e)
+                # Some adapters raise instead of returning an error dict; apply the
+                # same recovery path if the exception message looks auth-related.
+                if _is_auth_error(err_str) and not getattr(self, "_recovering", False):
+                    self._recovering = True
+                    try:
+                        if self._attempt_auth_recovery(err_str):
+                            return {"success": True, "message": "Connected after auth refresh"}
+                    finally:
+                        self._recovering = False
                 self.logger.exception(f"Failed to connect: {e}")
-                return {"success": False, "error": str(e)}
+                return {"success": False, "error": err_str}
 
     def subscribe(self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 5) -> dict:
         """
@@ -473,6 +586,10 @@ class ConnectionPool:
         requested mode is sent to the broker. All requested modes are tracked
         in subscription_map so unsubscribe can downgrade correctly.
 
+        Issue #1419: if the underlying subscribe fails with what looks like a
+        stale auth token, the pool tears itself down, re-reads the token from
+        ``auth_db``, and retries once.
+
         Args:
             symbol: Trading symbol
             exchange: Exchange code
@@ -481,6 +598,31 @@ class ConnectionPool:
 
         Returns:
             Subscription result dict
+        """
+        result = self._subscribe_inner(symbol, exchange, mode, depth_level)
+
+        if (
+            isinstance(result, dict)
+            and result.get("status") == "error"
+            and _is_auth_error(result.get("message", ""))
+            and not getattr(self, "_recovering", False)
+        ):
+            self._recovering = True
+            try:
+                if self._attempt_auth_recovery(result.get("message", "")):
+                    result = self._subscribe_inner(symbol, exchange, mode, depth_level)
+            finally:
+                self._recovering = False
+
+        return result
+
+    def _subscribe_inner(
+        self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 5
+    ) -> dict:
+        """Core subscribe logic without the auth-recovery wrapper.
+
+        ``subscribe()`` wraps this so it can retry once after a forced pool
+        refresh when an auth error is detected.
         """
         sub_key = (symbol, exchange, mode)
 

--- a/websocket_proxy/connection_manager.py
+++ b/websocket_proxy/connection_manager.py
@@ -483,8 +483,9 @@ class ConnectionPool:
 
         Tears down the existing adapter (which was constructed with a stale
         token), clears cached auth state, re-initializes the pool — which
-        re-reads the token from ``auth_db`` — and reconnects. Used to recover
-        from new-trading-day stale tokens without a container restart.
+        re-reads the token from ``auth_db`` — and reconnects. Existing
+        subscriptions are snapshotted before the rebuild and re-issued on the
+        new adapter so callers don't silently lose their feeds.
 
         Does not recurse into ``self.connect()``; it calls the adapter's
         ``connect()`` directly on the freshly rebuilt adapter. Returns ``True``
@@ -494,6 +495,13 @@ class ConnectionPool:
             f"Auth error on {self.broker_name} (user={self.user_id}): {error_msg}. "
             f"Refreshing token and rebuilding pool."
         )
+
+        # Snapshot subscriptions before initialize(force=True) clears them.
+        # depth_level is not tracked in subscription_map, so mode=3 restores
+        # use the default depth.
+        with self.lock:
+            prior_subs = list(self.subscription_map.keys())
+
         self._clear_auth_cache_for_user()
         reinit = self.initialize(force=True)
         if not reinit.get("success"):
@@ -512,6 +520,30 @@ class ConnectionPool:
             self.logger.error(f"Reconnect after auth refresh failed: {err}")
             return False
         self.connected = True
+
+        if prior_subs:
+            self.logger.info(
+                f"Restoring {len(prior_subs)} subscription(s) after auth refresh"
+            )
+            restored = 0
+            for symbol, exchange, mode in prior_subs:
+                try:
+                    sub_result = self._subscribe_inner(symbol, exchange, mode)
+                    if sub_result.get("status") == "success":
+                        restored += 1
+                    else:
+                        self.logger.warning(
+                            f"Failed to restore {symbol}.{exchange} mode={mode}: "
+                            f"{sub_result.get('message')}"
+                        )
+                except Exception as e:
+                    self.logger.warning(
+                        f"Error restoring {symbol}.{exchange} mode={mode}: {e}"
+                    )
+            self.logger.info(
+                f"Restored {restored}/{len(prior_subs)} subscriptions after auth refresh"
+            )
+
         self.logger.info(
             f"Auth recovery succeeded for {self.broker_name} (user={self.user_id})"
         )


### PR DESCRIPTION
fix(websocket): self-heal pool on stale auth-token failure (#1419) and fix(websocket): spawn WS proxy as subprocess under gunicorn+eventlet (#1421)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two WebSocket stability issues: self-heals the connection pool on stale auth tokens and preserves subscriptions (including depth), and runs the WebSocket proxy as a subprocess under `gunicorn`+`eventlet` to prevent greenlet crashes.

- **Bug Fixes**
  - Auth self-heal: On 401/403/token-expired during connect/subscribe, surface Fyers auth errors, clear `auth_cache`/`feed_token_cache`, rebuild the adapter via `initialize(force=True)`, retry once, and restore prior subscriptions with their original depth levels; also fixes a failed-init cleanup crash.
  - WS proxy isolation: Detect `eventlet` monkey patching and spawn `python -m websocket_proxy.server` as a child; inherit logs, terminate on exit (SIGTERM with SIGKILL fallback), dev server path stays thread-based.

<sup>Written for commit 26a09b4eefa2d09a021a2db41b0b8d76082fab98. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1438?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

