### PR TITLE
s

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -15,6 +15,8 @@ RUN pip install --no-cache-dir uv && \
 
 # ------------------------------ Frontend Builder Stage --------------------- #
 FROM node:20-bullseye-slim AS frontend-builder
+ARG OPENALGO_BASE=/
+ENV OPENALGO_BASE=$OPENALGO_BASE
 WORKDIR /app
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm install

--- a/app.py
+++ b/app.py
@@ -23,7 +23,7 @@ mimetypes.add_type("application/json", ".json")
 mimetypes.add_type("application/font-woff", ".woff")
 mimetypes.add_type("application/font-woff2", ".woff2")
 
-from flask import Flask, session
+from flask import Flask, session, request
 from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_wtf.csrf import CSRFProtect  # Import CSRF protection
 
@@ -203,6 +203,11 @@ def create_app():
     # Add cookie prefix for HTTPS environments
     if USE_HTTPS:
         app.config["SESSION_COOKIE_NAME"] = f"__Secure-{session_cookie_name}"
+
+    import os as _os
+    _url_prefix = _os.getenv("URL_PREFIX", "").rstrip("/")
+    if _url_prefix:
+        app.config["SESSION_COOKIE_PATH"] = _url_prefix
 
 
     # CSRF configuration from environment variables
@@ -425,6 +430,18 @@ def create_app():
 
         # NOTE: Telegram bot auto-start moved to background init thread
         # (after DB tables are created) to avoid "no such table" on fresh install
+
+    @app.after_request
+    def _prefix_redirect_location(response):
+        # Hardcoded redirect("/path") calls return a root-relative Location that
+        # ignores SCRIPT_NAME. When served under a prefix, prepend it — unless the
+        # Location already starts with the prefix (url_for-based redirects do).
+        script_name = request.environ.get("SCRIPT_NAME", "")
+        if script_name:
+            loc = response.headers.get("Location")
+            if loc and loc.startswith("/") and not loc.startswith(script_name + "/") and loc != script_name:
+                response.headers["Location"] = script_name + loc
+        return response
 
     @app.before_request
     def wait_for_db_ready():

--- a/app.py
+++ b/app.py
@@ -24,6 +24,7 @@ mimetypes.add_type("application/font-woff", ".woff")
 mimetypes.add_type("application/font-woff2", ".woff2")
 
 from flask import Flask, session
+from werkzeug.middleware.proxy_fix import ProxyFix
 from flask_wtf.csrf import CSRFProtect  # Import CSRF protection
 
 from blueprints.admin import admin_bp  # Import the admin blueprint
@@ -203,6 +204,7 @@ def create_app():
     if USE_HTTPS:
         app.config["SESSION_COOKIE_NAME"] = f"__Secure-{session_cookie_name}"
 
+
     # CSRF configuration from environment variables
     csrf_enabled = os.getenv("CSRF_ENABLED", "TRUE").upper() == "TRUE"
     app.config["WTF_CSRF_ENABLED"] = csrf_enabled
@@ -249,6 +251,12 @@ def create_app():
 
     # Initialize traffic logging middleware after security
     init_traffic_logging(app)
+
+    # Behind our nginx the console is served under a path prefix; nginx strips
+    # the prefix and sends X-Forwarded-Prefix. ProxyFix turns that into
+    # SCRIPT_NAME so url_for() generates prefixed URLs. x_prefix only — leave
+    # x_for=0 so the existing utils/ip_helper.py keeps owning client-IP logic.
+    app.wsgi_app = ProxyFix(app.wsgi_app, x_proto=1, x_prefix=1)
 
     # Register other blueprints
     app.register_blueprint(auth_bp)

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -2,8 +2,8 @@
 <html lang="en">
   <head>
     <meta charset="UTF-8" />
-    <link rel="icon" href="/favicon.ico" />
-    <link rel="apple-touch-icon" href="/apple-touch-icon.png" />
+    <link rel="icon" href="favicon.ico" />
+    <link rel="apple-touch-icon" href="apple-touch-icon.png" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <meta name="description" content="OpenAlgo - Open Source Algorithmic Trading Platform" />
     <meta name="theme-color" content="#3b82f6" />

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -147,7 +147,7 @@ function PageTitleUpdater() {
 function App() {
   return (
     <Providers>
-      <BrowserRouter>
+      <BrowserRouter basename={import.meta.env.BASE_URL.replace(/\/$/, '') || '/'}>
         <PageTitleUpdater />
         <AuthSync>
           <Suspense fallback={<PageLoader />}>

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,10 +1,15 @@
 import axios from 'axios'
 
-const API_BASE_URL = import.meta.env.VITE_API_URL || ''
+// Serve under the Vite base path: BASE_URL is "/" by default or e.g.
+// "/portfolio/openalgo/" when built with OPENALGO_BASE. Strip the trailing
+// slash so `${API_BASE_URL}/api/v1` and `${API_BASE_URL}/auth/...` stay correct.
+const API_BASE_URL =
+  (import.meta.env.VITE_API_URL as string | undefined) ??
+  import.meta.env.BASE_URL.replace(/\/$/, '')
 
 // Helper to fetch CSRF token
 export async function fetchCSRFToken(): Promise<string> {
-  const response = await fetch('/auth/csrf-token', {
+  const response = await fetch(`${API_BASE_URL}/auth/csrf-token`, {
     credentials: 'include',
   })
   const data = await response.json()
@@ -36,7 +41,7 @@ apiClient.interceptors.response.use(
   (error) => {
     if (error.response?.status === 401) {
       // Handle unauthorized - redirect to login
-      window.location.href = '/login'
+      window.location.href = `${API_BASE_URL}/login`
     }
     return Promise.reject(error)
   }
@@ -125,7 +130,7 @@ webClient.interceptors.response.use(
     const status = error.response?.status
     if (status === 401) {
       // Unauthorized - redirect to login
-      window.location.href = '/login'
+      window.location.href = `${API_BASE_URL}/login`
     } else if (status === 403) {
       // Forbidden - user doesn't have permission for this resource
       // Create a more descriptive error for the caller to handle

--- a/frontend/src/hooks/useOrderEventRefresh.ts
+++ b/frontend/src/hooks/useOrderEventRefresh.ts
@@ -128,6 +128,7 @@ export function useSocketConnection(enabled = true): {
     const port = window.location.port
 
     socketRef.current = io(`${protocol}//${host}:${port}`, {
+      path: `${import.meta.env.BASE_URL}socket.io`,
       transports: ['polling'],
       upgrade: false,
     })

--- a/frontend/src/hooks/useOrderEventRefresh.ts
+++ b/frontend/src/hooks/useOrderEventRefresh.ts
@@ -72,6 +72,7 @@ export function useOrderEventRefresh(
     const port = window.location.port
 
     socketRef.current = io(`${protocol}//${host}:${port}`, {
+      path: `${import.meta.env.BASE_URL}socket.io`,
       transports: ['polling'],
       upgrade: false,
     })

--- a/frontend/src/hooks/useSocket.ts
+++ b/frontend/src/hooks/useSocket.ts
@@ -123,7 +123,7 @@ export function useSocket() {
     }
 
     // Create audio element
-    audioRef.current = new Audio('/sounds/alert.mp3')
+    audioRef.current = new Audio(`${import.meta.env.BASE_URL}sounds/alert.mp3`)
     audioRef.current.preload = 'auto'
 
     // Enable audio on user interaction
@@ -143,6 +143,7 @@ export function useSocket() {
     // Use polling transport only - WebSocket upgrade fails with threading async mode
     // Polling is still real-time via HTTP long-polling
     socketRef.current = io(`${protocol}//${host}:${port}`, {
+      path: `${import.meta.env.BASE_URL}socket.io`,
       transports: ['polling'],
       upgrade: false,
       reconnectionAttempts: 5,
@@ -164,7 +165,7 @@ export function useSocket() {
         duration: 10000,
       })
       setTimeout(() => {
-        window.location.href = '/login'
+        window.location.href = `${import.meta.env.BASE_URL.replace(/\/$/, '')}/login`
       }, 2000)
     })
 

--- a/frontend/src/main.tsx
+++ b/frontend/src/main.tsx
@@ -3,8 +3,13 @@ import { createRoot } from 'react-dom/client'
 import './index.css'
 import { ErrorBoundary } from '@/components/ErrorBoundary'
 import { clearChunkReloadFlag } from '@/utils/chunkReload'
+import { installApiBasePath } from '@/utils/apiBasePath'
 import { installGlobalErrorReporter } from '@/utils/errorReporter'
 import App from './App.tsx'
+
+// Must run before anything fetches: rewrites absolute API paths to include the
+// sub-path base (e.g. /portfolio/openalgo) so login and all API calls work.
+installApiBasePath()
 
 installGlobalErrorReporter()
 

--- a/frontend/src/utils/apiBasePath.ts
+++ b/frontend/src/utils/apiBasePath.ts
@@ -1,0 +1,56 @@
+// Prefix absolute API paths with the Vite base path so OpenAlgo works when it is
+// served under a sub-path (e.g. "/portfolio/openalgo/") behind a reverse proxy.
+//
+// Most of the codebase calls fetch() with absolute root paths like
+// "/auth/csrf-token" or "/api/v1/...". Those ignore the deployment prefix and
+// hit the gateway root, which breaks login and every other API call under a
+// sub-path. (axios goes through src/api/client.ts, which is already base-aware.)
+//
+// This installs a one-time fetch() shim that rewrites same-origin absolute API
+// paths to include the base prefix. It is a no-op when served at root.
+const BASE = import.meta.env.BASE_URL.replace(/\/$/, '') // "" at root, "/portfolio/openalgo" under a sub-path
+
+// Root path prefixes that belong to the OpenAlgo backend and must carry the base.
+const API_PREFIXES = [
+  '/auth/',
+  '/api/',
+  '/admin/',
+  '/flow/',
+  '/python/',
+  '/tools/',
+  '/sandbox/',
+  '/analyzer/',
+  '/chartink/',
+  '/download/',
+  '/ws/',
+  '/socket.io/',
+]
+
+function needsPrefix(path: string): boolean {
+  return (
+    path.startsWith('/') &&
+    !path.startsWith(BASE + '/') &&
+    API_PREFIXES.some((p) => path === p.slice(0, -1) || path.startsWith(p))
+  )
+}
+
+export function installApiBasePath(): void {
+  if (!BASE) return // served at root — nothing to rewrite
+  const orig = window.fetch.bind(window)
+  window.fetch = (input: RequestInfo | URL, init?: RequestInit): Promise<Response> => {
+    if (typeof input === 'string' && needsPrefix(input)) {
+      return orig(BASE + input, init)
+    }
+    if (input instanceof Request) {
+      try {
+        const u = new URL(input.url)
+        if (u.origin === window.location.origin && needsPrefix(u.pathname)) {
+          return orig(new Request(BASE + u.pathname + u.search + u.hash, input), init)
+        }
+      } catch {
+        // non-absolute or unparsable URL — leave untouched
+      }
+    }
+    return orig(input as RequestInfo, init)
+  }
+}

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -5,6 +5,7 @@ import path from 'path'
 
 // https://vite.dev/config/
 export default defineConfig({
+  base: process.env.OPENALGO_BASE || '/',
   plugins: [
     react(),
     tailwindcss(),


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Add full support for hosting OpenAlgo under a sub-path (e.g. /portfolio/openalgo) behind a reverse proxy. Fixes routing, API calls, sockets, assets, and redirects when not served at root.

- **New Features**
  - Frontend respects the base path: `vite` base from `OPENALGO_BASE`, `BrowserRouter` basename, `axios` API base, and a one-time `fetch()` shim to prefix API calls.
  - `socket.io` and alert sound now resolve under `import.meta.env.BASE_URL`; favicon links are relative.
  - Backend honors reverse-proxy prefixes: added `ProxyFix` (`x_prefix=1`, `x_proto=1`), prefixes bare redirect `Location` headers, and sets session cookie path from `URL_PREFIX`.
  - Docker: new `OPENALGO_BASE` build arg to produce sub-path builds.

- **Migration**
  - When deploying under a prefix, build the frontend with `OPENALGO_BASE=/your/prefix/`.
  - Configure the proxy to strip the prefix and send `X-Forwarded-Prefix: /your/prefix`; set backend `URL_PREFIX=/your/prefix`.
  - Ensure `/socket.io/` is proxied under the same prefix.
  - No changes needed when served at root.

<sup>Written for commit d61dfa67b333cc1a29df503131c6c42e2ab0561b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

