### PR TITLE
fix(fivepaisa): support market orders via MPP and fix smart order auth  , return historical candles for index symbols , close WebSocket FD/thread leaks in reconnect path, harden WebSocket reconnect (ping timeout, interruptible backoff, race),chore(fivepaisa): demote verbose per-chunk history logs to debug and feat(fivepaisa): batch WebSocket subscriptions like Zerodha 

### DIFF
--- a/broker/fivepaisa/api/data.py
+++ b/broker/fivepaisa/api/data.py
@@ -709,8 +709,15 @@ class BrokerData:
                 interval = "1d"  # Always use 1d internally for daily
                 logger.debug(f"Debug: Converted interval from {original_interval} to {interval}")
 
+            # Normalize exchange for index symbols. Index tokens are stored under
+            # NSE_INDEX / BSE_INDEX in the symbol DB, so looking them up with the
+            # raw NSE / BSE exchange returns the wrong (or no) token and the
+            # historical API then returns nothing.
+            normalized_exchange = normalize_exchange_for_query(symbol, exchange)
+            is_index = normalized_exchange.endswith("_INDEX")
+
             # Get token from symbol
-            token = get_token(symbol, exchange)
+            token = get_token(symbol, normalized_exchange)
 
             # Map interval
             fivepaisa_interval = self.map_interval(interval)
@@ -809,16 +816,22 @@ class BrokerData:
                             # 1. Zero volume
                             # 2. All prices are zero
                             # 3. High = Low (usually indicates no trading)
-                            if (
-                                volume == 0
-                                or (
-                                    open_price == 0
-                                    and high_price == 0
-                                    and low_price == 0
-                                    and close_price == 0
-                                )
-                                or (high_price == low_price)
-                            ):
+                            #
+                            # Indices (NIFTY, SENSEX, INDIAVIX, ...) have no traded
+                            # volume, so a zero-volume candle is valid data for them.
+                            # Applying the volume/high==low filters to indices drops
+                            # every candle. For indices we only skip fully-empty
+                            # (all-zero OHLC) candles.
+                            all_prices_zero = (
+                                open_price == 0
+                                and high_price == 0
+                                and low_price == 0
+                                and close_price == 0
+                            )
+                            if is_index:
+                                if all_prices_zero:
+                                    continue
+                            elif volume == 0 or all_prices_zero or (high_price == low_price):
                                 continue
 
                             # For daily candles, create timestamp at midnight UTC like Angel does

--- a/broker/fivepaisa/api/data.py
+++ b/broker/fivepaisa/api/data.py
@@ -469,7 +469,7 @@ class BrokerData:
 
                 for i in range(0, len(symbols), BATCH_SIZE):
                     batch = symbols[i : i + BATCH_SIZE]
-                    logger.info(
+                    logger.debug(
                         f"Processing batch {i // BATCH_SIZE + 1}: symbols {i + 1} to {min(i + BATCH_SIZE, len(symbols))}"
                     )
 
@@ -683,7 +683,7 @@ class BrokerData:
         # Reorder columns
         df = df[["timestamp", "open", "high", "low", "close", "volume"]]
 
-        logger.info(f"Processed {len(df)} candles from raw data")
+        logger.debug(f"Processed {len(df)} candles from raw data")
         return df
 
     def get_history(
@@ -789,7 +789,7 @@ class BrokerData:
 
                     candles = response.get("data", {}).get("candles", [])
                     if not candles:
-                        logger.info(f"No data for chunk {chunk_start} to {chunk_end}")
+                        logger.debug(f"No data for chunk {chunk_start} to {chunk_end}")
                         current_start = current_end + pd.Timedelta(days=1)
                         continue
 
@@ -892,7 +892,7 @@ class BrokerData:
                             )
                             continue
                         dfs.append(chunk_df)
-                        logger.info(f"Added {len(transformed_candles)} candles from chunk")
+                        logger.debug(f"Added {len(transformed_candles)} candles from chunk")
 
                 except Exception as e:
                     logger.error(f"Error processing chunk {chunk_start} to {chunk_end}: {e}")

--- a/broker/fivepaisa/api/order_api.py
+++ b/broker/fivepaisa/api/order_api.py
@@ -296,12 +296,18 @@ def place_order_api(data: dict[str, Any], auth: str) -> dict[str, Any]:
     AUTH_TOKEN = auth
 
     token = get_token(data["symbol"], data["exchange"])
-    newdata = transform_data(data, token)
+    # Pass the auth token so transform_data can fetch quotes for Market Price
+    # Protection (5Paisa rejects plain market orders; MARKET -> protected LIMIT).
+    newdata = transform_data(data, token, AUTH_TOKEN)
     headers = {"Content-Type": "application/json", "Authorization": f"bearer {AUTH_TOKEN}"}
 
     json_data = {"head": {"key": api_key}, "body": newdata}
 
     payload = json.dumps(json_data)
+
+    # Log the outgoing request at INFO so order placement is captured even when
+    # LOG_LEVEL is the default INFO (sensitive keys are redacted by the logger).
+    logger.info(f"5Paisa PlaceOrder request: {payload}")
 
     try:
         # Get the shared httpx client
@@ -316,15 +322,51 @@ def place_order_api(data: dict[str, Any], auth: str) -> dict[str, Any]:
         response.raise_for_status()
         response_data = response.json()
 
-        logger.debug(f"Order Response: {response_data}")
+        logger.info(f"5Paisa PlaceOrder response: {response_data}")
 
-        if response_data["head"]["statusDescription"] == "Success":
-            orderid = response_data["body"]["BrokerOrderID"]
+        head = response_data.get("head", {}) or {}
+        body = response_data.get("body", {}) or {}
+        broker_order_id = body.get("BrokerOrderID", 0)
+        body_status = body.get("Status")
+        broker_message = body.get("Message", "")
+
+        # 5Paisa sends Status as int 0, but normalize in case it arrives as "0".
+        try:
+            status_ok = int(body_status) == 0
+        except (TypeError, ValueError):
+            status_ok = False
+
+        # 5Paisa returns HTTP 200 with head.statusDescription == "Success" even
+        # when the order is rejected by RMS. A genuinely accepted order has
+        # body.Status == 0 AND a non-zero BrokerOrderID. Anything else (margin
+        # shortfall, market closed, invalid scrip, etc.) is a rejection and must
+        # NOT be reported as a phantom success with orderid 0.
+        if (
+            head.get("statusDescription") == "Success"
+            and status_ok
+            and broker_order_id
+        ):
+            orderid = broker_order_id
+            # Add status attribute to make it compatible with place_order.py
+            response.status = response.status_code
         else:
             orderid = None
-
-        # Add status attribute to make it compatible with place_order.py
-        response.status = response.status_code
+            reason = (
+                broker_message
+                or head.get("statusDescription")
+                or "Order rejected by 5Paisa"
+            )
+            logger.error(
+                f"5Paisa order rejected - Status: {body_status}, "
+                f"BrokerOrderID: {broker_order_id}, "
+                f"RMSResponseCode: {body.get('RMSResponseCode')}, Message: {reason}"
+            )
+            # Surface the broker's rejection reason to the service layer, which
+            # reads response_data.get("message") and res.status.
+            response_data["message"] = reason
+            # Force a non-200 status so place_order_service reports an error
+            # instead of a success with orderid 0.
+            response.status = 400
 
         return response, response_data, orderid
 
@@ -423,7 +465,7 @@ def _place_smartorder_locked(data, AUTH_TOKEN, symbol, exchange, product):
 
         # logger.debug(f"{order_data}")
         # Place the order
-        res, response, orderid = place_order_api(order_data, auth)
+        res, response, orderid = place_order_api(order_data, AUTH_TOKEN)
         _invalidate_position_cache(AUTH_TOKEN)
         logger.debug(f"{response}")
         logger.debug(f"{orderid}")

--- a/broker/fivepaisa/mapping/transform_data.py
+++ b/broker/fivepaisa/mapping/transform_data.py
@@ -1,23 +1,93 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Angel Broking Parameters https://smartapi.angelbroking.com/docs/Orders
 
-from database.token_db import get_br_symbol
+from database.token_db import get_br_symbol, get_symbol_info
+from utils.logging import get_logger
+from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
+
+logger = get_logger(__name__)
 
 
-def transform_data(data, token):
+def transform_data(data, token, auth_token=None):
     """
     Transforms the new API request structure to the current expected structure.
+
+    5Paisa does not accept plain market orders (Price=0 is rejected by RMS).
+    For MARKET orders we apply Market Price Protection (MPP): fetch the LTP,
+    add/subtract a slab-based buffer (rounded to tick size), and send a LIMIT
+    order at that protected price. This mirrors the Flattrade implementation.
     """
     symbol = get_br_symbol(data["symbol"], data["exchange"])
+    action = data["action"].upper()
+
+    # Default price comes straight from the request (LIMIT / SL orders).
+    price = float(data.get("price", "0"))
+
+    # Apply Market Price Protection for MARKET orders
+    if data.get("pricetype") == "MARKET":
+        logger.info(
+            f"MPP: MARKET order detected for Symbol={data['symbol']}, "
+            f"Exchange={data['exchange']}, Action={action}"
+        )
+        try:
+            if auth_token:
+                # Lazy import to avoid a circular import at module load time
+                from broker.fivepaisa.api.data import BrokerData
+
+                broker_data = BrokerData(auth_token)
+                quote_data = broker_data.get_quotes(data["symbol"], data["exchange"])
+                ltp = float((quote_data or {}).get("ltp", 0))
+
+                # 5Paisa quotes don't carry tick size; pull it from the symbol DB.
+                tick_size = None
+                sym_info = get_symbol_info(data["symbol"], data["exchange"])
+                if sym_info is not None:
+                    tick_size = getattr(sym_info, "tick_size", None)
+
+                instrument_type = get_instrument_type_from_symbol(data["symbol"])
+                logger.info(
+                    f"MPP Quote: Symbol={data['symbol']}, LTP={ltp}, "
+                    f"InstrumentType={instrument_type}, TickSize={tick_size}"
+                )
+
+                if ltp > 0:
+                    protected_price = calculate_protected_price(
+                        price=ltp,
+                        action=action,
+                        symbol=data["symbol"],
+                        instrument_type=instrument_type,
+                        tick_size=tick_size,
+                    )
+                    price = protected_price
+                    logger.info(
+                        f"MPP Conversion Complete: Symbol={data['symbol']}, "
+                        f"OrderType=MARKET->LIMIT, FinalPrice={protected_price}"
+                    )
+                else:
+                    logger.warning(
+                        f"MPP Warning: LTP is 0 or invalid for Symbol={data['symbol']}, "
+                        f"Exchange={data['exchange']}. Sending price={price} as-is."
+                    )
+            else:
+                logger.warning(
+                    f"MPP Warning: No auth token available for Symbol={data['symbol']}. "
+                    f"Cannot fetch quote for MPP adjustment."
+                )
+        except Exception as e:
+            logger.error(
+                f"MPP Error: Failed to apply MPP for Symbol={data['symbol']}, "
+                f"Exchange={data['exchange']}, Error={e}. Sending price={price} as-is."
+            )
+
     # Basic mapping
     transformed = {
-        "OrderType": map_action(data["action"].upper()),
+        "OrderType": map_action(action),
         "Exchange": map_exchange(data["exchange"]),
         "ExchangeType": map_exchange_type(data["exchange"]),
         "ScripCode": token,
         # "ScriData": symbol,
         # "iOrderValidity": "0",
-        "Price": float(data.get("price", "0")),
+        "Price": price,
         "Qty": int(data["quantity"]),
         "StopLossPrice": float(data.get("trigger_price", "0")),
         "DisQty": int(data.get("disclosed_quantity", "0")),

--- a/broker/fivepaisa/streaming/fivepaisa_adapter.py
+++ b/broker/fivepaisa/streaming/fivepaisa_adapter.py
@@ -37,6 +37,9 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.max_reconnect_attempts = 10
         self.running = False
         self.lock = threading.Lock()
+        # Single reconnect driver: only one _connect_with_retry thread may be
+        # alive at a time so two run_forever sockets can never overlap.
+        self._connect_thread = None
         self.last_snapshot = {}  # Store last known values for each token
 
     def initialize(
@@ -140,7 +143,18 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 new_client.on_error = self._on_error
                 new_client.on_close = self._on_close
                 new_client.on_message = self._on_message
+
+                # Close the previous client before dropping the reference so its
+                # socket/ping thread are released now rather than waiting on GC
+                # (which is not guaranteed to close the underlying socket).
+                old_client = self.ws_client
                 self.ws_client = new_client
+                if old_client is not None:
+                    try:
+                        old_client.close_connection()
+                    except Exception as e:
+                        self.logger.debug(f"Error closing previous WebSocket client: {e}")
+
                 self.logger.info("Rebuilt 5Paisa WebSocket client with fresh auth token")
             except Exception as e:
                 self.logger.error(f"Failed to rebuild client with fresh token: {e}")
@@ -151,10 +165,29 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.error("WebSocket client not initialized. Call initialize() first.")
             return
 
-        threading.Thread(target=self._connect_with_retry, daemon=True).start()
+        with self.lock:
+            # Reset run/backoff state so an adapter reused after disconnect() or
+            # after a prior max-attempts giveup will actually reconnect.
+            self.running = True
+            self.reconnect_attempts = 0
+            if self._connect_thread and self._connect_thread.is_alive():
+                self.logger.debug("Connect thread already running; not starting another.")
+                return
+            self._connect_thread = threading.Thread(
+                target=self._connect_with_retry, daemon=True
+            )
+            self._connect_thread.start()
 
     def _connect_with_retry(self) -> None:
-        """Connect to 5Paisa WebSocket with retry logic"""
+        """Single reconnection driver for the 5Paisa WebSocket.
+
+        ws_client.connect() blocks in run_forever() until the socket closes;
+        when it returns we loop and reconnect (with exponential backoff) as long
+        as we're still running. This is the ONLY code path that opens a socket,
+        so two connections can never overlap. reconnect_attempts is reset in
+        _on_open once a connection actually succeeds, so backoff grows only
+        across consecutive failures.
+        """
         while self.running and self.reconnect_attempts < self.max_reconnect_attempts:
             try:
                 # Re-read a fresh token before every connect attempt so a
@@ -164,17 +197,26 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.logger.info(
                     f"Connecting to 5Paisa WebSocket (attempt {self.reconnect_attempts + 1})"
                 )
+                # Blocks until the socket closes (clean drop or error).
                 self.ws_client.connect()
-                self.reconnect_attempts = 0  # Reset attempts on successful connection
+            except Exception as e:
+                self.logger.error(f"Connection error: {e}")
+
+            # Stop requested via disconnect() -> exit cleanly, no reconnect.
+            if not self.running:
                 break
 
-            except Exception as e:
-                self.reconnect_attempts += 1
-                delay = min(
-                    self.reconnect_delay * (2**self.reconnect_attempts), self.max_reconnect_delay
-                )
-                self.logger.error(f"Connection failed: {e}. Retrying in {delay} seconds...")
-                time.sleep(delay)
+            # Socket closed while we still want to run: back off and reconnect.
+            self.reconnect_attempts += 1
+            if self.reconnect_attempts >= self.max_reconnect_attempts:
+                break
+            delay = min(
+                self.reconnect_delay * (2**self.reconnect_attempts), self.max_reconnect_delay
+            )
+            self.logger.warning(
+                f"5Paisa WebSocket disconnected; reconnecting in {delay} seconds..."
+            )
+            time.sleep(delay)
 
         if self.reconnect_attempts >= self.max_reconnect_attempts:
             self.logger.error("Max reconnection attempts reached. Giving up.")
@@ -330,6 +372,8 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Callback when connection is established"""
         self.logger.info("Connected to 5Paisa WebSocket")
         self.connected = True
+        # Connection succeeded; reset backoff so the next drop retries promptly.
+        self.reconnect_attempts = 0
 
         # Resubscribe to existing subscriptions if reconnecting
         with self.lock:
@@ -347,13 +391,15 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.error(f"5Paisa WebSocket error: {error}")
 
     def _on_close(self, wsapp) -> None:
-        """Callback when connection is closed"""
+        """Callback when connection is closed.
+
+        Reconnection is driven solely by the _connect_with_retry loop: when the
+        socket closes, run_forever() returns there and that loop reconnects. We
+        must NOT spawn another connect thread here, or two sockets could run
+        concurrently (FD/thread leak).
+        """
         self.logger.info("5Paisa WebSocket connection closed")
         self.connected = False
-
-        # Attempt to reconnect if we're still running
-        if self.running:
-            threading.Thread(target=self._connect_with_retry, daemon=True).start()
 
     def _on_message(self, wsapp, message) -> None:
         """Callback for text messages from the WebSocket"""

--- a/broker/fivepaisa/streaming/fivepaisa_adapter.py
+++ b/broker/fivepaisa/streaming/fivepaisa_adapter.py
@@ -5,6 +5,7 @@ import re
 import sys
 import threading
 import time
+from collections import deque
 from datetime import datetime
 from typing import Any, Dict, List, Optional
 
@@ -24,6 +25,14 @@ from .fivepaisa_mapping import FivePaisaCapabilityRegistry, FivePaisaExchangeMap
 class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """5Paisa-specific implementation of the WebSocket adapter"""
 
+    # Subscription batching: 5Paisa accepts an array of scrips per
+    # MarketFeedV3 / MarketDepthService frame, so coalesce scrips of the SAME
+    # method into one frame instead of one frame per symbol.
+    MAX_SCRIPS_PER_SUBSCRIBE = 50
+    # Delay between successive batch frames (server prefers fewer, larger frames
+    # with breathing room; only applied when more batches remain).
+    SUBSCRIPTION_DELAY = 0.5
+
     def __init__(self):
         super().__init__()
         self.logger = logging.getLogger("fivepaisa_websocket")
@@ -40,6 +49,11 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Single reconnect driver: only one _connect_with_retry thread may be
         # alive at a time so two run_forever sockets can never overlap.
         self._connect_thread = None
+        # Subscription batch queue: items are (method, scrip_dict). A single
+        # processor thread drains it into coalesced multi-scrip frames.
+        self.pending_subscriptions = deque()
+        self._sub_thread = None
+        self._stop_event = threading.Event()
         self.last_snapshot = {}  # Store last known values for each token
 
     def initialize(
@@ -170,6 +184,7 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # after a prior max-attempts giveup will actually reconnect.
             self.running = True
             self.reconnect_attempts = 0
+            self._stop_event.clear()
             if self._connect_thread and self._connect_thread.is_alive():
                 self.logger.debug("Connect thread already running; not starting another.")
                 return
@@ -224,11 +239,93 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def disconnect(self) -> None:
         """Disconnect from 5Paisa WebSocket"""
         self.running = False
+        # Wake the batch processor out of any inter-batch wait and drop queued work.
+        self._stop_event.set()
+        with self.lock:
+            self.pending_subscriptions.clear()
+
         if hasattr(self, "ws_client") and self.ws_client:
             self.ws_client.close_connection()
 
         # Clean up ZeroMQ resources
         self.cleanup_zmq()
+
+    def _enqueue_subscriptions(self, items: list) -> None:
+        """Queue (method, scrip) items for batched sending and ensure the batch
+        processor thread is running."""
+        if not items:
+            return
+        with self.lock:
+            self.pending_subscriptions.extend(items)
+            if self._sub_thread is None or not self._sub_thread.is_alive():
+                self._sub_thread = threading.Thread(
+                    target=self._process_pending_subscriptions, daemon=True
+                )
+                self._sub_thread.start()
+
+    def _process_pending_subscriptions(self) -> None:
+        """Drain the pending queue into coalesced 5Paisa subscribe frames.
+
+        Scrips are grouped by method (MarketFeedV3 vs MarketDepthService cannot
+        share a frame) and sent up to MAX_SCRIPS_PER_SUBSCRIBE per frame, with a
+        throttle between frames. Failed batches are re-queued. This replaces the
+        previous one-frame-per-symbol flood on bulk subscribe / resubscribe.
+        """
+        consecutive_failures = 0
+        while self.pending_subscriptions and self.running and not self._stop_event.is_set():
+            if not (self.connected and self.ws_client):
+                # Not connected yet; _on_open re-queues everything on connect,
+                # so just back off briefly and re-check (interruptible).
+                consecutive_failures += 1
+                if consecutive_failures > 5:
+                    self.logger.warning(
+                        "Batch processor: not connected after retries; pausing queue."
+                    )
+                    break
+                if self._stop_event.wait(min(2 * consecutive_failures, 10)):
+                    break
+                continue
+            consecutive_failures = 0
+
+            # Pull a batch of same-method scrips off the front of the queue.
+            batch_method = None
+            batch_scrips = []
+            with self.lock:
+                while (
+                    self.pending_subscriptions
+                    and len(batch_scrips) < self.MAX_SCRIPS_PER_SUBSCRIBE
+                ):
+                    method, scrip = self.pending_subscriptions[0]
+                    if batch_method is None:
+                        batch_method = method
+                    elif method != batch_method:
+                        break
+                    self.pending_subscriptions.popleft()
+                    batch_scrips.append(scrip)
+
+            if not batch_scrips:
+                continue
+
+            try:
+                self.ws_client.subscribe(batch_method, batch_scrips)
+                self.logger.info(
+                    f"Sent batched subscription: {len(batch_scrips)} scrips via {batch_method}"
+                )
+            except Exception as e:
+                self.logger.error(f"Batch subscription failed ({batch_method}): {e}")
+                # Re-queue the failed batch (front, preserving order) for retry.
+                with self.lock:
+                    for scrip in reversed(batch_scrips):
+                        self.pending_subscriptions.appendleft((batch_method, scrip))
+                if self._stop_event.wait(self.SUBSCRIPTION_DELAY * 2):
+                    break
+                continue
+
+            # Throttle only when more work remains, so a single-symbol subscribe
+            # (the common UI case) isn't penalized with a wait it doesn't need.
+            if self.pending_subscriptions:
+                if self._stop_event.wait(self.SUBSCRIPTION_DELAY):
+                    break
 
     def subscribe(
         self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 5
@@ -295,17 +392,15 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 "scrip_data": scrip_data,
             }
 
-        # Subscribe if connected
+        # Queue for batched sending when connected. When not connected, _on_open
+        # re-queues every stored subscription on (re)connect, so we skip here to
+        # avoid double-enqueuing the same scrip.
         if self.connected and self.ws_client:
-            try:
-                self.logger.info(
-                    f"Subscribing to {symbol} ({exchange}/{brexchange}) - Token: {token}, Method: {method}, Exch: {exch_code}, Type: {exch_type}"
-                )
-                self.ws_client.subscribe(method, scrip_data)
-                self.logger.info(f"Successfully sent subscription request for {symbol}.{exchange}")
-            except Exception as e:
-                self.logger.error(f"Error subscribing to {symbol}.{exchange}: {e}")
-                return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
+            self.logger.debug(
+                f"Queueing subscription for {symbol} ({exchange}/{brexchange}) - "
+                f"Token: {token}, Method: {method}, Exch: {exch_code}, Type: {exch_type}"
+            )
+            self._enqueue_subscriptions([(method, scrip_data[0])])
 
         # Return success
         return self._create_success_response(
@@ -375,16 +470,15 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Connection succeeded; reset backoff so the next drop retries promptly.
         self.reconnect_attempts = 0
 
-        # Resubscribe to existing subscriptions if reconnecting
+        # Resubscribe to existing subscriptions via the batch queue (coalesced
+        # into multi-scrip frames) rather than one frame per symbol.
         with self.lock:
-            for correlation_id, sub in self.subscriptions.items():
-                try:
-                    self.ws_client.subscribe(sub["method"], sub["scrip_data"])
-                    self.logger.info(f"Resubscribed to {sub['symbol']}.{sub['exchange']}")
-                except Exception as e:
-                    self.logger.error(
-                        f"Error resubscribing to {sub['symbol']}.{sub['exchange']}: {e}"
-                    )
+            items = [
+                (sub["method"], sub["scrip_data"][0]) for sub in self.subscriptions.values()
+            ]
+        if items:
+            self.logger.info(f"Resubscribing {len(items)} subscription(s) in batches")
+            self._enqueue_subscriptions(items)
 
     def _on_error(self, wsapp, error) -> None:
         """Callback for WebSocket errors"""

--- a/broker/fivepaisa/streaming/fivepaisa_adapter.py
+++ b/broker/fivepaisa/streaming/fivepaisa_adapter.py
@@ -202,8 +202,23 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         so two connections can never overlap. reconnect_attempts is reset in
         _on_open once a connection actually succeeds, so backoff grows only
         across consecutive failures.
+
+        The exit decision is taken at the top of the loop under self.lock and
+        clears self._connect_thread there, so connect() cannot race us into a
+        state where running=True but no driver thread is alive: if connect() set
+        running=True first we observe it and keep going; otherwise we clear the
+        handle before connect()'s guard inspects it and it starts a fresh driver.
         """
-        while self.running and self.reconnect_attempts < self.max_reconnect_attempts:
+        while True:
+            with self.lock:
+                if not self.running:
+                    self._connect_thread = None
+                    return
+                if self.reconnect_attempts >= self.max_reconnect_attempts:
+                    self.logger.error("Max reconnection attempts reached. Giving up.")
+                    self._connect_thread = None
+                    return
+
             try:
                 # Re-read a fresh token before every connect attempt so a
                 # daily-rolled token doesn't leave the feed permanently dead.
@@ -217,21 +232,20 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             except Exception as e:
                 self.logger.error(f"Connection error: {e}")
 
-            # Stop requested via disconnect() -> exit cleanly, no reconnect.
-            if not self.running:
-                break
-
-            # Socket closed while we still want to run: back off and reconnect.
+            # Socket closed; count this attempt and back off before the next one.
+            # The top-of-loop locked check handles running / max-attempts exit.
             self.reconnect_attempts += 1
-            if self.reconnect_attempts >= self.max_reconnect_attempts:
-                break
-            delay = min(
-                self.reconnect_delay * (2**self.reconnect_attempts), self.max_reconnect_delay
-            )
-            self.logger.warning(
-                f"5Paisa WebSocket disconnected; reconnecting in {delay} seconds..."
-            )
-            time.sleep(delay)
+            if self.reconnect_attempts < self.max_reconnect_attempts:
+                delay = min(
+                    self.reconnect_delay * (2**self.reconnect_attempts),
+                    self.max_reconnect_delay,
+                )
+                self.logger.warning(
+                    f"5Paisa WebSocket disconnected; reconnecting in {delay} seconds..."
+                )
+                # Interruptible: disconnect() sets _stop_event so we wake immediately
+                # instead of lingering in a non-interruptible sleep.
+                self._stop_event.wait(delay)
 
         if self.reconnect_attempts >= self.max_reconnect_attempts:
             self.logger.error("Max reconnection attempts reached. Giving up.")

--- a/broker/fivepaisa/streaming/fivepaisa_websocket.py
+++ b/broker/fivepaisa/streaming/fivepaisa_websocket.py
@@ -168,10 +168,23 @@ class FivePaisaWebSocket:
             raise e
 
     def close_connection(self):
-        """Close the WebSocket connection"""
-        if self.wsapp:
-            self.connected = False
-            self.wsapp.close()
+        """Close the WebSocket connection.
+
+        Idempotent and exception-safe: callers (reconnect, token rebuild,
+        adapter disconnect) may invoke this on an already-closed or partially
+        initialized client. We always clear state and never propagate, so a
+        failed close can't leak the handle or break the caller.
+        """
+        self.connected = False
+        wsapp = self.wsapp
+        if wsapp is None:
+            return
+        # Drop our reference first so a second call is a no-op even if close() blocks.
+        self.wsapp = None
+        try:
+            wsapp.close()
+        except Exception as e:
+            self.logger.debug(f"Error closing 5Paisa WebSocket: {e}")
 
     def subscribe(self, method: str, scrip_data: list[dict]) -> None:
         """

--- a/broker/fivepaisa/streaming/fivepaisa_websocket.py
+++ b/broker/fivepaisa/streaming/fivepaisa_websocket.py
@@ -25,7 +25,11 @@ class FivePaisaWebSocket:
         "default": "wss://openfeed.5paisa.com/Feeds/api/chat",
     }
 
-    HEART_BEAT_INTERVAL = 10  # seconds
+    HEART_BEAT_INTERVAL = 10  # seconds (websocket ping interval)
+    # Pong deadline; must be < HEART_BEAT_INTERVAL. Without it, a half-open
+    # (dead-but-not-closed) TCP connection is never detected: run_forever blocks
+    # forever, on_close never fires, the socket FD leaks and no reconnect occurs.
+    PING_TIMEOUT = 5  # seconds
 
     # Subscription Methods
     MARKET_FEED = "MarketFeedV3"
@@ -158,9 +162,13 @@ class FivePaisaWebSocket:
                 on_close=self._on_close,
             )
 
-            # Run the WebSocket connection
+            # Run the WebSocket connection. ping_timeout enforces a pong deadline
+            # so a half-open connection is detected and closed (freeing the FD and
+            # triggering reconnect) instead of blocking run_forever indefinitely.
             self.wsapp.run_forever(
-                sslopt={"cert_reqs": ssl.CERT_NONE}, ping_interval=self.HEART_BEAT_INTERVAL
+                sslopt={"cert_reqs": ssl.CERT_NONE},
+                ping_interval=self.HEART_BEAT_INTERVAL,
+                ping_timeout=self.PING_TIMEOUT,
             )
 
         except Exception as e:


### PR DESCRIPTION
fix(fivepaisa): support market orders via MPP and fix smart order auth  , return historical candles for index symbols , close WebSocket FD/thread leaks in reconnect path, harden WebSocket reconnect (ping timeout, interruptible backoff, race),chore(fivepaisa): demote verbose per-chunk history logs to debug and feat(fivepaisa): batch WebSocket subscriptions like Zerodha 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds MPP-backed market orders, batches WebSocket subscriptions, fixes index history, and hardens 5Paisa reconnects to stop FD/thread leaks and phantom order successes.

- **New Features**
  - MARKET orders now use Market Price Protection (convert to LIMIT using LTP + slab, tick-size aware). Request/response logged at INFO.
  - Batched WebSocket subscriptions: group by method, up to 50 scrips per frame with a short delay; reconnect resubscribe uses the same queue.

- **Bug Fixes**
  - Index history: normalize NSE/BSE → NSE_INDEX/BSE_INDEX, keep zero-volume candles for indices, only drop all-zero OHLC; per-chunk history logs moved to debug.
  - WebSocket reliability: single reconnect driver (no on_close threads), ping timeout to detect half-open sockets, interruptible backoff, close previous client on rebuild, idempotent close; reset backoff on open.
  - Orders/auth: fix smart order auth usage; treat RMS rejections as failures (only succeed when Status==0 and BrokerOrderID>0) and surface broker message with non-200 status.

<sup>Written for commit 1aec3f19cc983c7d3662ba35c6e5de11a2166c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1524?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

