### PR TITLE
fix(freeze): honor freeze quantities for all F&O exchanges (BFO/CDS/MCX)

### DIFF
--- a/database/qty_freeze_db.py
+++ b/database/qty_freeze_db.py
@@ -6,10 +6,10 @@ Handles freeze quantity limits for F&O instruments.
 Freeze quantity is the maximum order quantity allowed in a single order.
 Orders exceeding this limit need to be split.
 
-Currently supports:
-- NFO: Actual freeze quantities from NSE
-- BFO: Actual freeze quantities (admin-managed via the Freeze Quantities page)
-- CDS, MCX: Default value of 1 (to be implemented later)
+Freeze quantities are admin-managed per exchange + underlying (NFO seeded from
+NSE's qtyfreeze.csv; BFO/CDS/MCX and others added via the Freeze Quantities page
+or a CSV upload). Any F&O exchange with a configured entry is honored; symbols
+without an entry default to 1 (no splitting cap applied).
 """
 
 import csv
@@ -159,12 +159,12 @@ def get_freeze_qty(symbol: str, exchange: str) -> int:
     Get freeze quantity for a symbol.
     Uses in-memory cache for fast lookups.
 
-    For NFO/BFO: Returns actual freeze quantity from database
-    For other exchanges (CDS, MCX): Returns 1 (default)
+    Returns the configured freeze quantity for any F&O exchange (NFO, BFO, CDS,
+    MCX, ...) that has an entry, and 1 as the default when none is configured.
 
     Args:
-        symbol: The underlying symbol (e.g., "NIFTY", "RELIANCE", "SENSEX")
-        exchange: Exchange code (NFO, BFO, CDS, MCX)
+        symbol: The underlying symbol (e.g., "NIFTY", "RELIANCE", "SENSEX", "CRUDEOIL")
+        exchange: Exchange code (NFO, BFO, CDS, MCX, ...)
 
     Returns:
         Freeze quantity (integer)
@@ -175,11 +175,7 @@ def get_freeze_qty(symbol: str, exchange: str) -> int:
     if not _cache_loaded:
         load_freeze_qty_cache()
 
-    # Exchanges without freeze data yet (CDS, MCX) fall back to 1
-    if exchange not in ["NFO", "BFO"]:
-        return 1
-
-    # Look up in cache
+    # Look up the configured entry for this exchange+symbol; default to 1 if none.
     cache_key = f"{exchange}:{symbol}"
     if cache_key in _freeze_qty_cache:
         return _freeze_qty_cache[cache_key]
@@ -194,10 +190,10 @@ def get_freeze_qty_for_option(option_symbol: str, exchange: str) -> int:
     Extracts the underlying from the symbol and looks up freeze qty.
 
     Examples:
-        NIFTY24DEC24000CE -> NIFTY
-        BANKNIFTY24DEC24FUT -> BANKNIFTY
-        RELIANCE24DEC241000CE -> RELIANCE
+        NIFTY24DEC24000CE -> NIFTY (NFO)
         SENSEX25DEC2480000CE -> SENSEX (BFO)
+        CRUDEOIL25DEC246000CE -> CRUDEOIL (MCX)
+        USDINR25DEC2487CE -> USDINR (CDS)
 
     Args:
         option_symbol: Full option/futures symbol
@@ -207,10 +203,6 @@ def get_freeze_qty_for_option(option_symbol: str, exchange: str) -> int:
         Freeze quantity (integer)
     """
     import re
-
-    # Exchanges without freeze data yet (CDS, MCX) fall back to 1
-    if exchange not in ["NFO", "BFO"]:
-        return 1
 
     # Extract underlying from option/futures symbol
     # Pattern: SYMBOL + DATE + optional(STRIKE) + TYPE(FUT/CE/PE)

--- a/database/qty_freeze_db.py
+++ b/database/qty_freeze_db.py
@@ -8,12 +8,12 @@ Orders exceeding this limit need to be split.
 
 Currently supports:
 - NFO: Actual freeze quantities from NSE
-- BFO, CDS, MCX: Default value of 1 (to be implemented later)
+- BFO: Actual freeze quantities (admin-managed via the Freeze Quantities page)
+- CDS, MCX: Default value of 1 (to be implemented later)
 """
 
 import csv
 import os
-from typing import Dict, Optional
 
 from sqlalchemy import Column, Index, Integer, String, create_engine
 from sqlalchemy.ext.declarative import declarative_base
@@ -159,11 +159,11 @@ def get_freeze_qty(symbol: str, exchange: str) -> int:
     Get freeze quantity for a symbol.
     Uses in-memory cache for fast lookups.
 
-    For NFO: Returns actual freeze quantity from database
-    For other exchanges (BFO, CDS, MCX): Returns 1 (default)
+    For NFO/BFO: Returns actual freeze quantity from database
+    For other exchanges (CDS, MCX): Returns 1 (default)
 
     Args:
-        symbol: The underlying symbol (e.g., "NIFTY", "RELIANCE")
+        symbol: The underlying symbol (e.g., "NIFTY", "RELIANCE", "SENSEX")
         exchange: Exchange code (NFO, BFO, CDS, MCX)
 
     Returns:
@@ -175,8 +175,8 @@ def get_freeze_qty(symbol: str, exchange: str) -> int:
     if not _cache_loaded:
         load_freeze_qty_cache()
 
-    # For non-NFO exchanges, return 1 as default (to be implemented later)
-    if exchange not in ["NFO"]:
+    # Exchanges without freeze data yet (CDS, MCX) fall back to 1
+    if exchange not in ["NFO", "BFO"]:
         return 1
 
     # Look up in cache
@@ -197,6 +197,7 @@ def get_freeze_qty_for_option(option_symbol: str, exchange: str) -> int:
         NIFTY24DEC24000CE -> NIFTY
         BANKNIFTY24DEC24FUT -> BANKNIFTY
         RELIANCE24DEC241000CE -> RELIANCE
+        SENSEX25DEC2480000CE -> SENSEX (BFO)
 
     Args:
         option_symbol: Full option/futures symbol
@@ -207,16 +208,20 @@ def get_freeze_qty_for_option(option_symbol: str, exchange: str) -> int:
     """
     import re
 
-    # For non-NFO exchanges, return 1 as default
-    if exchange not in ["NFO"]:
+    # Exchanges without freeze data yet (CDS, MCX) fall back to 1
+    if exchange not in ["NFO", "BFO"]:
         return 1
 
     # Extract underlying from option/futures symbol
     # Pattern: SYMBOL + DATE + optional(STRIKE) + TYPE(FUT/CE/PE)
-    # Examples: NIFTY24DEC24FUT, NIFTY24DEC2424000CE, RELIANCE24DEC241000PE
+    # Examples: NIFTY24DEC24FUT, NIFTY24DEC2424000CE, SENSEX25DEC2480000PE
 
-    # Try to match known index symbols first
-    index_symbols = ["NIFTY", "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY", "NIFTYNXT50"]
+    # Try to match known index symbols first. Longest-prefix-first so e.g. NIFTYNXT50
+    # is not shadowed by NIFTY, and SENSEX50 is not shadowed by SENSEX.
+    index_symbols = [
+        "BANKNIFTY", "FINNIFTY", "MIDCPNIFTY", "NIFTYNXT50", "NIFTY",
+        "SENSEX50", "BANKEX", "SENSEX",
+    ]
     for idx_sym in index_symbols:
         if option_symbol.upper().startswith(idx_sym):
             return get_freeze_qty(idx_sym, exchange)


### PR DESCRIPTION
## Summary
Freeze quantities were only honored for `NFO`; every other exchange hard-returned `1`, so admin-configured entries (e.g. `BFO:SENSEX`) were silently ignored.

This PR makes the configured `qty_freeze` cache the single source of truth for **all F&O exchanges**.

## Changes
- `get_freeze_qty` / `get_freeze_qty_for_option`: removed the exchange allow-list. Any exchange with a configured entry (NFO, BFO, CDS, MCX, …) is honored; symbols without an entry still default to `1`.
- Added BSE index underlyings (`SENSEX`, `BANKEX`, `SENSEX50`) to the matcher and reordered it **longest-prefix-first** — also fixes a latent bug where `NIFTYNXT50` was shadowed by `NIFTY`.
- Updated docstrings; removed a dead `typing` import.

## Notes
- Freeze qty is attached at query time to search / symbol-info / get_option_symbol responses — it is **not** a master-contract column, so `SymToken` rows do not change (by design).
- Informational only today; not yet wired into automatic order-splitting enforcement.

## Verification
Exercised the real functions with a simulated cache: CRUDEOIL/GOLD (MCX), USDINR (CDS), SENSEX/SENSEX50/BANKEX (BFO), NIFTY/NIFTYNXT50 (NFO) all resolve correctly; unconfigured symbols fall back to 1. `ruff` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)