### PR TITLE
fix(firstock): map BSE_INDEX to BSE in quote/depth/history paths

### DIFF
--- a/broker/firstock/api/data.py
+++ b/broker/firstock/api/data.py
@@ -13,6 +13,19 @@ from utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+def map_firstock_exchange(exchange: str) -> str:
+    """Map OpenAlgo index exchanges to the exchange code Firstock expects.
+
+    Firstock has no separate index exchange segment: NSE indices (e.g. NIFTY)
+    are quoted under "NSE" and BSE indices (e.g. SENSEX) under "BSE".
+    """
+    if exchange == "NSE_INDEX":
+        return "NSE"
+    if exchange == "BSE_INDEX":
+        return "BSE"
+    return exchange
+
+
 def get_api_response(endpoint, auth, method="POST", payload=None, custom_timeout=None):
     """
     Common function to make API calls to Firstock using shared httpx client with connection pooling
@@ -169,8 +182,8 @@ class BrokerData:
             # Convert symbol to broker format
             br_symbol = get_br_symbol(symbol, exchange)
 
-            # Map exchange to Firstock format (NSE_INDEX -> NSE)
-            firstock_exchange = "NSE" if exchange == "NSE_INDEX" else exchange
+            # Map exchange to Firstock format (NSE_INDEX -> NSE, BSE_INDEX -> BSE)
+            firstock_exchange = map_firstock_exchange(exchange)
 
             payload = {
                 "userId": os.getenv("BROKER_API_KEY")[:-4],
@@ -283,12 +296,8 @@ class BrokerData:
                 )
                 continue
 
-            # Map exchange to Firstock format (NSE_INDEX -> NSE)
-            firstock_exchange = (
-                "NSE"
-                if exchange == "NSE_INDEX"
-                else ("BSE" if exchange == "BSE_INDEX" else exchange)
-            )
+            # Map exchange to Firstock format (NSE_INDEX -> NSE, BSE_INDEX -> BSE)
+            firstock_exchange = map_firstock_exchange(exchange)
 
             data_array.append({"exchange": firstock_exchange, "tradingSymbol": br_symbol})
 
@@ -350,8 +359,8 @@ class BrokerData:
             # Convert symbol to broker format
             br_symbol = get_br_symbol(symbol, exchange)
 
-            # Map exchange to Firstock format (NSE_INDEX -> NSE)
-            firstock_exchange = "NSE" if exchange == "NSE_INDEX" else exchange
+            # Map exchange to Firstock format (NSE_INDEX -> NSE, BSE_INDEX -> BSE)
+            firstock_exchange = map_firstock_exchange(exchange)
 
             payload = {
                 "userId": os.getenv("BROKER_API_KEY")[:-4],
@@ -639,7 +648,7 @@ class BrokerData:
                     try:
                         # Prepare request for this chunk
                         br_symbol = get_br_symbol(symbol, exchange)
-                        firstock_exchange = "NSE" if exchange == "NSE_INDEX" else exchange
+                        firstock_exchange = map_firstock_exchange(exchange)
 
                         payload = {
                             "userId": os.getenv("BROKER_API_KEY")[:-4],
@@ -973,8 +982,8 @@ class BrokerData:
 
             logger.info(f"Getting {interval} data for {br_symbol} from {start_str} to {end_str}")
 
-            # Map exchange to Firstock format (NSE_INDEX -> NSE)
-            firstock_exchange = "NSE" if exchange == "NSE_INDEX" else exchange
+            # Map exchange to Firstock format (NSE_INDEX -> NSE, BSE_INDEX -> BSE)
+            firstock_exchange = map_firstock_exchange(exchange)
 
             # Prepare payload according to new API format
             payload = {


### PR DESCRIPTION
SENSEX/BANKEX option chain failed with 'invalid exchange: BSE_INDEX' because get_quotes/get_depth/history only translated NSE_INDEX -> NSE, leaking BSE_INDEX to the Firstock API. Added a shared map_firstock_exchange() helper (NSE_INDEX->NSE, BSE_INDEX->BSE) and routed all paths through it, fixing the option chain underlying LTP fetch plus BSE index quotes, depth, and historical data.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes SENSEX/BANKEX option chain failures and BSE index data by mapping BSE_INDEX to BSE across Firstock quote, depth, and history requests. Centralizes exchange mapping to prevent invalid exchange errors.

- **Bug Fixes**
  - Added a shared `map_firstock_exchange()` that maps `NSE_INDEX`→`NSE` and `BSE_INDEX`→`BSE`.
  - Routed `get_quotes`, `get_depth`, and history paths (batch and chunked) through this helper.
  - Resolves “invalid exchange: BSE_INDEX” and restores BSE index quotes, depth, history, and option chain underlying LTP fetch.

<sup>Written for commit 4c816c83cce05846454f896bff46bd6ef380a1bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1533?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

