### PR TITLE
fix(frontend): show numeric keypad for TOTP input on Reset Password

### DIFF
--- a/frontend/src/pages/ResetPassword.tsx
+++ b/frontend/src/pages/ResetPassword.tsx
@@ -379,10 +379,11 @@ export default function ResetPassword() {
                   <Input
                     id="totp"
                     type="text"
+                    inputMode="numeric"
                     value={totpCode}
                     onChange={(e) => setTotpCode(e.target.value.replace(/\D/g, '').slice(0, 6))}
                     placeholder="000000"
-                    pattern="[0-9]{6}"
+                    pattern="[0-9]*"
                     maxLength={6}
                     className="text-center text-2xl tracking-widest"
                     required


### PR DESCRIPTION
Closes #1009 

## What this does

TOTP/OTP input fields used `type="text"` without `inputMode="numeric"`, so mobile devices showed a full alphanumeric keyboard instead of a numeric keypad — making 6-digit code entry harder. This adds the standard mobile numeric-keyboard hints to the TOTP input on the **Reset Password** page.

## Scope

The issue listed three files, but investigation showed two were **already fixed**:
- `Login.tsx` (TOTP `#totp_code`) — already has `inputMode="numeric"` + `pattern`
- `components/auth/TwoFactorEnforcement.tsx` (TOTP setup input used from Profile) — already has both

So only `ResetPassword.tsx` needed the change. Other OTP inputs (`BrokerTOTP.tsx` broker configs, `SamcoAuth.tsx`) also lack one/both attributes but are out of scope for this issue and left as follow-ups.

## Testing

- `npm run build` (tsc + vite) — passes, no type errors
- `biome lint src/pages/ResetPassword.tsx` — clean
- Verified in DevTools mobile emulation: rendered input carries `inputmode="numeric"` and `pattern="[0-9]*"` with `type="text"` (no spinner arrows); letters are still ignored by the existing digit filter

## Acceptance criteria

- [x] Numeric keyboard appears on mobile for TOTP inputs
- [x] No spinner arrows (uses `type="text"`, not `type="number"`)
- [x] Works on both iOS (`pattern="[0-9]*"`) and Android (`inputMode="numeric"`)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the numeric keypad for the 6‑digit TOTP field on the Reset Password page to make code entry easier on mobile. Adds inputMode="numeric" and pattern="[0-9]*" while keeping type="text" and the digit-only filter.

<sup>Written for commit 6ff9bac37e419ad54f4fa1453ad30870b34d3456. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1478?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

