### PR TITLE
fix: use aio alias for asyncio calls in stop()

### DIFF
--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -247,11 +247,11 @@ class WebSocketProxy:
             # Wait for all connections to close with timeout
             if close_tasks:
                 try:
-                    await asyncio.wait_for(
-                        asyncio.gather(*close_tasks, return_exceptions=True),
+                    await aio.wait_for(
+                        aio.gather(*close_tasks, return_exceptions=True),
                         timeout=2.0,  # 2 second timeout
                     )
-                except asyncio.TimeoutError:
+                except aio.TimeoutError:
                     logger.warning("Timeout waiting for client connections to close")
 
             # Disconnect all broker adapters


### PR DESCRIPTION
## What this does
`WebSocketProxy.stop()` referenced `asyncio.wait_for`, `asyncio.gather`, and
`asyncio.TimeoutError`, but the module only imports `asyncio as aio`. When the
shutdown path ran with non-empty `close_tasks`, these raised `NameError`
instead of cleanly closing client connections.

Switched the three references to the `aio` alias already used throughout the
file. No new import added.

## Scope
Single fix, limited to the `if close_tasks:` block in `stop()`.
No other code paths touched.

## Testing
- `uv run ruff check` — the three `F821 Undefined name asyncio` errors are
  resolved; no new issues introduced.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes shutdown errors in `WebSocketProxy.stop()` by using the `aio` alias for `asyncio.wait_for`, `asyncio.gather`, and `asyncio.TimeoutError`. Prevents `NameError` when closing connections and ensures clients are closed cleanly.

<sup>Written for commit 9f793189c681480594efd67c39253a45a8794300. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1471?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

