### PR TITLE
fix(definedge): anchor intraday history end-time to IST to stop data lag on non-IST hosts

### DIFF
--- a/broker/definedge/api/data.py
+++ b/broker/definedge/api/data.py
@@ -536,8 +536,13 @@ class BrokerData:
                 # Set start time to 09:15 (market open) for the start date
                 from_date = from_date.replace(hour=9, minute=15)
 
-                # If end_date is today, set the end time to current time
-                current_time = pd.Timestamp.now()
+                # If end_date is today, set the end time to current time.
+                # Anchor "now" to IST wall-clock (not the server's local time) so
+                # the client-side clip below stays correct on UTC/non-IST hosts.
+                # Definedge candle timestamps are naive IST; comparing them against
+                # a server-local now() would truncate the most recent candles by the
+                # host's UTC offset (~5.5h of missing data on a UTC deployment).
+                current_time = pd.Timestamp.now(tz="Asia/Kolkata").tz_localize(None)
                 if to_date.date() == current_time.date():
                     to_date = current_time.replace(second=0, microsecond=0)
                 else:


### PR DESCRIPTION
Definedge's /sds/history endpoint ignores the 'to' boundary and returns all candles up to the latest available, so get_history() clips client-side with df[timestamp] <= to_date. For end_date == today, to_date was pd.Timestamp.now() (server-local wall-clock) compared against naive-IST candle timestamps.

On a UTC/non-IST deployment now() is ~5.5h behind IST, so the clip silently dropped the most recent ~5.5h of candles (e.g. intraday data stopping at ~09:30 when it is really 15:00 IST). On an IST host it happened to work, masking the bug.

Fix: anchor 'now' to IST wall-clock via pd.Timestamp.now(tz='Asia/Kolkata').tz_localize(None) so the clip is correct regardless of host timezone. Broker-only change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Anchors intraday history end-time to IST so today’s data isn’t clipped on UTC/non-IST hosts, restoring the latest candles in intraday views.

- **Bug Fixes**
  - Use IST-based `pd.Timestamp.now(tz="Asia/Kolkata").tz_localize(None)` when `end_date` is today to align with naive-IST candle timestamps.
  - Fixes ~5.5h data lag on UTC deployments where recent candles were being dropped.

<sup>Written for commit 119f801265a8e11ddde172d6e285b12589f352ec. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1544?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

