### PR TITLE
Add reusable EmptyState component and replace plain text empty states

### DIFF
--- a/frontend/src/components/ui/emptyState.tsx
+++ b/frontend/src/components/ui/emptyState.tsx
@@ -1,0 +1,21 @@
+import { type LucideIcon } from 'lucide-react'
+
+type EmptyStateProps = {
+    icon: LucideIcon
+    title: string
+    description: string
+    action?: React.ReactNode //Optional action button
+}
+
+function EmptyState({ icon: Icon, title, description, action }: EmptyStateProps) {
+    return (
+        <div className="flex flex-col items-center justify-center py-12 text-center">
+            <Icon className="h-12 w-12 text-muted-foreground/50 mb-4" />
+            <h3 className="text-lg font-medium">{title}</h3>
+            <p className="text-sm text-muted-foreground mt-1">{description}</p>
+            {action}
+        </div>
+    )
+}
+
+export { EmptyState }

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -7,6 +7,7 @@ import {
   RefreshCw,
   TrendingDown,
   TrendingUp,
+  Wallet,
 } from 'lucide-react'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { tradingApi } from '@/api/trading'
@@ -31,6 +32,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
+import { EmptyState } from '@/components/ui/emptyState'
 
 function formatPercent(value: number): string {
   return `${value >= 0 ? '+' : ''}${value.toFixed(2)}%`
@@ -323,7 +325,11 @@ export default function Holdings() {
           ) : error ? (
             <div className="text-center py-12 text-muted-foreground">{error}</div>
           ) : holdings.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">No holdings found</div>
+            <EmptyState
+              icon={Wallet}
+              title="No holdings found"
+              description="Connect a broker to start tracking your portfolio."
+            />
           ) : (
             <div className="overflow-x-auto">
               <Table>

--- a/frontend/src/pages/OrderBook.tsx
+++ b/frontend/src/pages/OrderBook.tsx
@@ -2,8 +2,10 @@ import {
   ArrowDown,
   ArrowUp,
   CheckCircle2,
+  ClipboardList,
   Clock,
   Download,
+  FilterX,
   Loader2,
   Pencil,
   RefreshCw,
@@ -56,6 +58,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Order, OrderStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
+import { EmptyState } from '@/components/ui/emptyState'
 
 // Sort configuration types
 type SortKey = 'timestamp' | 'symbol' | 'action' | 'order_status'
@@ -589,18 +592,20 @@ export default function OrderBook() {
               ) : error ? (
                 <div className="text-center py-12 text-muted-foreground">{error}</div>
               ) : sortedAndFilteredOrders.length === 0 ? (
-                <div className="text-center py-12 text-muted-foreground">
-                  {hasActiveFilters ? (
-                    <div>
-                      <p className="mb-4">No orders match your filters</p>
-                      <Button variant="ghost" size="sm" onClick={clearFilters}>
-                        Clear Filters
-                      </Button>
-                    </div>
-                  ) : (
-                    'No orders today'
-                  )}
-                </div>
+                hasActiveFilters ? (
+                  <EmptyState
+                    icon={FilterX}
+                    title="No orders match your filters"
+                    description="Try adjusting or clearing your filters to see results."
+                    action={<Button variant="ghost" size="sm" onClick={clearFilters}>Clear Filters</Button>}
+                  />
+                ) : (
+                  <EmptyState
+                    icon={ClipboardList}
+                    title="No orders today"
+                    description="Orders you place will display here."
+                  />
+                )
               ) : (
                 <div className="overflow-x-auto">
                   <Table>

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -1,6 +1,7 @@
 import {
   AlertTriangle,
   ArrowUpDown,
+  ChartCandlestick,
   ChevronDown,
   ChevronRight,
   Download,
@@ -58,6 +59,7 @@ import { useAuthStore } from '@/stores/authStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
 import { showToast } from '@/utils/toast'
+import { EmptyState } from '@/components/ui/emptyState'
 
 const STORAGE_KEY = 'openalgo_positions_prefs'
 
@@ -196,7 +198,7 @@ export default function Positions() {
             exchange: prefs.filters.exchange || [],
           })
       }
-    } catch (_e) {}
+    } catch (_e) { }
   }, [])
 
   // Save preferences to localStorage
@@ -868,14 +870,16 @@ export default function Positions() {
           ) : error ? (
             <div className="text-center py-12 text-muted-foreground">{error}</div>
           ) : filteredPositions.length === 0 ? (
-            <div className="text-center py-12 text-muted-foreground">
-              <p className="mb-4">No positions match your filters</p>
-              {hasActiveFilters && (
+            <EmptyState
+              icon={ChartCandlestick}
+              title="No positions match your filters"
+              description="Try adjusting or clearing your filters to see results."
+              action={hasActiveFilters ?
                 <Button variant="ghost" size="sm" onClick={clearFilters}>
                   Clear Filters
-                </Button>
-              )}
-            </div>
+                </Button> : undefined
+              }
+            />
           ) : (
             <div className="overflow-x-auto">
               <Table>


### PR DESCRIPTION
## Summary
Fixes #1006 
Replaces plain text empty states across three pages with a reusable `EmptyState` component, as described in the issue.

## Changes
- Created `frontend/src/components/ui/EmptyState.tsx` with `icon`, `title`, `description`, and an optional `action` button.
- Updated `Holdings.tsx` (line 326) — empty state with no action.
- Updated `OrderBook.tsx` (line 595) — two sub-states: one for no orders today, one for when filters return no results (with a Clear Filters button)
- Updated `Positions.tsx` (line 873) — single empty state with a conditionally rendered Clear Filters button

## Notes

I noticed `OrderBook` had two distinct empty states depending on whether filters were active or not, so I handled both with two separates `EmptyState` calls and different icons/descriptions rather than a single generic message. If this choice is not what you have in mind, please message me and I'll be happy to adjust it.

First-time contributor — open to any feedback!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a reusable `EmptyState` component and replaces plain text empty messages in Holdings, OrderBook, and Positions for a more consistent, helpful UI. Aligns with Linear #1006.

**New Features**
- Added `EmptyState` with icon, title, description, and optional action.
- Holdings: clear no-holdings message with guidance.
- OrderBook: distinct states for “no orders today” and “no filter results,” with “Clear Filters” when applicable.
- Positions: empty state with conditional “Clear Filters” action.

<sup>Written for commit a7a3597569def683052d645f00f46dac07327096. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1484?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

