### PR TITLE
feat(ws): add get_subscriptions and get_global_subscriptions actions (#1490)

### DIFF
--- a/collections/openalgo/IN_stock/WEBSOCKET_README.md
+++ b/collections/openalgo/IN_stock/WEBSOCKET_README.md
@@ -86,6 +86,8 @@ Valid string modes: `"LTP"`, `"Quote"`, `"Depth"`
 | ws_unsubscribe_all.bru | unsubscribe_all | Unsubscribe from all |
 | ws_get_broker_info.bru | get_broker_info | Get broker information |
 | ws_get_supported_brokers.bru | get_supported_brokers | List supported brokers |
+| ws_get_subscriptions.bru | get_subscriptions | Get own active subscriptions |
+| ws_get_global_subscriptions.bru | get_global_subscriptions | Get client-wise subscription details & summary |
 | ws_ping.bru | ping | Test connection latency |
 
 ## Supported Exchanges

--- a/collections/openalgo/IN_stock/ws_get_global_subscriptions.bru
+++ b/collections/openalgo/IN_stock/ws_get_global_subscriptions.bru
@@ -1,0 +1,45 @@
+meta {
+  name: Get Global Subscriptions
+  type: websocket
+  seq: 15
+}
+
+websocket {
+  url: ws://127.0.0.1:8765
+  description: Get client-wise subscription breakdown with global summary across all connected clients
+}
+
+message:json {
+  {
+    "action": "get_global_subscriptions"
+  }
+}
+
+docs {
+  Returns a per-client breakdown of all active subscriptions plus global summary stats.
+
+  Server responds with:
+  {
+    "type": "global_subscriptions",
+    "status": "success",
+    "summary": {
+      "total_clients": 2,
+      "subscriptions_count": 25,
+      "by_mode": {"LTP": 20, "Quote": 15, "Depth": 5},
+      "by_exchange": {"NSE": 18, "NSE_INDEX": 5, "BSE": 2},
+      "broker": "angel"
+    },
+    "clients": [
+      {
+        "client_id": 140234567890,
+        "subscription_count": 25,
+        "subscriptions": [
+          {"symbol": "RELIANCE", "exchange": "NSE", "mode": "Quote", "depth": 5},
+          {"symbol": "NIFTY", "exchange": "NSE_INDEX", "mode": "LTP", "depth": 5}
+        ]
+      }
+    ]
+  }
+
+  Must be authenticated first.
+}

--- a/collections/openalgo/IN_stock/ws_get_subscriptions.bru
+++ b/collections/openalgo/IN_stock/ws_get_subscriptions.bru
@@ -1,0 +1,38 @@
+meta {
+  name: Get Subscriptions
+  type: websocket
+  seq: 14
+}
+
+websocket {
+  url: ws://127.0.0.1:8765
+  description: Get the requesting client's own active subscriptions with symbol, mode, and summary stats
+}
+
+message:json {
+  {
+    "action": "get_subscriptions"
+  }
+}
+
+docs {
+  Returns the authenticated client's own active subscriptions.
+
+  Server responds with:
+  {
+    "type": "subscriptions",
+    "status": "success",
+    "summary": {
+      "subscriptions_count": 15,
+      "by_mode": {"LTP": 10, "Quote": 4, "Depth": 1},
+      "by_exchange": {"NSE": 12, "NSE_INDEX": 2, "BSE": 1},
+      "broker": "angel"
+    },
+    "subscriptions": [
+      {"symbol": "RELIANCE", "exchange": "NSE", "mode": "Quote", "depth": 5},
+      {"symbol": "NIFTY", "exchange": "NSE_INDEX", "mode": "LTP", "depth": 5}
+    ]
+  }
+
+  Must be authenticated first.
+}

--- a/frontend/src/components/playground/MessageComposer.tsx
+++ b/frontend/src/components/playground/MessageComposer.tsx
@@ -207,6 +207,20 @@ function getMessageTemplates(isCrypto: boolean): CategorizedTemplate[] {
       category: 'broker',
     },
     {
+      key: 'get_subscriptions',
+      label: 'Get Subscriptions',
+      description: "Get requesting client's own active subscriptions",
+      template: { action: 'get_subscriptions' },
+      category: 'broker',
+    },
+    {
+      key: 'get_global_subscriptions',
+      label: 'Get Global Subscriptions',
+      description: 'Get client-wise subscriptions with global summary',
+      template: { action: 'get_global_subscriptions' },
+      category: 'broker',
+    },
+    {
       key: 'ping',
       label: 'Ping',
       description: 'Test connection latency',

--- a/test/test_cleanup_client.py
+++ b/test/test_cleanup_client.py
@@ -142,8 +142,8 @@ def test_no_teardown_when_other_client_still_connected():
 # Defensive subscription_index sweep
 # ---------------------------------------------------------------------------
 
-def test_purges_subscription_index_for_unparseable_subscription():
-    """Stale index entries for a client with bad JSON subscriptions must be purged."""
+def test_purges_subscription_index_and_unsubscribes_adapter_for_unparseable_subscription():
+    """Stale index entries for unparseable subscriptions must be unsubscribed at adapter before purging."""
     proxy = _make_ws_proxy()
     adapter = Mock()
     _seed_client(proxy, "c1", "u1", "zerodha", adapter)
@@ -153,5 +153,22 @@ def test_purges_subscription_index_for_unparseable_subscription():
     asyncio.run(proxy.cleanup_client("c1"))
 
     assert ("SBIN", "NSE", 2) not in proxy.subscription_index
-    adapter.unsubscribe.assert_not_called()
+    adapter.unsubscribe.assert_called_once_with("SBIN", "NSE", 2)
     adapter.disconnect.assert_called_once()
+
+
+def test_defensive_sweep_unsubscribes_adapter_when_sibling_client_remains():
+    """Unparseable subscription dropped in defensive sweep must unsubscribe adapter even when another client stays connected."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    _seed_client(proxy, "c1", "u1", "zerodha", adapter)
+    proxy.user_mapping["c2"] = "u1"
+    proxy.subscriptions["c1"] = {"bad-json"}
+    proxy.subscription_index[("TATASTEEL", "NSE", 1)].add("c1")
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    assert ("TATASTEEL", "NSE", 1) not in proxy.subscription_index
+    adapter.unsubscribe.assert_called_once_with("TATASTEEL", "NSE", 1)
+    adapter.disconnect.assert_not_called()
+

--- a/test/test_cleanup_client.py
+++ b/test/test_cleanup_client.py
@@ -1,0 +1,157 @@
+"""Regression tests for WebSocketProxy.cleanup_client teardown/keep-alive (issue #1490).
+
+Covers the five paths through cleanup_client's adapter-disposal logic:
+
+1. Normal full-disconnect (Zerodha, Angel, etc.)
+2. Full-disconnect when adapter.disconnect() raises
+3. Flattrade/Shoonya keep-alive normal path
+4. Flattrade/Shoonya keep-alive when unsubscribe_all() raises
+5. Multi-client: adapter not torn down while sibling clients remain
+6. Defensive sweep: stale subscription_index entries purged
+
+These construct a WebSocketProxy via __new__ to bypass __init__ (which binds
+a port and opens ZeroMQ sockets), and exercise only the state-mapping logic.
+
+Run with: uv run pytest test/test_cleanup_client.py -v
+"""
+
+import asyncio
+import os
+import sys
+from collections import defaultdict
+from unittest.mock import Mock
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from websocket_proxy.server import WebSocketProxy
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _make_ws_proxy():
+    """Create a minimal WebSocketProxy without binding a port or ZeroMQ."""
+    proxy = WebSocketProxy.__new__(WebSocketProxy)
+    proxy.clients = {}
+    proxy.subscriptions = {}
+    proxy.broker_adapters = {}
+    proxy.user_mapping = {}
+    proxy.user_broker_mapping = {}
+    proxy.subscription_index = defaultdict(set)
+    return proxy
+
+
+def _seed_client(proxy, client_id, user_id, broker_name, adapter):
+    """Register a fake client in the proxy's internal state maps."""
+    proxy.clients[client_id] = object()
+    proxy.subscriptions[client_id] = set()
+    proxy.user_mapping[client_id] = user_id
+    proxy.broker_adapters[user_id] = adapter
+    proxy.user_broker_mapping[user_id] = broker_name
+
+
+# ---------------------------------------------------------------------------
+# Full-disconnect branch (Zerodha, Angel, etc.)
+# ---------------------------------------------------------------------------
+
+def test_full_disconnect_removes_mappings_even_when_disconnect_raises():
+    """adapter.disconnect() raises — mappings must still be cleaned up."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    adapter.disconnect.side_effect = RuntimeError("adapter died mid-disconnect")
+    _seed_client(proxy, "c1", "u1", "zerodha", adapter)
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    adapter.disconnect.assert_called_once()
+    assert "c1" not in proxy.clients
+    assert "c1" not in proxy.subscriptions
+    assert "c1" not in proxy.user_mapping
+    assert "u1" not in proxy.broker_adapters
+    assert "u1" not in proxy.user_broker_mapping
+
+
+def test_full_disconnect_normal_path():
+    """Normal broker disconnect clears adapter and user-broker mappings."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    _seed_client(proxy, "c1", "u1", "angel", adapter)
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    adapter.disconnect.assert_called_once()
+    adapter.unsubscribe_all.assert_not_called()
+    assert "u1" not in proxy.broker_adapters
+    assert "u1" not in proxy.user_broker_mapping
+
+
+# ---------------------------------------------------------------------------
+# Keep-alive branch (Flattrade, Shoonya)
+# ---------------------------------------------------------------------------
+
+def test_flattrade_keeps_mapping_even_when_unsubscribe_all_raises():
+    """unsubscribe_all() raises — adapter mapping must survive (keep-alive)."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    adapter.unsubscribe_all.side_effect = RuntimeError("unsubscribe_all failed")
+    _seed_client(proxy, "c1", "u1", "flattrade", adapter)
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    assert "u1" in proxy.broker_adapters
+    assert proxy.user_broker_mapping.get("u1") == "flattrade"
+    adapter.unsubscribe_all.assert_called_once()
+    adapter.disconnect.assert_not_called()
+
+
+def test_shoonya_keep_alive_normal_path():
+    """Shoonya adapter stays alive after last client disconnects."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    _seed_client(proxy, "c1", "u1", "shoonya", adapter)
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    adapter.unsubscribe_all.assert_called_once()
+    adapter.disconnect.assert_not_called()
+    assert "u1" in proxy.broker_adapters
+    assert "u1" in proxy.user_broker_mapping
+
+
+# ---------------------------------------------------------------------------
+# Multi-client scenarios
+# ---------------------------------------------------------------------------
+
+def test_no_teardown_when_other_client_still_connected():
+    """Adapter must not disconnect when another client for the same user exists."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    _seed_client(proxy, "c1", "u1", "zerodha", adapter)
+    proxy.user_mapping["c2"] = "u1"
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    adapter.disconnect.assert_not_called()
+    assert "u1" in proxy.broker_adapters
+    assert "u1" in proxy.user_broker_mapping
+    assert "c2" in proxy.user_mapping
+
+
+# ---------------------------------------------------------------------------
+# Defensive subscription_index sweep
+# ---------------------------------------------------------------------------
+
+def test_purges_subscription_index_for_unparseable_subscription():
+    """Stale index entries for a client with bad JSON subscriptions must be purged."""
+    proxy = _make_ws_proxy()
+    adapter = Mock()
+    _seed_client(proxy, "c1", "u1", "zerodha", adapter)
+    proxy.subscriptions["c1"] = {"not-json"}
+    proxy.subscription_index[("SBIN", "NSE", 2)].add("c1")
+
+    asyncio.run(proxy.cleanup_client("c1"))
+
+    assert ("SBIN", "NSE", 2) not in proxy.subscription_index
+    adapter.unsubscribe.assert_not_called()
+    adapter.disconnect.assert_called_once()

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -563,15 +563,14 @@ class WebSocketProxy:
         Args:
             client_id: Client ID to clean up
         """
-        # Remove client from tracking
-        if client_id in self.clients:
-            del self.clients[client_id]
+        # Remove client from tracking safely
+        self.clients.pop(client_id, None)
 
-        # Clean up subscriptions
+        # Clean up subscriptions safely
         if client_id in self.subscriptions:
             subscriptions = self.subscriptions[client_id]
             # Unsubscribe from all subscriptions
-            for sub_json in subscriptions:
+            for sub_json in list(subscriptions):
                 try:
                     # Parse the JSON string to get the subscription info
                     sub_info = json.loads(sub_json)
@@ -586,7 +585,7 @@ class WebSocketProxy:
                         self.subscription_index[sub_key].discard(client_id)
                         # Clean up empty entries and mark for adapter unsubscription
                         if not self.subscription_index[sub_key]:
-                            del self.subscription_index[sub_key]
+                            self.subscription_index.pop(sub_key, None)
                             # Only unsubscribe from adapter when last client unsubscribes
                             should_unsubscribe_from_adapter = True
 
@@ -609,9 +608,9 @@ class WebSocketProxy:
                     logger.exception(f"Error processing subscription: {e}")
                     continue
 
-            del self.subscriptions[client_id]
+            self.subscriptions.pop(client_id, None)
 
-        # Remove from user mapping
+        # Remove from user mapping safely
         if client_id in self.user_mapping:
             user_id = self.user_mapping[client_id]
 
@@ -627,23 +626,27 @@ class WebSocketProxy:
                 adapter = self.broker_adapters[user_id]
                 broker_name = self.user_broker_mapping.get(user_id)
 
-                # For Flattrade and Shoonya, keep the connection alive and just unsubscribe from data
-                if broker_name in ["flattrade", "shoonya"] and hasattr(adapter, "unsubscribe_all"):
-                    logger.info(
-                        f"{broker_name.title()} adapter for user {user_id}: last client disconnected. Unsubscribing all symbols instead of disconnecting."
-                    )
-                    adapter.unsubscribe_all()
-                else:
-                    # For all other brokers, disconnect the adapter completely
-                    logger.info(
-                        f"Last client for user {user_id} disconnected. Disconnecting {broker_name or 'unknown broker'} adapter."
-                    )
-                    adapter.disconnect()
-                    del self.broker_adapters[user_id]
-                    if user_id in self.user_broker_mapping:
-                        del self.user_broker_mapping[user_id]
+                try:
+                    # For Flattrade and Shoonya, keep the connection alive and just unsubscribe from data
+                    if broker_name in ["flattrade", "shoonya"] and hasattr(adapter, "unsubscribe_all"):
+                        logger.info(
+                            f"{broker_name.title()} adapter for user {user_id}: last client disconnected. Unsubscribing all symbols instead of disconnecting."
+                        )
+                        adapter.unsubscribe_all()
+                    else:
+                        # For all other brokers, disconnect the adapter completely
+                        logger.info(
+                            f"Last client for user {user_id} disconnected. Disconnecting {broker_name or 'unknown broker'} adapter."
+                        )
+                        adapter.disconnect()
+                except Exception as e:
+                    logger.exception(f"Error cleaning up adapter state for user {user_id}: {e}")
+                finally:
+                    # Guarantee removal from adapter mappings even if disconnect/unsubscribe raised an exception
+                    self.broker_adapters.pop(user_id, None)
+                    self.user_broker_mapping.pop(user_id, None)
 
-            del self.user_mapping[client_id]
+            self.user_mapping.pop(client_id, None)
 
     async def process_client_message(self, client_id, message):
         """

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -1166,17 +1166,17 @@ class WebSocketProxy:
         by_mode = {}
         by_exchange = {}
 
-        for (symbol, exchange, mode), client_ids in self.subscription_index.items():
+        for (_, exchange, mode), _ in self.subscription_index.items():
             subscriptions_count += 1
             mode_label = MODE_CANONICAL.get(mode, "Quote")
             by_mode[mode_label] = by_mode.get(mode_label, 0) + 1
             by_exchange[exchange] = by_exchange.get(exchange, 0) + 1
 
-        # Per-client detail from self.subscriptions
+        # Per-client detail from self.user_mapping (only active, authenticated clients)
         clients_list = []
-        for cid in sorted(self.subscriptions.keys()):
+        for cid in sorted(self.user_mapping.keys()):
             subs = []
-            for sub_json in self.subscriptions[cid]:
+            for sub_json in self.subscriptions.get(cid, set()):
                 try:
                     sub = json.loads(sub_json)
                     mode_num = sub.get("mode", 2)

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -22,6 +22,7 @@ from .base_adapter import BaseBrokerWebSocketAdapter
 from .broker_factory import create_broker_adapter
 from .mode_utils import (
     MODE_BY_UPPER_LABEL as _MODE_BY_UPPER_LABEL,
+    MODE_CANONICAL,
     normalize_mode,
     normalize_mode_or_none,
 )
@@ -675,6 +676,10 @@ class WebSocketProxy:
                 await self.get_supported_brokers(client_id)
             elif action == "ping":
                 await self.handle_ping(client_id, data)
+            elif action == "get_subscriptions":
+                await self.get_subscriptions(client_id, data)
+            elif action == "get_global_subscriptions":
+                await self.get_global_subscriptions(client_id, data)
             else:
                 logger.warning(f"Client {client_id} requested invalid action: {action}")
                 await self.send_error(client_id, "INVALID_ACTION", f"Invalid action: {action}")
@@ -1088,6 +1093,123 @@ class WebSocketProxy:
 
         logger.debug(f"Sending pong to client {client_id}: {response}")
         await self.send_message(client_id, response)
+
+    async def get_subscriptions(self, client_id, data):
+        """
+        Return the requesting client's own subscriptions with detail and summary.
+
+        Args:
+            client_id: ID of the client
+            data: Request data (unused, kept for API consistency)
+        """
+        if client_id not in self.user_mapping:
+            await self.send_error(client_id, "NOT_AUTHENTICATED", "You must authenticate first")
+            return
+
+        user_id = self.user_mapping[client_id]
+        broker_name = self.user_broker_mapping.get(user_id, "unknown")
+
+        client_subs = self.subscriptions.get(client_id, set())
+        parsed = []
+        by_mode = {}
+        by_exchange = {}
+
+        for sub_json in client_subs:
+            try:
+                sub = json.loads(sub_json)
+                mode_num = sub.get("mode", 2)
+                mode_label = MODE_CANONICAL.get(mode_num, "Quote")
+                exchange = sub.get("exchange", "")
+                parsed.append({
+                    "symbol": sub.get("symbol", ""),
+                    "exchange": exchange,
+                    "mode": mode_label,
+                    "depth": sub.get("depth_level", 5),
+                })
+                by_mode[mode_label] = by_mode.get(mode_label, 0) + 1
+                by_exchange[exchange] = by_exchange.get(exchange, 0) + 1
+            except (json.JSONDecodeError, TypeError):
+                continue
+
+        await self.send_message(
+            client_id,
+            {
+                "type": "subscriptions",
+                "status": "success",
+                "summary": {
+                    "subscriptions_count": len(parsed),
+                    "by_mode": by_mode,
+                    "by_exchange": by_exchange,
+                    "broker": broker_name,
+                },
+                "subscriptions": parsed,
+            },
+        )
+
+    async def get_global_subscriptions(self, client_id, data):
+        """
+        Return client-wise subscription breakdown with global summary.
+
+        Args:
+            client_id: ID of the requesting client
+            data: Request data (unused, kept for API consistency)
+        """
+        if client_id not in self.user_mapping:
+            await self.send_error(client_id, "NOT_AUTHENTICATED", "You must authenticate first")
+            return
+
+        user_id = self.user_mapping[client_id]
+        broker_name = self.user_broker_mapping.get(user_id, "unknown")
+
+        # Global stats from subscription_index
+        subscriptions_count = 0
+        by_mode = {}
+        by_exchange = {}
+
+        for (symbol, exchange, mode), client_ids in self.subscription_index.items():
+            subscriptions_count += 1
+            mode_label = MODE_CANONICAL.get(mode, "Quote")
+            by_mode[mode_label] = by_mode.get(mode_label, 0) + 1
+            by_exchange[exchange] = by_exchange.get(exchange, 0) + 1
+
+        # Per-client detail from self.subscriptions
+        clients_list = []
+        for cid in sorted(self.subscriptions.keys()):
+            subs = []
+            for sub_json in self.subscriptions[cid]:
+                try:
+                    sub = json.loads(sub_json)
+                    mode_num = sub.get("mode", 2)
+                    mode_label = MODE_CANONICAL.get(mode_num, "Quote")
+                    subs.append({
+                        "symbol": sub.get("symbol", ""),
+                        "exchange": sub.get("exchange", ""),
+                        "mode": mode_label,
+                        "depth": sub.get("depth_level", 5),
+                    })
+                except (json.JSONDecodeError, TypeError):
+                    continue
+            clients_list.append({
+                "client_id": cid,
+                "subscription_count": len(subs),
+                "subscriptions": subs,
+            })
+
+        await self.send_message(
+            client_id,
+            {
+                "type": "global_subscriptions",
+                "status": "success",
+                "summary": {
+                    "total_clients": len(clients_list),
+                    "subscriptions_count": subscriptions_count,
+                    "by_mode": by_mode,
+                    "by_exchange": by_exchange,
+                    "broker": broker_name,
+                },
+                "clients": clients_list,
+            },
+        )
 
     async def subscribe_client(self, client_id, data):
         """

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -610,6 +610,12 @@ class WebSocketProxy:
 
             self.subscriptions.pop(client_id, None)
 
+        # Defensive sweep: ensure client_id is completely purged from subscription_index
+        for sub_key, client_set in list(self.subscription_index.items()):
+            client_set.discard(client_id)
+            if not client_set:
+                self.subscription_index.pop(sub_key, None)
+
         # Remove from user mapping safely
         if client_id in self.user_mapping:
             user_id = self.user_mapping[client_id]
@@ -626,25 +632,28 @@ class WebSocketProxy:
                 adapter = self.broker_adapters[user_id]
                 broker_name = self.user_broker_mapping.get(user_id)
 
-                try:
-                    # For Flattrade and Shoonya, keep the connection alive and just unsubscribe from data
-                    if broker_name in ["flattrade", "shoonya"] and hasattr(adapter, "unsubscribe_all"):
-                        logger.info(
-                            f"{broker_name.title()} adapter for user {user_id}: last client disconnected. Unsubscribing all symbols instead of disconnecting."
-                        )
+                # For Flattrade and Shoonya, keep the connection alive and just unsubscribe from data
+                if broker_name in ["flattrade", "shoonya"] and hasattr(adapter, "unsubscribe_all"):
+                    logger.info(
+                        f"{broker_name.title()} adapter for user {user_id}: last client disconnected. Unsubscribing all symbols instead of disconnecting."
+                    )
+                    try:
                         adapter.unsubscribe_all()
-                    else:
-                        # For all other brokers, disconnect the adapter completely
-                        logger.info(
-                            f"Last client for user {user_id} disconnected. Disconnecting {broker_name or 'unknown broker'} adapter."
-                        )
+                    except Exception as e:
+                        logger.exception(f"Error unsubscribing all symbols for user {user_id}: {e}")
+                else:
+                    # For all other brokers, disconnect the adapter completely
+                    logger.info(
+                        f"Last client for user {user_id} disconnected. Disconnecting {broker_name or 'unknown broker'} adapter."
+                    )
+                    try:
                         adapter.disconnect()
-                except Exception as e:
-                    logger.exception(f"Error cleaning up adapter state for user {user_id}: {e}")
-                finally:
-                    # Guarantee removal from adapter mappings even if disconnect/unsubscribe raised an exception
-                    self.broker_adapters.pop(user_id, None)
-                    self.user_broker_mapping.pop(user_id, None)
+                    except Exception as e:
+                        logger.exception(f"Error cleaning up adapter state for user {user_id}: {e}")
+                    finally:
+                        # Guarantee removal from adapter mappings only for full disconnect branch
+                        self.broker_adapters.pop(user_id, None)
+                        self.user_broker_mapping.pop(user_id, None)
 
             self.user_mapping.pop(client_id, None)
 
@@ -1097,6 +1106,32 @@ class WebSocketProxy:
         logger.debug(f"Sending pong to client {client_id}: {response}")
         await self.send_message(client_id, response)
 
+    def _parse_subscriptions(self, sub_json_set):
+        """
+        Parse a set or list of raw subscription JSON strings into structured subscription dictionaries.
+
+        Args:
+            sub_json_set: Iterable of JSON formatted subscription strings
+
+        Returns:
+            List of dictionaries containing symbol, exchange, mode (label), and depth.
+        """
+        parsed = []
+        for sub_json in sub_json_set:
+            try:
+                sub = json.loads(sub_json)
+                mode_num = sub.get("mode", 2)
+                mode_label = MODE_CANONICAL.get(mode_num, "Quote")
+                parsed.append({
+                    "symbol": sub.get("symbol", ""),
+                    "exchange": sub.get("exchange", ""),
+                    "mode": mode_label,
+                    "depth": sub.get("depth_level", 5),
+                })
+            except (json.JSONDecodeError, TypeError):
+                continue
+        return parsed
+
     async def get_subscriptions(self, client_id, data):
         """
         Return the requesting client's own subscriptions with detail and summary.
@@ -1113,26 +1148,15 @@ class WebSocketProxy:
         broker_name = self.user_broker_mapping.get(user_id, "unknown")
 
         client_subs = self.subscriptions.get(client_id, set())
-        parsed = []
+        parsed = self._parse_subscriptions(client_subs)
         by_mode = {}
         by_exchange = {}
 
-        for sub_json in client_subs:
-            try:
-                sub = json.loads(sub_json)
-                mode_num = sub.get("mode", 2)
-                mode_label = MODE_CANONICAL.get(mode_num, "Quote")
-                exchange = sub.get("exchange", "")
-                parsed.append({
-                    "symbol": sub.get("symbol", ""),
-                    "exchange": exchange,
-                    "mode": mode_label,
-                    "depth": sub.get("depth_level", 5),
-                })
-                by_mode[mode_label] = by_mode.get(mode_label, 0) + 1
-                by_exchange[exchange] = by_exchange.get(exchange, 0) + 1
-            except (json.JSONDecodeError, TypeError):
-                continue
+        for sub in parsed:
+            mode_label = sub["mode"]
+            exchange = sub["exchange"]
+            by_mode[mode_label] = by_mode.get(mode_label, 0) + 1
+            by_exchange[exchange] = by_exchange.get(exchange, 0) + 1
 
         await self.send_message(
             client_id,
@@ -1165,6 +1189,7 @@ class WebSocketProxy:
         broker_name = self.user_broker_mapping.get(user_id, "unknown")
 
         # Global stats from subscription_index
+        # Note: subscriptions_count represents unique broker-level subscriptions (distinct (symbol, exchange, mode) entries), not a sum of per-client counts
         subscriptions_count = 0
         by_mode = {}
         by_exchange = {}
@@ -1178,20 +1203,7 @@ class WebSocketProxy:
         # Per-client detail from self.user_mapping (only active, authenticated clients)
         clients_list = []
         for cid in sorted(self.user_mapping.keys()):
-            subs = []
-            for sub_json in self.subscriptions.get(cid, set()):
-                try:
-                    sub = json.loads(sub_json)
-                    mode_num = sub.get("mode", 2)
-                    mode_label = MODE_CANONICAL.get(mode_num, "Quote")
-                    subs.append({
-                        "symbol": sub.get("symbol", ""),
-                        "exchange": sub.get("exchange", ""),
-                        "mode": mode_label,
-                        "depth": sub.get("depth_level", 5),
-                    })
-                except (json.JSONDecodeError, TypeError):
-                    continue
+            subs = self._parse_subscriptions(self.subscriptions.get(cid, set()))
             clients_list.append({
                 "client_id": cid,
                 "subscription_count": len(subs),

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -611,10 +611,29 @@ class WebSocketProxy:
             self.subscriptions.pop(client_id, None)
 
         # Defensive sweep: ensure client_id is completely purged from subscription_index
+        user_id = self.user_mapping.get(client_id)
         for sub_key, client_set in list(self.subscription_index.items()):
-            client_set.discard(client_id)
-            if not client_set:
-                self.subscription_index.pop(sub_key, None)
+            if client_id in client_set:
+                client_set.discard(client_id)
+                if not client_set:
+                    self.subscription_index.pop(sub_key, None)
+                    if (
+                        user_id
+                        and user_id in self.broker_adapters
+                        and isinstance(sub_key, tuple)
+                        and len(sub_key) == 3
+                    ):
+                        symbol, exchange, mode = sub_key
+                        try:
+                            adapter = self.broker_adapters[user_id]
+                            adapter.unsubscribe(symbol, exchange, mode)
+                            logger.debug(
+                                f"Defensive sweep: last client unsubscribed from {symbol}:{exchange}, unsubscribing from adapter"
+                            )
+                        except Exception as e:
+                            logger.exception(
+                                f"Error unsubscribing adapter in defensive sweep for {symbol}:{exchange}: {e}"
+                            )
 
         # Remove from user mapping safely
         if client_id in self.user_mapping:


### PR DESCRIPTION
Addresses #1490 by adding two new WebSocket actions for client subscription visibility and diagnostics:

- **`get_subscriptions`**: Returns the requesting client's active subscriptions with mode and exchange breakdown.
- **`get_global_subscriptions`**: Returns per-client subscriptions with a global summary (total clients, total subscriptions, by mode, by exchange).

### Other changes:
- **Robustness Fix:** Wrapped adapter cleanup on disconnect in a `try...except...finally` block in `cleanup_client` to prevent disconnected/inactive clients from lingering in memory with 0 subscriptions if the broker disconnect fails.
- **Playground Integration:** Added templates for the new actions to the WebSocket Composer dropdown list.
- **Docs:** Updated `WEBSOCKET_README.md` to document the new `.bru` template files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `get_subscriptions` and `get_global_subscriptions` WebSocket actions to inspect active subscriptions and global stats, and hardens disconnect cleanup to prevent stale clients and orphaned broker streams. Adds Playground templates, docs, and regression tests. Addresses #1490.

- **New Features**
  - `get_subscriptions`: Returns the requesting client’s subscriptions with symbol, exchange, canonical mode, depth, and a summary (count, by_mode, by_exchange, broker).
  - `get_global_subscriptions`: Returns per-client subscriptions plus a global summary (total_clients, subscriptions_count, by_mode, by_exchange, broker). Note: `subscriptions_count` is unique broker-level entries, not the sum of per-client counts.
  - Added WebSocket Composer templates and updated `WEBSOCKET_README.md`.

- **Bug Fixes**
  - Scoped adapter cleanup to the full-disconnect branch; keep-alive preserved for `flattrade`/`shoonya` via `unsubscribe_all` with try/except. Safe map removals using `.pop(...)` and set `.discard(...)`.
  - Defensive cleanup now purges `subscription_index` and calls `adapter.unsubscribe(symbol, exchange, mode)` when dropping the final client for a key, preventing orphaned ticks even if another client remains.
  - Normalized subscription parsing via `_parse_subscriptions`; global view filters to authenticated (active) clients. Added regression tests covering normal/raises disconnects, keep-alive paths, multi-client, and defensive sweep.

<sup>Written for commit 84ed528f27efc9e2b5f505b1354d5af60d248e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1495?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

