### PR TITLE
fix(shoonya): include uid in GenAcsTok payload to fix INVALID_VERIFIER OAuth login

### DIFF
--- a/broker/shoonya/api/auth_api.py
+++ b/broker/shoonya/api/auth_api.py
@@ -18,6 +18,7 @@ def authenticate_broker(code):
         full_api_key = os.getenv("BROKER_API_KEY")
         if not full_api_key or ":::" not in full_api_key:
             return None, "BROKER_API_KEY must be in format userid:::client_id"
+        userid = full_api_key.split(":::")[0]  # Noren user id
         client_id = full_api_key.split(":::")[1]  # appKey / client_id
         secret_key = os.getenv("BROKER_API_SECRET")
         if not secret_key:
@@ -33,10 +34,13 @@ def authenticate_broker(code):
         checksum_input = f"{client_id}{secret_key}{code}"
         checksum = hashlib.sha256(checksum_input.encode()).hexdigest()
 
-        # Prepare token exchange payload
+        # Prepare token exchange payload. Shoonya's GenAcsTok requires the
+        # uid field; without it the server returns INVALID_VERIFIER even with
+        # a correct checksum (matches Finvasia's NorenRestApiOAuth.getAccessToken).
         payload = {
             "code": code,
             "checksum": checksum,
+            "uid": userid,
         }
 
         # Convert payload to jData format
@@ -53,7 +57,10 @@ def authenticate_broker(code):
         # Handle the response
         if response.status_code == 200:
             data = response.json()
-            if data.get("stat") == "Ok" and "access_token" in data:
+            # GenAcsTok success returns the access_token; it is not guaranteed
+            # to carry stat == "Ok", so key the success on access_token presence
+            # (matches Finvasia's NorenRestApiOAuth.getAccessToken).
+            if "access_token" in data:
                 logger.info("Shoonya authentication successful")
                 return data["access_token"], None
             else:


### PR DESCRIPTION
## What

Fixes Shoonya OAuth login failing with `Invalid Input : INVALID_VERIFIER`.

Closes #1508.

## Why

`broker/shoonya/api/auth_api.py` omits the **`uid`** field from the GenAcsTok `jData` payload. Finvasia's own `NorenRestApiOAuth.getAccessToken` sends it:

```python
values = {"code": authcode, "checksum": app_verifier, "uid": UID}
```

Without `uid`, Shoonya returns `INVALID_VERIFIER` even with a correct `SHA256(client_id + secret + code)` checksum, so retail Shoonya OAuth accounts cannot connect.

## Changes

- Extract `userid` from `BROKER_API_KEY` (`userid:::client_id`) and include `"uid": userid` in the GenAcsTok payload. **(the fix)**
- Key the success branch on `access_token` presence rather than requiring `stat == "Ok"`, matching the reference library — the GenAcsTok success response is not documented to carry `stat`, so this avoids a false-negative. Loosening it can only accept valid token-bearing responses, never reject them.

The checksum construction and endpoint are unchanged.

## Verification

Verified end-to-end on a live FN-series Shoonya account on 2026-06-13: after the change the token exchange succeeds, the master contract downloads, and ~186k symbols load into cache. Two-line behavioural change; no other broker touched.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Shoonya OAuth login errors (`INVALID_VERIFIER`) by sending the required `uid` in the GenAcsTok request. Also updates success handling to accept any response that includes `access_token`.

- **Bug Fixes**
  - Extract `userid` from `BROKER_API_KEY` (`userid:::client_id`) and include `"uid": userid` in the GenAcsTok `jData`.
  - Consider the exchange successful when `access_token` is present, instead of requiring `stat == "Ok"`.

<sup>Written for commit 130a956415681d25fe56d9e7c957eab5b891d2ad. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1509?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

