### PR TITLE
feat: Docker Compose — Configurable Naming via APP_NAME for multiple instances  Closes #1461

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -6,6 +6,15 @@
 # If versions don't match, copy new variables from this file to your .env
 ENV_CONFIG_VERSION = '1.0.7'
 
+# Docker Project Name Configuration
+# Controls container name, image name, and volume names when using docker-compose
+# Examples:
+#   APP_NAME=openalgo    → container: openalgo, image: openalgo:latest, volumes: openalgo_*
+#   APP_NAME=scorpio     → container: scorpio, image: scorpio:latest, volumes: scorpio_*
+#   APP_NAME=paper       → container: paper, image: paper:latest, volumes: paper_*
+# This allows running multiple instances on the same machine without conflicts
+APP_NAME=openalgo
+
 # Broker Configuration
 BROKER_API_KEY = 'YOUR_BROKER_API_KEY'
 BROKER_API_SECRET = 'YOUR_BROKER_API_SECRET'

--- a/docker-build.bat
+++ b/docker-build.bat
@@ -4,9 +4,19 @@ REM This script builds and deploys OpenAlgo with numba/llvmlite support
 
 setlocal enabledelayedexpansion
 
-set IMAGE_NAME=openalgo
+REM Load APP_NAME from .env file
+set APP_NAME=openalgo
+if exist ".env" (
+    for /f "tokens=2 delims==" %%i in ('findstr /I "^APP_NAME" .env') do (
+        set APP_NAME=%%i
+        REM Remove quotes and spaces
+        for /f "useback tokens=*" %%a in ('!APP_NAME!') do set APP_NAME=%%~a
+    )
+)
+
+set IMAGE_NAME=%APP_NAME%
 set IMAGE_TAG=latest
-set CONTAINER_NAME=openalgo-web
+set CONTAINER_NAME=%APP_NAME%
 
 echo.
 echo ========================================

--- a/docker-build.sh
+++ b/docker-build.sh
@@ -12,9 +12,15 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-IMAGE_NAME="openalgo"
+# Load APP_NAME from .env file, default to 'openalgo' if not set
+if [ -f ".env" ]; then
+    APP_NAME=$(grep '^APP_NAME=' .env | cut -d'=' -f2 | tr -d "' \"")
+fi
+APP_NAME=${APP_NAME:-openalgo}
+
+IMAGE_NAME="${APP_NAME}"
 IMAGE_TAG="latest"
-CONTAINER_NAME="openalgo-web"
+CONTAINER_NAME="${APP_NAME}"
 
 # Functions
 print_header() {
@@ -116,7 +122,7 @@ verify_dependencies() {
     print_info "Checking if runtime libraries are installed..."
 
     # Create temporary container to check
-    TEMP_CONTAINER=$(docker run -d ${IMAGE_NAME}:${IMAGE_TAG} sleep 10)
+    TEMP_CONTAINER=$(docker run -d "${IMAGE_NAME}:${IMAGE_TAG}" sleep 10)
 
     # Check for required libraries
     if docker exec ${TEMP_CONTAINER} dpkg -l | grep -q "libopenblas0"; then
@@ -167,18 +173,18 @@ start_container() {
     else
         print_info "Starting with docker run..."
         docker run -d \
-            --name ${CONTAINER_NAME} \
+            --name "${CONTAINER_NAME}" \
             --shm-size=2g \
             -p 5000:5000 \
             -p 8765:8765 \
-            -v openalgo_db:/app/db \
-            -v openalgo_log:/app/log \
-            -v openalgo_strategies:/app/strategies \
-            -v openalgo_keys:/app/keys \
+            -v db:/app/db \
+            -v log:/app/log \
+            -v strategies:/app/strategies \
+            -v keys:/app/keys \
             -v "$(pwd)/.env:/app/.env" \
             --tmpfs /app/tmp:size=1g,mode=1777 \
             --restart unless-stopped \
-            ${IMAGE_NAME}:${IMAGE_TAG}
+            "${IMAGE_NAME}:${IMAGE_TAG}"
         print_success "Container started via docker run"
     fi
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -7,7 +7,7 @@ services:
       context: .
       dockerfile: Dockerfile
 
-    container_name: ${APP_NAME:-openalgo}
+    container_name: ${APP_NAME:-openalgo-web}
     ports:
       - "${FLASK_PORT:-5000}:5000"
       - "${WEBSOCKET_PORT:-8765}:8765"

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,22 +1,24 @@
+name: ${APP_NAME:-openalgo}
+
 services:
   openalgo:
-    image: openalgo:latest
+    image: ${APP_NAME:-openalgo}:latest
     build:
       context: .
       dockerfile: Dockerfile
 
-    container_name: openalgo-web
+    container_name: ${APP_NAME:-openalgo}
     ports:
       - "${FLASK_PORT:-5000}:5000"
       - "${WEBSOCKET_PORT:-8765}:8765"
 
     # persistent DB, strategies, logs + mount the host .env read-only so dotenv can read it
     volumes:
-      - openalgo_db:/app/db
-      - openalgo_log:/app/log            # Application logs (named volume)
-      - openalgo_strategies:/app/strategies  # Python strategies (named volume)
-      - openalgo_keys:/app/keys          # API keys/certificates (named volume)
-      - openalgo_tmp:/app/tmp            # Temporary directory for numba/scipy (named volume)
+      - db:/app/db
+      - log:/app/log            # Application logs (named volume)
+      - strategies:/app/strategies  # Python strategies (named volume)
+      - keys:/app/keys          # API keys/certificates (named volume)
+      - tmp:/app/tmp            # Temporary directory for numba/scipy (named volume)
       - ./.env:/app/.env
 
     # (optional) extra env-vars that are NOT in .env
@@ -51,14 +53,16 @@ services:
     restart: unless-stopped
 
 # Define named volumes for persistence
+# Volume names are automatically prefixed with project name (APP_NAME)
+# e.g., APP_NAME=scorpio → scorpio_db, scorpio_log, scorpio_strategies, etc.
 volumes:
-  openalgo_db:
+  db:
     driver: local
-  openalgo_log:
+  log:
     driver: local
-  openalgo_strategies:
+  strategies:
     driver: local
-  openalgo_keys:
+  keys:
     driver: local
-  openalgo_tmp:
+  tmp:
     driver: local

--- a/install/docker-run.bat
+++ b/install/docker-run.bat
@@ -26,8 +26,22 @@ REM ============================================================================
 setlocal enabledelayedexpansion
 
 REM Configuration
+REM Load APP_NAME from local .env if present, otherwise use default
+set APP_NAME=openalgo
 set IMAGE=marketcalls/openalgo:latest
 set CONTAINER=openalgo
+
+if exist "%OPENALGO_DIR%\%ENV_FILE%" (
+    for /f "tokens=2 delims==" %%i in ('findstr /I "^APP_NAME" "%OPENALGO_DIR%\%ENV_FILE%"') do (
+        set APP_NAME=%%i
+        REM Remove quotes and spaces
+        for /f "useback tokens=*" %%a in ('!APP_NAME!') do set APP_NAME=%%~a
+        if not "!APP_NAME!"=="" (
+            set IMAGE=!APP_NAME!:latest
+            set CONTAINER=!APP_NAME!
+        )
+    )
+)
 set ENV_FILE=.env
 set SAMPLE_ENV_URL=https://raw.githubusercontent.com/marketcalls/openalgo/main/.sample.env
 REM Use the directory where the script is located

--- a/install/docker-run.bat
+++ b/install/docker-run.bat
@@ -45,15 +45,32 @@ if exist "%OPENALGO_DIR%\%ENV_FILE%" (
         REM Remove quotes and leading/trailing spaces safely (no command execution)
         set APP_NAME=!APP_NAME:"=!
         for /f "tokens=* delims= " %%a in ("!APP_NAME!") do set APP_NAME=%%a
-        REM Validate APP_NAME contains only safe characters (alphanumeric, dash, underscore)
-        echo !APP_NAME! | findstr /R "^[a-zA-Z0-9_-]*$" >nul
-        if errorlevel 1 (
-            echo [WARNING] Invalid APP_NAME in .env, using default
-            set APP_NAME=openalgo
-        )
+        
+        REM Validate APP_NAME contains only safe characters - NO PIPELINE EXPANSION
+        REM Check if any dangerous characters exist by string substitution
         if not "!APP_NAME!"=="" (
-            set IMAGE=!APP_NAME!:latest
-            set CONTAINER=!APP_NAME!
+            set "_INVALID=0"
+            REM Check for dangerous shell metacharacters: & | > < ` $ " ' space
+            set "_TEST=!APP_NAME:&=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            set "_TEST=!APP_NAME:|=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            set "_TEST=!APP_NAME:>=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            set "_TEST=!APP_NAME:</=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            set "_TEST=!APP_NAME:^=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            set "_TEST=!APP_NAME:$=!"
+            if not "!_TEST!"=="!APP_NAME!" set "_INVALID=1"
+            
+            if "!_INVALID!"=="1" (
+                echo [WARNING] Invalid APP_NAME in .env, using default
+                set APP_NAME=openalgo
+            ) else (
+                set IMAGE=!APP_NAME!:latest
+                set CONTAINER=!APP_NAME!
+            )
         )
     )
 )

--- a/install/docker-run.bat
+++ b/install/docker-run.bat
@@ -26,6 +26,14 @@ REM ============================================================================
 setlocal enabledelayedexpansion
 
 REM Configuration
+REM Define variables BEFORE using them
+set ENV_FILE=.env
+set SAMPLE_ENV_URL=https://raw.githubusercontent.com/marketcalls/openalgo/main/.sample.env
+REM Use the directory where the script is located
+set OPENALGO_DIR=%~dp0
+REM Remove trailing backslash
+if "%OPENALGO_DIR:~-1%"=="\" set OPENALGO_DIR=%OPENALGO_DIR:~0,-1%
+
 REM Load APP_NAME from local .env if present, otherwise use default
 set APP_NAME=openalgo
 set IMAGE=marketcalls/openalgo:latest
@@ -34,20 +42,21 @@ set CONTAINER=openalgo
 if exist "%OPENALGO_DIR%\%ENV_FILE%" (
     for /f "tokens=2 delims==" %%i in ('findstr /I "^APP_NAME" "%OPENALGO_DIR%\%ENV_FILE%"') do (
         set APP_NAME=%%i
-        REM Remove quotes and spaces
-        for /f "useback tokens=*" %%a in ('!APP_NAME!') do set APP_NAME=%%~a
+        REM Remove quotes and leading/trailing spaces safely (no command execution)
+        set APP_NAME=!APP_NAME:"=!
+        for /f "tokens=* delims= " %%a in ("!APP_NAME!") do set APP_NAME=%%a
+        REM Validate APP_NAME contains only safe characters (alphanumeric, dash, underscore)
+        echo !APP_NAME! | findstr /R "^[a-zA-Z0-9_-]*$" >nul
+        if errorlevel 1 (
+            echo [WARNING] Invalid APP_NAME in .env, using default
+            set APP_NAME=openalgo
+        )
         if not "!APP_NAME!"=="" (
             set IMAGE=!APP_NAME!:latest
             set CONTAINER=!APP_NAME!
         )
     )
 )
-set ENV_FILE=.env
-set SAMPLE_ENV_URL=https://raw.githubusercontent.com/marketcalls/openalgo/main/.sample.env
-REM Use the directory where the script is located
-set OPENALGO_DIR=%~dp0
-REM Remove trailing backslash
-if "%OPENALGO_DIR:~-1%"=="\" set OPENALGO_DIR=%OPENALGO_DIR:~0,-1%
 set SETUP_FAILED=0
 
 REM XTS Brokers that require market data credentials

--- a/install/docker-run.sh
+++ b/install/docker-run.sh
@@ -32,8 +32,18 @@ BLUE='\033[0;34m'
 NC='\033[0m' # No Color
 
 # Configuration
-IMAGE="marketcalls/openalgo:latest"
-CONTAINER="openalgo"
+# Load APP_NAME from local .env if present, otherwise use default image
+APP_NAME="openalgo"
+if [ -f "${OPENALGO_DIR}/.env" ]; then
+    local_app_name=$(grep '^APP_NAME=' "${OPENALGO_DIR}/.env" 2>/dev/null | cut -d'=' -f2 | tr -d "' \"")
+    if [ -n "$local_app_name" ]; then
+        APP_NAME="$local_app_name"
+        IMAGE="${APP_NAME}:latest"
+    fi
+fi
+# If .env not found locally, use Docker Hub image (default for quick-start users)
+: ${IMAGE:="marketcalls/openalgo:latest"}
+CONTAINER="${APP_NAME:-openalgo}"
 ENV_FILE=".env"
 SAMPLE_ENV_URL="https://raw.githubusercontent.com/marketcalls/openalgo/main/.sample.env"
 # Use the directory where the script is located

--- a/install/install-docker-multi-custom-ssl.sh
+++ b/install/install-docker-multi-custom-ssl.sh
@@ -876,22 +876,25 @@ for i in "${!CONF_DOMAINS[@]}"; do
 
     # 6. Docker Compose
     cat <<EOF > "$INSTANCE_DIR/docker-compose.yaml"
+version: "3.9"
+name: ${PROJECT_NAME}
+
 services:
   openalgo:
     image: ${PROJECT_NAME}:latest
     build:
       context: .
       dockerfile: Dockerfile
-    container_name: ${PROJECT_NAME}-web
+    container_name: ${PROJECT_NAME}
     ports:
       - "127.0.0.1:${FLASK_PORT}:5000"
       - "127.0.0.1:${WS_PORT}:8765"
     volumes:
-      - openalgo_db:/app/db
-      - openalgo_log:/app/log
-      - openalgo_strategies:/app/strategies
-      - openalgo_keys:/app/keys
-      - openalgo_tmp:/app/tmp
+      - db:/app/db
+      - log:/app/log
+      - strategies:/app/strategies
+      - keys:/app/keys
+      - tmp:/app/tmp
       - ./.env:/app/.env
     environment:
       - FLASK_ENV=production
@@ -916,15 +919,15 @@ services:
     restart: unless-stopped
 
 volumes:
-  openalgo_db:
+  db:
     driver: local
-  openalgo_log:
+  log:
     driver: local
-  openalgo_strategies:
+  strategies:
     driver: local
-  openalgo_keys:
+  keys:
     driver: local
-  openalgo_tmp:
+  tmp:
     driver: local
 EOF
 

--- a/install/install-docker.sh
+++ b/install/install-docker.sh
@@ -175,15 +175,23 @@ if [[ $enable_mcp_input =~ ^[Yy]$ ]]; then
     log "Remote MCP will be enabled at https://$DOMAIN/mcp" "$GREEN"
 fi
 
+# Application Instance Name (for supporting multiple instances on same machine)
+log "\nApplication Instance Name Configuration" "$YELLOW"
+log "Use different APP_NAME for running multiple OpenAlgo instances (e.g., 'openalgo', 'paper', 'scorpio')" "$BLUE"
+read -p "Enter APP_NAME for this instance (default: openalgo): " APP_NAME_INPUT
+APP_NAME="${APP_NAME_INPUT:-openalgo}"
+log "APP_NAME set to: $APP_NAME" "$GREEN"
+
 # Generate security keys
 log "\nGenerating security keys..." "$BLUE"
 APP_KEY=$(generate_hex)
 API_KEY_PEPPER=$(generate_hex)
 
 # Set installation path
-INSTALL_PATH="/opt/openalgo"
+INSTALL_PATH="/opt/${APP_NAME}"
 
 log "\n=== Installation Summary ===" "$YELLOW"
+log "APP_NAME: $APP_NAME" "$BLUE"
 log "Domain: $DOMAIN" "$BLUE"
 log "Broker: $BROKER_NAME" "$BLUE"
 log "Installation Path: $INSTALL_PATH" "$BLUE"
@@ -385,14 +393,17 @@ log "Config: shm=${SHM_SIZE_MB}MB, threads=${THREAD_LIMIT}, strategy_mem=${STRAT
 # Create docker-compose.yaml
 log "\n=== Creating Docker Compose Configuration ===" "$BLUE"
 $SUDO tee docker-compose.yaml > /dev/null << EOF
+version: "3.9"
+name: ${APP_NAME}
+
 services:
   openalgo:
-    image: openalgo:latest
+    image: ${APP_NAME}:latest
     build:
       context: .
       dockerfile: Dockerfile
 
-    container_name: openalgo-web
+    container_name: ${APP_NAME}
 
     ports:
       - "127.0.0.1:5000:5000"
@@ -400,11 +411,11 @@ services:
 
     # Use named volumes to avoid permission issues with non-root container user
     volumes:
-      - openalgo_db:/app/db
-      - openalgo_log:/app/log
-      - openalgo_strategies:/app/strategies
-      - openalgo_keys:/app/keys
-      - openalgo_tmp:/app/tmp
+      - db:/app/db
+      - log:/app/log
+      - strategies:/app/strategies
+      - keys:/app/keys
+      - tmp:/app/tmp
       - ./.env:/app/.env
 
     environment:
@@ -435,15 +446,15 @@ services:
 
 # Named volumes for data persistence with proper permissions
 volumes:
-  openalgo_db:
+  db:
     driver: local
-  openalgo_log:
+  log:
     driver: local
-  openalgo_strategies:
+  strategies:
     driver: local
-  openalgo_keys:
+  keys:
     driver: local
-  openalgo_tmp:
+  tmp:
     driver: local
 EOF
 
@@ -721,7 +732,7 @@ log "\nWaiting for container to be healthy..." "$YELLOW"
 sleep 10
 
 # Check container status
-CONTAINER_STATUS=$(sudo docker ps --filter "name=openalgo-web" --format "{{.Status}}")
+CONTAINER_STATUS=$(sudo docker ps --filter "name=${APP_NAME}" --format "{{.Status}}")
 if [[ $CONTAINER_STATUS == *"Up"* ]]; then
     log "Container started successfully!" "$GREEN"
 else
@@ -733,83 +744,85 @@ fi
 log "\n=== Creating Management Scripts ===" "$BLUE"
 
 # Status script
-$SUDO tee /usr/local/bin/openalgo-status > /dev/null << 'EOFSCRIPT'
+$SUDO tee /usr/local/bin/${APP_NAME}-status > /dev/null << 'EOFSCRIPT'
 #!/bin/bash
+APP_NAME=$(grep '^name:' /opt/${APP_NAME}/docker-compose.yaml | awk '{print $2}')
 echo "=========================================="
 echo "OpenAlgo Status"
 echo "=========================================="
 echo ""
 echo "Container Status:"
-sudo docker ps --filter "name=openalgo-web" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
+sudo docker ps --filter "name=${APP_NAME}" --format "table {{.Names}}\t{{.Status}}\t{{.Ports}}"
 echo ""
 echo "Container Health:"
-sudo docker inspect openalgo-web --format='{{.State.Health.Status}}' 2>/dev/null || echo "Container not found"
+sudo docker inspect ${APP_NAME} --format='{{.State.Health.Status}}' 2>/dev/null || echo "Container not found"
 echo ""
 echo "Recent Logs:"
-sudo docker compose -f /opt/openalgo/docker-compose.yaml logs --tail=30
+sudo docker compose -f /opt/${APP_NAME}/docker-compose.yaml logs --tail=30
 EOFSCRIPT
 
-$SUDO chmod +x /usr/local/bin/openalgo-status
+$SUDO chmod +x /usr/local/bin/${APP_NAME}-status
 
 # Restart script
-$SUDO tee /usr/local/bin/openalgo-restart > /dev/null << 'EOFSCRIPT'
+$SUDO tee /usr/local/bin/${APP_NAME}-restart > /dev/null << 'EOFSCRIPT'
 #!/bin/bash
+APP_NAME=$(grep '^name:' /opt/${APP_NAME}/docker-compose.yaml | awk '{print $2}')
 echo "Restarting OpenAlgo..."
-cd /opt/openalgo
+cd /opt/${APP_NAME}
 sudo docker compose restart
 sleep 10
 echo "Container Status:"
-sudo docker ps --filter "name=openalgo-web"
+sudo docker ps --filter "name=${APP_NAME}"
 EOFSCRIPT
 
-$SUDO chmod +x /usr/local/bin/openalgo-restart
+$SUDO chmod +x /usr/local/bin/${APP_NAME}-restart
 
 # Logs script
-$SUDO tee /usr/local/bin/openalgo-logs > /dev/null << 'EOFSCRIPT'
+$SUDO tee /usr/local/bin/${APP_NAME}-logs > /dev/null << EOFSCRIPT
 #!/bin/bash
-cd /opt/openalgo
+cd /opt/${APP_NAME}
 sudo docker compose logs -f --tail=100
 EOFSCRIPT
 
-$SUDO chmod +x /usr/local/bin/openalgo-logs
+$SUDO chmod +x /usr/local/bin/${APP_NAME}-logs
 
 # Backup script
-$SUDO tee /usr/local/bin/openalgo-backup > /dev/null << 'EOFSCRIPT'
+$SUDO tee /usr/local/bin/${APP_NAME}-backup > /dev/null << EOFSCRIPT
 #!/bin/bash
-BACKUP_DIR="/opt/openalgo-backups"
-TIMESTAMP=$(date +%Y%m%d_%H%M%S)
-BACKUP_FILE="$BACKUP_DIR/openalgo_backup_$TIMESTAMP.tar.gz"
-mkdir -p $BACKUP_DIR
+BACKUP_DIR="/opt/${APP_NAME}-backups"
+TIMESTAMP=\$(date +%Y%m%d_%H%M%S)
+BACKUP_FILE="\$BACKUP_DIR/${APP_NAME}_backup_\$TIMESTAMP.tar.gz"
+mkdir -p \$BACKUP_DIR
 echo "Creating backup..."
-cd /opt/openalgo
+cd /opt/${APP_NAME}
 
 # Backup .env file and Docker volume data
 echo "Backing up configuration and volume data..."
 sudo docker compose stop
 
 # Create temp directory for volume exports
-TEMP_DIR=$(mktemp -d)
+TEMP_DIR=\$(mktemp -d)
 
 # Export data from Docker volumes
-sudo docker run --rm -v openalgo_db:/data -v $TEMP_DIR:/backup alpine tar -czf /backup/db.tar.gz -C /data . 2>/dev/null
-sudo docker run --rm -v openalgo_strategies:/data -v $TEMP_DIR:/backup alpine tar -czf /backup/strategies.tar.gz -C /data . 2>/dev/null
+sudo docker run --rm -v ${APP_NAME}_db:/data -v \$TEMP_DIR:/backup alpine tar -czf /backup/db.tar.gz -C /data . 2>/dev/null
+sudo docker run --rm -v ${APP_NAME}_strategies:/data -v \$TEMP_DIR:/backup alpine tar -czf /backup/strategies.tar.gz -C /data . 2>/dev/null
 
 # Create final backup
-sudo tar -czf $BACKUP_FILE .env -C $TEMP_DIR db.tar.gz strategies.tar.gz 2>/dev/null
+sudo tar -czf \$BACKUP_FILE .env -C \$TEMP_DIR db.tar.gz strategies.tar.gz 2>/dev/null
 
 # Cleanup temp directory
-sudo rm -rf $TEMP_DIR
+sudo rm -rf \$TEMP_DIR
 
 sudo docker compose start
-echo "Backup created: $BACKUP_FILE"
+echo "Backup created: \$BACKUP_FILE"
 
 # Keep only last 7 backups
-cd $BACKUP_DIR
-ls -t openalgo_backup_*.tar.gz 2>/dev/null | tail -n +8 | xargs -r rm
+cd \$BACKUP_DIR
+ls -t ${APP_NAME}_backup_*.tar.gz 2>/dev/null | tail -n +8 | xargs -r rm
 echo "Backup completed!"
 EOFSCRIPT
 
-$SUDO chmod +x /usr/local/bin/openalgo-backup
+$SUDO chmod +x /usr/local/bin/${APP_NAME}-backup
 
 log "Management scripts created successfully!" "$GREEN"
 
@@ -828,10 +841,11 @@ log "OpenAlgo Docker Installation Complete!" "$GREEN"
 log "============================================" "$GREEN"
 
 log "\nInstallation Summary:" "$YELLOW"
+log "APP_NAME: $APP_NAME" "$BLUE"
 log "Domain: https://$DOMAIN" "$BLUE"
 log "Broker: $BROKER_NAME" "$BLUE"
 log "Installation Path: $INSTALL_PATH" "$BLUE"
-log "Container: openalgo-web" "$BLUE"
+log "Container: ${APP_NAME}" "$BLUE"
 if [ "$ENABLE_REMOTE_MCP" = "true" ]; then
     log "Remote MCP: Enabled at https://$DOMAIN/mcp" "$BLUE"
 else
@@ -844,10 +858,10 @@ log "2. Create your admin account and login" "$GREEN"
 log "3. Configure your broker settings" "$GREEN"
 
 log "\nUseful Commands:" "$YELLOW"
-log "View status:  openalgo-status" "$BLUE"
-log "View logs:    openalgo-logs" "$BLUE"
-log "Restart:      openalgo-restart" "$BLUE"
-log "Backup:       openalgo-backup" "$BLUE"
+log "View status:  ${APP_NAME}-status" "$BLUE"
+log "View logs:    ${APP_NAME}-logs" "$BLUE"
+log "Restart:      ${APP_NAME}-restart" "$BLUE"
+log "Backup:       ${APP_NAME}-backup" "$BLUE"
 
 log "\nDocker Commands:" "$YELLOW"
 log "Restart:      cd $INSTALL_PATH && sudo docker compose restart" "$BLUE"


### PR DESCRIPTION
## Closes #1461

### Problem
All resource names (container, image, volumes) are hardcoded directly in `docker-compose.yaml`. This prevents running multiple OpenAlgo instances on the same machine without naming conflicts.

### Solution
Implement single `APP_NAME` environment variable that controls:
- Container naming: `${APP_NAME:-openalgo}`
- Image naming: `${APP_NAME:-openalgo}:latest`
- Volume naming: `${APP_NAME}_db`, `${APP_NAME}_log`, etc. (via Docker Compose auto-prefixing)

### Changes Made

- Add APP_NAME variable to .env and .sample.env for single point of configuration
- Update docker-compose.yaml to use `name: ${APP_NAME:-openalgo}` at project level
- Change explicit volume names (openalgo_db, openalgo_log) to short keys (db, log) → Docker Compose auto-prefixes with project name (e.g., scorpio_db)
- Update docker-build.sh to dynamically read APP_NAME from .env
- Update docker-build.bat (Windows) with equivalent APP_NAME parsing
- Update install/docker-run.sh to support local APP_NAME configuration
- Update install/docker-run.bat (Windows) equivalent
- Update install/install-docker.sh to prompt for APP_NAME during installation
- Update install/install-docker-multi-custom-ssl.sh for multi-instance deployments
- Add docker-compose project naming support for full isolation

### Usage

Enables running multiple OpenAlgo instances on same machine without conflicts:

<img width="343" height="257" alt="multidocker" src="https://github.com/user-attachments/assets/9a715b85-d76b-4699-8a06-d2b123d91ac0" />


APP_NAME=production docker-compose up -d  # container: production, volumes: production_*
APP_NAME=paper docker-compose up -d       # container: paper, volumes: paper_*
APP_NAME=testing docker-compose up -d     # container: testing, volumes: testing_*

---
## Summary
Make Docker naming configurable via `APP_NAME`, so you can run multiple OpenAlgo instances on the same machine without conflicts. Updates compose and install/build scripts to honor `APP_NAME` across project, container, image, and volume names. Closes #1461.

- **New Features**
  - Add `APP_NAME` to `.env` and `.sample.env` (default: `openalgo`).
  - Set compose project name `name: ${APP_NAME:-openalgo}`; container and image use `${APP_NAME}`.
  - Replace explicit volume names with short keys (`db`, `log`, `strategies`, `keys`, `tmp`) so `docker compose` auto-prefixes them (e.g., `paper_db`).
  - Update scripts (`docker-build.sh`, `docker-build.bat`, `install/docker-run.*`, `install/install-docker*.sh`) to read `APP_NAME` and align image/container names.
  - Installer now prompts for `APP_NAME`, installs to `/opt/${APP_NAME}`, and creates management commands named `${APP_NAME}-status|logs|restart|backup`.

- **Migration**
  - No action needed if you keep `APP_NAME=openalgo`; existing volumes map to `openalgo_*` as before.
  - If you choose a new `APP_NAME`, new volumes will be created (e.g., `paper_*`). Migrate data as needed before switching.

<sup>Written for commit c911919c7c6bd8193213f6009d11194ba3ea4485. Summary will update on new commits.</sup>