### PR TITLE
Split Dhan data-API rate limit by endpoint class

### DIFF
--- a/benchmark_api.py
+++ b/benchmark_api.py
@@ -1,0 +1,111 @@
+"""
+OpenAlgo REST API benchmark.
+
+Usage (key from env, not hardcoded):
+    OPENALGO_APIKEY=xxxx python benchmark_api.py
+
+Measures per-endpoint latency (min/p50/p95/p99/max), sequential throughput,
+and probes the configured per-IP rate limit (429 ceiling).
+"""
+import os
+import statistics
+import threading
+import time
+from datetime import datetime, timedelta
+
+import httpx
+
+BASE = os.getenv("OPENALGO_BASE", "http://127.0.0.1:5000/api/v1")
+APIKEY = os.environ["OPENALGO_APIKEY"]
+
+today = datetime.now()
+start_5d = (today - timedelta(days=5)).strftime("%Y-%m-%d")
+end_today = today.strftime("%Y-%m-%d")
+
+client = httpx.Client(timeout=30.0)
+
+ENDPOINTS = {
+    "intervals":   {},
+    "quotes":      {"symbol": "RELIANCE", "exchange": "NSE"},
+    "history":     {"symbol": "RELIANCE", "exchange": "NSE", "interval": "5m",
+                    "start_date": start_5d, "end_date": end_today},
+    "multiquotes": {"symbols": [{"symbol": "RELIANCE", "exchange": "NSE"},
+                                {"symbol": "TCS", "exchange": "NSE"},
+                                {"symbol": "INFY", "exchange": "NSE"}]},
+}
+
+
+def call(path, body):
+    t0 = time.time()
+    r = client.post(f"{BASE}/{path}", json={"apikey": APIKEY, **body})
+    dt = (time.time() - t0) * 1000
+    ok = False
+    try:
+        ok = r.status_code == 200 and r.json().get("status") == "success"
+    except Exception:
+        pass
+    return r.status_code, dt, ok
+
+
+def pct(vals, p):
+    s = sorted(vals)
+    k = max(0, min(len(s) - 1, int(round((p / 100) * (len(s) - 1)))))
+    return s[k]
+
+
+print("=" * 74)
+print(f"OpenAlgo API benchmark   base={BASE}   key=...{APIKEY[-6:]}")
+print(f"history window: {start_5d} .. {end_today}")
+print("=" * 74)
+
+# --- Latency / sequential throughput ---------------------------------------
+print("\nLATENCY (sequential)            min     p50     p95     p99     max   ok/n   thru")
+print("-" * 74)
+SAMPLES = {"intervals": 30, "quotes": 10, "history": 10, "multiquotes": 8}
+for ep, body in ENDPOINTS.items():
+    n = SAMPLES[ep]
+    times, ok = [], 0
+    t0 = time.time()
+    for _ in range(n):
+        code, dt, good = call(ep, body)
+        times.append(dt)
+        ok += good
+    wall = time.time() - t0
+    print(f"  {ep:<14} {min(times):7.1f} {pct(times,50):7.1f} {pct(times,95):7.1f} "
+          f"{pct(times,99):7.1f} {max(times):7.1f}  {ok:>2}/{n:<2}  {n/wall:5.2f}/s")
+
+# --- Rate-limit probe (against fast JSON endpoint) -------------------------
+print("\nRATE LIMIT  (concurrent burst on /intervals; configured 50/s per IP)")
+print("-" * 74)
+
+
+def burst(n):
+    res = [None] * n
+
+    def fire(i):
+        try:
+            r = client.post(f"{BASE}/intervals", json={"apikey": APIKEY})
+            res[i] = r.status_code
+        except Exception:
+            res[i] = "ERR"
+
+    ts = [threading.Thread(target=fire, args=(i,)) for i in range(n)]
+    t0 = time.time()
+    for t in ts:
+        t.start()
+    for t in ts:
+        t.join()
+    wall = time.time() - t0
+    ok = sum(1 for c in res if c == 200)
+    rl = sum(1 for c in res if c == 429)
+    other = sorted({str(c) for c in res if c not in (200, 429)})
+    print(f"  burst {n:>3} in {wall:5.3f}s ({n/wall:5.1f} req/s admit) "
+          f"-> 200={ok:>3}  429={rl:>3}" + (f"  other={other}" if other else ""))
+
+
+for n in (50, 100, 200):
+    burst(n)
+    time.sleep(2)
+
+client.close()
+print("\nDone.")

--- a/broker/dhan/api/data.py
+++ b/broker/dhan/api/data.py
@@ -17,28 +17,36 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-# Rate limiter for Dhan API - max 1 request per second
-_last_api_call_time = 0
+# Rate limiters for Dhan API. Dhan enforces different limits per API class:
+#   - Data/History APIs (/v2/charts/*):   5 req/s -> 0.2s spacing
+#   - Quote APIs (/v2/marketfeed/*):       1 req/s -> 1.1s spacing
+# Each class is throttled independently so fast history fetches don't get
+# capped to the slower quote limit (and vice versa).
 _rate_limit_lock = threading.Lock()
-DHAN_MIN_REQUEST_INTERVAL = 1.1  # seconds between requests
+_last_api_call_time = {"data": 0.0, "quote": 0.0}
+DHAN_DATA_INTERVAL = 0.2  # seconds between /v2/charts/* requests (5 req/s)
+DHAN_QUOTE_INTERVAL = 1.1  # seconds between /v2/marketfeed/* requests (1 req/s)
 
 
-def _apply_rate_limit():
-    """Apply rate limiting to avoid Dhan API error 805 (too many requests)"""
+def _apply_rate_limit(category="data"):
+    """Apply per-category rate limiting to avoid Dhan API error 805 (too many requests)"""
     global _last_api_call_time
+    interval = DHAN_DATA_INTERVAL if category == "data" else DHAN_QUOTE_INTERVAL
     sleep_time = 0
 
     with _rate_limit_lock:
         current_time = time.time()
-        time_since_last_call = current_time - _last_api_call_time
-        if time_since_last_call < DHAN_MIN_REQUEST_INTERVAL:
-            sleep_time = DHAN_MIN_REQUEST_INTERVAL - time_since_last_call
+        time_since_last_call = current_time - _last_api_call_time[category]
+        if time_since_last_call < interval:
+            sleep_time = interval - time_since_last_call
         # Update timestamp immediately to reserve this slot
-        _last_api_call_time = current_time + sleep_time
+        _last_api_call_time[category] = current_time + sleep_time
 
     # Sleep outside the lock to avoid blocking other threads
     if sleep_time > 0:
-        logger.debug(f"Rate limiting: sleeping {sleep_time:.2f}s before Dhan API call")
+        logger.debug(
+            f"Rate limiting ({category}): sleeping {sleep_time:.2f}s before Dhan API call"
+        )
         time.sleep(sleep_time)
 
 
@@ -47,8 +55,10 @@ def get_api_response(endpoint, auth, method="POST", payload="", retry_count=0):
     MAX_RETRIES = 3
     RETRY_DELAY = 2.0  # Base delay for exponential backoff
 
-    # Apply rate limiting before making the request
-    _apply_rate_limit()
+    # Apply rate limiting before making the request. Quote endpoints
+    # (/v2/marketfeed/*) are capped at 1 req/s by Dhan; charts/history at 5 req/s.
+    category = "quote" if endpoint.startswith("/v2/marketfeed") else "data"
+    _apply_rate_limit(category)
 
     AUTH_TOKEN = auth
 


### PR DESCRIPTION
Throttle history (/v2/charts/*) at 0.2s (5 req/s) and quote endpoints (/v2/marketfeed/*) at 1.1s (1 req/s) independently, instead of one shared 1.1s interval. Historical fetches are ~3x faster end-to-end while quote calls stay within Dhan's 1 req/s cap. The 805 retry/backoff is unchanged, and the multiquotes batch delay is left as-is.

Add benchmark_api.py to measure REST API latency and probe the per-IP rate limit; the API key is read from the OPENALGO_APIKEY env var (never hardcoded).