### PR TITLE
fix: normalize expiry date format in option chain service

### DIFF
--- a/services/option_chain_service.py
+++ b/services/option_chain_service.py
@@ -240,6 +240,9 @@ def get_option_chain(
         if not final_expiry:
             return False, {"status": "error", "message": "Expiry date is required."}, 400
 
+        # Normalize to DDMMMYY format: accept "16-JUN-26" (from expiry API) or "16JUN26"
+        final_expiry = final_expiry.upper().replace("-", "")
+
         # Step 2: Determine quote exchange for underlying LTP
         quote_exchange = exchange
         if exchange.upper() in ["NFO", "BFO"]:

--- a/services/option_symbol_service.py
+++ b/services/option_symbol_service.py
@@ -323,9 +323,10 @@ def get_available_strikes(
         _CACHE_STATS["misses"] += 1
         logger.debug(f"Cache MISS: Querying database for {base_symbol} {expiry_date} {option_type}")
 
-        # Convert expiry from DDMMMYY to DD-MMM-YY format used in database
-        # e.g., "28OCT25" -> "28-OCT-25"
-        expiry_formatted = f"{expiry_date[:2]}-{expiry_date[2:5]}-{expiry_date[5:]}"
+        # Normalize expiry to DDMMMYY (strip hyphens if caller passed "DD-MMM-YY")
+        # then convert to DD-MMM-YY for the DB expiry column.
+        expiry_no_dashes = expiry_date.upper().replace("-", "")
+        expiry_formatted = f"{expiry_no_dashes[:2]}-{expiry_no_dashes[2:5]}-{expiry_no_dashes[5:]}"
 
         if exchange.upper() in CRYPTO_EXCHANGES:
             # CRYPTO canonical format: BTC28FEB2580000CE (Indian F&O-style, no dashes)
@@ -347,8 +348,7 @@ def get_available_strikes(
         else:
             # Construct symbol pattern: BASE + EXPIRY (without hyphens) + % wildcard
             # e.g., "NIFTY" + "18NOV25" + "%" = "NIFTY18NOV25%"
-            expiry_no_hyphen = expiry_date.upper()  # Already in DDMMMYY format
-            symbol_pattern = f"{base_symbol}{expiry_no_hyphen}%{option_type.upper()}"
+            symbol_pattern = f"{base_symbol}{expiry_no_dashes}%{option_type.upper()}"
 
             # Query database for all strikes matching the criteria
             # Using LIKE to match symbol pattern and filter by exchange and instrumenttype


### PR DESCRIPTION
## Summary

- `/api/v1/expiry` returns dates in `DD-MMM-YY` format (e.g. `16-JUN-26`) because that is how they are stored in the DB
- The Strategy Builder passes this directly to `/api/v1/optionchain`, but `get_available_strikes()` assumed input was always `DDMMMYY` (no hyphens)
- This caused the symbol LIKE pattern to become `NIFTY16-JUN-26%CE` (no DB matches) and the expiry filter to become `16--JUN-26` (mangled string slice) — returning 0 strikes and a silent 404 for **all brokers** when an expiry is selected from the Strategy Builder dropdown

## Changes

- `services/option_chain_service.py`: normalize `final_expiry` to `DDMMMYY` immediately after it is determined, before it propagates to `get_available_strikes()` and `get_option_symbols_for_chain()`
- `services/option_symbol_service.py`: harden `get_available_strikes()` to strip hyphens before building the symbol pattern and DB expiry filter, so both `16JUN26` and `16-JUN-26` are accepted regardless of caller

## Test plan

- [x] `/api/v1/expiry` returns `16-JUN-26` style dates — verified unchanged
- [x] `/api/v1/optionchain` with `expiry_date: "16-JUN-26"` (hyphenated, as sent by frontend) now returns full chain with correct strikes and live quotes
- [x] `/api/v1/optionchain` with `expiry_date: "16JUN26"` (no hyphens, direct API call) continues to work as before
- [x] Strategy Builder option chain loads correctly end-to-end after selecting expiry from dropdown

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Normalize expiry date handling to fix empty option chains when selecting an expiry from Strategy Builder. `/api/v1/optionchain` now accepts both `DD-MMM-YY` and `DDMMMYY`.

- **Bug Fixes**
  - `services/option_chain_service.py`: normalize `final_expiry` to `DDMMMYY` (uppercase, no dashes) before downstream use.
  - `services/option_symbol_service.py`: strip hyphens and build correct DB filter (`DD-MMM-YY`) and symbol pattern (`BASEDDMMMYY%CE/PE`).

<sup>Written for commit eec2c3c3f4edde4390a25d669943d291beffa5e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1503?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

