### PR TITLE
Added TODOs

### DIFF
--- a/restx_api/telegram_bot.py
+++ b/restx_api/telegram_bot.py
@@ -94,7 +94,9 @@ preferences_model = api.model(
 
 
 def run_async(coro):
-    """Helper to run async coroutine in sync context"""
+    """
+    TODO: Change to Google-style docstring using PEP 257.
+    Helper to run async coroutine in sync context"""
     loop = asyncio.new_event_loop()
     asyncio.set_event_loop(loop)
     try:
@@ -276,6 +278,7 @@ class StopBot(Resource):
 
 def get_webhook_secret():
     """
+    TODO: Change to Google style docstring using PEP 257.
     Get or generate webhook secret for Telegram webhook verification.
     Uses TELEGRAM_WEBHOOK_SECRET env var, or derives from bot token if not set.
     """


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Added TODOs in `restx_api/telegram_bot.py` to update `run_async` and `get_webhook_secret` docstrings to Google-style per PEP 257. No functional changes.

<sup>Written for commit c0803f46416145f68072e16465e7795f8e348226. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1496?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

