### PR TITLE
fix(dhan): prevent null symbol/exchange in positions (#1463) 

### DIFF
--- a/broker/dhan/mapping/order_data.py
+++ b/broker/dhan/mapping/order_data.py
@@ -54,8 +54,16 @@ def map_order_data(order_data):
                 ):
                     order["productType"] = "NRML"
             else:
+                # Symbol resolution failed (e.g. stale/partial master contract).
+                # Never leave a null tradingSymbol — fall back to the raw broker
+                # symbol or securityId so the row stays usable instead of
+                # crashing the positions UI with null.toUpperCase(). See #1463.
+                order["tradingSymbol"] = (
+                    order.get("tradingSymbol") or str(order.get("securityId") or "")
+                )
                 logger.warning(
-                    f"Symbol not found for token {instrument_token} and exchange {exchange}. Keeping original trading symbol."
+                    f"Symbol not found for token {instrument_token} and exchange {exchange}. "
+                    f"Falling back to raw symbol '{order['tradingSymbol']}'."
                 )
 
     return order_data
@@ -190,7 +198,10 @@ def transform_positions_data(positions_data):
             if api_key_obj:
                 api_key = decrypt_token(api_key_obj.api_key_encrypted)
                 symbols_payload = [
-                    {"symbol": pos.get("tradingSymbol", ""), "exchange": pos.get("exchangeSegment", "")}
+                    {
+                        "symbol": pos.get("tradingSymbol") or "",
+                        "exchange": pos.get("exchangeSegment") or "",
+                    }
                     for pos in positions_data
                     if pos.get("tradingSymbol") and pos.get("exchangeSegment")
                 ]
@@ -208,14 +219,17 @@ def transform_positions_data(positions_data):
     for position in positions_data:
         realized_pnl = float(position.get("realizedProfit", 0))
         unrealized_pnl = float(position.get("unrealizedProfit", 0))
-        symbol = position.get("tradingSymbol", "")
-        exchange = position.get("exchangeSegment", "")
+        # Coerce nulls: dict.get(k, "") returns None (not "") when the key is
+        # present with a null value, so a null symbol/exchange/product would
+        # otherwise reach the frontend and crash null.toUpperCase(). See #1463.
+        symbol = position.get("tradingSymbol") or ""
+        exchange = position.get("exchangeSegment") or ""
         ltp = ltp_map.get(f"{exchange}:{symbol}", 0.0)
 
         transformed_position = {
             "symbol": symbol,
             "exchange": exchange,
-            "product": position.get("productType", ""),
+            "product": position.get("productType") or "",
             "quantity": position.get("netQty", 0),
             "average_price": position.get("costPrice", 0.0),
             "ltp": round(ltp, 2),

--- a/broker/dhan/mapping/transform_data.py
+++ b/broker/dhan/mapping/transform_data.py
@@ -136,7 +136,10 @@ def map_exchange(brexchange):
         "BSE_CURRENCY": "BCD",
         "MCX_COMM": "MCX",
     }
-    return exchange_mapping.get(brexchange)  # Default to MARKET if not found
+    # Fall back to the raw broker segment instead of None so an unmapped
+    # segment degrades to a visible label rather than propagating null
+    # downstream (which crashes the positions UI). See issue #1463.
+    return exchange_mapping.get(brexchange, brexchange)
 
 
 def map_product_type(product):


### PR DESCRIPTION
fix(dhan): prevent null symbol/exchange in positions (#1463) 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents the positions UI from crashing by ensuring Dhan positions never include null symbol, exchange, or product. Falls back to raw broker values and coerces nulls to safe strings. Fixes #1463.

- **Bug Fixes**
  - map_order_data: on symbol lookup miss, set `tradingSymbol` to existing value or `securityId`; improved warning.
  - transform_positions_data: coerce `tradingSymbol`, `exchangeSegment`, and `productType` with `or ""`; build symbols payload defensively.
  - map_exchange: return the raw broker segment when unmapped instead of None.

<sup>Written for commit 191008553ae976080c0831c6bb1500a51d6dc572. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1477?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

