### PR TITLE
fix(market-data): route depth packets to LTP consumers (issue #1453)

### DIFF
--- a/services/market_data_service.py
+++ b/services/market_data_service.py
@@ -472,6 +472,18 @@ class MarketDataService:
                         "ltp": market_data.get("ltp", 0),
                         "timestamp": market_data.get("timestamp", timestamp),
                     }
+                    # Depth packets carry valid LTP — mirror it into cache_entry["ltp"]
+                    # so get_ltp()/get_ltp_value() consumers see fresh prices when a
+                    # symbol is pooled in depth mode (issue #1453). Skip zero/None to
+                    # preserve a previously-valid LTP when the depth-only validator
+                    # path admits a packet without ltp.
+                    depth_ltp = market_data.get("ltp")
+                    if isinstance(depth_ltp, (int, float)) and depth_ltp > 0:
+                        cache_entry["ltp"] = {
+                            "value": depth_ltp,
+                            "timestamp": market_data.get("timestamp", timestamp),
+                            "volume": market_data.get("volume", 0),
+                        }
 
                 cache_entry["last_update"] = timestamp
                 self.metrics["total_updates"] += 1
@@ -898,6 +910,23 @@ class MarketDataService:
                 self.validator.clear_price_history()
                 logger.info("Cleared entire market data cache")
 
+    @staticmethod
+    def _mode_to_event_types(mode: int) -> list[str]:
+        """Event-type buckets a packet should fan out to.
+
+        Quote (mode=2) and Depth (mode=3) packets carry valid LTP, so they also
+        deliver "ltp" updates — otherwise CRITICAL trade-management subscribers
+        (which always register as "ltp") stop receiving ticks the moment a
+        pooled subscription is upgraded to Quote/Depth mode (issue #1453).
+        """
+        if mode == 1:
+            return ["ltp"]
+        if mode == 2:
+            return ["quote", "ltp"]
+        if mode == 3:
+            return ["depth", "ltp"]
+        return ["all"]
+
     def _broadcast_update_priority(self, symbol_key: str, mode: int, data: dict[str, Any]) -> None:
         """
         Broadcast updates to priority subscribers (critical first)
@@ -907,8 +936,7 @@ class MarketDataService:
             mode: Update mode (1=LTP, 2=Quote, 3=Depth)
             data: Full data to broadcast
         """
-        mode_to_event = {1: "ltp", 2: "quote", 3: "depth"}
-        event_type = mode_to_event.get(mode, "all")
+        event_types = self._mode_to_event_types(mode)
 
         # Process subscribers by priority (CRITICAL first)
         for priority in sorted(self.priority_subscribers.keys()):
@@ -919,7 +947,7 @@ class MarketDataService:
                 try:
                     # Check event type filter
                     sub_event_type = subscriber.get("event_type", "all")
-                    if sub_event_type != "all" and sub_event_type != event_type:
+                    if sub_event_type != "all" and sub_event_type not in event_types:
                         continue
 
                     # Check symbol filter
@@ -943,15 +971,16 @@ class MarketDataService:
             mode: Update mode (1=LTP, 2=Quote, 3=Depth)
             data: Full data to broadcast
         """
-        mode_to_event = {1: "ltp", 2: "quote", 3: "depth"}
-        event_type = mode_to_event.get(mode, "all")
+        event_types = self._mode_to_event_types(mode)
 
-        # Broadcast to specific event subscribers
+        # Collect subscribers from every applicable event-type bucket plus "all".
+        # Each subscriber_id lives in exactly one bucket, so no dedup needed.
         with self.data_lock:
-            subscribers = list(self.subscribers[event_type].values())
-            all_subscribers = list(self.subscribers["all"].values())
+            target_subscribers = []
+            for et in list(event_types) + ["all"]:
+                target_subscribers.extend(self.subscribers.get(et, {}).values())
 
-        for subscriber in subscribers + all_subscribers:
+        for subscriber in target_subscribers:
             try:
                 # Check filter
                 if subscriber["filter"] and symbol_key not in subscriber["filter"]:


### PR DESCRIPTION
Depth (mode=3) packets carry valid LTP, but MarketDataService only refreshed the depth cache and routed mode=3 to depth subscribers. This left cache_entry["ltp"] stale and starved CRITICAL trade-management subscribers (sandbox SL/TP engine, always registered as "ltp") of ticks the moment a pooled symbol was upgraded to Depth mode.

- mode=3 now mirrors a positive LTP into cache_entry["ltp"] (zero/None guarded so a previously-valid LTP is preserved)
- new _mode_to_event_types() fans Quote->[quote,ltp] and Depth->[depth,ltp] so ltp subscribers receive quote/depth packets in both broadcast paths

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure LTP stays fresh and LTP subscribers keep receiving ticks when a symbol switches to Depth mode. Addresses issue #1453 affecting critical trade-management consumers.

- **Bug Fixes**
  - Mirror positive `ltp` from Depth (mode=3) into `cache_entry["ltp"]`, skipping zero/None to preserve a valid prior LTP.
  - Fan Quote (mode=2) and Depth (mode=3) packets to `ltp` subscribers via `_mode_to_event_types()` used in both broadcast paths.

<sup>Written for commit 8c2d03e67cf8f18ed245b9c35849c954403a25f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1468?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

