### PR TITLE
fix(crypto): strengthen SMTP key derivation, remove weak pepper fallbacks

### DIFF
--- a/database/settings_db.py
+++ b/database/settings_db.py
@@ -4,12 +4,15 @@ import base64
 import os
 
 from cachetools import TTLCache
-from cryptography.fernet import Fernet
+from cryptography.fernet import Fernet, InvalidToken
+from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from sqlalchemy import Boolean, Column, Integer, MetaData, String, Text, create_engine
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 
+from database.auth_db import PEPPER
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -111,33 +114,58 @@ def set_analyze_mode(mode: bool):
         del _settings_cache["analyze_mode"]
 
 
-def _get_encryption_key():
-    """Get or create encryption key for SMTP password"""
-    # Use API_KEY_PEPPER as the base for encryption key
-    pepper = os.getenv("API_KEY_PEPPER", "default-pepper-key")
-    # Create a stable key from the pepper
-    key = base64.urlsafe_b64encode(pepper.ljust(32)[:32].encode())
-    return key
+# SMTP password encryption.
+#
+# New ciphertext uses a strong PBKDF2-HMAC-SHA256 key derived from the
+# validated API_KEY_PEPPER (imported from auth_db, which fails fast if the
+# pepper is missing or too short) plus a dedicated salt -- the same KDF
+# discipline as database/telegram_db.py. Older installs stored the SMTP
+# password under a weak legacy key (the raw pepper, padded/truncated to 32
+# bytes with no KDF); _decrypt_password() transparently falls back to that
+# legacy key so existing values keep working, and re-saving SMTP settings
+# re-encrypts under the strong key, migrating it forward.
+SMTP_KEY_SALT = os.getenv("SMTP_KEY_SALT", "smtp-openalgo-salt").encode()
+
+
+def _get_smtp_fernet() -> Fernet:
+    """Strong Fernet for the SMTP password: PBKDF2(PEPPER, SMTP_KEY_SALT)."""
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=SMTP_KEY_SALT,
+        iterations=100000,
+    )
+    return Fernet(base64.urlsafe_b64encode(kdf.derive(PEPPER.encode())))
+
+
+def _legacy_smtp_fernet() -> Fernet:
+    """Legacy read-only key (raw pepper, no KDF). Used only to decrypt values
+    stored before the switch to _get_smtp_fernet(); never for new writes.
+    """
+    return Fernet(base64.urlsafe_b64encode(PEPPER.ljust(32)[:32].encode()))
+
+
+# Module-level cipher; PEPPER is fixed for the process lifetime.
+_smtp_fernet = _get_smtp_fernet()
 
 
 def _encrypt_password(password: str) -> str:
-    """Encrypt SMTP password"""
+    """Encrypt SMTP password with the strong per-install key."""
     if not password:
         return None
-    key = _get_encryption_key()
-    f = Fernet(key)
-    encrypted = f.encrypt(password.encode())
-    return encrypted.decode()
+    return _smtp_fernet.encrypt(password.encode()).decode()
 
 
 def _decrypt_password(encrypted_password: str) -> str:
-    """Decrypt SMTP password"""
+    """Decrypt SMTP password, falling back to the legacy key for values
+    written before the KDF upgrade."""
     if not encrypted_password:
         return None
-    key = _get_encryption_key()
-    f = Fernet(key)
-    decrypted = f.decrypt(encrypted_password.encode())
-    return decrypted.decode()
+    token = encrypted_password.encode()
+    try:
+        return _smtp_fernet.decrypt(token).decode()
+    except InvalidToken:
+        return _legacy_smtp_fernet().decrypt(token).decode()
 
 
 def get_smtp_settings():

--- a/database/telegram_db.py
+++ b/database/telegram_db.py
@@ -29,6 +29,7 @@ from sqlalchemy.orm import relationship, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import func
 
+from database.auth_db import PEPPER
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -54,14 +55,13 @@ TELEGRAM_KEY_SALT = os.getenv("TELEGRAM_KEY_SALT", "telegram-openalgo-salt").enc
 
 def get_encryption_key():
     """Generate a Fernet key for encrypting API keys"""
-    pepper = os.getenv("API_KEY_PEPPER", "default-pepper-change-in-production")
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,
         salt=TELEGRAM_KEY_SALT,
         iterations=100000,
     )
-    key = base64.urlsafe_b64encode(kdf.derive(pepper.encode()))
+    key = base64.urlsafe_b64encode(kdf.derive(PEPPER.encode()))
     return Fernet(key)
 
 

--- a/database/whatsapp_db.py
+++ b/database/whatsapp_db.py
@@ -49,6 +49,7 @@ from sqlalchemy.orm import relationship, scoped_session, sessionmaker
 from sqlalchemy.pool import NullPool
 from sqlalchemy.sql import func
 
+from database.auth_db import PEPPER
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -82,14 +83,13 @@ def _resolve_whatsapp_salt() -> bytes:
 
 
 def _build_fernet() -> Fernet:
-    pepper = os.getenv("API_KEY_PEPPER", "default-pepper-change-in-production")
     kdf = PBKDF2HMAC(
         algorithm=hashes.SHA256(),
         length=32,
         salt=_resolve_whatsapp_salt(),
         iterations=100000,
     )
-    return Fernet(base64.urlsafe_b64encode(kdf.derive(pepper.encode())))
+    return Fernet(base64.urlsafe_b64encode(kdf.derive(PEPPER.encode())))
 
 
 fernet = _build_fernet()

--- a/upgrade/rotate_pepper.py
+++ b/upgrade/rotate_pepper.py
@@ -113,8 +113,22 @@ def _telegram_db_fernet(pepper: str) -> Fernet:
 
 
 def _settings_db_fernet(pepper: str) -> Fernet:
-    """Match database/settings_db.py:_get_encryption_key().
-    NB: settings_db uses raw pepper (no PBKDF2), padded/truncated to 32 bytes.
+    """Match database/settings_db.py:_get_smtp_fernet() (PBKDF2 + SMTP_KEY_SALT)."""
+    salt = os.getenv("SMTP_KEY_SALT", "smtp-openalgo-salt").encode()
+    kdf = PBKDF2HMAC(
+        algorithm=hashes.SHA256(),
+        length=32,
+        salt=salt,
+        iterations=100000,
+    )
+    key = base64.urlsafe_b64encode(kdf.derive(pepper.encode()))
+    return Fernet(key)
+
+
+def _legacy_settings_db_fernet(pepper: str) -> Fernet:
+    """Match the pre-KDF settings_db scheme (raw pepper, padded/truncated to 32
+    bytes, no PBKDF2). Decrypt-only, for SMTP passwords stored before the
+    settings_db KDF upgrade.
     """
     key = base64.urlsafe_b64encode(pepper.ljust(32)[:32].encode())
     return Fernet(key)
@@ -214,6 +228,8 @@ class Rotator:
         self.new_telegram = _telegram_db_fernet(new_pepper)
         self.old_settings = _settings_db_fernet(old_pepper)
         self.new_settings = _settings_db_fernet(new_pepper)
+        # Decrypt-only fallback for SMTP passwords stored before the KDF upgrade.
+        self.old_settings_legacy = _legacy_settings_db_fernet(old_pepper)
         # ph for re-hashing api_key_hash. Argon2 verifier needs the new pepper
         # appended to the plaintext key, then ph.hash() with default params.
         self.ph = PasswordHasher()
@@ -357,8 +373,12 @@ class Rotator:
                 try:
                     pt = self.old_settings.decrypt(smtp_v.encode()).decode()
                 except (InvalidToken, ValueError):
-                    print(f"  WARN: settings.smtp_password_encrypted row {row_id}: cannot decrypt, leaving alone")
-                    continue
+                    # Value may predate the KDF upgrade (raw-pepper legacy key).
+                    try:
+                        pt = self.old_settings_legacy.decrypt(smtp_v.encode()).decode()
+                    except (InvalidToken, ValueError):
+                        print(f"  WARN: settings.smtp_password_encrypted row {row_id}: cannot decrypt, leaving alone")
+                        continue
                 new_ct = self.new_settings.encrypt(pt.encode()).decode()
                 self.conn.execute(
                     "UPDATE settings SET smtp_password_encrypted = ? WHERE id = ?",


### PR DESCRIPTION
## Summary

Fixes two cryptography findings from a security review of the secrets-handling code.

### #2 — SMTP password key derivation (`database/settings_db.py`)
The SMTP password was encrypted with a Fernet key built by base64-encoding the raw pepper padded/truncated to 32 bytes — **no KDF** — plus a hardcoded `"default-pepper-key"` fallback. Every other module runs the pepper through PBKDF2.

- New writes now use `_get_smtp_fernet()` → PBKDF2-HMAC-SHA256 (100k iterations) over the validated pepper + a dedicated `SMTP_KEY_SALT` (same discipline as `telegram_db`).
- `_decrypt_password()` falls back to a decrypt-only legacy key so **existing installs don't break** (password-reset email keeps working). Re-saving SMTP settings re-encrypts under the strong key — forward migration, no DB script needed.

### #4 — Hardcoded pepper fallbacks (`settings_db`, `telegram_db`, `whatsapp_db`)
These three modules defaulted `API_KEY_PEPPER` to a public literal instead of failing fast like `auth_db`/`user_db`. They now `from database.auth_db import PEPPER` (the single validated source that fails fast on a missing/short pepper). The Telegram/WhatsApp ciphertext formats are unchanged.

### Kept in sync
`upgrade/rotate_pepper.py` mirrors each module's Fernet scheme. Updated `_settings_db_fernet` to the new KDF scheme and added a legacy-decrypt fallback so pepper rotation handles both old and new SMTP ciphertext.

## Verification
- SMTP new-key encrypt→decrypt round-trips; legacy ciphertext still decrypts via fallback; new ciphertext is **not** readable with the old key (KDF confirmed effective).
- Telegram/WhatsApp Fernets still round-trip (format unchanged).
- All three modules now raise `RuntimeError` on a missing/too-short pepper (confirmed at runtime).
- All four files `py_compile` clean; `ruff` shows only pre-existing warnings (none on changed lines).

## Migration notes for operators
- No action required. Existing SMTP passwords keep working via the legacy-decrypt fallback and migrate to the strong key the next time SMTP settings are saved.
- A deployment that was somehow running **without** `API_KEY_PEPPER` set will now fail fast at startup (this was already the case for `auth_db`/`user_db`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)