### PR TITLE
fix(definedge): correct swapped LotSize/TickSize columns in allmaster

### DIFF
--- a/broker/definedge/database/master_contract_db.py
+++ b/broker/definedge/database/master_contract_db.py
@@ -310,7 +310,7 @@ def process_definedge_allmaster_csv(path):
 
         # Define column names based on DefinedGe format
         # Based on the sample: ['NFO', '144537', 'ZYDUSLIFE', 'ZYDUSLIFE30SEP25P1360', 'OPTSTK', '30092025', '5', '900', 'PE', '136000', '2', '1', 'Unnamed: 12', '1.000000', 'Unnamed: 14']
-        # Format appears to be: Exchange, Token, Name, TradingSymbol, InstrumentType, Expiry, LotSize, TickSize, OptionType, StrikePrice, ...
+        # Format: Exchange, Token, Name, TradingSymbol, InstrumentType, Expiry, TickSize (paise), LotSize, OptionType, StrikePrice (paise), ...
         column_names = [
             "Exchange",
             "Token",
@@ -318,8 +318,8 @@ def process_definedge_allmaster_csv(path):
             "TradingSymbol",
             "InstrumentType",
             "Expiry",
-            "LotSize",
             "TickSize",
+            "LotSize",
             "OptionType",
             "StrikePrice",
             "Col10",
@@ -346,7 +346,9 @@ def process_definedge_allmaster_csv(path):
             pd.to_numeric(df["StrikePrice"], errors="coerce").fillna(0.0) / 100
         )  # Convert paise to rupees
         processed_df["lotsize"] = pd.to_numeric(df["LotSize"], errors="coerce").fillna(1)
-        processed_df["tick_size"] = pd.to_numeric(df["TickSize"], errors="coerce").fillna(0.05)
+        processed_df["tick_size"] = (
+            pd.to_numeric(df["TickSize"], errors="coerce").fillna(5) / 100
+        )  # Convert paise to rupees
 
         # Map instrument types based on exchange and instrument type
         processed_df["instrumenttype"] = df["InstrumentType"].fillna("EQ")


### PR DESCRIPTION
The headerless allmaster.csv stores tick size at column 6 (paise) and lot size at column 7, but column_names had them reversed. Tick size also needs the same paise->rupees /100 conversion already applied to strike.

Symptom: /api/v1/symbol returned lotsize: 5, tick_size: 65.0 for NIFTY options instead of lotsize: 65, tick_size: 0.05.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Definedge `allmaster.csv` parsing by swapping `TickSize` and `LotSize` columns and converting tick size from paise to rupees. This corrects `/api/v1/symbol` outputs (e.g., NIFTY options now show lotsize 65 and tick_size 0.05).

- **Bug Fixes**
  - Map column 6 to `TickSize` (paise) and column 7 to `LotSize`.
  - Convert `TickSize` from paise to rupees (/100) with a 5 paise default → 0.05.

<sup>Written for commit bf797e1122a9dd9eb3697305129663783fc99643. Summary will update on new commits. <a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1457?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

