### PR TITLE
fix: connect ZMQ SUB to candidate port range with 5555 default

### DIFF
--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -98,8 +98,30 @@ class WebSocketProxy:
         self.socket = self.context.socket(zmq.SUB)
         # Connecting to ZMQ
         ZMQ_HOST = os.getenv("ZMQ_HOST", "127.0.0.1")
-        ZMQ_PORT = os.getenv("ZMQ_PORT")
-        self.socket.connect(f"tcp://{ZMQ_HOST}:{ZMQ_PORT}")  # Connect to broker adapter publisher
+        # Default to 5555 when ZMQ_PORT isn't set — older releases use 5555
+        ZMQ_PORT = os.getenv("ZMQ_PORT", "5555")
+        # Connect to a small range of candidate ports so the proxy still
+        # receives messages if the publisher auto-bound to a nearby free port
+        try:
+            base_port = int(ZMQ_PORT)
+        except Exception:
+            base_port = 5555
+
+        candidate_ports = [base_port] + list(range(base_port + 1, base_port + 6))
+        connected_any = False
+        for port in candidate_ports:
+            try:
+                self.socket.connect(f"tcp://{ZMQ_HOST}:{port}")
+                logger.debug(f"ZMQ SUB socket connecting to tcp://{ZMQ_HOST}:{port}")
+                connected_any = True
+            except Exception as e:
+                logger.debug(f"ZMQ SUB connect failed for tcp://{ZMQ_HOST}:{port}: {e}")
+
+        if not connected_any:
+            logger.warning(
+                f"ZMQ SUB socket did not connect to any candidate ports starting at {base_port};"
+                " incoming market data may not be received until a publisher binds."
+            )
 
         # Set up ZeroMQ subscriber to receive all messages
         self.socket.setsockopt(zmq.SUBSCRIBE, b"")  # Subscribe to all topics


### PR DESCRIPTION
## What this does
Makes the WebSocket proxy's ZMQ SUB socket resilient to publisher port
variation. Previously `__init__` connected to a single `tcp://HOST:ZMQ_PORT`,
and when `ZMQ_PORT` was unset the endpoint became `tcp://HOST:None`.

Changes:
- Default `ZMQ_PORT` to 5555 when unset (matches the documented message-bus port).
- Guard non-numeric `ZMQ_PORT` values.
- Connect across a small candidate range (base_port .. base_port+5) so the
  proxy still receives ticks if the publisher auto-bound to a nearby free port.
- Log a warning if no candidate endpoint could be registered.

## Scope
Single fix, limited to the ZMQ connection block in `WebSocketProxy.__init__`.
No other code paths touched.

## Testing
- `uv run ruff format` / `ruff check` — no new issues introduced by this change.
- Tested in sandbox for Dhan WebSocket based python strategy. Initially it was subscribing successfully but no ticks were arriving in all 3 modes. Replicated the error with deltaexchange
- With this fix both have started to receive ticks across the 3 modes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the WebSocket proxy’s ZMQ SUB socket resilient to publisher port changes. It now defaults to 5555 and tries a small port range so ticks arrive even if the publisher auto-binds or the port is unset/invalid.

- **Bug Fixes**
  - Default port to 5555 when unset and guard non-numeric input.
  - Attempt connections across base_port..base_port+5; add debug logs and warn if none succeed.

<sup>Written for commit a3ef610e7b2e2b440a3ce184bea08c14490792ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1470?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

