### PR TITLE
feat: scalping live charts + /chart/test streaming page

### DIFF
--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from blueprints.broker_credentials import (
     broker_credentials_bp,  # Import the broker credentials blueprint
 )
 from blueprints.chartink import chartink_bp  # Import the chartink blueprint
+from blueprints.chart_test import chart_test_bp  # Standalone chart test page (dev/testing only)
 from blueprints.strategy_portfolio import strategy_portfolio_bp  # Strategy Builder portfolio
 from blueprints.core import core_bp
 from blueprints.dashboard import dashboard_bp
@@ -275,6 +276,7 @@ def create_app():
     app.register_blueprint(strategy_bp)
     app.register_blueprint(master_contract_status_bp)
     app.register_blueprint(websocket_bp)  # Register WebSocket example blueprint
+    app.register_blueprint(chart_test_bp)  # Register standalone chart test page (dev/testing only)
     app.register_blueprint(pnltracker_bp)  # Register PnL tracker blueprint
     app.register_blueprint(python_strategy_bp)  # Register Python strategy blueprint
     app.register_blueprint(telegram_bp)  # Register Telegram blueprint

--- a/blueprints/chart_test.py
+++ b/blueprints/chart_test.py
@@ -1,0 +1,186 @@
+"""
+Backend API for the standalone chart test page (DEV / TESTING ONLY).
+
+The page itself is a React route (`/chart/test`, served by react_app.py / the
+React SPA). This blueprint only exposes the one piece of data the React page
+needs that no existing endpoint provides: 1-minute candles for the most recent
+trading day.
+
+The React page reuses existing infrastructure for everything else:
+  - symbol search        -> /search/api/search
+  - websocket streaming  -> useMarketData() hook (shared MarketDataManager),
+                            which authenticates via /api/websocket/config and
+                            /api/websocket/apikey.
+
+The page is intentionally NOT linked from any menu, tools tile or navbar. It is
+reachable only by typing the URL: http://127.0.0.1:5000/chart/test
+Only the 1-minute interval is supported.
+"""
+
+import re
+from datetime import datetime, timedelta
+
+import pytz
+from flask import Blueprint, jsonify, request, session
+
+from database.auth_db import get_api_key_for_tradingview
+from services.history_service import get_history
+from utils.logging import get_logger
+from utils.session import check_session_validity
+
+logger = get_logger(__name__)
+
+chart_test_bp = Blueprint("chart_test_bp", __name__)
+
+IST = pytz.timezone("Asia/Kolkata")
+# Seconds to add to a UTC epoch so that, when lightweight-charts renders the
+# value as UTC, the displayed wall-clock equals IST. 5h30m = 19800s = a whole
+# number of minutes, so minute-bucketing is identical before/after the shift.
+# The React page applies the same offset to live ticks so history and live bars
+# line up on the time axis.
+IST_OFFSET_SECONDS = 19800
+
+# Supported intervals (OpenAlgo format) -> trading days of history to load.
+INTERVAL_TRADING_DAYS = {"1m": 1, "5m": 3, "15m": 9}
+
+
+@chart_test_bp.route("/chart/test/api/history", methods=["GET"])
+@check_session_validity
+def chart_test_history():
+    """Return candles for the most recent N trading days at the given interval.
+
+    ``interval`` is an OpenAlgo interval (1m/5m/15m). The lookback scales with
+    it: 1m -> 1 trading day, 5m -> 3, 15m -> 9. A generous calendar window is
+    fetched and the latest N IST dates with data are kept, which transparently
+    skips weekends/holidays without a market-calendar lookup. An optional
+    ``date=YYYY-MM-DD`` restricts the fetch to a single day (used by the page's
+    periodic reconcile).
+    """
+    username = session.get("user")
+    if not username:
+        return jsonify({"status": "error", "message": "Session not found"}), 401
+
+    api_key = get_api_key_for_tradingview(username)
+    if not api_key:
+        return jsonify(
+            {"status": "error", "message": "No API key found. Generate one at /apikey first."}
+        ), 404
+
+    symbol = (request.args.get("symbol", "") or "").strip().upper()[:50]
+    exchange = (request.args.get("exchange", "") or "").strip().upper()[:20]
+    if not symbol or not exchange:
+        return jsonify({"status": "error", "message": "symbol and exchange are required"}), 400
+
+    interval = (request.args.get("interval", "1m") or "1m").strip()
+    if interval not in INTERVAL_TRADING_DAYS:
+        interval = "1m"
+
+    # Optional ?date=YYYY-MM-DD restricts the fetch to a single trading day. The
+    # React page passes the date it learned on first load when it reconciles, so
+    # the periodic refresh pulls one day instead of the full lookback window.
+    date_param = (request.args.get("date", "") or "").strip()
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", date_param):
+        start_date = date_param
+        end_date = date_param
+        keep_days = 1
+    else:
+        keep_days = INTERVAL_TRADING_DAYS[interval]
+        today = datetime.now(IST).date()
+        # Fetch a generous calendar window, then keep the latest `keep_days`
+        # trading dates (covers weekends/holidays without a calendar lookup).
+        start_date = (today - timedelta(days=keep_days * 2 + 5)).strftime("%Y-%m-%d")
+        end_date = today.strftime("%Y-%m-%d")
+
+    try:
+        success, response, status_code = get_history(
+            symbol=symbol,
+            exchange=exchange,
+            interval=interval,
+            start_date=start_date,
+            end_date=end_date,
+            api_key=api_key,
+        )
+    except Exception as e:
+        logger.exception(f"chart/test history error for {symbol}.{exchange}: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+    if not success:
+        message = response.get("message") if isinstance(response, dict) else str(response)
+        return jsonify(
+            {"status": "error", "message": message or "History fetch failed"}
+        ), status_code
+
+    rows = response.get("data", []) if isinstance(response, dict) else []
+    if not rows:
+        return jsonify(
+            {
+                "status": "success",
+                "symbol": symbol,
+                "exchange": exchange,
+                "interval": interval,
+                "date": None,
+                "candles": [],
+            }
+        ), 200
+
+    # Group rows by IST date so we can keep the latest `keep_days` trading dates.
+    by_date: dict[str, list] = {}
+    for r in rows:
+        ts = r.get("timestamp")
+        if ts is None:
+            continue
+        try:
+            ts = int(float(ts))
+        except (TypeError, ValueError):
+            continue
+        ist_dt = datetime.fromtimestamp(ts, tz=pytz.utc).astimezone(IST)
+        by_date.setdefault(ist_dt.strftime("%Y-%m-%d"), []).append((ts, r))
+
+    if not by_date:
+        return jsonify(
+            {
+                "status": "success",
+                "symbol": symbol,
+                "exchange": exchange,
+                "interval": interval,
+                "date": None,
+                "candles": [],
+            }
+        ), 200
+
+    selected_dates = sorted(by_date.keys())[-keep_days:]
+    latest_date = selected_dates[-1]
+    day_rows: list = []
+    for dkey in selected_dates:
+        day_rows.extend(by_date[dkey])
+    day_rows.sort(key=lambda x: x[0])
+
+    candles = []
+    for ts, r in day_rows:
+        # 5m/15m timestamps are already minute-aligned, so the minute floor is a
+        # no-op for them; it only normalizes 1m bars.
+        bar_time = ((ts + IST_OFFSET_SECONDS) // 60) * 60
+        try:
+            candles.append(
+                {
+                    "time": bar_time,
+                    "open": float(r.get("open", 0)),
+                    "high": float(r.get("high", 0)),
+                    "low": float(r.get("low", 0)),
+                    "close": float(r.get("close", 0)),
+                    "volume": float(r.get("volume", 0) or 0),
+                }
+            )
+        except (TypeError, ValueError):
+            continue
+
+    return jsonify(
+        {
+            "status": "success",
+            "symbol": symbol,
+            "exchange": exchange,
+            "interval": interval,
+            "date": latest_date,
+            "candles": candles,
+        }
+    ), 200

--- a/blueprints/react_app.py
+++ b/blueprints/react_app.py
@@ -224,6 +224,13 @@ def react_oitracker():
     return serve_react_app()
 
 
+# Chart test page (dev/testing only) - 1m history + live forming candle.
+# Intentionally not linked from any menu; reachable only by direct URL.
+@react_bp.route("/chart/test")
+def react_chart_test():
+    return serve_react_app()
+
+
 # Max Pain analysis
 @react_bp.route("/maxpain")
 def react_maxpain():

--- a/blueprints/scalping.py
+++ b/blueprints/scalping.py
@@ -14,12 +14,16 @@ Order constants (docs/prompt/order-constants.md):
 """
 
 import math
+import re
+from datetime import datetime, timedelta
 
+import pytz
 from flask import Blueprint, jsonify, request, session
 
 from database.auth_db import get_api_key_for_tradingview
 from database.settings_db import get_analyze_mode
 from services.expiry_service import get_expiry_dates
+from services.history_service import get_history
 from services.option_chain_service import get_option_chain
 from utils.logging import get_logger
 from utils.session import check_session_validity
@@ -33,6 +37,13 @@ scalping_bp = Blueprint("scalping_bp", __name__, url_prefix="/")
 
 # Strategy tag stamped on every scalping order (shown in order/trade books).
 SCALPING_STRATEGY = "Scalping"
+
+# Chart history: IST timezone + per-interval lookback (trading days). The bar
+# time carries a +5h30m offset so lightweight-charts (which renders UTC) shows
+# IST, and the client's live forming candle aligns with the history bars.
+IST = pytz.timezone("Asia/Kolkata")
+IST_OFFSET_SECONDS = 19800
+CHART_INTERVAL_TRADING_DAYS = {"1m": 1, "5m": 3, "15m": 9}
 
 # Order constants enforced on the order endpoint.
 VALID_ACTIONS = {"BUY", "SELL"}
@@ -132,6 +143,125 @@ def underlyings():
         for name, cfg in SUPPORTED_UNDERLYINGS.items()
     ]
     return jsonify({"status": "success", "data": data})
+
+
+@scalping_bp.route("/scalping/api/history", methods=["GET"])
+@check_session_validity
+def chart_history():
+    """Return candles for the most recent N trading days at the given interval.
+
+    Powers the scalping charts (candles + volume). ``interval`` is an OpenAlgo
+    interval (1m/5m/15m); the lookback scales 1m->1 day, 5m->3, 15m->9. A
+    generous calendar window is fetched and the latest N IST dates with data are
+    kept (skips weekends/holidays without a calendar lookup). An optional
+    ``date=YYYY-MM-DD`` restricts the fetch to a single day (used by the chart's
+    periodic reconcile). Works for any exchange (options, futures, equity,
+    indices); index symbols simply carry volume 0.
+    """
+    api_key = _get_api_key()
+    if not api_key:
+        return jsonify({"status": "error", "message": "API key not configured"}), 401
+
+    symbol = (request.args.get("symbol", "") or "").strip().upper()[:50]
+    exchange = (request.args.get("exchange", "") or "").strip().upper()[:20]
+    if not symbol or not exchange:
+        return jsonify({"status": "error", "message": "symbol and exchange are required"}), 400
+
+    interval = (request.args.get("interval", "1m") or "1m").strip()
+    if interval not in CHART_INTERVAL_TRADING_DAYS:
+        interval = "1m"
+
+    date_param = (request.args.get("date", "") or "").strip()
+    if re.match(r"^\d{4}-\d{2}-\d{2}$", date_param):
+        start_date = date_param
+        end_date = date_param
+        keep_days = 1
+    else:
+        keep_days = CHART_INTERVAL_TRADING_DAYS[interval]
+        today = datetime.now(IST).date()
+        start_date = (today - timedelta(days=keep_days * 2 + 5)).strftime("%Y-%m-%d")
+        end_date = today.strftime("%Y-%m-%d")
+
+    try:
+        success, response, status_code = get_history(
+            symbol=symbol,
+            exchange=exchange,
+            interval=interval,
+            start_date=start_date,
+            end_date=end_date,
+            api_key=api_key,
+        )
+    except Exception as e:
+        logger.exception(f"scalping chart history error for {symbol}.{exchange}: {e}")
+        return jsonify({"status": "error", "message": str(e)}), 500
+
+    if not success:
+        message = response.get("message") if isinstance(response, dict) else str(response)
+        return jsonify(
+            {"status": "error", "message": message or "History fetch failed"}
+        ), status_code
+
+    rows = response.get("data", []) if isinstance(response, dict) else []
+    by_date: dict[str, list] = {}
+    for r in rows:
+        ts = r.get("timestamp")
+        if ts is None:
+            continue
+        try:
+            ts = int(float(ts))
+        except (TypeError, ValueError):
+            continue
+        ist_dt = datetime.fromtimestamp(ts, tz=pytz.utc).astimezone(IST)
+        by_date.setdefault(ist_dt.strftime("%Y-%m-%d"), []).append((ts, r))
+
+    if not by_date:
+        return jsonify(
+            {
+                "status": "success",
+                "symbol": symbol,
+                "exchange": exchange,
+                "interval": interval,
+                "date": None,
+                "candles": [],
+            }
+        ), 200
+
+    selected_dates = sorted(by_date.keys())[-keep_days:]
+    latest_date = selected_dates[-1]
+    day_rows: list = []
+    for dkey in selected_dates:
+        day_rows.extend(by_date[dkey])
+    day_rows.sort(key=lambda x: x[0])
+
+    candles = []
+    for ts, r in day_rows:
+        # 5m/15m timestamps are already minute-aligned, so the minute floor is a
+        # no-op for them; it only normalizes 1m bars.
+        bar_time = ((ts + IST_OFFSET_SECONDS) // 60) * 60
+        try:
+            candles.append(
+                {
+                    "time": bar_time,
+                    "open": float(r.get("open", 0)),
+                    "high": float(r.get("high", 0)),
+                    "low": float(r.get("low", 0)),
+                    "close": float(r.get("close", 0)),
+                    "volume": float(r.get("volume", 0) or 0),
+                }
+            )
+        except (TypeError, ValueError):
+            continue
+
+    return jsonify(
+        {
+            "status": "success",
+            "symbol": symbol,
+            "exchange": exchange,
+            "interval": interval,
+            "date": latest_date,
+            "candles": candles,
+        }
+    ), 200
 
 
 @scalping_bp.route("/scalping/api/all_underlyings", methods=["GET"])

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -49,6 +49,7 @@ const Sandbox = lazy(() => import('@/pages/Sandbox'))
 const SandboxPnL = lazy(() => import('@/pages/SandboxPnL'))
 const Analyzer = lazy(() => import('@/pages/Analyzer'))
 const WebSocketTest = lazy(() => import('@/pages/WebSocketTest'))
+const ChartTest = lazy(() => import('@/pages/ChartTest'))
 const Playground = lazy(() => import('@/pages/Playground'))
 const Historify = lazy(() => import('@/pages/Historify'))
 const HistorifyCharts = lazy(() => import('@/pages/HistorifyCharts'))
@@ -215,6 +216,7 @@ function App() {
                   element={<Navigate to="/strategybuilder/portfolio" replace />}
                 />
                 <Route path="/websocket/test" element={<WebSocketTest />} />
+                <Route path="/chart/test" element={<ChartTest />} />
                 <Route path="/websocket/test/20" element={<WebSocketTest depthLevel={20} />} />
                 <Route path="/websocket/test/30" element={<WebSocketTest depthLevel={30} />} />
                 <Route path="/websocket/test/50" element={<WebSocketTest depthLevel={50} />} />

--- a/frontend/src/api/scalping.ts
+++ b/frontend/src/api/scalping.ts
@@ -75,6 +75,36 @@ export const scalpingApi = {
     return response.data
   },
 
+  // Historical candles for the scalping charts. interval is an OpenAlgo interval
+  // (1m/5m/15m); lookback scales 1m=1 day, 5m=3, 15m=9. Pass `date` (the trading
+  // date learned on first load) so the periodic reconcile pulls a single day.
+  getHistory: async (
+    symbol: string,
+    exchange: string,
+    interval: string,
+    date?: string
+  ): Promise<{
+    status: string
+    symbol: string
+    exchange: string
+    interval: string
+    date: string | null
+    candles: Array<{
+      time: number
+      open: number
+      high: number
+      low: number
+      close: number
+      volume: number
+    }>
+    message?: string
+  }> => {
+    const params: Record<string, string> = { symbol, exchange, interval }
+    if (date) params.date = date
+    const response = await webClient.get('/scalping/api/history', { params })
+    return response.data
+  },
+
   placeOrder: async (req: ScalpingOrderRequest): Promise<ScalpingOrderResponse> => {
     const response = await webClient.post<ScalpingOrderResponse>('/scalping/api/order', req)
     return response.data

--- a/frontend/src/components/scalping/ScalpChart.tsx
+++ b/frontend/src/components/scalping/ScalpChart.tsx
@@ -1,0 +1,425 @@
+/**
+ * ScalpChart - a self-contained live candlestick + volume chart for the
+ * scalping terminal.
+ *
+ * Given a symbol/exchange/interval it:
+ *   - loads history from /scalping/api/history (1m=1d, 5m=3d, 15m=9d lookback),
+ *   - draws candles + a volume histogram with a TradingView-style OHLC legend,
+ *   - streams the forming candle live via the shared useMarketData feed, and
+ *   - reconciles completed bars to the broker's official OHLC on a staggered
+ *     20-30s timer (so multiple charts never hit the API at the same instant).
+ *
+ * Works for any exchange (options/futures/equity/indices). Index symbols carry
+ * volume 0. Uses the bundled lightweight-charts v5 (no CDN).
+ */
+
+import {
+  CandlestickSeries,
+  ColorType,
+  CrosshairMode,
+  createChart,
+  HistogramSeries,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from 'lightweight-charts'
+import { useEffect, useRef, useState } from 'react'
+import { scalpingApi } from '@/api/scalping'
+import { useMarketData } from '@/hooks/useMarketData'
+import { useThemeStore } from '@/stores/themeStore'
+
+// Matches the IST shift the backend bakes into bar times so live bars line up
+// with history bars. 5h30m = 19800s, a whole multiple of 60/300/900s.
+const IST_OFFSET = 19800
+const INTERVAL_SEC: Record<string, number> = { '1m': 60, '5m': 300, '15m': 900 }
+
+const UP = '#26a69a'
+const DOWN = '#ef5350'
+const VOL_UP = 'rgba(38,166,154,0.45)'
+const VOL_DOWN = 'rgba(239,83,80,0.45)'
+
+interface Candle {
+  time: number
+  open: number
+  high: number
+  low: number
+  close: number
+  volume: number
+}
+
+function fmtPrice(n: number): string {
+  return n.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 })
+}
+function fmtVol(n: number): string {
+  const a = Math.abs(n)
+  if (a >= 1e9) return `${(n / 1e9).toFixed(2)}B`
+  if (a >= 1e6) return `${(n / 1e6).toFixed(2)}M`
+  if (a >= 1e3) return `${(n / 1e3).toFixed(2)}K`
+  return String(Math.round(n))
+}
+
+export function ScalpChart({
+  symbol,
+  exchange,
+  interval,
+  title,
+}: {
+  symbol: string
+  exchange: string
+  interval: string
+  title?: string
+}) {
+  const { mode } = useThemeStore()
+  const isDark = mode === 'dark'
+
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const legendRef = useRef<HTMLDivElement | null>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const candleRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
+  const volRef = useRef<ISeriesApi<'Histogram'> | null>(null)
+  const renderLegendRef = useRef<(time?: number) => void>(() => {})
+  const colorsRef = useRef({ title: '#d6dde6', muted: '#8a97a5' })
+
+  // Authoritative model: bucket time -> candle. Completed bars are reconciled
+  // from broker history; the current bucket is built live from ticks.
+  const candlesRef = useRef<Map<number, Candle>>(new Map())
+  const sortedRef = useRef<Candle[]>([])
+  const idxByTimeRef = useRef<Map<number, number>>(new Map())
+  const currentBucketRef = useRef<number | null>(null)
+  const tradingDateRef = useRef<string | null>(null)
+  const intervalSecRef = useRef<number>(INTERVAL_SEC[interval] ?? 60)
+  const intervalRef = useRef<string>(interval)
+  const barStartVolRef = useRef<number | null>(null)
+  const readyRef = useRef(false)
+
+  const [status, setStatus] = useState('')
+
+  const enabled = !!(symbol && exchange)
+  const { data } = useMarketData({
+    symbols: enabled ? [{ symbol, exchange }] : [],
+    mode: 'Quote',
+    enabled,
+    autoReconnect: true,
+  })
+
+  // Create the chart once per symbol/exchange (candles + volume + legend).
+  // isDark is used only for the initial colors; theme changes are applied by the
+  // separate re-theme effect below, so it is intentionally not a dependency.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isDark excluded; theme handled by the re-theme effect
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container || !enabled) return
+
+    const chart = createChart(container, {
+      autoSize: true,
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: colorsRef.current.muted,
+        fontSize: 11,
+      },
+      grid: {
+        vertLines: { color: isDark ? 'rgba(120,130,145,0.06)' : 'rgba(0,0,0,0.05)' },
+        horzLines: { color: isDark ? 'rgba(120,130,145,0.06)' : 'rgba(0,0,0,0.05)' },
+      },
+      rightPriceScale: { borderColor: isDark ? '#1b2330' : '#e2e8f0' },
+      timeScale: {
+        borderColor: isDark ? '#1b2330' : '#e2e8f0',
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      crosshair: { mode: CrosshairMode.Normal },
+    })
+    const candle = chart.addSeries(CandlestickSeries, {
+      upColor: UP,
+      downColor: DOWN,
+      borderVisible: false,
+      wickUpColor: UP,
+      wickDownColor: DOWN,
+    })
+    const vol = chart.addSeries(HistogramSeries, {
+      priceFormat: { type: 'volume' },
+      priceScaleId: '',
+    })
+    vol.priceScale().applyOptions({ scaleMargins: { top: 0.82, bottom: 0 } })
+
+    chartRef.current = chart
+    candleRef.current = candle
+    volRef.current = vol
+
+    // OHLC legend overlay: hovered bar, or the last bar when not hovering.
+    const renderLegend = (time?: number) => {
+      const el = legendRef.current
+      const arr = sortedRef.current
+      if (!el) return
+      if (!arr.length) {
+        el.innerHTML = ''
+        return
+      }
+      let idx = arr.length - 1
+      if (time != null) {
+        const i = idxByTimeRef.current.get(time)
+        if (i != null) idx = i
+      }
+      const bar = arr[idx]
+      const ref = idx > 0 ? arr[idx - 1].close : bar.open
+      const chg = bar.close - ref
+      const pct = ref ? (chg / ref) * 100 : 0
+      const col = chg >= 0 ? UP : DOWN
+      const sign = chg >= 0 ? '+' : ''
+      const { title: titleColor, muted } = colorsRef.current
+      el.innerHTML =
+        `<div style="color:${titleColor};font-weight:600">${symbol} ` +
+        `<span style="color:${muted};font-weight:500">· ${intervalRef.current} · ${exchange}</span></div>` +
+        `<div style="color:${col};margin-top:1px">O${fmtPrice(bar.open)} H${fmtPrice(bar.high)} ` +
+        `L${fmtPrice(bar.low)} C${fmtPrice(bar.close)} ${sign}${fmtPrice(chg)} (${sign}${pct.toFixed(2)}%)</div>` +
+        `<div style="color:${muted};margin-top:1px">Volume <span style="color:${col}">${fmtVol(bar.volume)}</span></div>`
+    }
+    renderLegendRef.current = renderLegend
+    chart.subscribeCrosshairMove((param) => {
+      renderLegend(typeof param.time === 'number' ? param.time : undefined)
+    })
+
+    return () => {
+      chart.remove()
+      chartRef.current = null
+      candleRef.current = null
+      volRef.current = null
+    }
+  }, [symbol, exchange, enabled])
+
+  // Load history for the selected interval and run the reconcile loop. Re-runs
+  // on timeframe change (instant flip; chart instance reused).
+  useEffect(() => {
+    const chart = chartRef.current
+    const candle = candleRef.current
+    const vol = volRef.current
+    if (!chart || !candle || !vol || !enabled) return
+    let disposed = false
+    let inflight = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    candlesRef.current = new Map()
+    sortedRef.current = []
+    idxByTimeRef.current = new Map()
+    currentBucketRef.current = null
+    barStartVolRef.current = null
+    intervalSecRef.current = INTERVAL_SEC[interval] ?? 60
+    intervalRef.current = interval
+    readyRef.current = false
+    setStatus('loading...')
+
+    const applyModel = (preserveRange: boolean) => {
+      const arr = Array.from(candlesRef.current.values()).sort((a, b) => a.time - b.time)
+      sortedRef.current = arr
+      const idxMap = new Map<number, number>()
+      arr.forEach((k, i) => idxMap.set(k.time, i))
+      idxByTimeRef.current = idxMap
+
+      const ts = chart.timeScale()
+      const range = preserveRange ? ts.getVisibleLogicalRange() : null
+      candle.setData(
+        arr.map((k) => ({ time: k.time as UTCTimestamp, open: k.open, high: k.high, low: k.low, close: k.close }))
+      )
+      vol.setData(
+        arr.map((k) => ({
+          time: k.time as UTCTimestamp,
+          value: k.volume,
+          color: k.close >= k.open ? VOL_UP : VOL_DOWN,
+        }))
+      )
+      if (range) {
+        try {
+          ts.setVisibleLogicalRange(range)
+        } catch {
+          /* range no longer valid */
+        }
+      } else {
+        ts.fitContent()
+      }
+      renderLegendRef.current()
+    }
+
+    const reconcile = async () => {
+      if (disposed || inflight) return
+      inflight = true
+      try {
+        const d = await scalpingApi.getHistory(
+          symbol,
+          exchange,
+          interval,
+          tradingDateRef.current || undefined
+        )
+        if (disposed || d.status !== 'success') return
+        const fetched = d.candles || []
+        if (!fetched.length) return
+        const cur = currentBucketRef.current
+        const completed = cur == null ? fetched : fetched.filter((k) => k.time < cur)
+        let changed = false
+        for (const k of completed.slice(-10)) {
+          const prev = candlesRef.current.get(k.time)
+          if (
+            !prev ||
+            prev.open !== k.open ||
+            prev.high !== k.high ||
+            prev.low !== k.low ||
+            prev.close !== k.close ||
+            prev.volume !== k.volume
+          ) {
+            candlesRef.current.set(k.time, { ...k })
+            changed = true
+          }
+        }
+        if (changed) applyModel(true)
+      } catch {
+        /* transient reconcile error; the next cycle retries */
+      } finally {
+        inflight = false
+      }
+    }
+
+    const schedule = () => {
+      const delay = 20000 + Math.random() * 10000
+      timer = setTimeout(async () => {
+        await reconcile()
+        if (!disposed) schedule()
+      }, delay)
+    }
+
+    scalpingApi
+      .getHistory(symbol, exchange, interval)
+      .then((d) => {
+        if (disposed) return
+        if (d.status !== 'success') {
+          setStatus(`error: ${d.message || 'history failed'}`)
+          schedule()
+          return
+        }
+        const candles = d.candles || []
+        tradingDateRef.current = d.date || null
+        if (!candles.length) {
+          setStatus('no history')
+          schedule()
+          return
+        }
+        candlesRef.current = new Map(candles.map((k) => [k.time, { ...k }]))
+        applyModel(false)
+        currentBucketRef.current = candles[candles.length - 1].time
+        setStatus('')
+        readyRef.current = true
+        schedule()
+      })
+      .catch(() => {
+        if (!disposed) {
+          setStatus('history fetch failed')
+          schedule()
+        }
+      })
+
+    return () => {
+      disposed = true
+      readyRef.current = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [symbol, exchange, interval, enabled])
+
+  // Re-theme the chart and legend without recreating it.
+  useEffect(() => {
+    colorsRef.current = isDark
+      ? { title: '#d6dde6', muted: '#8a97a5' }
+      : { title: '#0f172a', muted: '#64748b' }
+    const chart = chartRef.current
+    if (chart) {
+      chart.applyOptions({
+        layout: { textColor: colorsRef.current.muted },
+        grid: {
+          vertLines: { color: isDark ? 'rgba(120,130,145,0.06)' : 'rgba(0,0,0,0.05)' },
+          horzLines: { color: isDark ? 'rgba(120,130,145,0.06)' : 'rgba(0,0,0,0.05)' },
+        },
+        rightPriceScale: { borderColor: isDark ? '#1b2330' : '#e2e8f0' },
+        timeScale: { borderColor: isDark ? '#1b2330' : '#e2e8f0' },
+      })
+    }
+    renderLegendRef.current()
+  }, [isDark])
+
+  // Update the forming candle (and its volume) from each live tick.
+  const tick = data.get(`${exchange}:${symbol}`)?.data
+  const ltp = tick?.ltp
+  const ts = tick?.timestamp
+  const tickVol = typeof tick?.volume === 'number' ? tick.volume : null
+  useEffect(() => {
+    const candle = candleRef.current
+    const vol = volRef.current
+    if (!candle || !vol || !readyRef.current || ltp == null || !Number.isFinite(ltp)) return
+
+    const parsed = ts ? Date.parse(ts) : Number.NaN
+    const epochUtc = Number.isNaN(parsed) ? Math.floor(Date.now() / 1000) : Math.floor(parsed / 1000)
+    const sec = intervalSecRef.current
+    const bucket = Math.floor((epochUtc + IST_OFFSET) / sec) * sec
+    const cur = currentBucketRef.current
+
+    let bar: Candle
+    let isNew = false
+    if (cur == null || bucket > cur) {
+      isNew = true
+      barStartVolRef.current = tickVol
+      bar = { time: bucket, open: ltp, high: ltp, low: ltp, close: ltp, volume: 0 }
+      currentBucketRef.current = bucket
+    } else if (bucket === cur) {
+      const prev = candlesRef.current.get(bucket)
+      const v =
+        tickVol != null && barStartVolRef.current != null
+          ? Math.max(0, tickVol - barStartVolRef.current)
+          : (prev?.volume ?? 0)
+      bar = prev
+        ? {
+            time: bucket,
+            open: prev.open,
+            high: Math.max(prev.high, ltp),
+            low: Math.min(prev.low, ltp),
+            close: ltp,
+            volume: v,
+          }
+        : { time: bucket, open: ltp, high: ltp, low: ltp, close: ltp, volume: v }
+    } else {
+      return // stale tick older than the current bar
+    }
+
+    candlesRef.current.set(bucket, bar)
+    const arr = sortedRef.current
+    if (isNew) {
+      arr.push(bar)
+      idxByTimeRef.current.set(bucket, arr.length - 1)
+    } else if (arr.length) {
+      arr[arr.length - 1] = bar
+    }
+
+    const color = bar.close >= bar.open ? VOL_UP : VOL_DOWN
+    candle.update({ time: bar.time as UTCTimestamp, open: bar.open, high: bar.high, low: bar.low, close: bar.close })
+    vol.update({ time: bar.time as UTCTimestamp, value: bar.volume, color })
+    renderLegendRef.current()
+  }, [ltp, ts, tickVol])
+
+  if (!enabled) {
+    return (
+      <div className="flex h-full w-full items-center justify-center rounded-lg border bg-card text-xs text-muted-foreground">
+        {title ? `${title} — not selected` : 'No instrument'}
+      </div>
+    )
+  }
+
+  return (
+    <div className="relative h-full w-full overflow-hidden rounded-lg border bg-card">
+      <div ref={containerRef} className="absolute inset-0" />
+      <div
+        ref={legendRef}
+        className="pointer-events-none absolute left-2.5 top-2 z-10 font-mono text-[11px] leading-tight"
+      />
+      {status && (
+        <div className="pointer-events-none absolute inset-0 flex items-center justify-center text-xs text-muted-foreground">
+          {status}
+        </div>
+      )}
+    </div>
+  )
+}

--- a/frontend/src/pages/ChartTest.tsx
+++ b/frontend/src/pages/ChartTest.tsx
@@ -1,0 +1,550 @@
+/**
+ * ChartTest (DEV / TESTING ONLY) - route: /chart/test
+ *
+ * A throwaway test page (not linked from any menu) that:
+ *   - searches symbols (same /search/api/search backend as the WebSocket test page),
+ *   - lets you add multiple candlestick charts,
+ *   - loads 1-minute history for the most recent trading day
+ *     (/chart/test/api/history), and
+ *   - streams the forming 1-minute candle live via the shared useMarketData hook.
+ *
+ * Only the 1-minute interval is supported. lightweight-charts is the bundled
+ * v5 library (no CDN), and no CSP changes are required.
+ */
+
+import {
+  CandlestickSeries,
+  ColorType,
+  CrosshairMode,
+  createChart,
+  type IChartApi,
+  type ISeriesApi,
+  type UTCTimestamp,
+} from 'lightweight-charts'
+import { X } from 'lucide-react'
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { Button } from '@/components/ui/button'
+import { Input } from '@/components/ui/input'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useMarketData } from '@/hooks/useMarketData'
+import { useThemeStore } from '@/stores/themeStore'
+import { showToast } from '@/utils/toast'
+
+// Matches the IST shift baked into the backend candle times so live bars line
+// up with history bars on the time axis. 5h30m = 19800s.
+const IST_OFFSET = 19800
+
+const EXCHANGES = ['NSE', 'NFO', 'BFO', 'BSE', 'MCX', 'CDS', 'NSE_INDEX', 'BSE_INDEX']
+
+// Common timeframe switcher (OpenAlgo interval format). Bucket size in seconds
+// is a whole multiple of the 5h30m IST offset for each, so live ticks bucket in
+// exact alignment with the broker's bars (no phase correction needed).
+const TIMEFRAMES = [
+  { value: '1m', label: '1m' },
+  { value: '5m', label: '5m' },
+  { value: '15m', label: '15m' },
+]
+const INTERVAL_SEC: Record<string, number> = { '1m': 60, '5m': 300, '15m': 900 }
+
+interface SearchResult {
+  symbol: string
+  exchange: string
+  name?: string
+}
+
+interface Candle {
+  time: number
+  open: number
+  high: number
+  low: number
+  close: number
+  volume?: number
+}
+
+interface ChartItem {
+  id: string // `${exchange}:${symbol}`
+  symbol: string
+  exchange: string
+}
+
+export default function ChartTest() {
+  const [exchange, setExchange] = useState('NSE')
+  const [query, setQuery] = useState('')
+  const [results, setResults] = useState<SearchResult[]>([])
+  const [showResults, setShowResults] = useState(false)
+  const [charts, setCharts] = useState<ChartItem[]>([])
+  const [timeframe, setTimeframe] = useState('1m')
+  const searchTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const blurTimer = useRef<ReturnType<typeof setTimeout> | null>(null)
+
+  const runSearch = useCallback(
+    (q: string) => {
+      if (!q.trim()) {
+        setResults([])
+        return
+      }
+      fetch(
+        `/search/api/search?q=${encodeURIComponent(q)}&exchange=${encodeURIComponent(exchange)}`,
+        { credentials: 'include', headers: { Accept: 'application/json' } }
+      )
+        .then((r) => r.json())
+        .then((d) => {
+          setResults((d.results || []).slice(0, 12))
+          setShowResults(true)
+        })
+        .catch(() => setResults([]))
+    },
+    [exchange]
+  )
+
+  const onQueryChange = (v: string) => {
+    setQuery(v)
+    if (searchTimer.current) clearTimeout(searchTimer.current)
+    searchTimer.current = setTimeout(() => runSearch(v), 220)
+  }
+
+  const addChart = useCallback((symbol: string, ex: string) => {
+    const id = `${ex}:${symbol}`
+    setCharts((prev) => {
+      if (prev.some((c) => c.id === id)) {
+        showToast.info(`${symbol} (${ex}) is already added`)
+        return prev
+      }
+      return [...prev, { id, symbol, exchange: ex }]
+    })
+    setShowResults(false)
+    setQuery('')
+  }, [])
+
+  const removeChart = useCallback((id: string) => {
+    setCharts((prev) => prev.filter((c) => c.id !== id))
+  }, [])
+
+  return (
+    <div className="py-6 space-y-4">
+      <div className="flex flex-col gap-1">
+        <h1 className="text-2xl font-bold">Chart Test</h1>
+        <p className="text-sm text-muted-foreground">
+          History (1m=1d, 5m=3d, 15m=9d) + live forming candle. The timeframe switches all charts
+          at once. Add multiple charts. Testing only.
+        </p>
+      </div>
+
+      <div className="flex flex-wrap items-center gap-3">
+        <Select value={exchange} onValueChange={setExchange}>
+          <SelectTrigger className="w-[140px]">
+            <SelectValue placeholder="Exchange" />
+          </SelectTrigger>
+          <SelectContent>
+            {EXCHANGES.map((ex) => (
+              <SelectItem key={ex} value={ex}>
+                {ex}
+              </SelectItem>
+            ))}
+          </SelectContent>
+        </Select>
+
+        <div className="relative">
+          <Input
+            value={query}
+            placeholder="Search symbol (e.g. RELIANCE, NIFTY)"
+            className="w-[280px]"
+            autoComplete="off"
+            onChange={(e) => onQueryChange(e.target.value)}
+            onFocus={() => results.length && setShowResults(true)}
+            onBlur={() => {
+              if (blurTimer.current) clearTimeout(blurTimer.current)
+              blurTimer.current = setTimeout(() => setShowResults(false), 150)
+            }}
+            onKeyDown={(e) => {
+              if (e.key === 'Enter' && results[0]) addChart(results[0].symbol, results[0].exchange)
+            }}
+          />
+          {showResults && results.length > 0 && (
+            <div className="absolute z-30 mt-1 max-h-80 w-[340px] overflow-y-auto rounded-md border bg-popover shadow-lg">
+              {results.map((r) => (
+                <button
+                  type="button"
+                  key={`${r.exchange}:${r.symbol}`}
+                  className="block w-full px-3 py-2 text-left hover:bg-accent"
+                  onMouseDown={(e) => {
+                    e.preventDefault()
+                    addChart(r.symbol, r.exchange)
+                  }}
+                >
+                  <div className="font-medium">{r.symbol}</div>
+                  <div className="text-xs text-muted-foreground">
+                    {r.name ? `${r.name} · ` : ''}
+                    {r.exchange}
+                  </div>
+                </button>
+              ))}
+            </div>
+          )}
+        </div>
+
+        <div className="inline-flex items-center rounded-md border p-0.5">
+          {TIMEFRAMES.map((tf) => (
+            <button
+              type="button"
+              key={tf.value}
+              onClick={() => setTimeframe(tf.value)}
+              className={`rounded px-3 py-1 text-sm font-medium transition-colors ${
+                timeframe === tf.value
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tf.label}
+            </button>
+          ))}
+        </div>
+
+        {charts.length > 0 && (
+          <Button variant="outline" size="sm" onClick={() => setCharts([])}>
+            Remove all
+          </Button>
+        )}
+      </div>
+
+      {charts.length === 0 ? (
+        <div className="rounded-md border border-dashed py-16 text-center text-sm text-muted-foreground">
+          Search a symbol and select it to add a chart. You can add multiple charts.
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-4 xl:grid-cols-2">
+          {charts.map((c) => (
+            <LiveChart
+              key={c.id}
+              symbol={c.symbol}
+              exchange={c.exchange}
+              interval={timeframe}
+              onRemove={() => removeChart(c.id)}
+            />
+          ))}
+        </div>
+      )}
+    </div>
+  )
+}
+
+function LiveChart({
+  symbol,
+  exchange,
+  interval,
+  onRemove,
+}: {
+  symbol: string
+  exchange: string
+  interval: string
+  onRemove: () => void
+}) {
+  const { mode } = useThemeStore()
+  const isDark = mode === 'dark'
+  const containerRef = useRef<HTMLDivElement | null>(null)
+  const chartRef = useRef<IChartApi | null>(null)
+  const seriesRef = useRef<ISeriesApi<'Candlestick'> | null>(null)
+  // Authoritative model: bucket time -> candle. Completed bars are reconciled
+  // from broker history; the current bucket is built live from ticks.
+  const candlesRef = useRef<Map<number, Candle>>(new Map())
+  const currentBucketRef = useRef<number | null>(null)
+  const tradingDateRef = useRef<string | null>(null)
+  const intervalSecRef = useRef<number>(INTERVAL_SEC[interval] ?? 60)
+  const readyRef = useRef(false)
+
+  const [note, setNote] = useState('loading...')
+  const [last, setLast] = useState<number | null>(null)
+  const [refPrice, setRefPrice] = useState<number | null>(null)
+
+  const { data, isAuthenticated } = useMarketData({
+    symbols: [{ symbol, exchange }],
+    mode: 'Quote',
+    enabled: true,
+    autoReconnect: true,
+  })
+
+  // Create the chart once per symbol/exchange. Data (and timeframe changes) are
+  // handled by the separate effect below, so switching timeframe reloads data
+  // without destroying/recreating the chart.
+  // biome-ignore lint/correctness/useExhaustiveDependencies: isDark used only for initial colors; theme updates handled by the applyOptions effect
+  useEffect(() => {
+    const container = containerRef.current
+    if (!container) return
+
+    const chart = createChart(container, {
+      width: container.clientWidth,
+      height: 340,
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: isDark ? '#a6adbb' : '#333',
+      },
+      grid: {
+        vertLines: { color: isDark ? 'rgba(166,173,187,0.1)' : 'rgba(0,0,0,0.06)' },
+        horzLines: { color: isDark ? 'rgba(166,173,187,0.1)' : 'rgba(0,0,0,0.06)' },
+      },
+      rightPriceScale: { borderColor: isDark ? 'rgba(166,173,187,0.2)' : 'rgba(0,0,0,0.1)' },
+      timeScale: {
+        borderColor: isDark ? 'rgba(166,173,187,0.2)' : 'rgba(0,0,0,0.1)',
+        timeVisible: true,
+        secondsVisible: false,
+      },
+      crosshair: { mode: CrosshairMode.Normal },
+    })
+    const series = chart.addSeries(CandlestickSeries, {
+      upColor: '#22c55e',
+      downColor: '#ef4444',
+      borderVisible: false,
+      wickUpColor: '#22c55e',
+      wickDownColor: '#ef4444',
+    })
+    chartRef.current = chart
+    seriesRef.current = series
+
+    const ro = new ResizeObserver(() => {
+      if (containerRef.current) chart.applyOptions({ width: containerRef.current.clientWidth })
+    })
+    ro.observe(container)
+
+    return () => {
+      ro.disconnect()
+      chart.remove()
+      chartRef.current = null
+      seriesRef.current = null
+    }
+  }, [symbol, exchange])
+
+  // Load history for the selected interval and run the reconcile loop. Re-runs
+  // when the timeframe changes -> instant flip across all charts; the chart
+  // instance is reused (only the data is swapped).
+  useEffect(() => {
+    const chart = chartRef.current
+    const series = seriesRef.current
+    if (!chart || !series) return
+    let disposed = false
+    let inflight = false
+    let timer: ReturnType<typeof setTimeout> | null = null
+
+    // Reset the model for the new timeframe.
+    candlesRef.current = new Map()
+    currentBucketRef.current = null
+    intervalSecRef.current = INTERVAL_SEC[interval] ?? 60
+    readyRef.current = false
+    setNote('loading...')
+
+    // Push the in-memory model to the chart. On reconcile we preserve the
+    // user's current zoom/scroll; on first load we fit the range.
+    const applyModel = (preserveRange: boolean) => {
+      const ts = chart.timeScale()
+      const range = preserveRange ? ts.getVisibleLogicalRange() : null
+      series.setData(
+        Array.from(candlesRef.current.values())
+          .sort((a, b) => a.time - b.time)
+          .map((k) => ({
+            time: k.time as UTCTimestamp,
+            open: k.open,
+            high: k.high,
+            low: k.low,
+            close: k.close,
+          }))
+      )
+      if (range) {
+        try {
+          ts.setVisibleLogicalRange(range)
+        } catch {
+          /* range no longer valid after data change */
+        }
+      } else {
+        ts.fitContent()
+      }
+    }
+
+    // Reconcile the recent COMPLETED bars against the broker's official 1m
+    // OHLC. The live forming bar (currentBucket) is left untouched. Only the
+    // trailing 10 completed bars are patched so each refresh stays cheap and
+    // self-heals broker history lag.
+    const reconcile = async () => {
+      if (disposed || inflight) return
+      inflight = true
+      try {
+        const date = tradingDateRef.current
+        const url =
+          `/chart/test/api/history?symbol=${encodeURIComponent(symbol)}` +
+          `&exchange=${encodeURIComponent(exchange)}&interval=${encodeURIComponent(interval)}` +
+          `${date ? `&date=${encodeURIComponent(date)}` : ''}`
+        const res = await fetch(url, { credentials: 'include', headers: { Accept: 'application/json' } })
+        const d = await res.json()
+        if (disposed || d.status !== 'success') return
+        const fetched: Candle[] = d.candles || []
+        if (!fetched.length) return
+        if (d.date) tradingDateRef.current = d.date
+        const cur = currentBucketRef.current
+        const completed = cur == null ? fetched : fetched.filter((k) => k.time < cur)
+        let changed = false
+        for (const k of completed.slice(-10)) {
+          const prev = candlesRef.current.get(k.time)
+          if (
+            !prev ||
+            prev.open !== k.open ||
+            prev.high !== k.high ||
+            prev.low !== k.low ||
+            prev.close !== k.close
+          ) {
+            candlesRef.current.set(k.time, { ...k })
+            changed = true
+          }
+        }
+        if (changed) applyModel(true)
+      } catch {
+        /* transient reconcile error; the next cycle retries */
+      } finally {
+        inflight = false
+      }
+    }
+
+    // Random 20-30s loop, re-randomized every cycle so multiple charts drift
+    // apart and never hit the history API at the same instant.
+    const schedule = () => {
+      const delay = 20000 + Math.random() * 10000
+      timer = setTimeout(async () => {
+        await reconcile()
+        if (!disposed) schedule()
+      }, delay)
+    }
+
+    fetch(
+      `/chart/test/api/history?symbol=${encodeURIComponent(symbol)}&exchange=${encodeURIComponent(exchange)}&interval=${encodeURIComponent(interval)}`,
+      { credentials: 'include', headers: { Accept: 'application/json' } }
+    )
+      .then((r) => r.json())
+      .then((d) => {
+        if (disposed) return
+        if (d.status !== 'success') {
+          setNote(`history error: ${d.message || 'failed'}`)
+          schedule()
+          return
+        }
+        const candles: Candle[] = d.candles || []
+        tradingDateRef.current = d.date || null
+        if (!candles.length) {
+          setNote('no history')
+          schedule()
+          return
+        }
+        candlesRef.current = new Map(candles.map((k) => [k.time, { ...k }]))
+        applyModel(false)
+        const lastK = candles[candles.length - 1]
+        currentBucketRef.current = lastK.time
+        setRefPrice(candles.length > 1 ? candles[candles.length - 2].close : lastK.open)
+        setLast(lastK.close)
+        setNote(`${interval} · ${candles.length} bars`)
+        readyRef.current = true
+        schedule()
+      })
+      .catch(() => {
+        if (!disposed) {
+          setNote('history fetch failed')
+          schedule()
+        }
+      })
+
+    return () => {
+      disposed = true
+      readyRef.current = false
+      if (timer) clearTimeout(timer)
+    }
+  }, [symbol, exchange, interval])
+
+  // Re-apply theme colors without re-creating the chart.
+  useEffect(() => {
+    const chart = chartRef.current
+    if (!chart) return
+    chart.applyOptions({
+      layout: {
+        background: { type: ColorType.Solid, color: 'transparent' },
+        textColor: isDark ? '#a6adbb' : '#333',
+      },
+      grid: {
+        vertLines: { color: isDark ? 'rgba(166,173,187,0.1)' : 'rgba(0,0,0,0.06)' },
+        horzLines: { color: isDark ? 'rgba(166,173,187,0.1)' : 'rgba(0,0,0,0.06)' },
+      },
+    })
+  }, [isDark])
+
+  // Update the forming candle from each live tick, bucketed at the active
+  // interval. The 5h30m IST offset is a whole multiple of 60/300/900s, so a
+  // plain floor aligns 1m/5m/15m buckets with the broker's bars.
+  const tick = data.get(`${exchange}:${symbol}`)?.data
+  const ltp = tick?.ltp
+  const ts = tick?.timestamp
+  useEffect(() => {
+    const series = seriesRef.current
+    if (!series || !readyRef.current || ltp == null || !Number.isFinite(ltp)) return
+
+    const parsed = ts ? Date.parse(ts) : Number.NaN
+    const epochUtc = Number.isNaN(parsed) ? Math.floor(Date.now() / 1000) : Math.floor(parsed / 1000)
+    const sec = intervalSecRef.current
+    const bucket = Math.floor((epochUtc + IST_OFFSET) / sec) * sec
+    const cur = currentBucketRef.current
+
+    let bar: Candle
+    if (cur == null || bucket > cur) {
+      // New bar: open at the current price.
+      bar = { time: bucket, open: ltp, high: ltp, low: ltp, close: ltp }
+      currentBucketRef.current = bucket
+    } else if (bucket === cur) {
+      // Same bar: refine high/low/close, keep the open.
+      const prev = candlesRef.current.get(bucket)
+      bar = prev
+        ? {
+            time: bucket,
+            open: prev.open,
+            high: Math.max(prev.high, ltp),
+            low: Math.min(prev.low, ltp),
+            close: ltp,
+          }
+        : { time: bucket, open: ltp, high: ltp, low: ltp, close: ltp }
+    } else {
+      return // stale tick older than the current bar
+    }
+    candlesRef.current.set(bucket, bar)
+    series.update({
+      time: bar.time as UTCTimestamp,
+      open: bar.open,
+      high: bar.high,
+      low: bar.low,
+      close: bar.close,
+    })
+    setLast(ltp)
+  }, [ltp, ts])
+
+  const up = last != null && refPrice != null ? last >= refPrice : true
+
+  return (
+    <div className="rounded-lg border bg-card">
+      <div className="flex items-center gap-2 border-b px-3 py-2">
+        <span
+          className={`h-2 w-2 rounded-full ${isAuthenticated ? 'bg-green-500' : 'bg-zinc-400'}`}
+          title={isAuthenticated ? 'streaming' : 'connecting'}
+        />
+        <span className="font-semibold">{symbol}</span>
+        <span className="text-xs text-muted-foreground">{exchange}</span>
+        <span className="ml-2 text-xs text-muted-foreground">{note}</span>
+        <span
+          className={`ml-auto font-semibold tabular-nums ${up ? 'text-green-500' : 'text-red-500'}`}
+        >
+          {last != null ? last.toLocaleString('en-IN', { minimumFractionDigits: 2, maximumFractionDigits: 2 }) : '-'}
+        </span>
+        <Button variant="ghost" size="icon" className="h-6 w-6" onClick={onRemove} title="Remove">
+          <X className="h-4 w-4" />
+        </Button>
+      </div>
+      <div ref={containerRef} className="w-full" style={{ height: 340 }} />
+    </div>
+  )
+}

--- a/frontend/src/pages/Scalping.tsx
+++ b/frontend/src/pages/Scalping.tsx
@@ -2,6 +2,7 @@ import { useQuery, useQueryClient } from '@tanstack/react-query'
 import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
 import { scalpingApi } from '@/api/scalping'
 import { type QuotesData, tradingApi } from '@/api/trading'
+import { ScalpChart } from '@/components/scalping/ScalpChart'
 import { SetSLDialog } from '@/components/scalping/SetSLDialog'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
@@ -250,6 +251,10 @@ export default function Scalping() {
   const [lots, setLots] = useState(1)
   const [product, setProduct] = useState<ScalpingProduct>('NRML')
   const [lastLatencyMs, setLastLatencyMs] = useState<number | null>(null)
+
+  // Shared timeframe for the live charts (OpenAlgo interval format). One switch
+  // flips every chart (CE / underlying / PE, or the single instrument) at once.
+  const [chartTf, setChartTf] = useState('1m')
 
   // Global predefined SL / Target — when enabled, auto-attached to every new entry.
   // Value is in points or percent of entry (default points).
@@ -1210,6 +1215,67 @@ export default function Scalping() {
             high={peTick?.high}
             low={peTick?.low}
           />
+        </div>
+      )}
+
+      {/* Live charts (candles + volume + OHLC legend), shared timeframe */}
+      <div className="flex items-center gap-1.5">
+        <span className="text-xs text-muted-foreground">Timeframe</span>
+        <div className="inline-flex items-center rounded-md border p-0.5">
+          {['1m', '5m', '15m'].map((tf) => (
+            <button
+              type="button"
+              key={tf}
+              onClick={() => setChartTf(tf)}
+              className={`rounded px-2.5 py-1 text-xs font-medium transition-colors ${
+                chartTf === tf
+                  ? 'bg-primary text-primary-foreground'
+                  : 'text-muted-foreground hover:text-foreground'
+              }`}
+            >
+              {tf}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {isSingle ? (
+        <div className="grid grid-cols-1 gap-3">
+          <div className="h-[340px]">
+            <ScalpChart
+              symbol={singleLeg?.symbol ?? ''}
+              exchange={singleLeg?.exchange ?? ''}
+              interval={chartTf}
+              title={segment === 'EQUITY' ? 'Equity' : 'Futures'}
+            />
+          </div>
+        </div>
+      ) : (
+        <div className="grid grid-cols-1 gap-3 md:grid-cols-3">
+          <div className="h-[340px]">
+            <ScalpChart
+              symbol={ceLeg?.symbol ?? ''}
+              exchange={ceLeg?.exchange ?? ''}
+              interval={chartTf}
+              title="Call (CE)"
+            />
+          </div>
+          <div className="h-[340px]">
+            <ScalpChart
+              symbol={underlyingSym}
+              exchange={underlyingExch}
+              interval={chartTf}
+              title={underlying || 'Underlying'}
+            />
+          </div>
+          <div className="h-[340px]">
+            <ScalpChart
+              symbol={peLeg?.symbol ?? ''}
+              exchange={peLeg?.exchange ?? ''}
+              interval={chartTf}
+              title="Put (PE)"
+            />
+          </div>
         </div>
       )}
 


### PR DESCRIPTION
## Summary
Two chart features built interactively in this branch.

### Scalping charts (primary)
- New `ScalpChart` component: live candlestick + volume histogram with a crosshair-driven OHLC legend; forming candle from the shared `useMarketData` feed; completed bars reconciled to broker OHLC on a staggered 20-30s timer.
- `/scalping` now shows CE / underlying / PE charts (options) or a single chart (equity/futures) under the tickers, with a shared 1m/5m/15m timeframe switcher. Works across NFO/BFO/MCX/CDS and NSE/BSE; index symbols carry volume 0.
- New `GET /scalping/api/history` endpoint (per-interval lookback 1m=1d, 5m=3d, 15m=9d; IST-aligned bar times; single-day reconcile param).

### /chart/test dev page (testing only, not linked from any menu)
- Standalone multi-chart live-streaming test page at `/chart/test`: symbol search, add/stream multiple charts, 1m/5m/15m timeframe, same history + reconcile machinery. Backed by `GET /chart/test/api/history`.

## Notes
- `frontend/dist/` intentionally not committed - CI rebuilds it on main.
- Uses the bundled lightweight-charts v5 (no CDN, no CSP changes).

## Test plan
- Restart app, open `/scalping`, select underlying/strikes -> CE/underlying/PE charts stream live; the timeframe switch flips all charts.
- Open `/chart/test`, search and add symbols across exchanges.