### PR TITLE
fix(nubra): emulate market/stop-market orders, add MCX, harden TOTP & order status

### DIFF
--- a/broker/nubra/api/auth_api.py
+++ b/broker/nubra/api/auth_api.py
@@ -23,6 +23,59 @@ def get_device_id():
     return "OPENALGO"
 
 
+def _normalize_totp(totp_code):
+    """
+    Normalize a TOTP code to a clean, zero-padded 6-digit string.
+
+    TOTP codes are 6-digit strings where a leading zero is significant
+    (e.g. "012345"). Returns None if the input is not 1-6 digits.
+    """
+    s = str(totp_code).strip()
+    if not s.isdigit() or not 1 <= len(s) <= 6:
+        return None
+    return s.zfill(6)
+
+
+def _totp_login(client, base_url, device_id, phone, totp_str):
+    """
+    Call POST /totp/login, hedging the int-vs-string ambiguity for leading-zero
+    codes.
+
+    Nubra's docs show ``totp`` as a JSON integer, but ``int("012345")`` drops the
+    leading zero -- which fails if the server compares the code as a string. For
+    a leading-zero code we therefore try the documented integer first, then fall
+    back to the zero-padded string (which is correct whether the server compares
+    numerically or as a string). The TOTP stays valid within its 30s window, so
+    the retry reuses the same live code.
+
+    Returns:
+        (response, data) for the first attempt that yields an auth_token, or the
+        last attempt if none succeeded.
+    """
+    headers = {"Content-Type": "application/json", "x-device-id": device_id}
+
+    candidates = [int(totp_str)]
+    # Only a leading-zero code needs the string fallback (int repr differs).
+    if totp_str != str(int(totp_str)):
+        candidates.append(totp_str)
+
+    last = None
+    for totp_val in candidates:
+        response = client.post(
+            f"{base_url}/totp/login",
+            json={"phone": phone, "totp": totp_val},
+            headers=headers,
+        )
+        try:
+            data = response.json()
+        except ValueError:
+            data = {}
+        last = (response, data)
+        if data.get("auth_token"):
+            return response, data
+    return last
+
+
 def authenticate_broker(totp_code):
     """
     Authenticate with Nubra broker using TOTP flow.
@@ -51,24 +104,23 @@ def authenticate_broker(totp_code):
             "Missing BROKER_API_KEY (phone) or BROKER_API_SECRET (mpin) in environment",
         )
 
+    # Normalize the TOTP up front so a leading-zero code (e.g. "012345") is not
+    # silently mangled by int() later in the flow.
+    totp_str = _normalize_totp(totp_code)
+    if totp_str is None:
+        return None, None, "Invalid TOTP code: expected a 6-digit numeric code"
+
     base_url = get_base_url()
     device_id = get_device_id()
 
     try:
         client = get_httpx_client()
 
-        # Step 1: Login via TOTP
+        # Step 1: Login via TOTP (int per docs, with a string fallback for
+        # leading-zero codes).
         logger.info(f"Nubra TOTP login initiated for phone: {phone[:5]}***")
 
-        totp_login_payload = {"phone": phone, "totp": int(totp_code)}
-
-        totp_login_headers = {"Content-Type": "application/json", "x-device-id": device_id}
-
-        totp_response = client.post(
-            f"{base_url}/totp/login", json=totp_login_payload, headers=totp_login_headers
-        )
-
-        totp_data = totp_response.json()
+        totp_response, totp_data = _totp_login(client, base_url, device_id, phone, totp_str)
         logger.info(f"Nubra TOTP login response status: {totp_response.status_code}")
         logger.info(f"Nubra TOTP login response data: {totp_data}")
 

--- a/broker/nubra/api/data.py
+++ b/broker/nubra/api/data.py
@@ -649,7 +649,7 @@ class BrokerData:
                 )
 
             # Determine instrument type based on exchange
-            # Nubra only supports: NSE, BSE, NFO, BFO, NSE_INDEX, BSE_INDEX
+            # Nubra supports: NSE, BSE, NFO, BFO, MCX, NSE_INDEX, BSE_INDEX
             # For NFO/BFO, Nubra expects exchange=NSE/BSE with type=FUT/OPT
             if exchange == "NSE_INDEX":
                 instrument_type = "INDEX"
@@ -671,11 +671,18 @@ class BrokerData:
                 else:
                     instrument_type = "FUT"
                 api_exchange = "BSE"  # Nubra expects BSE for F&O
+            elif exchange == "MCX":
+                # MCX commodities are all derivatives (FUT/OPT); exchange stays MCX
+                if "CE" in symbol or "PE" in symbol:
+                    instrument_type = "OPT"
+                else:
+                    instrument_type = "FUT"
+                api_exchange = "MCX"
             elif exchange in ["NSE", "BSE"]:
                 instrument_type = "STOCK"
                 api_exchange = exchange
             else:
-                raise Exception(f"Exchange '{exchange}' is not supported by Nubra. Supported exchanges: NSE, BSE, NFO, BFO, NSE_INDEX, BSE_INDEX")
+                raise Exception(f"Exchange '{exchange}' is not supported by Nubra. Supported exchanges: NSE, BSE, NFO, BFO, MCX, NSE_INDEX, BSE_INDEX")
 
             # Convert dates to datetime objects
             from_date = pd.to_datetime(start_date)

--- a/broker/nubra/api/order_api.py
+++ b/broker/nubra/api/order_api.py
@@ -6,6 +6,7 @@ import time
 import httpx
 
 from broker.nubra.mapping.transform_data import (
+    _market_protection_pct,
     map_product_type,
     reverse_map_product_type,
     transform_data,
@@ -25,6 +26,22 @@ NUBRA_BASE_URL = "https://api.nubra.io"
 # Trading APIs: 10 ops/sec (PROD), 100 ops/sec (UAT)
 _MAX_RETRIES = 3
 _RATE_LIMIT_BASE_DELAY = 1.0  # Base delay for 429 retry (seconds)
+
+
+class _StubResponse:
+    """Minimal response stand-in for paths that fail before any HTTP call.
+
+    The service layer only reads ``.status`` (and occasionally ``.text``), so we
+    mimic an httpx response without performing a request.
+    """
+
+    def __init__(self, status_code, text=""):
+        self.status_code = status_code
+        self.status = status_code
+        self.text = text
+
+    def json(self):
+        return {}
 
 
 def get_api_response(endpoint, auth, method="GET", payload=""):
@@ -81,10 +98,59 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
         return {}
 
 
+def _compute_mpp_price_paise(symbol, exchange, action, auth):
+    """
+    Compute the Market-Protection-Price (MPP, in paise) for a MARKET order.
+
+    Nubra does not support price_type=MARKET and has no broker-side
+    market-protection flag, so an OpenAlgo MARKET order is emulated the way
+    Zerodha's market_protection / Arrow's mpp works: a DAY LIMIT priced at the
+    LTP offset by the protection band:
+      - BUY  -> LTP * (1 + band)   (upper protection price)
+      - SELL -> LTP * (1 - band)   (lower protection price)
+    The order rests as a DAY limit (NOT IOC). The band is NUBRA_MARKET_PROTECTION_PCT
+    (percent, default 1.0).
+
+    Returns:
+        int price in paise, or None if no price context could be obtained
+        (the caller must then refuse to place the order rather than send price 0).
+    """
+    token = get_token(symbol, exchange)
+    if not token or not str(token).isdigit():
+        logger.warning(f"Nubra MPP emulation: no numeric ref_id for {symbol} on {exchange}")
+        return None
+
+    try:
+        resp = get_api_response(f"/orderbooks/{token}?levels=1", auth)
+    except Exception as e:
+        logger.warning(f"Nubra MPP emulation: order book fetch failed for {symbol}: {e}")
+        return None
+
+    orderbook = resp.get("orderBook") or {} if isinstance(resp, dict) else {}
+    side = action.upper()
+
+    # Reference price = LTP; fall back to the best opposite quote if LTP missing
+    ref_price = int(orderbook.get("ltp", 0) or 0)
+    if not ref_price:
+        if side == "BUY":
+            asks = [int(a.get("p", 0) or 0) for a in (orderbook.get("ask") or []) if a.get("p")]
+            ref_price = asks[0] if asks else 0
+        else:
+            bids = [int(b.get("p", 0) or 0) for b in (orderbook.get("bid") or []) if b.get("p")]
+            ref_price = bids[0] if bids else 0
+
+    if not ref_price:
+        logger.warning(f"Nubra MPP emulation: no LTP/quote for {symbol} on {exchange}")
+        return None
+
+    band = _market_protection_pct()
+    return int(round(ref_price * (1 + band))) if side == "BUY" else int(round(ref_price * (1 - band)))
+
+
 def get_order_book(auth):
     """
     Fetch all orders for the day from Nubra API.
-    
+
     Nubra API: GET /orders/v2
     Returns list of orders with their current status.
     """
@@ -241,11 +307,44 @@ def place_order_api(data, auth):
     
     # Get token (ref_id) for the symbol
     token = get_token(data["symbol"], data["exchange"])
-    
+
     logger.debug(f"Nubra order - Symbol: {data['symbol']}, Exchange: {data['exchange']}, Token: {token}")
-    
+
+    pricetype = data.get("pricetype", "MARKET").upper()
+
+    # Stop orders (SL / SL-M) require a trigger price. SL-M is a stop-MARKET that
+    # Nubra has no native type for, so it is emulated as a stop-LIMIT priced at
+    # the trigger +/- the protection band (see transform_data) - which is
+    # impossible without a trigger. Fail fast with a clear message.
+    if pricetype in ("SL", "SL-M"):
+        try:
+            trigger = float(data.get("trigger_price", 0) or 0)
+        except (TypeError, ValueError):
+            trigger = 0
+        if not trigger:
+            msg = f"{pricetype} order requires a non-zero trigger_price for {data['symbol']} on {data['exchange']}."
+            logger.error(msg)
+            return _StubResponse(400), {"status": False, "error": msg}, None
+
+    # MARKET emulation: Nubra is limit-only, so derive the Market-Protection-Price
+    # (LTP +/- band) and send it as a DAY limit (MPP style, no IOC).
+    market_price_paise = None
+    if pricetype == "MARKET":
+        market_price_paise = _compute_mpp_price_paise(
+            data["symbol"], data["exchange"], data["action"], AUTH_TOKEN
+        )
+        if not market_price_paise:
+            msg = (
+                f"Could not determine a market price to emulate a MARKET order for "
+                f"{data['symbol']} on {data['exchange']} (Nubra is limit-only). "
+                f"Place a LIMIT order or retry when quotes are available."
+            )
+            logger.error(msg)
+            response_data = {"status": False, "error": msg}
+            return _StubResponse(400), response_data, None
+
     # Transform OpenAlgo data to Nubra format
-    nubra_data = transform_data(data, token)
+    nubra_data = transform_data(data, token, market_price_paise=market_price_paise)
     
     headers = {
         "Authorization": f"Bearer {AUTH_TOKEN}",
@@ -589,10 +688,17 @@ def modify_order(data, auth):
     # Get the shared httpx client with connection pooling
     client = get_httpx_client()
 
+    # MARKET emulation on modify: derive the Market-Protection-Price (DAY limit, MPP style)
+    market_price_paise = None
+    if data.get("pricetype", "MARKET").upper() == "MARKET" and data.get("symbol") and data.get("exchange"):
+        market_price_paise = _compute_mpp_price_paise(
+            data["symbol"], data["exchange"], data.get("action", "BUY"), AUTH_TOKEN
+        )
+
     # Transform OpenAlgo data to Nubra modify order format
     # Note: token/ref_id is not needed for modify order
-    transformed_data = transform_modify_order_data(data, None)
-    
+    transformed_data = transform_modify_order_data(data, None, market_price_paise=market_price_paise)
+
     # Get order_id from the data
     orderid = data.get("orderid", "")
     
@@ -688,12 +794,14 @@ def cancel_all_orders_api(data, auth):
     if not orders:
         return [], []
 
-    # Filter orders that are in 'open' or 'pending' state
-    # Nubra uses ORDER_STATUS_OPEN, ORDER_STATUS_PENDING
+    # Filter orders that are still cancellable (not filled/cancelled/rejected).
+    # Per Nubra's OrderStatus enum the working states are PENDING, SENT, OPEN and
+    # TRIGGERED (there is no ORDER_STATUS_TRIGGER_PENDING).
     open_statuses = [
-        "ORDER_STATUS_OPEN", 
+        "ORDER_STATUS_OPEN",
         "ORDER_STATUS_PENDING",
-        "ORDER_STATUS_TRIGGER_PENDING",
+        "ORDER_STATUS_SENT",
+        "ORDER_STATUS_TRIGGERED",
     ]
     
     orders_to_cancel = [

--- a/broker/nubra/database/master_contract_db.py
+++ b/broker/nubra/database/master_contract_db.py
@@ -76,7 +76,7 @@ def copy_from_dataframe(df):
 
 def download_nubra_instruments(output_path):
     """
-    Downloads instrument data from Nubra API for NSE and BSE exchanges.
+    Downloads instrument data from Nubra API for NSE, BSE and MCX exchanges.
     """
     date = datetime.now().strftime('%Y-%m-%d')
 
@@ -98,7 +98,7 @@ def download_nubra_instruments(output_path):
 
     all_data = []
 
-    for exchange in ['NSE', 'BSE']:
+    for exchange in ['NSE', 'BSE', 'MCX']:
         url = f'https://api.nubra.io/refdata/refdata/{date}?exchange={exchange}'
         logger.info(f"Downloading Nubra instruments for {exchange}")
 
@@ -128,11 +128,16 @@ def process_nubra_json(path):
     Rules:
     - NSE + non-STOCK  -> exchange = NFO, brexchange = NSE
     - BSE + non-STOCK  -> exchange = BFO, brexchange = BSE
+    - MCX (commodity FUT/OPT) -> exchange stays MCX, brexchange = MCX
     - STOCK instruments keep their original exchange
     - Expiry column remains in DB as DD-MMM-YY
     - Symbol format follows OpenAlgo F&O spec:
-        FUT : [BASE][DDMMMYY]FUT
-        OPT : [BASE][DDMMMYY][STRIKE][CE/PE]
+        FUT : [BASE][DDMMMYY]FUT       e.g. CRUDEOILM20MAY24FUT (MCX)
+        OPT : [BASE][DDMMMYY][STRIKE][CE/PE]  e.g. CRUDEOIL17APR246750CE (MCX)
+
+    Note: strike_price and tick_size are scaled by /100 (paise) uniformly across
+    NSE/BSE/MCX per Nubra's unified refdata schema. Verify MCX strike/tick
+    scaling against a live MCX master download (commodity scaling can differ).
     """
 
     df = pd.read_json(path)

--- a/broker/nubra/mapping/order_data.py
+++ b/broker/nubra/mapping/order_data.py
@@ -56,15 +56,19 @@ def map_order_data(order_data):
         else:
             transaction_type = order_side.replace("ORDER_SIDE_", "") if order_side else ""
 
-        # Nubra: order_status -> status (complete/open/rejected)
+        # Nubra: order_status -> status (complete/open/rejected/cancelled).
+        # Nubra OrderStatus enum: PENDING, SENT, OPEN, REJECTED, CANCELLED,
+        # FILLED, TRIGGERED. (There is no PARTIALLY_FILLED state - partial fills
+        # stay OPEN with filled_qty < order_qty.)
         order_status = order.get("order_status", "")
         status_map = {
             "ORDER_STATUS_FILLED": "complete",
             "ORDER_STATUS_OPEN": "open",
             "ORDER_STATUS_PENDING": "open",
+            "ORDER_STATUS_SENT": "open",
+            "ORDER_STATUS_TRIGGERED": "open",
             "ORDER_STATUS_REJECTED": "rejected",
             "ORDER_STATUS_CANCELLED": "cancelled",
-            "ORDER_STATUS_PARTIALLY_FILLED": "open",
         }
         status = status_map.get(order_status, order_status.replace("ORDER_STATUS_", "").lower() if order_status else "")
 
@@ -100,6 +104,16 @@ def map_order_data(order_data):
         else:
             # Fallback: try to derive from price_type or default to MARKET
             ordertype = price_type.upper() if price_type else "MARKET"
+
+        # A stop (SL/SL-M) order that is still working (not filled/cancelled/
+        # rejected) is awaiting its trigger -> surface as OpenAlgo "trigger pending"
+        # (matches the zerodha reference vocabulary).
+        if ordertype in ("SL", "SL-M") and order_status in (
+            "ORDER_STATUS_PENDING",
+            "ORDER_STATUS_OPEN",
+            "ORDER_STATUS_SENT",
+        ):
+            status = "trigger pending"
 
         # Nubra: order_delivery_type -> producttype (CNC/MIS/NRML)
         delivery_type = order.get("order_delivery_type", "")
@@ -280,10 +294,13 @@ def map_trade_data(trade_data):
     if not orders:
         return []
 
-    # Filter for filled/completed orders only (these are the "trades")
+    # Treat any order with a non-zero filled quantity as a trade. Nubra has no
+    # PARTIALLY_FILLED status (partial fills stay OPEN with filled_qty > 0), so
+    # filtering on filled_qty captures both full and partial fills.
     filled_orders = [
         order for order in orders
-        if order.get("order_status") in ["ORDER_STATUS_FILLED", "ORDER_STATUS_PARTIALLY_FILLED"]
+        if (order.get("filled_qty") or 0) > 0
+        or order.get("order_status") == "ORDER_STATUS_FILLED"
     ]
 
     normalized_trades = []

--- a/broker/nubra/mapping/transform_data.py
+++ b/broker/nubra/mapping/transform_data.py
@@ -1,13 +1,33 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Nubra API Parameters https://api.nubra.io/docs
 
+import os
+
 from database.token_db import get_br_symbol
 
 
-def transform_data(data, token):
+def _market_protection_pct():
+    """
+    Market-Protection-Price (MPP) band (fraction) for emulating MARKET / SL-M.
+
+    Nubra does NOT support MARKET price_type (docs: "Do not send MARKET as
+    price_type") and has no broker-side market-protection flag (unlike Zerodha's
+    market_protection / Arrow's mpp). We therefore emulate a market order the way
+    those brokers' MPP feature does: a DAY LIMIT priced at LTP +/- this band
+    (BUY above, SELL below) so it is marketable but capped. The same band sets
+    the marketable limit for SL-M stop orders. Configurable via
+    NUBRA_MARKET_PROTECTION_PCT (percent, default 1.0).
+    """
+    try:
+        return float(os.getenv("NUBRA_MARKET_PROTECTION_PCT", "1.0")) / 100.0
+    except (TypeError, ValueError):
+        return 0.01
+
+
+def transform_data(data, token, market_price_paise=None):
     """
     Transforms the OpenAlgo API request structure to Nubra's expected structure.
-    
+
     OpenAlgo format:
     - action: BUY/SELL
     - product: CNC/MIS/NRML
@@ -15,79 +35,97 @@ def transform_data(data, token):
     - price: float (in rupees)
     - trigger_price: float (in rupees, for stoploss orders)
     - quantity: int
-    
+
     Nubra format:
     - order_side: ORDER_SIDE_BUY/ORDER_SIDE_SELL
     - order_delivery_type: ORDER_DELIVERY_TYPE_CNC/ORDER_DELIVERY_TYPE_IDAY
     - order_type: ORDER_TYPE_REGULAR/ORDER_TYPE_STOPLOSS
-    - price_type: MARKET/LIMIT
+    - price_type: LIMIT (Nubra is limit-only; MARKET is emulated as an MPP limit)
     - order_price: int (in paise)
+    - validity_type: DAY (Nubra has no IOC routing; MPP limits rest as DAY)
     - algo_params.trigger_price: int (in paise, for stoploss orders)
     - order_qty: int
+
+    Args:
+        market_price_paise: Market-Protection-Price (in paise, LTP +/- band)
+            computed by the caller, used to emulate a MARKET order as a DAY LIMIT.
+            When None for a MARKET request, the caller is expected to have guarded
+            against placement.
     """
     # Convert price from rupees to paise (multiply by 100)
     price = float(data.get("price", 0))
     price_in_paise = int(round(price * 100)) if price else 0
-    
+
     trigger_price = float(data.get("trigger_price", 0))
     trigger_price_in_paise = int(round(trigger_price * 100)) if trigger_price else 0
-    
-    pricetype = data.get("pricetype", "MARKET")
-    
-    # Determine validity type based on price type
-    # MARKET and SL-M orders require IOC (Immediate or Cancel)
-    # LIMIT and SL orders use DAY validity
-    if pricetype == "MARKET":
-        validity_type = "IOC"
-    else:
-        validity_type = "DAY"
-    
+
+    pricetype = data.get("pricetype", "MARKET").upper()
+    side = data["action"].upper()
+
+    # All orders use DAY validity. Nubra has no IOC routing, and the MPP-style
+    # market emulation deliberately rests as a DAY limit (like Zerodha/Arrow MPP).
+    validity_type = "DAY"
+
     # Build the transformed data structure for Nubra API
     transformed = {
         "ref_id": int(token),  # Instrument reference ID from token
-        "order_side": map_order_side(data["action"]),
+        "order_side": map_order_side(side),
         "order_delivery_type": map_order_delivery_type(data["product"]),
         "order_type": map_order_type(pricetype),
-        "price_type": map_price_type(pricetype),
+        "price_type": map_price_type(pricetype),  # always LIMIT (Nubra is limit-only)
         "order_qty": int(data["quantity"]),
         "validity_type": validity_type,
         "order_price": price_in_paise,
         "tag": data.get("strategy", "openalgo"),
     }
-    
+
+    # MARKET emulation: Nubra rejects price_type=MARKET and has no market-protection
+    # flag, so we send a DAY LIMIT at the Market-Protection-Price (LTP +/- band,
+    # computed by the caller) -- the same idea as Zerodha market_protection / Arrow mpp.
+    if pricetype == "MARKET":
+        if market_price_paise:
+            transformed["order_price"] = int(market_price_paise)
+        # else: leave price_in_paise (the caller should have guarded placement)
+
     # Add algo_params for stoploss orders
-    if pricetype in ["SL", "SL-M"]:
+    if pricetype in ("SL", "SL-M"):
         transformed["algo_params"] = {
             "trigger_price": trigger_price_in_paise
         }
-        # For SL-M orders, Nubra requires order_price >= trigger_price
-        # Set order_price = trigger_price to pass validation;
-        # actual execution happens at market price since price_type is MARKET
-        if pricetype == "SL-M" and not price_in_paise:
-            transformed["order_price"] = trigger_price_in_paise
-    
+        # SL-M is a stop-MARKET order, which Nubra has no native type for. Emulate
+        # it as a stop-LIMIT whose limit is placed beyond the trigger by the
+        # protection band so it is marketable the moment the trigger fires.
+        # Nubra rule: BUY stop needs order_price >= trigger; SELL needs <= trigger.
+        if pricetype == "SL-M" and trigger_price_in_paise:
+            buf = _market_protection_pct()
+            if side == "BUY":
+                transformed["order_price"] = int(round(trigger_price_in_paise * (1 + buf)))
+            else:
+                transformed["order_price"] = int(round(trigger_price_in_paise * (1 - buf)))
+
     return transformed
 
 
-def transform_modify_order_data(data, token):
+def transform_modify_order_data(data, token, market_price_paise=None):
     """
     Transforms modify order data from OpenAlgo format to Nubra's format.
-    
+
     Nubra Modify Order API: POST /orders/v2/modify/{order_id}
-    
+
     Compulsory fields: order_price, order_qty, exchange, order_type
     For ORDER_TYPE_STOPLOSS: also requires trigger_price in algo_params
-    
+
     Note: order_id goes in the URL, not in the payload
     """
     price = float(data.get("price", 0))
     price_in_paise = int(round(price * 100)) if price else 0
-    
+
     trigger_price = float(data.get("trigger_price", 0))
     trigger_price_in_paise = int(round(trigger_price * 100)) if trigger_price else 0
-    
-    pricetype = data.get("pricetype", "MARKET")
-    
+
+    pricetype = data.get("pricetype", "MARKET").upper()
+    side = data.get("action", "BUY").upper()
+
     # Build payload per Nubra API requirements
     # order_id is passed in URL, not in payload
     transformed = {
@@ -96,13 +134,24 @@ def transform_modify_order_data(data, token):
         "exchange": data["exchange"],  # Compulsory field
         "order_type": map_order_type(pricetype),
     }
-    
+
+    # MARKET emulation on modify: aggressive limit from the live book (caller-supplied)
+    if pricetype == "MARKET" and market_price_paise:
+        transformed["order_price"] = int(market_price_paise)
+
     # Add algo_params for stoploss orders (trigger_price is compulsory for stoploss)
-    if pricetype in ["SL", "SL-M"]:
+    if pricetype in ("SL", "SL-M"):
         transformed["algo_params"] = {
             "trigger_price": trigger_price_in_paise
         }
-    
+        # SL-M -> marketable stop-limit beyond the trigger (see transform_data)
+        if pricetype == "SL-M" and trigger_price_in_paise:
+            buf = _market_protection_pct()
+            if side == "BUY":
+                transformed["order_price"] = int(round(trigger_price_in_paise * (1 + buf)))
+            else:
+                transformed["order_price"] = int(round(trigger_price_in_paise * (1 - buf)))
+
     return transformed
 
 
@@ -149,15 +198,19 @@ def map_order_type(pricetype):
 def map_price_type(pricetype):
     """
     Maps OpenAlgo pricetype to Nubra price_type.
-    Only MARKET or LIMIT in Nubra.
+
+    Nubra is LIMIT-only for order entry (docs: "Do not send MARKET as
+    price_type"). Every OpenAlgo pricetype therefore maps to LIMIT; MARKET and
+    SL-M are emulated with an aggressive/marketable limit price (see
+    transform_data / _market_protection_pct).
     """
     price_type_mapping = {
-        "MARKET": "MARKET",
+        "MARKET": "LIMIT",  # emulated via MPP limit (LTP +/- band), DAY validity
         "LIMIT": "LIMIT",
         "SL": "LIMIT",      # Stoploss Limit
-        "SL-M": "LIMIT",    # Nubra doesn't support stoploss+market; use LIMIT with price=trigger
+        "SL-M": "LIMIT",    # emulated stop-market via marketable limit
     }
-    return price_type_mapping.get(pricetype.upper(), "MARKET")
+    return price_type_mapping.get(pricetype.upper(), "LIMIT")
 
 
 def map_product_type(product):

--- a/broker/nubra/plugin.json
+++ b/broker/nubra/plugin.json
@@ -5,7 +5,7 @@
     "Version": "1.0",
     "Author": "Roch Ronaldo M",
     "Author URI": "https://openalgo.in",
-    "supported_exchanges": ["NSE", "BSE", "NFO", "BFO", "NSE_INDEX", "BSE_INDEX"],
+    "supported_exchanges": ["NSE", "BSE", "NFO", "BFO", "MCX", "NSE_INDEX", "BSE_INDEX"],
     "broker_type": "IN_stock",
     "leverage_config": false
 }


### PR DESCRIPTION
## Summary
Validated the Nubra broker plugin against the Nubra REST API docs and fixed the issues found. Nubra is **limit-only** and rejects `price_type=MARKET`, so market and stop-market orders were failing outright. Also adds **MCX** support and fixes order-status / auth edge cases.

## Order entry
- **MARKET** → emulated as a **Market-Protection-Price (MPP) DAY limit** at `LTP ± band` (`NUBRA_MARKET_PROTECTION_PCT`, default 1%), computed from the live order book. No IOC — mirrors Zerodha `market_protection` / Arrow `mpp`.
- **SL-M** (stop-market; no native Nubra type) → emulated as a **stop-LIMIT** whose limit sits beyond the trigger by the same band (BUY `≥` trigger, SELL `≤` trigger) so it's marketable when the stop fires.
- `map_price_type` always returns `LIMIT`; refuse MARKET when no price context is available and SL/SL-M without a `trigger_price`.

## Order status
- Map the real Nubra `OrderStatus` enum (add `SENT`, `TRIGGERED`; drop the non-existent `PARTIALLY_FILLED`); surface working stops as **"trigger pending"**.
- Tradebook keys off `filled_qty > 0` so **partial fills appear**.
- `cancel_all` uses the real statuses (`SENT`/`TRIGGERED`, not the bogus `TRIGGER_PENDING`).

## MCX support
- Download the MCX instrument master + add `MCX` to `supported_exchanges`. Existing FUT/OPT symbol construction yields OpenAlgo format (`CRUDEOIL…FUT`, `…CE/PE`), exchange stays `MCX` (verified via synthetic rows through `process_nubra_json`).
- `get_history` handles MCX (`type` FUT/OPT, `api_exchange=MCX`).

## Auth
- Normalize TOTP to a zero-padded 6-digit string and hedge the int-vs-string ambiguity for **leading-zero codes** (try documented int, fall back to string).

## Verification
- `py_compile` clean; ruff shows only pre-existing unused imports.
- Unit-checked: MARKET→DAY LIMIT (no IOC), SL-M BUY limit ≥ trigger / SELL ≤ trigger, status mapping + partial-fill tradebook, MCX symbol conversion, TOTP normalization/fallback candidates.
- Adapter still resolves via the `websocket_proxy` factory; no raw HTTP clients introduced.

## Live-verification notes (no live Nubra session available)
- Confirm MCX `strike_price`/`tick_size` arrive ×100 (paise) like equity/index, and `asset` naming (mini contracts).
- Tune `NUBRA_MARKET_PROTECTION_PCT` if Nubra rejects limits outside the circuit band on thin contracts.

🤖 Generated with [Claude Code](https://claude.com/claude-code)