### PR TITLE
fix(fivepaisa): use real intraday history timestamps + cubic.dev review fixes

### DIFF
--- a/broker/fivepaisa/api/data.py
+++ b/broker/fivepaisa/api/data.py
@@ -1,7 +1,7 @@
 import json
 import os
 import time
-from datetime import datetime, timedelta
+from datetime import datetime
 from typing import Any, Dict, Optional
 
 import httpx
@@ -46,8 +46,12 @@ def normalize_exchange_for_query(symbol: str, exchange: str) -> str:
         "INDIAVIX",
     ]
 
-    # Check if symbol is an index
-    if symbol.upper() in index_symbols or "NIFTY" in symbol.upper() or "SENSEX" in symbol.upper():
+    # Match only on an EXACT symbol name. A substring test ("NIFTY" in symbol)
+    # is too broad: it wrongly remaps tradeable cash instruments such as
+    # NIFTYBEES / JUNIORBEES to *_INDEX, so their (non-index) token is never
+    # found and history comes back empty. Real index spot names are enumerated
+    # above, so exact membership is both sufficient and safe.
+    if symbol.upper() in index_symbols:
         if exchange == "NSE":
             return "NSE_INDEX"
         elif exchange == "BSE":
@@ -801,10 +805,10 @@ class BrokerData:
                             if len(candle) < 6:
                                 continue
 
-                            # Parse date and values
+                            # Parse the candle datetime. 5Paisa historical candles
+                            # are stamped in IST wall-clock (e.g. 2026-06-17T09:15:00),
+                            # so keep it naive here and localize per-branch below.
                             dt = datetime.strptime(candle[0], "%Y-%m-%dT%H:%M:%S")
-                            # Make the datetime timezone-aware (UTC)
-                            dt = pytz.UTC.localize(dt)
 
                             open_price = float(candle[1])
                             high_price = float(candle[2])
@@ -829,10 +833,23 @@ class BrokerData:
                                 and close_price == 0
                             )
                             if is_index:
+                                # Indices have no traded volume; only fully-empty.
                                 if all_prices_zero:
                                     continue
-                            elif volume == 0 or all_prices_zero or (high_price == low_price):
-                                continue
+                            elif interval.upper() == "D":
+                                # Daily non-index: a holiday/no-trade day shows up as
+                                # flat or empty data, so the stricter filter is correct
+                                # at this resolution.
+                                if volume == 0 or all_prices_zero or (high_price == low_price):
+                                    continue
+                            else:
+                                # Intraday non-index: a quiet minute legitimately has
+                                # volume == 0 and/or high == low. Dropping those candles
+                                # (combined with the old index-based timestamp rebuild)
+                                # made intraday series appear to stop mid-session. Only
+                                # drop genuinely empty candles.
+                                if all_prices_zero:
+                                    continue
 
                             # For daily candles, create timestamp at midnight UTC like Angel does
                             if interval.upper() == "D":
@@ -845,28 +862,13 @@ class BrokerData:
                                 dt_midnight = pytz.UTC.localize(dt_midnight)
                                 timestamp_sec = int(dt_midnight.timestamp())
                             else:
-                                # For intraday candles, convert to IST and fix market hours
+                                # Intraday: localize the API's IST wall-clock time
+                                # directly and keep it. We use the REAL candle time
+                                # (no market-hours shifting, no index-based rebuild),
+                                # so missing/filtered candles leave honest gaps instead
+                                # of silently shifting the whole series earlier.
                                 ist = pytz.timezone("Asia/Kolkata")
-                                dt = dt.astimezone(ist)
-
-                                # Make sure we handle the timing correctly
-                                # Create a reference time at 9:15 AM on the same date
-                                market_open = dt.replace(hour=9, minute=15, second=0)
-
-                                # Check if the timestamp is outside of valid market hours
-                                if (
-                                    dt.hour < 9
-                                    or (dt.hour == 9 and dt.minute < 15)
-                                    or dt.hour > 15
-                                    or (dt.hour == 15 and dt.minute > 30)
-                                ):
-                                    # Shift to market hours by making it relative to market open
-                                    minutes_offset = (dt.hour * 60 + dt.minute) % (
-                                        6 * 60 + 15
-                                    )  # 6h15m market duration
-                                    dt = market_open + timedelta(minutes=minutes_offset)
-
-                                # Convert to Unix timestamp in seconds
+                                dt = ist.localize(dt)
                                 timestamp_sec = int(dt.timestamp())
 
                             transformed_candle = {
@@ -935,16 +937,12 @@ class BrokerData:
                     f"Debug: First timestamp value: {df['timestamp'].iloc[0] if len(df) > 0 else 'empty'}"
                 )
             else:
-                # For intraday data, apply timestamp fixing
-                if interval == "10m" and not df.empty:
-                    logger.debug("Debug: Fixing 10m timestamps")
-                    df = self.fix_timestamps(df, "10m")
-                else:
-                    logger.debug(f"Debug: Fixing timestamps for {interval}")
-                    df = self.fix_timestamps(df, interval)
-
-                # Convert back to Unix timestamp in seconds
-                df["timestamp"] = df["timestamp"].astype("int64") // 10**9
+                # Intraday timestamps are already the real IST candle times stored
+                # as epoch seconds. Keep them verbatim — do NOT renumber by row
+                # index (the old fix_timestamps() rebuilt every timestamp as
+                # 09:15 + i*interval, which assumed a gapless series and truncated
+                # the session whenever any candle was filtered out).
+                df["timestamp"] = df["timestamp"].astype("int64")
 
             # Log first timestamp after processing
             if len(df) > 0:
@@ -984,108 +982,6 @@ class BrokerData:
                     logger.error(f"Recovery attempt failed: {recovery_error}")
 
             raise
-
-    def fix_timestamps(self, df, interval):
-        """
-        Helper function to fix timestamps in any DataFrame
-        Args:
-            df: DataFrame with timestamp column
-            interval: Time interval (e.g., 1m, 5m, 15m, 30m, 1h, 1d)
-        Returns:
-            DataFrame with fixed timestamps
-        """
-        # Make a copy to avoid modifying the original
-        df = df.copy()
-
-        # Ensure timestamp is a pandas datetime
-        if pd.api.types.is_numeric_dtype(df["timestamp"]):
-            df["timestamp"] = pd.to_datetime(df["timestamp"], unit="s")
-        elif not pd.api.types.is_datetime64_dtype(df["timestamp"]):
-            df["timestamp"] = pd.to_datetime(df["timestamp"])
-
-        # Add timezone info if not present
-        if df["timestamp"].dt.tz is None:
-            # Assume timestamps are in IST
-            ist = pytz.timezone("Asia/Kolkata")
-            df["timestamp"] = df["timestamp"].dt.tz_localize(ist)
-
-        # Extract unique dates
-        dates = df["timestamp"].dt.date.unique()
-
-        # Check if we're getting daily candles with intraday interval
-        is_daily_data = True
-        # Group by date and check if there's only one candle per date
-        date_counts = df.groupby(df["timestamp"].dt.date).size()
-        if (date_counts > 1).any():
-            # If any date has more than one candle, it's not daily data
-            is_daily_data = False
-
-        # Get interval in minutes
-        interval_minutes = 5
-        # Standardize how we check for daily interval
-        is_daily_interval = interval.upper() == "D" or interval == "1d" or interval == "d"
-        logger.debug(
-            f"Debug: is_daily_interval={is_daily_interval}, is_daily_data={is_daily_data}, interval={interval}"
-        )
-
-        if is_daily_interval or is_daily_data:
-            # For daily or data that looks like daily (1 candle per day),
-            # set all to 9:15 AM
-            df["timestamp"] = df["timestamp"].apply(
-                lambda ts: ts.replace(hour=9, minute=15, second=0)
-            )
-            return df
-        else:
-            # Parse interval
-            if "m" in interval.lower():
-                try:
-                    interval_minutes = int(interval.lower().replace("m", ""))
-                except Exception:
-                    interval_minutes = 5
-            elif "h" in interval.lower():
-                try:
-                    interval_minutes = int(interval.lower().replace("h", "")) * 60
-                except Exception:
-                    interval_minutes = 60
-
-        # Create new timestamps dictionary by date
-        new_timestamps = {}
-
-        for date in dates:
-            # Get candles for this date
-            mask = df["timestamp"].dt.date == date
-            date_candles = df[mask]
-
-            # Create proper sequence of timestamps based on interval
-            # Market always opens at 9:15 AM
-            market_open_hour = 9
-            first_candle_minute = 15  # 9:15 AM
-
-            market_open = pd.Timestamp(date).replace(
-                hour=market_open_hour, minute=first_candle_minute, second=0
-            )
-            market_open = market_open.tz_localize(pytz.timezone("Asia/Kolkata"))
-
-            # Store index to timestamp mapping
-            idx_to_ts = {}
-            for i, idx in enumerate(date_candles.index):
-                new_ts = market_open + pd.Timedelta(minutes=i * interval_minutes)
-                # Ensure we don't exceed market hours
-                if new_ts.hour > 15 or (new_ts.hour == 15 and new_ts.minute > 30):
-                    new_ts = market_open.replace(hour=15, minute=30)
-                idx_to_ts[idx] = new_ts
-
-            # Add to our dictionary
-            new_timestamps.update(idx_to_ts)
-
-        # Replace timestamps
-        for idx, ts in new_timestamps.items():
-            df.loc[idx, "timestamp"] = ts
-
-        # Sort by the new timestamps
-        df = df.sort_values("timestamp").reset_index(drop=True)
-
-        return df
 
     def get_supported_intervals(self) -> list:
         """Get list of supported intervals"""

--- a/broker/fivepaisa/api/order_api.py
+++ b/broker/fivepaisa/api/order_api.py
@@ -305,9 +305,12 @@ def place_order_api(data: dict[str, Any], auth: str) -> dict[str, Any]:
 
     payload = json.dumps(json_data)
 
-    # Log the outgoing request at INFO so order placement is captured even when
-    # LOG_LEVEL is the default INFO (sensitive keys are redacted by the logger).
-    logger.info(f"5Paisa PlaceOrder request: {payload}")
+    # Log the order body at INFO so placements are captured even at the default
+    # INFO level. We deliberately log only `body`, never the full payload: the
+    # `head.key` field carries the broker API key in plaintext and the JSON key
+    # name "key" is NOT covered by the logger's redaction patterns, so logging
+    # the whole payload would leak the credential to app logs on every order.
+    logger.info(f"5Paisa PlaceOrder request body: {json.dumps(newdata)}")
 
     try:
         # Get the shared httpx client

--- a/broker/fivepaisa/streaming/fivepaisa_adapter.py
+++ b/broker/fivepaisa/streaming/fivepaisa_adapter.py
@@ -286,7 +286,19 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         previous one-frame-per-symbol flood on bulk subscribe / resubscribe.
         """
         consecutive_failures = 0
-        while self.pending_subscriptions and self.running and not self._stop_event.is_set():
+        while self.running and not self._stop_event.is_set():
+            # Decide whether to exit on an EMPTY queue under the same lock that
+            # _enqueue_subscriptions holds when it appends work and checks our
+            # liveness. Doing the emptiness test outside the lock is a lost-wakeup
+            # race: an enqueue could add an item and observe this thread still
+            # alive (so skip starting a new one) in the instant between our
+            # unlocked test and our return, stranding that item until the next
+            # enqueue/reconnect. Clearing _sub_thread here closes that window.
+            with self.lock:
+                if not self.pending_subscriptions:
+                    self._sub_thread = None
+                    return
+
             if not (self.connected and self.ws_client):
                 # Not connected yet; _on_open re-queues everything on connect,
                 # so just back off briefly and re-check (interruptible).
@@ -340,6 +352,11 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             if self.pending_subscriptions:
                 if self._stop_event.wait(self.SUBSCRIPTION_DELAY):
                     break
+
+        # Loop exited via stop/pause (not the empty-queue return above): clear the
+        # handle so a later _enqueue_subscriptions starts a fresh processor.
+        with self.lock:
+            self._sub_thread = None
 
     def subscribe(
         self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 5
@@ -460,10 +477,19 @@ class FivepaisaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Generate correlation ID
         correlation_id = f"{symbol}_{exchange}_{mode}"
 
-        # Remove from subscriptions
+        # Remove from subscriptions and cancel any still-queued subscribe for the
+        # same (method, scrip). Without this, a quick subscribe->unsubscribe would
+        # send Unsubscribe now but leave the batched Subscribe in the queue, which
+        # the processor then sends afterwards — resurrecting a stale server-side
+        # subscription and unwanted feed traffic.
+        target = (method, scrip_data[0])
         with self.lock:
             if correlation_id in self.subscriptions:
                 del self.subscriptions[correlation_id]
+            if self.pending_subscriptions:
+                self.pending_subscriptions = deque(
+                    item for item in self.pending_subscriptions if item != target
+                )
 
         # Unsubscribe if connected
         if self.connected and self.ws_client:


### PR DESCRIPTION
fix(fivepaisa): use real intraday history timestamps + cubic.dev review fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes FivePaisa intraday history to use real IST candle timestamps, preventing mid‑session cutoffs and preserving legitimate quiet-minute candles. Also hardens order logging and makes streaming subscriptions more reliable.

- **Bug Fixes**
  - Intraday history: keep the API’s IST timestamps; remove renumbering; only drop fully empty candles. Daily keeps stricter holiday filters; indices keep all‑zero rule.
  - Parse candle time as IST instead of localizing to UTC, removing a hidden +5:30 offset.
  - Index mapping: exact symbol match only to avoid remapping cash instruments like NIFTYBEES to `*_INDEX`.
  - Order placement: log only the request body (exclude `head.key`) to prevent API key leakage in logs.
  - Streaming: on unsubscribe, remove any queued subscribe for the same scrip to avoid stale re‑subscriptions; fix a lost‑wakeup race by deciding empty-queue exits under lock and clearing the worker handle.

<sup>Written for commit 6b8fbf4e5aa2bb916a1379cb798cec5887ce2bdd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1536?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

