### PR TITLE
Refactor: replace broker-init param_count magic numbers with named constants (#895)

### DIFF
--- a/services/depth_service.py
+++ b/services/depth_service.py
@@ -6,6 +6,13 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# At module level:
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+# If param_count > 2, the broker also accepts feed_token
+_MIN_BROKER_INIT_PARAMS = 2
+# BrokerData.__init__ params: self (1) + auth_token (1) + feed_token (1) = 3 minimum
+_MIN_BROKER_INIT_PARAMS_WITH_FEED_TOKEN = 3
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -95,9 +102,9 @@ def get_depth_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 3:  # More than self, auth_token, and feed_token
+            if param_count > _MIN_BROKER_INIT_PARAMS_WITH_FEED_TOKEN:  # More than self, auth_token, and feed_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token, user_id)
-            elif param_count > 2:  # More than self and auth_token
+            elif param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -9,6 +9,11 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# At module level:
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+# If param_count > 2, the broker also accepts feed_token
+_MIN_BROKER_INIT_PARAMS = 2
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -117,7 +122,7 @@ def get_history_with_auth(
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -130,10 +130,6 @@ def get_quotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
-            # At module level:
-            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
-            # If param_count > 2, the broker also accepts feed_token
-            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
             if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
@@ -265,10 +261,6 @@ def get_multiquotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
-            # At module level:
-            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
-            # If param_count > 2, the broker also accepts feed_token
-            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
             if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -125,9 +125,13 @@ def get_quotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
+            # At module level:
+            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+            # If param_count > 2, the broker also accepts feed_token
+            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)
@@ -256,9 +260,13 @@ def get_multiquotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
+            # At module level:
+            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+            # If param_count > 2, the broker also accepts feed_token
+            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
-            if param_count > 2:  # More than self and auth_token
+            if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
                 data_handler = broker_module.BrokerData(auth_token, feed_token)
             else:
                 data_handler = broker_module.BrokerData(auth_token)

--- a/services/quotes_service.py
+++ b/services/quotes_service.py
@@ -6,6 +6,11 @@ from database.token_db import get_token
 from utils.constants import VALID_EXCHANGES
 from utils.logging import get_logger
 
+# At module level:
+# BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
+# If param_count > 2, the broker also accepts feed_token
+_MIN_BROKER_INIT_PARAMS = 2
+
 # Initialize logger
 logger = get_logger(__name__)
 
@@ -125,10 +130,6 @@ def get_quotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
-            # At module level:
-            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
-            # If param_count > 2, the broker also accepts feed_token
-            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
             if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token
@@ -260,10 +261,6 @@ def get_multiquotes_with_auth(
     try:
         # Initialize broker's data handler based on broker's requirements
         if hasattr(broker_module.BrokerData.__init__, "__code__"):
-            # At module level:
-            # BrokerData.__init__ params: self (1) + auth_token (1) = 2 minimum
-            # If param_count > 2, the broker also accepts feed_token
-            _MIN_BROKER_INIT_PARAMS = 2
             # Check number of parameters the broker's __init__ accepts
             param_count = broker_module.BrokerData.__init__.__code__.co_argcount
             if param_count > _MIN_BROKER_INIT_PARAMS:  # More than self and auth_token


### PR DESCRIPTION
## Description

**What does this PR do?**

Replaces the unexplained magic numbers `2` and `3` in the broker data-handler initialization logic with self-documenting module-level constants, across the three service files that inspect `BrokerData.__init__` via `co_argcount`:

- `services/quotes_service.py`
- `services/history_service.py`
- `services/depth_service.py`

The check decides how many arguments a given broker's `BrokerData.__init__` accepts beyond `self`:

- `_MIN_BROKER_INIT_PARAMS = 2` → `self` + `auth_token` (baseline). If `param_count` exceeds this, the broker also accepts `feed_token`.
- `_MIN_BROKER_INIT_PARAMS_WITH_FEED_TOKEN = 3` (depth only) → `self` + `auth_token` + `feed_token`. If exceeded, the broker also accepts `user_id`.

Each constant is defined once at module level with a comment explaining the arithmetic, and the literals at the comparison sites are replaced with the named constants.

**Scope note:** The issue estimated "~5 more service files," but only these 3 actually use the `co_argcount` inspection pattern. Other services that touch `BrokerData` (`option_chain_service.py`, `oi_tracker_service.py`, `intervals_service.py`) call `BrokerData(auth_token)` directly and contain no magic number, so they are intentionally left untouched.

This is a pure readability refactor — **no runtime behavior change.**

## Related Issues

Closes [#895](https://github.com/marketcalls/openalgo/issues/895)

## Screenshots

N/A — no UI changes (backend service-layer refactor only).

## Testing

- `uv run python -c "import services.quotes_service, services.history_service, services.depth_service"` — all modules import cleanly.
- `grep -nE "param_count > [0-9]" services/*.py` — confirms no raw magic numbers remain at the comparison sites (only explanatory comments match).
- `uv run ruff check` on the three files — no new issues introduced.
- Verified the constants evaluate to the same values as the original literals (`2` and `3`), so the broker-init branch selection is identical to before. Existing quote / history / depth fetch paths are unaffected.

## Checklist

- [x] Code follows the project's style guidelines (Ruff)
- [x] Self-reviewed the changes
- [x] Added comments explaining the named constants
- [x] No new warnings or magic numbers introduced
- [x] Change is backward-compatible (pure refactor, no behavior change)
- [x] Documentation updated (N/A — no doc-facing change)
- [x] Tests added (N/A — no behavioral change; covered by existing service paths)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced magic numbers in `BrokerData.__init__` param-count checks with named constants to clarify broker data-handler initialization in `quotes_service`, `history_service`, and `depth_service`. No behavior changes; addresses #895.

- **Refactors**
  - Added `_MIN_BROKER_INIT_PARAMS = 2` and `_MIN_BROKER_INIT_PARAMS_WITH_FEED_TOKEN = 3` (depth only) as module-level constants with brief comments.
  - Swapped `param_count > 2/3` comparisons for the constants in the three services to self-document when `feed_token` and `user_id` are passed.

<sup>Written for commit 76283dfc58ff7f3cbb2fec04529dbdf6fca49335. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1561?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

