### PR TITLE
feat(tools): Gamma Density tool + forward-based IV for index weeklies

### DIFF
--- a/app.py
+++ b/app.py
@@ -48,6 +48,7 @@ from blueprints.historify import historify_bp  # Import the historify blueprint
 from blueprints.ivchart import ivchart_bp  # Import the IV chart blueprint
 from blueprints.scalping import scalping_bp  # Import the Scalping terminal blueprint
 from blueprints.oitracker import oitracker_bp  # Import the OI tracker blueprint
+from blueprints.gamma_density import gamma_density_bp  # Import the Gamma Density blueprint
 from blueprints.straddle_chart import straddle_bp  # Import the straddle chart blueprint
 from blueprints.strategy_chart import strategy_chart_bp  # Import the strategy chart blueprint
 from blueprints.custom_straddle import custom_straddle_bp  # Import custom straddle blueprint
@@ -290,6 +291,7 @@ def create_app():
     app.register_blueprint(ivchart_bp)  # Register IV chart blueprint
     app.register_blueprint(scalping_bp)  # Register Scalping terminal blueprint
     app.register_blueprint(oitracker_bp)  # Register OI tracker blueprint
+    app.register_blueprint(gamma_density_bp)  # Register Gamma Density blueprint
     app.register_blueprint(straddle_bp)  # Register straddle chart blueprint
     app.register_blueprint(strategy_chart_bp)  # Register strategy chart blueprint
     app.register_blueprint(custom_straddle_bp)  # Register custom straddle blueprint

--- a/blueprints/gamma_density.py
+++ b/blueprints/gamma_density.py
@@ -1,0 +1,81 @@
+"""
+Gamma Density Blueprint
+
+Serves Γ×OI gamma density and convexity-zone data for option chains.
+
+Endpoint:
+    POST /gammadensity/api/gamma-data  - Gamma density + expected-move bands
+
+Underlyings and expiries are served by the shared search blueprint
+(/search/api/underlyings, /search/api/expiries).
+"""
+
+import re
+
+from flask import Blueprint, jsonify, request, session
+from flask_cors import cross_origin
+
+from database.auth_db import get_api_key_for_tradingview
+from services.gamma_density_service import calculate_gamma_density
+from utils.logging import get_logger
+from utils.session import check_session_validity
+
+logger = get_logger(__name__)
+
+gamma_density_bp = Blueprint("gamma_density_bp", __name__, url_prefix="/")
+
+
+@gamma_density_bp.route("/gammadensity/api/gamma-data", methods=["POST"])
+@cross_origin()
+@check_session_validity
+def gamma_data():
+    """Get gamma density (Γ×OI) and convexity-zone data for all strikes."""
+    try:
+        login_username = session.get("user")
+        if not login_username:
+            return jsonify({"status": "error", "message": "Authentication required"}), 401
+
+        api_key = get_api_key_for_tradingview(login_username)
+        if not api_key:
+            return jsonify(
+                {
+                    "status": "error",
+                    "message": "API key not configured. Please generate an API key in /apikey",
+                }
+            ), 401
+
+        data = request.get_json(silent=True) or {}
+        underlying = data.get("underlying", "").strip()[:20]
+        exchange = data.get("exchange", "").strip()[:20]
+        expiry_date = data.get("expiry_date", "").strip()[:10]
+
+        if not underlying or not exchange or not expiry_date:
+            return jsonify(
+                {
+                    "status": "error",
+                    "message": "underlying, exchange, and expiry_date are required",
+                }
+            ), 400
+
+        if not re.match(r"^[A-Z0-9]+$", underlying) or not re.match(r"^[A-Z0-9_]+$", exchange):
+            return jsonify({"status": "error", "message": "Invalid input format"}), 400
+
+        if not re.match(r"^\d{2}[A-Z]{3}\d{2}$", expiry_date):
+            return jsonify(
+                {"status": "error", "message": "Invalid expiry_date format. Expected DDMMMYY"}
+            ), 400
+
+        success, response, status_code = calculate_gamma_density(
+            underlying=underlying,
+            exchange=exchange,
+            expiry_date=expiry_date,
+            api_key=api_key,
+        )
+
+        return jsonify(response), status_code
+
+    except Exception as e:
+        logger.exception(f"Error in Gamma Density API: {e}")
+        return jsonify(
+            {"status": "error", "message": "An error occurred processing your request"}
+        ), 500

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -61,6 +61,7 @@ const IVChart = lazy(() => import('@/pages/IVChart'))
 const Scalping = lazy(() => import('@/pages/Scalping'))
 const OITracker = lazy(() => import('@/pages/OITracker'))
 const OIRange = lazy(() => import('@/pages/OIRange'))
+const GammaDensity = lazy(() => import('@/pages/GammaDensity'))
 const MaxPain = lazy(() => import('@/pages/MaxPain'))
 const StraddleChart = lazy(() => import('@/pages/StraddleChart'))
 const CustomStraddle = lazy(() => import('@/pages/CustomStraddle'))
@@ -199,6 +200,7 @@ function App() {
                 <Route path="/ivchart" element={<IVChart />} />
                 <Route path="/oitracker" element={<OITracker />} />
                 <Route path="/oirange" element={<OIRange />} />
+                <Route path="/gammadensity" element={<GammaDensity />} />
                 <Route path="/maxpain" element={<MaxPain />} />
                 <Route path="/straddle" element={<StraddleChart />} />
                 <Route path="/straddlepnl" element={<CustomStraddle />} />

--- a/frontend/src/api/gamma-density.ts
+++ b/frontend/src/api/gamma-density.ts
@@ -1,0 +1,80 @@
+import { webClient } from './client'
+
+export interface GammaDensityStrike {
+  strike: number
+  ce_oi: number
+  pe_oi: number
+  iv: number | null
+  density_intraday: number
+  density_expiry: number
+}
+
+export interface ExpectedMoveBand {
+  sigma_move: number
+  one_sigma_low: number
+  one_sigma_high: number
+  two_sigma_low: number
+  two_sigma_high: number
+}
+
+export interface GammaDensityResponse {
+  status: 'success' | 'error'
+  message?: string
+  underlying?: string
+  exchange?: string
+  expiry_date?: string
+  spot_price?: number
+  forward_price?: number
+  atm_strike?: number
+  atm_iv?: number
+  dte_days?: number
+  interest_rate?: number
+  peak_intraday_strike?: number | null
+  peak_expiry_strike?: number | null
+  sigma_move?: number
+  one_sigma_low?: number
+  one_sigma_high?: number
+  two_sigma_low?: number
+  two_sigma_high?: number
+  intraday_band?: ExpectedMoveBand
+  expiry_band?: ExpectedMoveBand
+  chain?: GammaDensityStrike[]
+}
+
+export interface UnderlyingsResponse {
+  status: 'success' | 'error'
+  underlyings: string[]
+}
+
+export interface ExpiriesResponse {
+  status: 'success' | 'error'
+  expiries: string[]
+}
+
+export const gammaDensityApi = {
+  getGammaDensity: async (params: {
+    underlying: string
+    exchange: string
+    expiry_date: string
+  }): Promise<GammaDensityResponse> => {
+    const response = await webClient.post<GammaDensityResponse>(
+      '/gammadensity/api/gamma-data',
+      params
+    )
+    return response.data
+  },
+
+  getUnderlyings: async (exchange: string): Promise<UnderlyingsResponse> => {
+    const response = await webClient.get<UnderlyingsResponse>(
+      `/search/api/underlyings?exchange=${exchange}`
+    )
+    return response.data
+  },
+
+  getExpiries: async (exchange: string, underlying: string): Promise<ExpiriesResponse> => {
+    const response = await webClient.get<ExpiriesResponse>(
+      `/search/api/expiries?exchange=${exchange}&underlying=${underlying}`
+    )
+    return response.data
+  },
+}

--- a/frontend/src/hooks/usePageTitle.ts
+++ b/frontend/src/hooks/usePageTitle.ts
@@ -31,6 +31,7 @@ const PAGE_TITLES: Record<string, string> = {
   '/ivchart': 'IV Chart',
   '/oitracker': 'OI Tracker',
   '/oirange': 'OI Range',
+  '/gammadensity': 'Gamma Density',
   '/maxpain': 'Max Pain',
   '/straddle': 'Straddle Chart',
   '/straddlepnl': 'Straddle P&L',

--- a/frontend/src/pages/GammaDensity.tsx
+++ b/frontend/src/pages/GammaDensity.tsx
@@ -1,0 +1,599 @@
+import { Check, ChevronsUpDown } from 'lucide-react'
+import type * as PlotlyTypes from 'plotly.js'
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import {
+  type ExpectedMoveBand,
+  type GammaDensityResponse,
+  gammaDensityApi,
+} from '@/api/gamma-density'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent } from '@/components/ui/card'
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '@/components/ui/command'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
+import Plot from '@/lib/Plot2D'
+import { useThemeStore } from '@/stores/themeStore'
+import { showToast } from '@/utils/toast'
+
+const AUTO_REFRESH_MS = 60_000
+const GAUSSIAN_POINTS = 121
+
+function convertExpiryForAPI(expiry: string): string {
+  if (!expiry) return ''
+  const parts = expiry.split('-')
+  if (parts.length === 3) {
+    return `${parts[0]}${parts[1].toUpperCase()}${parts[2].slice(-2)}`
+  }
+  return expiry.replace(/-/g, '').toUpperCase()
+}
+
+function formatNum(n: number | undefined | null, digits = 2): string {
+  if (n == null || !Number.isFinite(n)) return '--'
+  return n.toLocaleString('en-IN', { maximumFractionDigits: digits })
+}
+
+export default function GammaDensity() {
+  const { mode, appMode } = useThemeStore()
+  const {
+    toolsFnoExchanges: fnoExchanges,
+    defaultToolsFnoExchange: defaultFnoExchange,
+    defaultUnderlyings,
+  } = useSupportedExchanges()
+  const isAnalyzer = appMode === 'analyzer'
+  const isDark = mode === 'dark' || isAnalyzer
+
+  const [selectedExchange, setSelectedExchange] = useState(defaultFnoExchange)
+  const [underlyings, setUnderlyings] = useState<string[]>(
+    defaultUnderlyings[defaultFnoExchange] || []
+  )
+  const [underlyingOpen, setUnderlyingOpen] = useState(false)
+  const [selectedUnderlying, setSelectedUnderlying] = useState(
+    defaultUnderlyings[defaultFnoExchange]?.[0] || ''
+  )
+  const [expiries, setExpiries] = useState<string[]>([])
+  const [selectedExpiry, setSelectedExpiry] = useState('')
+  const [data, setData] = useState<GammaDensityResponse | null>(null)
+  const [isLoading, setIsLoading] = useState(false)
+  const [autoRefresh, setAutoRefresh] = useState(false)
+  const [lastUpdated, setLastUpdated] = useState<Date | null>(null)
+  const requestIdRef = useRef(0)
+
+  // Re-sync exchange when broker capabilities load asynchronously
+  useEffect(() => {
+    setSelectedExchange((prev) =>
+      prev && fnoExchanges.some((ex) => ex.value === prev) ? prev : defaultFnoExchange
+    )
+  }, [defaultFnoExchange, fnoExchanges])
+
+  // Fetch underlyings when exchange changes
+  useEffect(() => {
+    const defaults = defaultUnderlyings[selectedExchange] || []
+    setUnderlyings(defaults)
+    setSelectedUnderlying(defaults[0] || '')
+    setExpiries([])
+    setSelectedExpiry('')
+    setData(null)
+
+    let cancelled = false
+    const fetchUnderlyings = async () => {
+      try {
+        const response = await gammaDensityApi.getUnderlyings(selectedExchange)
+        if (cancelled) return
+        if (response.status === 'success' && response.underlyings.length > 0) {
+          setUnderlyings(response.underlyings)
+          if (!response.underlyings.includes(defaults[0])) {
+            setSelectedUnderlying(response.underlyings[0])
+          }
+        }
+      } catch {
+        // Keep defaults
+      }
+    }
+    fetchUnderlyings()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedExchange, defaultUnderlyings[selectedExchange]])
+
+  // Fetch expiries when underlying changes
+  useEffect(() => {
+    if (!selectedUnderlying) return
+    setExpiries([])
+    setSelectedExpiry('')
+    setData(null)
+
+    let cancelled = false
+    const fetchExpiries = async () => {
+      try {
+        const response = await gammaDensityApi.getExpiries(selectedExchange, selectedUnderlying)
+        if (cancelled) return
+        if (response.status === 'success' && response.expiries.length > 0) {
+          setExpiries(response.expiries)
+          setSelectedExpiry(response.expiries[0])
+        } else {
+          setExpiries([])
+          setSelectedExpiry('')
+        }
+      } catch {
+        if (cancelled) return
+        setExpiries([])
+        setSelectedExpiry('')
+      }
+    }
+    fetchExpiries()
+    return () => {
+      cancelled = true
+    }
+  }, [selectedUnderlying, selectedExchange])
+
+  const fetchData = useCallback(async () => {
+    if (!selectedExpiry) return
+    const requestId = ++requestIdRef.current
+    setIsLoading(true)
+    try {
+      const response = await gammaDensityApi.getGammaDensity({
+        underlying: selectedUnderlying,
+        exchange: selectedExchange,
+        expiry_date: convertExpiryForAPI(selectedExpiry),
+      })
+      if (requestIdRef.current !== requestId) return
+      if (response.status === 'success') {
+        setData(response)
+        setLastUpdated(new Date())
+      } else {
+        showToast.error(response.message || 'Failed to fetch gamma density')
+      }
+    } catch {
+      if (requestIdRef.current !== requestId) return
+      showToast.error('Failed to fetch gamma density')
+    } finally {
+      if (requestIdRef.current === requestId) setIsLoading(false)
+    }
+  }, [selectedUnderlying, selectedExpiry, selectedExchange])
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: fire only on expiry change to avoid stale mixed-param requests during exchange/underlying switches
+  useEffect(() => {
+    if (selectedExpiry) fetchData()
+  }, [selectedExpiry])
+
+  useEffect(() => {
+    if (!autoRefresh || !selectedExpiry) return
+    const id = window.setInterval(() => fetchData(), AUTO_REFRESH_MS)
+    return () => window.clearInterval(id)
+  }, [autoRefresh, selectedExpiry, fetchData])
+
+  const themeColors = useMemo(
+    () => ({
+      bg: 'rgba(0,0,0,0)',
+      text: isDark ? '#e0e0e0' : '#333333',
+      grid: isDark
+        ? isAnalyzer
+          ? 'rgba(180,160,255,0.1)'
+          : 'rgba(255,255,255,0.08)'
+        : 'rgba(0,0,0,0.08)',
+      density: '#f59e0b', // amber — Γ×OI line
+      densityFill: 'rgba(245,158,11,0.12)',
+      convexity: '#22c55e', // green — convexity bell
+      convexityFill: 'rgba(34,197,94,0.14)',
+      spot: isDark ? '#60a5fa' : '#2563eb',
+      band: isDark ? 'rgba(96,165,250,0.10)' : 'rgba(37,99,235,0.07)',
+      hoverBg: isDark ? (isAnalyzer ? '#2d2545' : '#1e293b') : '#ffffff',
+      hoverFont: isDark ? '#e0e0e0' : '#333333',
+      hoverBorder: isDark ? (isAnalyzer ? '#7c3aed' : '#475569') : '#e2e8f0',
+    }),
+    [isDark, isAnalyzer]
+  )
+
+  // Build one Plotly panel (Intraday or To Expiry)
+  const buildPanel = useCallback(
+    (
+      densityKey: 'density_intraday' | 'density_expiry',
+      band: ExpectedMoveBand | undefined
+    ): { data: PlotlyTypes.Data[]; layout: Partial<PlotlyTypes.Layout> } => {
+      const chain = data?.chain ?? []
+      const spot = data?.spot_price
+      if (chain.length === 0 || !spot) return { data: [], layout: {} }
+
+      const strikes = chain.map((c) => c.strike)
+      const minK = Math.min(...strikes)
+      const maxK = Math.max(...strikes)
+
+      // Density (Γ×OI), normalized to its own peak so it sits on a 0..1 axis
+      const rawDensity = chain.map((c) => c[densityKey] || 0)
+      const maxDensity = Math.max(...rawDensity, 1e-12)
+      const density = rawDensity.map((d) => d / maxDensity)
+
+      // Convexity zone — Gaussian centred on spot, width = 1σ expected move
+      const sigma = band?.sigma_move && band.sigma_move > 0 ? band.sigma_move : 0
+      const gx: number[] = []
+      const gy: number[] = []
+      if (sigma > 0) {
+        const step = (maxK - minK) / (GAUSSIAN_POINTS - 1)
+        for (let i = 0; i < GAUSSIAN_POINTS; i++) {
+          const x = minK + i * step
+          gx.push(x)
+          gy.push(Math.exp(-0.5 * ((x - spot) / sigma) ** 2))
+        }
+      }
+
+      const traces: PlotlyTypes.Data[] = [
+        {
+          x: gx,
+          y: gy,
+          type: 'scatter' as const,
+          mode: 'lines' as const,
+          name: 'Convexity Zone',
+          line: { color: themeColors.convexity, width: 2 },
+          fill: 'tozeroy' as const,
+          fillcolor: themeColors.convexityFill,
+          hovertemplate: 'Price %{x:,.0f}<extra>Convexity</extra>',
+        },
+        {
+          x: strikes,
+          y: density,
+          type: 'scatter' as const,
+          mode: 'lines+markers' as const,
+          name: 'Density (Γ×OI)',
+          line: { color: themeColors.density, width: 2, shape: 'linear' as const },
+          marker: { color: themeColors.density, size: 3 },
+          hovertemplate: 'Strike %{x:,.0f}<br>Density %{y:.2f}<extra></extra>',
+        },
+      ]
+
+      const shapes: Partial<PlotlyTypes.Shape>[] = []
+      const annotations: Partial<PlotlyTypes.Annotations>[] = []
+
+      // ±1σ shaded expected-move band
+      if (band && band.one_sigma_low < band.one_sigma_high) {
+        shapes.push({
+          type: 'rect' as const,
+          xref: 'x' as const,
+          yref: 'paper' as const,
+          x0: band.one_sigma_low,
+          x1: band.one_sigma_high,
+          y0: 0,
+          y1: 1,
+          fillcolor: themeColors.band,
+          line: { width: 0 },
+          layer: 'below' as const,
+        })
+      }
+
+      // Spot vertical line
+      shapes.push({
+        type: 'line' as const,
+        xref: 'x' as const,
+        yref: 'paper' as const,
+        x0: spot,
+        x1: spot,
+        y0: 0,
+        y1: 1,
+        line: { color: themeColors.spot, width: 1.5, dash: 'dash' as const },
+      })
+      annotations.push({
+        x: spot,
+        y: 1,
+        yref: 'paper' as const,
+        text: 'Spot',
+        showarrow: false,
+        font: { color: themeColors.spot, size: 11 },
+        yanchor: 'bottom' as const,
+      })
+
+      const layout: Partial<PlotlyTypes.Layout> = {
+        paper_bgcolor: themeColors.bg,
+        plot_bgcolor: themeColors.bg,
+        font: { color: themeColors.text, family: 'system-ui, sans-serif' },
+        hovermode: 'x unified' as const,
+        hoverlabel: {
+          bgcolor: themeColors.hoverBg,
+          font: { color: themeColors.hoverFont, size: 12 },
+          bordercolor: themeColors.hoverBorder,
+        },
+        showlegend: true,
+        legend: {
+          orientation: 'h' as const,
+          x: 0.5,
+          xanchor: 'center' as const,
+          y: 1.08,
+          font: { color: themeColors.text, size: 11 },
+        },
+        margin: { l: 50, r: 20, t: 30, b: 40 },
+        xaxis: {
+          range: [minK, maxK],
+          title: { text: 'Strike / Price', font: { color: themeColors.text, size: 11 } },
+          tickfont: { color: themeColors.text, size: 10 },
+          gridcolor: themeColors.grid,
+        },
+        yaxis: {
+          range: [0, 1.08],
+          tickfont: { color: themeColors.text, size: 10 },
+          gridcolor: themeColors.grid,
+        },
+        shapes,
+        annotations,
+      }
+
+      return { data: traces, layout }
+    },
+    [data, themeColors]
+  )
+
+  const intradayPanel = useMemo(
+    () => buildPanel('density_intraday', data?.intraday_band),
+    [buildPanel, data]
+  )
+  const expiryPanel = useMemo(
+    () => buildPanel('density_expiry', data?.expiry_band),
+    [buildPanel, data]
+  )
+
+  const plotConfig: Partial<PlotlyTypes.Config> = useMemo(
+    () => ({
+      displayModeBar: false,
+      displaylogo: false,
+      responsive: true,
+    }),
+    []
+  )
+
+  const hasData = data?.status === 'success' && (data.chain?.length ?? 0) > 0
+
+  return (
+    <div className="py-6 space-y-4">
+      {/* Header */}
+      <div className="flex flex-col gap-3 lg:flex-row lg:items-start lg:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <h1 className="text-2xl font-bold">Gamma Density</h1>
+            {lastUpdated && (
+              <Badge variant={autoRefresh ? 'default' : 'secondary'} className="uppercase">
+                {autoRefresh ? 'Live' : 'Snapshot'}
+              </Badge>
+            )}
+          </div>
+          <p className="text-muted-foreground text-sm mt-1">
+            Γ×OI density and convexity zones — where hedging pressure concentrates
+          </p>
+        </div>
+
+        <div className="flex flex-wrap items-center gap-3">
+          {/* Exchange selector */}
+          <Select value={selectedExchange} onValueChange={setSelectedExchange}>
+            <SelectTrigger className="w-[100px]">
+              <SelectValue placeholder="Exchange" />
+            </SelectTrigger>
+            <SelectContent>
+              {fnoExchanges.map((ex) => (
+                <SelectItem key={ex.value} value={ex.value}>
+                  {ex.label}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Underlying selector */}
+          <Popover open={underlyingOpen} onOpenChange={setUnderlyingOpen}>
+            <PopoverTrigger asChild>
+              <Button
+                variant="outline"
+                role="combobox"
+                aria-expanded={underlyingOpen}
+                className="w-[160px] justify-between"
+              >
+                {selectedUnderlying || 'Underlying'}
+                <ChevronsUpDown className="ml-2 h-4 w-4 shrink-0 opacity-50" />
+              </Button>
+            </PopoverTrigger>
+            <PopoverContent className="w-48 p-0" align="start">
+              <Command>
+                <CommandInput placeholder="Search underlying..." />
+                <CommandList>
+                  <CommandEmpty>No underlying found</CommandEmpty>
+                  <CommandGroup>
+                    {underlyings.map((u) => (
+                      <CommandItem
+                        key={u}
+                        value={u}
+                        onSelect={() => {
+                          setSelectedUnderlying(u)
+                          setUnderlyingOpen(false)
+                        }}
+                      >
+                        <Check
+                          className={`mr-2 h-4 w-4 ${selectedUnderlying === u ? 'opacity-100' : 'opacity-0'}`}
+                        />
+                        {u}
+                      </CommandItem>
+                    ))}
+                  </CommandGroup>
+                </CommandList>
+              </Command>
+            </PopoverContent>
+          </Popover>
+
+          {/* Expiry selector */}
+          <Select
+            value={selectedExpiry}
+            onValueChange={setSelectedExpiry}
+            disabled={expiries.length === 0}
+          >
+            <SelectTrigger className="w-[160px]">
+              <SelectValue placeholder="Expiry" />
+            </SelectTrigger>
+            <SelectContent>
+              {expiries.map((e) => (
+                <SelectItem key={e} value={e}>
+                  {e}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+
+          {/* Auto-refresh toggle */}
+          <Button
+            variant={autoRefresh ? 'default' : 'outline'}
+            size="sm"
+            onClick={() => setAutoRefresh((v) => !v)}
+            disabled={!selectedExpiry}
+          >
+            Auto: {autoRefresh ? 'ON' : 'OFF'}
+          </Button>
+
+          {/* Refresh */}
+          <Button variant="outline" size="sm" onClick={fetchData} disabled={isLoading}>
+            {isLoading ? 'Loading...' : 'Refresh'}
+          </Button>
+        </div>
+      </div>
+
+      {/* Stat cards */}
+      {hasData && (
+        <div className="grid grid-cols-2 sm:grid-cols-4 xl:grid-cols-8 gap-3">
+          <StatCard label="Spot" value={formatNum(data?.spot_price, 1)} />
+          <StatCard label="ATM IV" value={`${formatNum(data?.atm_iv)}%`} />
+          <StatCard
+            label="Sigma Move"
+            value={`±${formatNum(data?.sigma_move)}`}
+            sub={`${formatNum(data?.dte_days, 1)}d to expiry`}
+          />
+          <StatCard
+            label="1σ Low"
+            value={formatNum(data?.one_sigma_low, 0)}
+            valueClass="text-red-500"
+          />
+          <StatCard
+            label="1σ High"
+            value={formatNum(data?.one_sigma_high, 0)}
+            valueClass="text-green-500"
+          />
+          <StatCard
+            label="2σ Lower Tail"
+            value={formatNum(data?.two_sigma_low, 0)}
+            valueClass="text-red-500"
+          />
+          <StatCard
+            label="2σ Upper Tail"
+            value={formatNum(data?.two_sigma_high, 0)}
+            valueClass="text-green-500"
+          />
+          <StatCard label="DTE" value={formatNum(data?.dte_days, 1)} sub="days" />
+        </div>
+      )}
+
+      {/* Charts */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-4">
+        <ChartPanel
+          title="Intraday"
+          subtitle="1-day hedging pressure"
+          isLoading={isLoading && !data}
+          hasData={hasData && intradayPanel.data.length > 0}
+          panel={intradayPanel}
+          plotConfig={plotConfig}
+          emptyText={selectedExpiry ? 'No gamma data available' : 'Select an underlying and expiry'}
+        />
+        <ChartPanel
+          title="To Expiry"
+          subtitle="Terminal pin / gravity"
+          isLoading={isLoading && !data}
+          hasData={hasData && expiryPanel.data.length > 0}
+          panel={expiryPanel}
+          plotConfig={plotConfig}
+          emptyText={selectedExpiry ? 'No gamma data available' : 'Select an underlying and expiry'}
+        />
+      </div>
+
+      <p className="text-xs text-muted-foreground">
+        Shaded band = ±1σ expected range. The density curve marks strikes where dealer Γ×OI is
+        concentrated — spot gravitates to (long gamma) or accelerates away from (short gamma) these
+        zones. Greeks use the Black-76 model (opengreeks).
+        {lastUpdated && (
+          <span className="ml-1">Last updated: {lastUpdated.toLocaleTimeString()}.</span>
+        )}
+      </p>
+    </div>
+  )
+}
+
+function StatCard({
+  label,
+  value,
+  sub,
+  valueClass,
+}: {
+  label: string
+  value: string
+  sub?: string
+  valueClass?: string
+}) {
+  return (
+    <Card>
+      <CardContent className="p-3">
+        <div className="text-[11px] uppercase tracking-wide text-muted-foreground">{label}</div>
+        <div className={`text-lg font-bold ${valueClass ?? ''}`}>{value}</div>
+        {sub && <div className="text-[11px] text-muted-foreground">{sub}</div>}
+      </CardContent>
+    </Card>
+  )
+}
+
+function ChartPanel({
+  title,
+  subtitle,
+  isLoading,
+  hasData,
+  panel,
+  plotConfig,
+  emptyText,
+}: {
+  title: string
+  subtitle: string
+  isLoading: boolean
+  hasData: boolean
+  panel: { data: PlotlyTypes.Data[]; layout: Partial<PlotlyTypes.Layout> }
+  plotConfig: Partial<PlotlyTypes.Config>
+  emptyText: string
+}) {
+  return (
+    <Card>
+      <CardContent className="p-3 sm:p-4">
+        <div className="mb-1">
+          <div className="font-semibold">{title}</div>
+          <div className="text-xs text-muted-foreground">{subtitle}</div>
+        </div>
+        {isLoading ? (
+          <div className="flex items-center justify-center h-[420px] text-muted-foreground">
+            Loading…
+          </div>
+        ) : hasData ? (
+          <Plot
+            data={panel.data}
+            layout={panel.layout}
+            config={plotConfig}
+            useResizeHandler
+            style={{ width: '100%', height: '420px' }}
+          />
+        ) : (
+          <div className="flex items-center justify-center h-[420px] text-muted-foreground">
+            {emptyText}
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  )
+}

--- a/frontend/src/pages/Tools.tsx
+++ b/frontend/src/pages/Tools.tsx
@@ -75,6 +75,13 @@ const tools = [
     color: 'bg-indigo-500',
   },
   {
+    title: 'Gamma Density',
+    description:
+      'Γ×OI density and convexity zones with intraday & to-expiry views, ATM IV, and ±1σ/±2σ expected-move bands',
+    href: '/gammadensity',
+    color: 'bg-lime-500',
+  },
+  {
     title: 'IV Smile',
     description: 'Implied Volatility smile with Call/Put IV curves, ATM IV, and skew analysis',
     href: '/ivsmile',

--- a/services/gamma_density_service.py
+++ b/services/gamma_density_service.py
@@ -1,0 +1,353 @@
+"""
+Gamma Density Service
+
+Computes the "Gamma Density" view (inspired by Vtrender's Gamma Density chart):
+
+  * Density (Γ×OI)   - per-strike dealer gamma exposure = option gamma × open
+                       interest, summed across CE and PE legs. The orange curve.
+  * Convexity Zone   - a Gaussian centred on spot whose width is the 1σ expected
+                       move (from ATM IV). The green bell. Marks where price is
+                       statistically expected to gravitate / accelerate.
+
+Two horizons are returned so the UI can show side-by-side panels:
+  * Intraday  - gamma computed with a 1-trading-day horizon, narrow expected-move
+                band. Highlights today's hedging pressure (sharper ATM peak).
+  * To Expiry - gamma computed with the full days-to-expiry, wider expected-move
+                band. The terminal pin/gravity view.
+
+Reuses the option chain service for OI + LTP, and the Black-76 model (opengreeks)
+- the same model used by option_greeks_service - for IV and gamma. No extra
+broker calls beyond the single option-chain fetch.
+
+Functions:
+    calculate_gamma_density() - full gamma density payload for an underlying/expiry
+"""
+
+import math
+from datetime import datetime
+from typing import Any
+
+from services.option_chain_service import get_option_chain
+from services.option_greeks_service import (
+    DEFAULT_INTEREST_RATES,
+    _resolve_index_weekly_forward,
+    calculate_time_to_expiry,
+    get_underlying_exchange,
+)
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Trading days per year used to annualise the 1-day (intraday) sigma move.
+# Vtrender / standard expected-move convention uses calendar 365 for the
+# annualisation factor, so spot * IV * sqrt(1/365) is the 1-day 1σ move.
+_DAYS_PER_YEAR = 365.0
+
+# Intraday gamma horizon: one calendar day in years (capped at real DTE).
+# A short horizon sharpens the ATM gamma peak - that is the "intraday gamma
+# wall" the convexity zone is meant to surface.
+_INTRADAY_T_YEARS = 1.0 / _DAYS_PER_YEAR
+
+# Fallback IV (decimal) used only if every strike's IV inversion fails
+# (e.g. a fully stale chain with no usable premiums). Keeps the curves drawable.
+_FALLBACK_IV = 0.15
+
+_MONTH_MAP = {
+    "JAN": 1,
+    "FEB": 2,
+    "MAR": 3,
+    "APR": 4,
+    "MAY": 5,
+    "JUN": 6,
+    "JUL": 7,
+    "AUG": 8,
+    "SEP": 9,
+    "OCT": 10,
+    "NOV": 11,
+    "DEC": 12,
+}
+
+
+def _expiry_datetime(expiry_date: str, exchange: str) -> datetime:
+    """
+    Build an expiry datetime from a DDMMMYY string and exchange.
+
+    Uses the same default expiry times as option_greeks_service.parse_option_symbol:
+    NFO/BFO 15:30, CDS 12:30, MCX 23:30.
+
+    Args:
+        expiry_date: Expiry in DDMMMYY format (e.g. 30JAN26)
+        exchange: Options exchange (NFO, BFO, CDS, MCX, ...)
+
+    Returns:
+        Naive datetime at the exchange close (interpreted as IST downstream)
+    """
+    day = int(expiry_date[:2])
+    month = _MONTH_MAP[expiry_date[2:5].upper()]
+    year = 2000 + int(expiry_date[5:7])
+
+    ex = exchange.upper()
+    if ex == "MCX":
+        hour, minute = 23, 30
+    elif ex == "CDS":
+        hour, minute = 12, 30
+    else:  # NFO, BFO, crypto, equity
+        hour, minute = 15, 30
+
+    return datetime(year, month, day, hour, minute)
+
+
+def _safe_iv(black76, price: float, F: float, K: float, r: float, t: float, flag: str) -> float | None:
+    """Black-76 implied volatility (decimal), or None if it cannot be inverted."""
+    if not price or price <= 0 or F <= 0 or K <= 0 or t <= 0:
+        return None
+    try:
+        # black76.implied_volatility(price, F, K, r, t, flag) -> decimal
+        iv = black76.implied_volatility(price, F, K, r, t, flag)
+        if iv is None or not math.isfinite(iv) or iv <= 0 or iv > 5:
+            return None
+        return iv
+    except Exception:
+        return None
+
+
+def _safe_gamma(black76, flag: str, F: float, K: float, t: float, r: float, sigma: float) -> float:
+    """Black-76 gamma, or 0.0 on any numerical failure."""
+    if not sigma or sigma <= 0 or F <= 0 or K <= 0 or t <= 0:
+        return 0.0
+    try:
+        g = black76.gamma(flag, F, K, t, r, sigma)
+        if g is None or not math.isfinite(g) or g < 0:
+            return 0.0
+        return g
+    except Exception:
+        return 0.0
+
+
+def calculate_gamma_density(
+    underlying: str,
+    exchange: str,
+    expiry_date: str,
+    api_key: str,
+    interest_rate: float | None = None,
+) -> tuple[bool, dict[str, Any], int]:
+    """
+    Calculate the Gamma Density payload for an underlying / expiry.
+
+    Pipeline:
+      1. Fetch the option chain (47 strikes around ATM) with live OI + LTP.
+      2. Derive time-to-expiry (years, days) from the expiry date + exchange.
+      3. Per strike: invert IV from CE/PE premiums (Black-76), find ATM IV.
+      4. Per strike: compute gamma at the intraday and to-expiry horizons and
+         multiply by OI -> Γ×OI density for each horizon (CE+PE).
+      5. Compute the daily and to-expiry 1σ moves and the ±1σ / ±2σ levels.
+
+    Args:
+        underlying: Underlying symbol (e.g. NIFTY, BANKNIFTY)
+        exchange: Options exchange (NFO, BFO, CDS, MCX, crypto)
+        expiry_date: Expiry in DDMMMYY format
+        api_key: OpenAlgo API key
+        interest_rate: Optional risk-free rate (annualized %); default per exchange
+
+    Returns:
+        Tuple of (success, response_data, status_code)
+    """
+    try:
+        try:
+            from opengreeks import black76
+        except ImportError:
+            logger.error("opengreeks library not installed.")
+            return (
+                False,
+                {
+                    "status": "error",
+                    "message": "Gamma Density requires the opengreeks library. Install with: pip install opengreeks",
+                },
+                500,
+            )
+
+        # 1. Option chain with OI + LTP. 23 each side of ATM = 47 strikes / 94
+        #    symbols, sized to fit broker multiquote OI buckets (see oi_tracker).
+        success, chain_response, status_code = get_option_chain(
+            underlying=underlying,
+            exchange=exchange,
+            expiry_date=expiry_date,
+            strike_count=23,
+            api_key=api_key,
+        )
+        if not success:
+            return False, chain_response, status_code
+
+        full_chain = chain_response.get("chain", [])
+        spot_price = chain_response.get("underlying_ltp")
+        atm_strike = chain_response.get("atm_strike")
+
+        if not spot_price or spot_price <= 0 or not full_chain:
+            return (
+                False,
+                {"status": "error", "message": "Spot price or option chain unavailable"},
+                404,
+            )
+
+        # 2. Time to expiry
+        expiry_dt = _expiry_datetime(expiry_date, exchange)
+        t_years, dte_days = calculate_time_to_expiry(expiry_dt)
+        t_intraday = min(t_years, _INTRADAY_T_YEARS) if t_years > 0 else _INTRADAY_T_YEARS
+
+        if interest_rate is None:
+            interest_rate = DEFAULT_INTEREST_RATES.get(exchange.upper(), 0)
+        r = interest_rate / 100.0
+
+        # Forward price for Black-76, consistent with option_greeks_service:
+        # index weekly -> per-expiry synthetic future; monthly index / stocks ->
+        # spot. The expected-move band and Spot marker still use the cash spot.
+        base_for_forward = chain_response.get("underlying", underlying)
+        forward = _resolve_index_weekly_forward(
+            base_for_forward,
+            exchange,
+            get_underlying_exchange(base_for_forward, exchange),
+            expiry_dt,
+            api_key,
+        )
+        F = forward or spot_price
+
+        # 3. Pass one: per-strike IV (CE / PE) + ATM IV
+        strikes: list[dict[str, Any]] = []
+        valid_ivs: list[float] = []
+        atm_iv: float | None = None
+
+        for item in full_chain:
+            K = item.get("strike")
+            if not isinstance(K, (int, float)) or K <= 0:
+                continue
+            ce = item.get("ce") or {}
+            pe = item.get("pe") or {}
+            ce_oi = ce.get("oi", 0) or 0
+            pe_oi = pe.get("oi", 0) or 0
+            ce_ltp = ce.get("ltp", 0) or 0
+            pe_ltp = pe.get("ltp", 0) or 0
+
+            ce_iv = _safe_iv(black76, ce_ltp, F, K, r, t_years, "c")
+            pe_iv = _safe_iv(black76, pe_ltp, F, K, r, t_years, "p")
+
+            side_ivs = [v for v in (ce_iv, pe_iv) if v is not None]
+            strike_iv = sum(side_ivs) / len(side_ivs) if side_ivs else None
+            if strike_iv is not None:
+                valid_ivs.append(strike_iv)
+            if atm_strike is not None and K == atm_strike and strike_iv is not None:
+                atm_iv = strike_iv
+
+            strikes.append(
+                {
+                    "strike": K,
+                    "ce_oi": ce_oi,
+                    "pe_oi": pe_oi,
+                    "ce_iv": ce_iv,
+                    "pe_iv": pe_iv,
+                    "strike_iv": strike_iv,
+                }
+            )
+
+        # ATM IV fallback: median of valid strike IVs, else a sane default.
+        if atm_iv is None:
+            if valid_ivs:
+                s = sorted(valid_ivs)
+                atm_iv = s[len(s) // 2]
+            else:
+                atm_iv = _FALLBACK_IV
+                logger.warning(
+                    f"No invertible IV for {underlying} {expiry_date}; using fallback IV {_FALLBACK_IV}"
+                )
+
+        # 4. Pass two: gamma at both horizons -> Γ×OI density
+        density_chain: list[dict[str, Any]] = []
+        max_intraday = 0.0
+        max_expiry = 0.0
+        peak_intraday_strike = None
+        peak_expiry_strike = None
+
+        for s in strikes:
+            K = s["strike"]
+            ce_sigma = s["ce_iv"] or atm_iv
+            pe_sigma = s["pe_iv"] or atm_iv
+
+            ce_g_exp = _safe_gamma(black76, "c", F, K, t_years, r, ce_sigma)
+            pe_g_exp = _safe_gamma(black76, "p", F, K, t_years, r, pe_sigma)
+            ce_g_intra = _safe_gamma(black76, "c", F, K, t_intraday, r, ce_sigma)
+            pe_g_intra = _safe_gamma(black76, "p", F, K, t_intraday, r, pe_sigma)
+
+            density_expiry = ce_g_exp * s["ce_oi"] + pe_g_exp * s["pe_oi"]
+            density_intraday = ce_g_intra * s["ce_oi"] + pe_g_intra * s["pe_oi"]
+
+            if density_expiry > max_expiry:
+                max_expiry = density_expiry
+                peak_expiry_strike = K
+            if density_intraday > max_intraday:
+                max_intraday = density_intraday
+                peak_intraday_strike = K
+
+            density_chain.append(
+                {
+                    "strike": K,
+                    "ce_oi": s["ce_oi"],
+                    "pe_oi": s["pe_oi"],
+                    "iv": round(s["strike_iv"] * 100, 2) if s["strike_iv"] is not None else None,
+                    "density_intraday": density_intraday,
+                    "density_expiry": density_expiry,
+                }
+            )
+
+        # 5. Expected-move bands. Daily (intraday) and to-expiry 1σ moves.
+        sqrt_intraday = math.sqrt(_INTRADAY_T_YEARS)
+        sqrt_expiry = math.sqrt(max(t_years, 1e-9))
+        sigma_intraday = spot_price * atm_iv * sqrt_intraday
+        sigma_expiry = spot_price * atm_iv * sqrt_expiry
+
+        def _band(sigma: float) -> dict[str, float]:
+            return {
+                "sigma_move": round(sigma, 2),
+                "one_sigma_low": round(spot_price - sigma, 2),
+                "one_sigma_high": round(spot_price + sigma, 2),
+                "two_sigma_low": round(spot_price - 2 * sigma, 2),
+                "two_sigma_high": round(spot_price + 2 * sigma, 2),
+            }
+
+        intraday_band = _band(sigma_intraday)
+        expiry_band = _band(sigma_expiry)
+
+        return (
+            True,
+            {
+                "status": "success",
+                "underlying": chain_response.get("underlying", underlying),
+                "exchange": exchange,
+                "expiry_date": expiry_date,
+                "spot_price": round(spot_price, 2),
+                "forward_price": round(F, 2),
+                "atm_strike": atm_strike,
+                "atm_iv": round(atm_iv * 100, 2),
+                "dte_days": round(dte_days, 2),
+                "interest_rate": round(interest_rate, 2),
+                "peak_intraday_strike": peak_intraday_strike,
+                "peak_expiry_strike": peak_expiry_strike,
+                # Default band shown in the stat cards = daily (intraday) 1σ,
+                # matching the Vtrender-style 1-day expected move.
+                "sigma_move": intraday_band["sigma_move"],
+                "one_sigma_low": intraday_band["one_sigma_low"],
+                "one_sigma_high": intraday_band["one_sigma_high"],
+                "two_sigma_low": intraday_band["two_sigma_low"],
+                "two_sigma_high": intraday_band["two_sigma_high"],
+                "intraday_band": intraday_band,
+                "expiry_band": expiry_band,
+                "chain": density_chain,
+            },
+            200,
+        )
+
+    except Exception as e:
+        logger.exception(f"Error in calculate_gamma_density: {e}")
+        return (
+            False,
+            {"status": "error", "message": "Error computing gamma density"},
+            500,
+        )

--- a/services/option_greeks_service.py
+++ b/services/option_greeks_service.py
@@ -223,6 +223,119 @@ def get_underlying_exchange(base_symbol: str, options_exchange: str) -> str:
     return "NSE"
 
 
+def _is_index_symbol(base_symbol: str) -> bool:
+    """True for NSE/BSE index underlyings (which can have weekly expiries)."""
+    return base_symbol in NSE_INDEX_SYMBOLS or base_symbol in BSE_INDEX_SYMBOLS
+
+
+def _parse_db_expiry(date_str: str) -> "datetime | None":
+    """Parse a master-contract expiry ('31-JUL-25' or '31-JUL-2025') to a date."""
+    for fmt in ("%d-%b-%y", "%d-%b-%Y"):
+        try:
+            return datetime.strptime(date_str, fmt).date()
+        except (ValueError, TypeError):
+            continue
+    return None
+
+
+def _is_monthly_expiry(
+    base_symbol: str,
+    options_exchange: str,
+    expiry: datetime,
+    api_key: str | None,
+    expiry_cache: dict | None = None,
+) -> bool:
+    """
+    Classify an expiry as monthly (last expiry of its calendar month) vs weekly.
+
+    Monthly = the latest available option expiry within the same year+month for
+    this underlying. Anything earlier in that month is a weekly. If the expiry
+    list can't be resolved, default to monthly (i.e. use spot) — the safe path.
+
+    expiry_cache: optional dict reused across a batch to avoid refetching the
+    expiry list per leg.
+    """
+    if expiry_cache is None:
+        expiry_cache = {}
+    key = (base_symbol, options_exchange.upper())
+    dates = expiry_cache.get(key)
+    if dates is None:
+        from services.expiry_service import get_expiry_dates
+
+        dates = []
+        try:
+            ok, resp, _ = get_expiry_dates(base_symbol, options_exchange, "options", api_key)
+            if ok:
+                for s in resp.get("data", []):
+                    d = _parse_db_expiry(s)
+                    if d:
+                        dates.append(d)
+        except Exception as e:
+            logger.warning(f"Could not load expiries for {base_symbol} {options_exchange}: {e}")
+        expiry_cache[key] = dates
+
+    target = expiry.date()
+    same_month = [d for d in dates if d.year == target.year and d.month == target.month]
+    if not same_month:
+        return True  # unknown → treat as monthly (use spot)
+    return target >= max(same_month)
+
+
+def _get_synthetic_future(
+    base_symbol: str,
+    underlying_exchange: str,
+    expiry_code: str,
+    api_key: str | None,
+    synth_cache: dict | None = None,
+) -> float | None:
+    """Synthetic future (forward) for an underlying+expiry, cached. None on failure."""
+    if synth_cache is None:
+        synth_cache = {}
+    key = (base_symbol, underlying_exchange, expiry_code)
+    if key in synth_cache:
+        return synth_cache[key]
+
+    price = None
+    try:
+        from services.synthetic_future_service import calculate_synthetic_future
+
+        ok, resp, _ = calculate_synthetic_future(base_symbol, underlying_exchange, expiry_code, api_key)
+        if ok:
+            price = resp.get("synthetic_future_price")
+    except Exception as e:
+        logger.warning(f"Synthetic future calc failed for {base_symbol} {expiry_code}: {e}")
+    synth_cache[key] = price
+    return price
+
+
+def _resolve_index_weekly_forward(
+    base_symbol: str,
+    options_exchange: str,
+    underlying_exchange: str,
+    expiry: datetime,
+    api_key: str | None,
+    expiry_cache: dict | None = None,
+    synth_cache: dict | None = None,
+) -> float | None:
+    """
+    Forward price to use for an INDEX option's Greeks:
+      * weekly expiry  -> per-expiry synthetic future (forward)
+      * monthly expiry -> None (caller falls back to spot index)
+      * non-index      -> None (caller uses spot stock/commodity price)
+
+    This is the single source of truth for the "weekly = synthetic future,
+    monthly = spot" rule.
+    """
+    if not _is_index_symbol(base_symbol):
+        return None
+    if _is_monthly_expiry(base_symbol, options_exchange, expiry, api_key, expiry_cache):
+        return None
+    expiry_code = expiry.strftime("%d%b%y").upper()
+    return _get_synthetic_future(
+        base_symbol, underlying_exchange, expiry_code, api_key, synth_cache
+    )
+
+
 def calculate_time_to_expiry(expiry: datetime) -> tuple[float, float]:
     """
     Calculate time to expiry in years (for the Black-76 model).
@@ -644,21 +757,37 @@ def get_option_greeks(
             else:
                 spot_exchange = get_underlying_exchange(base_symbol, exchange)
 
-            # Fetch underlying price
-            logger.info(f"Fetching spot price for {spot_symbol} from {spot_exchange}")
-            success, spot_response, status_code = get_quotes(spot_symbol, spot_exchange, api_key)
-
-            if not success:
-                return (
-                    False,
-                    {
-                        "status": "error",
-                        "message": f"Failed to fetch underlying price: {spot_response.get('message', 'Unknown error')}",
-                    },
-                    status_code,
+            # Index weekly expiries use the per-expiry synthetic future as the
+            # Black-76 forward; monthly index / stocks fall back to spot. Skipped
+            # when the caller supplied a custom underlying (e.g. a FUT symbol).
+            synthetic_forward = None
+            if not underlying_symbol or underlying_symbol == base_symbol:
+                synthetic_forward = _resolve_index_weekly_forward(
+                    base_symbol, exchange, spot_exchange, expiry, api_key
                 )
 
-            spot_price = spot_response.get("data", {}).get("ltp")
+            if synthetic_forward:
+                spot_price = synthetic_forward
+                logger.info(
+                    f"Using synthetic future {synthetic_forward} as forward for weekly {option_symbol}"
+                )
+                success = True
+            else:
+                # Fetch underlying spot price
+                logger.info(f"Fetching spot price for {spot_symbol} from {spot_exchange}")
+                success, spot_response, status_code = get_quotes(spot_symbol, spot_exchange, api_key)
+
+                if not success:
+                    return (
+                        False,
+                        {
+                            "status": "error",
+                            "message": f"Failed to fetch underlying price: {spot_response.get('message', 'Unknown error')}",
+                        },
+                        status_code,
+                    )
+
+                spot_price = spot_response.get("data", {}).get("ltp")
             if not spot_price:
                 return False, {"status": "error", "message": "Underlying LTP not available"}, 404
 
@@ -734,6 +863,9 @@ def get_multi_option_greeks(
     parsed_symbols = {}  # symbol -> (base_symbol, expiry, strike, opt_type)
     spot_keys = {}  # (spot_symbol, spot_exchange) -> spot_price
     symbol_to_spot_key = {}  # symbol -> (spot_symbol, spot_exchange)
+    symbol_forward = {}  # symbol -> synthetic forward price (index weeklies only)
+    expiry_cache = {}  # (base, options_exchange) -> [expiry dates]  (per-batch reuse)
+    synth_cache = {}  # (base, underlying_exchange, expiry_code) -> synthetic future
 
     for sym_req in symbols:
         symbol = sym_req.get("symbol")
@@ -742,12 +874,24 @@ def get_multi_option_greeks(
             base_symbol, expiry, strike, opt_type = parse_option_symbol(symbol, exchange, expiry_time)
             parsed_symbols[symbol] = (base_symbol, expiry, strike, opt_type)
 
-            # Determine spot symbol/exchange for this option
-            spot_symbol = sym_req.get("underlying_symbol") or base_symbol
+            # Determine spot symbol/exchange for this option (also the fallback
+            # if the synthetic future cannot be computed for an index weekly)
+            passed_underlying = sym_req.get("underlying_symbol")
+            spot_symbol = passed_underlying or base_symbol
             spot_exchange = sym_req.get("underlying_exchange") or get_underlying_exchange(base_symbol, exchange)
             spot_key = (spot_symbol, spot_exchange)
             spot_keys[spot_key] = None  # will be filled with price
             symbol_to_spot_key[symbol] = spot_key
+
+            # Index weekly -> per-expiry synthetic future as the Black-76 forward;
+            # monthly index / stocks keep spot. Skipped if the caller passed a
+            # custom underlying (e.g. an explicit FUT symbol).
+            if not passed_underlying or passed_underlying == base_symbol:
+                forward = _resolve_index_weekly_forward(
+                    base_symbol, exchange, spot_exchange, expiry, api_key, expiry_cache, synth_cache
+                )
+                if forward:
+                    symbol_forward[symbol] = forward
         except Exception as e:
             logger.warning(f"Failed to parse symbol {symbol}: {e}")
             failed_count += 1
@@ -811,9 +955,10 @@ def get_multi_option_greeks(
         if symbol not in parsed_symbols:
             continue
 
-        # Get spot price
+        # Forward price: synthetic future for index weeklies, else spot.
+        # Falls back to spot if the synthetic future could not be computed.
         spot_key = symbol_to_spot_key.get(symbol)
-        spot_price = spot_keys.get(spot_key) if spot_key else None
+        spot_price = symbol_forward.get(symbol) or (spot_keys.get(spot_key) if spot_key else None)
         if not spot_price:
             failed_count += 1
             results.append({


### PR DESCRIPTION
## Summary
- **New Gamma Density tool** (Vtrender-style Γ×OI density + convexity zones) for all exchanges/underlyings, with Intraday and To-Expiry panels, ±1σ/±2σ expected-move bands, ATM IV, and stat cards.
- **IV correctness fix:** index **weekly** options now price off the **per-expiry synthetic future** (Black-76 forward) instead of spot — fixes IV/Greeks mismatch vs Opstra. Monthly index, stocks, and explicit-underlying paths are unchanged.

## Backend
- `services/option_greeks_service.py`: new `_resolve_index_weekly_forward()` (single source of truth). Weekly/monthly detected as the last option expiry of the calendar month; synthetic future via `calculate_synthetic_future()`, cached per batch. Wired into `get_option_greeks` and `get_multi_option_greeks` (Strategy Builder path). Falls back to spot if synthetic can't be computed.
- `services/gamma_density_service.py`: reuses `get_option_chain` for OI+LTP, inverts per-strike IV + gamma via opengreeks black76; same forward rule (band/Spot marker stay on cash spot).
- `blueprints/gamma_density.py`: `POST /gammadensity/api/gamma-data` (session auth), registered in `app.py`.

## Frontend
- `pages/GammaDensity.tsx`, `api/gamma-density.ts`, route in `App.tsx`, Tools card, page title.

## Verification
- `ruff` clean, services import clean, `npm run build` passes (GammaDensity chunk emitted).
- FD audit: no new DB engines/sessions, sockets, threads, or subprocesses — only existing shared helpers.
- `frontend/dist/` intentionally not committed; CI rebuilds the canonical build on `main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)