### PR TITLE
docs: add Delta Exchange symbol format examples

### DIFF
--- a/docs/prompt/symbol-format.md
+++ b/docs/prompt/symbol-format.md
@@ -72,6 +72,14 @@ Options symbols in OpenAlgo are structured to include the base symbol, the expir
 
 * **Example:** For an Goverent bond (726GS2032) put option with a strike price of 97, expiring on 25th April 2024, the symbol would be `726GS203225APR2497PE`.
 
+**Crypto Options (Delta Exchange):**
+
+Delta Exchange instruments use OpenAlgo's broker-agnostic `CRYPTO` exchange code. Option symbols follow the same canonical OpenAlgo format as other options, while the broker-native Delta symbol is stored separately as `brsymbol`.
+
+* **Example:** For a BTC call option with a strike price of 80,000, expiring on 28th February 2025, the OpenAlgo symbol would be `BTC28FEB2580000CE` and the Delta-native symbol would be `C-BTC-80000-280225`.
+* **Example:** For a BTC put option with a strike price of 80,000, expiring on 28th February 2025, the OpenAlgo symbol would be `BTC28FEB2580000PE` and the Delta-native symbol would be `P-BTC-80000-280225`.
+* **Example:** For an ETH put option with a strike price of 2,500, expiring on 28th February 2025, the OpenAlgo symbol would be `ETH28FEB252500PE` and the Delta-native symbol would be `P-ETH-2500-280225`.
+
 ### Common NSE Index Symbols (Exchange Code : NSE\_INDEX)
 
 {% columns %}
@@ -275,10 +283,24 @@ The supported exchange symbol formats in OpenAlgo allow for an identification sy
 * **CDS:** `CDS` for NSE Currency Derivatives.
 * **MCX:** `MCX` for commodities traded on the Multi Commodity Exchange.
 * **NCO:** `NCO` for NSE Commodities (futures + options). Zerodha only.
+* **CRYPTO:** `CRYPTO` for crypto futures, perpetual futures, spot, and options through the Delta Exchange plugin.
 * **NSE\_INDEX:** `NSE_INDEX` for indices on the National Stock Exchange.
 * **BSE\_INDEX:** `BSE_INDEX` for indices on the Bombay Stock Exchange.
 * **MCX\_INDEX:** `MCX_INDEX` for MCX commodity sectoral indices (MCXBULLDEX, MCXMETLDEX, MCXAGRI, ...). Quote-only.
 * **GLOBAL\_INDEX:** `GLOBAL_INDEX` for global indices (US30, JAPAN225, HANGSENG, FRANCE40, AUS200, GIFTNIFTY, ...). Quote-only. Zerodha only.
+
+### Crypto Symbol Examples (Exchange Code : CRYPTO)
+
+Delta Exchange symbols are stored in OpenAlgo's canonical format for `symbol`, with the exchange's native symbol stored in `brsymbol`.
+
+| Instrument | OpenAlgo Symbol | Delta-native brsymbol |
+| ---------- | --------------- | --------------------- |
+| BTC perpetual future | `BTCUSDFUT` | `BTCUSD` |
+| BTC dated future, 28th Feb 2025 | `BTC28FEB25FUT` | `BTCUSD28Feb2025` |
+| BTC 80000 Call, 28th Feb 2025 | `BTC28FEB2580000CE` | `C-BTC-80000-280225` |
+| BTC 80000 Put, 28th Feb 2025 | `BTC28FEB2580000PE` | `P-BTC-80000-280225` |
+
+When placing orders or calling APIs, use the OpenAlgo symbol with `exchange: "CRYPTO"` rather than the Delta-native `brsymbol`.
 
 ### Database Schema (Common Symbols)
 

--- a/docs/userguide/symbol-format/README.md
+++ b/docs/userguide/symbol-format/README.md
@@ -28,6 +28,11 @@ Understanding the symbol format is **essential** for placing orders correctly. I
 │  Format: [Symbol][DD][MMM][YY][Strike][CE/PE]                               │
 │  Example: NIFTY30JAN2521500CE, BANKNIFTY27FEB2548000PE                     │
 │                                                                              │
+│  CRYPTO                                                                      │
+│  ──────                                                                      │
+│  Exchange: CRYPTO                                                            │
+│  Examples: BTCUSDFUT, BTC28FEB2580000CE, ETH28FEB252500PE                  │
+│                                                                              │
 └─────────────────────────────────────────────────────────────────────────────┘
 ```
 
@@ -160,6 +165,16 @@ Where:
 | Crude Oil 6500 Call, 17th Feb 2025 | `CRUDEOIL17FEB256500CE` |
 | Gold 62000 Put, 5th Feb 2025 | `GOLD05FEB2562000PE` |
 
+#### Crypto Options (Delta Exchange)
+
+Delta Exchange instruments use OpenAlgo's broker-agnostic `CRYPTO` exchange code. Option symbols follow the same canonical format as other OpenAlgo options.
+
+| Description | OpenAlgo Symbol | Delta-native symbol |
+|-------------|-----------------|---------------------|
+| BTC 80000 Call, 28th Feb 2025 | `BTC28FEB2580000CE` | `C-BTC-80000-280225` |
+| BTC 80000 Put, 28th Feb 2025 | `BTC28FEB2580000PE` | `P-BTC-80000-280225` |
+| ETH 2500 Put, 28th Feb 2025 | `ETH28FEB252500PE` | `P-ETH-2500-280225` |
+
 ### Usage
 
 ```json
@@ -204,6 +219,12 @@ OpenAlgo uses standardized exchange codes to identify trading venues.
 |----------|------|-------------|
 | Multi Commodity Exchange | `MCX` | Commodities trading |
 | NSE Commodities | `NCO` | NSE commodity futures and options (currently Zerodha only) |
+
+### Crypto Derivatives
+
+| Exchange | Code | Description |
+|----------|------|-------------|
+| Delta Exchange | `CRYPTO` | Crypto futures, perpetual futures, spot, and options through the Delta Exchange plugin |
 
 ### Index Symbols
 
@@ -377,6 +398,36 @@ OpenAlgo has rolled out a **standardized index symbol set across all supported b
 }
 ```
 
+### Crypto Perpetual Futures Order
+
+```json
+{
+  "apikey": "your-api-key",
+  "strategy": "CryptoStrategy",
+  "symbol": "BTCUSDFUT",
+  "exchange": "CRYPTO",
+  "action": "BUY",
+  "quantity": "1",
+  "pricetype": "MARKET",
+  "product": "NRML"
+}
+```
+
+### Crypto Options Order
+
+```json
+{
+  "apikey": "your-api-key",
+  "strategy": "CryptoOptionsStrategy",
+  "symbol": "BTC28FEB2580000CE",
+  "exchange": "CRYPTO",
+  "action": "BUY",
+  "quantity": "1",
+  "pricetype": "MARKET",
+  "product": "NRML"
+}
+```
+
 ## Multi-Leg Options Strategies
 
 ### Bull Call Spread
@@ -503,6 +554,13 @@ POST /api/v1/search
 ✅ "SBIN"          (uppercase - correct)
 ```
 
+### Mistake 5: Using Delta-Native Symbols Directly
+
+```
+❌ C-BTC-80000-280225 with exchange: "CRYPTO"  (Delta-native option symbol)
+✅ BTC28FEB2580000CE with exchange: "CRYPTO"   (OpenAlgo canonical symbol)
+```
+
 ## Troubleshooting
 
 | Error | Cause | Solution |
@@ -525,6 +583,8 @@ POST /api/v1/search
 │  Future        [Symbol][DD][MMM][YY]FUT    NIFTY30JAN25FUT                  │
 │  Call Option   [Symbol][DD][MMM][YY][Strike]CE   NIFTY30JAN2521500CE       │
 │  Put Option    [Symbol][DD][MMM][YY][Strike]PE   NIFTY30JAN2521000PE       │
+│  Crypto Perp   [Symbol]USDFUT              BTCUSDFUT                       │
+│  Crypto Option [Symbol][DD][MMM][YY][Strike]CE/PE BTC28FEB2580000CE        │
 │                                                                              │
 │  EXCHANGE CODES                                                             │
 │  ──────────────                                                             │
@@ -532,6 +592,7 @@ POST /api/v1/search
 │  BSE     = BSE Equity           BFO = BSE F&O                              │
 │  CDS     = NSE Currency         BCD = BSE Currency                         │
 │  MCX     = Commodities                                                      │
+│  CRYPTO  = Crypto derivatives                                               │
 │  NSE_INDEX / BSE_INDEX = Index values                                       │
 │                                                                              │
 │  PRODUCT CODES                                                              │


### PR DESCRIPTION
## Summary
- add Delta Exchange / CRYPTO examples to the live symbol-format docs source
- add matching examples to the userguide symbol-format reference
- clarify that API calls should use OpenAlgo canonical symbols while Delta-native symbols are stored as brsymbol

Fixes #1390.

## Verification
- git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add Delta Exchange `CRYPTO` symbol examples to the symbol-format docs and user guide for perps, dated futures, and options. Clarifies that APIs must use OpenAlgo canonical symbols with `exchange: "CRYPTO"` while Delta-native symbols are stored as `brsymbol`, and adds quick tables and order JSON samples to reduce symbol confusion (fixes #1390).

<sup>Written for commit 09b22eb547b707f0c3b8c387949b2f194bd22cb5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1514?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

