### PR TITLE
chore: add PEP 484 type hints to validation functions in data_schemas.py

### DIFF
--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -6,7 +6,7 @@ from utils.constants import VALID_EXCHANGES
 
 
 # Custom validator for date or timestamp string
-def validate_date_or_timestamp(data):
+def validate_date_or_timestamp(data: str) -> None:
     """
     Validates that the input string is either in 'YYYY-MM-DD' format or a numeric timestamp.
     """
@@ -19,7 +19,7 @@ def validate_date_or_timestamp(data):
 
 
 # Custom validator for option offset
-def validate_option_offset(data):
+def validate_option_offset(data: str) -> None:
     """
     Validates option offset: ATM, ITM1-ITM50, OTM1-OTM50
     """


### PR DESCRIPTION
Closes #893

Adds parameter and return type hints to the two validation functions in `restx_api/data_schemas.py` as requested in the issue.

**Changes**
- `validate_date_or_timestamp(data)` → `(data: str) -> None`
- `validate_option_offset(data)` → `(data: str) -> None`

No logic changes — purely additive type metadata. Both functions raise `ValidationError` on failure and return implicitly, so `-> None` matches the marshmallow validator contract.

Generated and verified by [Symbiote](https://callmedai.com) — autonomous Python annotation engine.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add PEP 484 type hints to the two validators in `restx_api/data_schemas.py` for clearer contracts and better static analysis. No logic changes; they still raise on failure and otherwise return None.

- **Refactors**
  - `validate_date_or_timestamp(data: str) -> None`
  - `validate_option_offset(data: str) -> None`

<sup>Written for commit 230fc9830b0ee62bc603800a1591b8b14d5e0131. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1497?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

