### PR TITLE
fix(whatsapp): bump wars to 0.1.4 (PN→LID delivery) + fix on_disconnect crash

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -113,7 +113,7 @@ dependencies = [
   "python-multipart==0.0.27",
   "python-socketio==5.16.1",
   "python-telegram-bot==22.6",
-  "wars==0.1.3",
+  "wars==0.1.4",
   "pytz==2026.1.post1",
   "PyYAML==6.0.3",
   "pyzmq==27.1.0",

--- a/requirements-nginx.txt
+++ b/requirements-nginx.txt
@@ -108,7 +108,7 @@ python-engineio==4.13.1
 python-multipart==0.0.27
 python-socketio==5.16.1
 python-telegram-bot==22.6
-wars==0.1.3
+wars==0.1.4
 pytz==2026.1.post1
 PyYAML==6.0.3
 pyzmq==27.1.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -108,7 +108,7 @@ python-engineio==4.13.1
 python-multipart==0.0.27
 python-socketio==5.16.1
 python-telegram-bot==22.6
-wars==0.1.3
+wars==0.1.4
 pytz==2026.1.post1
 PyYAML==6.0.3
 pyzmq==27.1.0

--- a/services/whatsapp_bot_service.py
+++ b/services/whatsapp_bot_service.py
@@ -829,32 +829,34 @@ class WhatsAppBotService:
         for jid in recipients:
             try:
                 if jid == self._SELF_MARKER:
-                    # Self-send. Per wars docs, `send("text")` (single-arg)
-                    # routes to the paired device's own number without
-                    # needing us to know the JID. Media-to-self isn't
-                    # supported in wars 0.1 single-arg form, so we require
-                    # an explicit JID for that case — captured lazily from
-                    # incoming is_from_me messages and surfaced after the
-                    # first round-trip.
+                    # Self-send. PREFER the captured owner JID (reliable): sending
+                    # explicitly to own_jid lands in the "Message Yourself" chat.
+                    # The single-arg wars.send("text") "route to owner" form does
+                    # NOT reliably deliver in wars 0.1.3 (it returns without error
+                    # but nothing arrives), so we only use it as a last-resort
+                    # fallback when own_jid hasn't been captured yet.
+                    cfg_jid = get_bot_config().get("own_jid")
                     if media_kwargs:
-                        cfg_jid = get_bot_config().get("own_jid")
                         if not cfg_jid:
                             raise RuntimeError(
                                 "Self-send with media needs the owner JID. "
                                 "Send any /command from your phone first so "
                                 "we can capture it, then retry."
                             )
-                        self._wa.send(cfg_jid, **media_kwargs)
+                        ret = self._wa.send(cfg_jid, **media_kwargs)
                         if document and (text or caption):
                             self._wa.send(cfg_jid, text or caption)
+                    elif cfg_jid:
+                        ret = self._wa.send(cfg_jid, text or "")  # explicit owner JID
                     else:
-                        self._wa.send(text or "")  # single-arg → owner
+                        ret = self._wa.send(text or "")  # single-arg fallback
                 elif media_kwargs:
-                    self._wa.send(jid, **media_kwargs)
+                    ret = self._wa.send(jid, **media_kwargs)
                     if document and (text or caption):
                         self._wa.send(jid, text or caption)
                 else:
-                    self._wa.send(jid, text or "")
+                    ret = self._wa.send(jid, text or "")
+                logger.info("WhatsApp send to %s -> %r", jid, ret)
                 report["sent"].append(jid)
             except Exception as e:
                 logger.exception("WhatsApp send to %s failed", jid)
@@ -899,6 +901,15 @@ class WhatsAppBotService:
             except Exception:
                 logger.exception("WhatsApp message handler crashed")
 
+        @wa.on_disconnect
+        def _on_disconnect() -> None:
+            logger.warning("WhatsApp wars on_disconnect fired")
+            with self._lock:
+                self._is_running = False
+            self._emit(
+                "whatsapp_status", {"is_running": False, "is_paired": self.is_paired}
+            )
+
     def _maybe_capture_own_jid(self, sender_jid: str) -> None:
         """Persist sender_jid as the device's own JID + own_phone if we
         don't have one yet. Idempotent — once set we never overwrite."""
@@ -907,7 +918,6 @@ class WhatsAppBotService:
         cfg = get_bot_config()
         if cfg.get("own_jid"):
             return
-        from database.whatsapp_db import save_session_blob  # local to avoid cycle
         # We don't want to re-encrypt the blob — there's no API for
         # "update identity only". Cheapest path: a tiny dedicated DB helper.
         from database.whatsapp_db import _persist_owner_identity  # noqa: E501
@@ -921,15 +931,6 @@ class WhatsAppBotService:
             logger.info("WhatsApp: captured own_jid=%s lazily", sender_jid)
         except Exception:
             logger.exception("Failed to persist own_jid")
-
-        @wa.on_disconnect
-        def _on_disconnect() -> None:
-            logger.warning("WhatsApp wars on_disconnect fired")
-            with self._lock:
-                self._is_running = False
-            self._emit(
-                "whatsapp_status", {"is_running": False, "is_paired": self.is_paired}
-            )
 
     def _dispatch_command(self, wa, msg, text: str) -> None:
         """Parse `/cmd arg1 arg2 ...` and route to the matching handler.

--- a/uv.lock
+++ b/uv.lock
@@ -1849,7 +1849,7 @@ requires-dist = [
     { name = "tzlocal", specifier = "==5.3.1" },
     { name = "urllib3", specifier = "==2.7.0" },
     { name = "uvicorn", specifier = "==0.44.0" },
-    { name = "wars", specifier = "==0.1.3" },
+    { name = "wars", specifier = "==0.1.4" },
     { name = "wcwidth", specifier = "==0.6.0" },
     { name = "websocket-client", specifier = "==1.9.0" },
     { name = "websockets", specifier = "==15.0.1" },
@@ -3205,17 +3205,17 @@ wheels = [
 
 [[package]]
 name = "wars"
-version = "0.1.3"
+version = "0.1.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "qrcode", extra = ["pil"] },
 ]
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/52/9c/c801518ec5b3edd5695601cccaac9eabcd4d702f111839072da2c4e97b3e/wars-0.1.3-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:31b261f52a8df71a3888f0c600bf577e195035ebcb2f2ab3cdf933de2d7520a1", size = 6485955, upload-time = "2026-05-17T02:13:11.852Z" },
-    { url = "https://files.pythonhosted.org/packages/a1/dc/28ddb0ccff13f34864ebbf57bacf3a703f03171f8628b44ce219ecc320e2/wars-0.1.3-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:bf5f827106b9ca575e910eaf9542d95ffc8429ab14eb7f419e4409aeb0ceba56", size = 6082421, upload-time = "2026-05-17T02:13:14.284Z" },
-    { url = "https://files.pythonhosted.org/packages/44/01/024d3898c6bc6c895f243e900fe431bbe5bbffa4a0e401bc3d75be279f77/wars-0.1.3-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:aba35e9331bc0644ea535e0e2a99f169d8fce467680ccde89fa0823f79dfc44a", size = 6222786, upload-time = "2026-05-17T02:13:16.321Z" },
-    { url = "https://files.pythonhosted.org/packages/53/6a/18852e5159004246b00f836b3481e2a028aba50e02d6c3f71b63b746ede6/wars-0.1.3-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:3fd4a40822a301f727b620c2e59ef04c86e65b6d36a80c446e6a0718244a112a", size = 6743583, upload-time = "2026-05-17T02:13:18.599Z" },
-    { url = "https://files.pythonhosted.org/packages/78/cb/d0820994018014527f048b8f321d3064dd1c0a261e4f257ed9ff136b4810/wars-0.1.3-cp38-abi3-win_amd64.whl", hash = "sha256:612d5bdf5a0d934d064ae4c0d8c549dbd065afac6a039f816a5a5d6fb7f122bd", size = 7015317, upload-time = "2026-05-17T02:13:20.5Z" },
+    { url = "https://files.pythonhosted.org/packages/a2/4b/18b40e2ab13318c42f560f21d73d0759c1dea7a18b29ec7efabe644b2408/wars-0.1.4-cp38-abi3-macosx_10_12_x86_64.whl", hash = "sha256:6269e23f26005a6325787f2cbd301fcc8e22da024d768b6856978690636ff340", size = 6181615, upload-time = "2026-06-14T17:45:54.87Z" },
+    { url = "https://files.pythonhosted.org/packages/03/ad/01be49827393520185734a669f627f8924bbac9dff111102dae40d69d3d8/wars-0.1.4-cp38-abi3-macosx_11_0_arm64.whl", hash = "sha256:570e41aebd6777f70df38d2fb98ea38ac26664dc34ccb949b21a4efd207986aa", size = 5790476, upload-time = "2026-06-14T17:45:57.04Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/9d/21ce3ad24b8429d107d12ca9f02ebafd0353f38023e8e8458c76824e2709/wars-0.1.4-cp38-abi3-manylinux_2_28_aarch64.whl", hash = "sha256:a5d0de216e17ff18486626b977e15425d9218cfd0ba2caeb28ea3a5d59818648", size = 5912616, upload-time = "2026-06-14T17:45:59.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/e6/62a29d50a6c518f309ef0e4c185adc5c3bfaae6d5ebbc5e67f25cac2251e/wars-0.1.4-cp38-abi3-manylinux_2_28_x86_64.whl", hash = "sha256:6a10d382f3ba818234a03ea7baaced87bcefee07379465baccff459c14c228a1", size = 6430810, upload-time = "2026-06-14T17:46:01.707Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/6c/974993ccc855fb1032b10a1029c249cc4a77d276cc9df544c0c812ac3b6b/wars-0.1.4-cp38-abi3-win_amd64.whl", hash = "sha256:02a2ecd1df3d6ec56d929939344d1e4513faccc06385b05bf1ce11fbe0f79779", size = 6745831, upload-time = "2026-06-14T17:46:03.415Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary

Restores WhatsApp message delivery, which broke when WhatsApp's server-side **PN→LID** device-addressing migration reached the account.

- **Bump `wars` 0.1.3 → 0.1.4** (`pyproject.toml`, `requirements.txt`, `requirements-nginx.txt`, `uv.lock`). 0.1.4 is rebuilt against the current `whatsapp-rust` core, which handles the PN→LID Signal-session migration. Pre-0.1.4, sends returned a `message_id` but the core logged `session not found. Skipping` and silently dropped delivery (`{"sent":["<self>"]}` with nothing received).
- **Fix `NameError` in `whatsapp_bot_service.py`**: the `@wa.on_disconnect` handler was misplaced inside `_maybe_capture_own_jid` (where `wa` is undefined), crashing the inbound message handler on the first `is_from_me` message. Moved it into `_register_handlers` and dropped the now-unused `save_session_blob` import.

## Testing

- Verified self-send delivery end-to-end with `wars` 0.1.4 (message received on the paired phone).
- `uv sync` resolves `wars==0.1.4` from PyPI (all 5 platform wheels published).

🤖 Generated with [Claude Code](https://claude.com/claude-code)