### PR TITLE
Introduce OpenAlgo Configuration SDK (OCS) & Declarative UI for Python

### DIFF
--- a/app.py
+++ b/app.py
@@ -89,9 +89,11 @@ from blueprints.playground import playground_bp  # Import the API playground blu
 from blueprints.pnltracker import pnltracker_bp  # Import the pnl tracker blueprint
 from blueprints.python_strategy import python_strategy_bp, initialize_with_app_context as init_python_strategy  # Import the python strategy blueprint
 from blueprints.react_app import (  # Import React frontend blueprint
+    frontend_auto_build_enabled,
     is_react_frontend_available,
     react_bp,
     serve_react_app,
+    start_frontend_auto_build,
 )
 from blueprints.sandbox import sandbox_bp  # Import the sandbox blueprint
 from blueprints.search import search_bp
@@ -260,9 +262,14 @@ def create_app():
     # Register RESTx API blueprint first
     # Register React frontend blueprint FIRST for migrated routes
     # Register React frontend routes
-    if is_react_frontend_available():
+    start_frontend_auto_build()
+    react_available = is_react_frontend_available()
+    if react_available or frontend_auto_build_enabled():
         app.register_blueprint(react_bp)
-        logger.debug("React frontend enabled (frontend/dist found)")
+        if react_available:
+            logger.debug("React frontend enabled (frontend/dist found)")
+        else:
+            logger.debug("React frontend routes enabled while opt-in auto-build runs")
     else:
         logger.warning("React frontend not available - run 'npm run build' in frontend/")
 

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -100,6 +100,7 @@ def broadcast_status_update(strategy_id: str, status: str, message: str = None):
 
 
 # File paths - use Path for cross-platform compatibility
+APP_ROOT = Path(__file__).resolve().parent.parent
 STRATEGIES_DIR = Path("strategies") / "scripts"
 LOGS_DIR = Path("log") / "strategies"  # Using existing log folder
 CONFIG_FILE = Path("strategies") / "strategy_configs.json"
@@ -392,6 +393,16 @@ def inject_ocs_environment(strategy_env: dict, strategy_id: str):
             strategy_env[env_key] = json.dumps(value, ensure_ascii=False)
         else:
             strategy_env[env_key] = str(value)
+
+
+def inject_strategy_pythonpath(strategy_env: dict):
+    """Ensure uploaded scripts can import OpenAlgo app-local helper packages."""
+    app_root = str(APP_ROOT)
+    existing = strategy_env.get("PYTHONPATH", "")
+    parts = [part for part in existing.split(os.pathsep) if part]
+    if app_root not in parts:
+        parts.insert(0, app_root)
+    strategy_env["PYTHONPATH"] = os.pathsep.join(parts)
 
 
 UI_FIELD_TYPES = {
@@ -730,7 +741,7 @@ def start_strategy_process(strategy_id):
             subprocess_args = create_subprocess_args()
             subprocess_args["stdout"] = log_handle
             subprocess_args["stderr"] = subprocess.STDOUT
-            subprocess_args["cwd"] = str(Path.cwd())
+            subprocess_args["cwd"] = str(APP_ROOT)
 
             # Inject documented strategy environment variables
             # (per strategies/README.md: STRATEGY_ID, STRATEGY_NAME, OPENALGO_API_KEY, OPENALGO_HOST)
@@ -751,6 +762,7 @@ def start_strategy_process(strategy_id):
             except Exception as e:
                 logger.warning(f"Could not inject API key for strategy {strategy_id}: {e}")
             inject_ocs_environment(strategy_env, strategy_id)
+            inject_strategy_pythonpath(strategy_env)
             subprocess_args["env"] = strategy_env
 
             # Start the process

--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -6,6 +6,7 @@ Supports: Windows, Linux, macOS
 Note: Each strategy runs in a separate process for complete isolation
 """
 
+import ast
 import json
 import logging
 import os
@@ -43,6 +44,13 @@ from database.market_calendar_db import (
     get_special_session,
     is_market_holiday,
     is_market_open,
+)
+from openalgo_config import (
+    ConfigStore,
+    OCSValidationError,
+    build_runtime_config,
+    normalize_schema,
+    validate_values,
 )
 from utils.constants import CRYPTO_EXCHANGES
 from utils.session import check_session_validity
@@ -95,6 +103,7 @@ def broadcast_status_update(strategy_id: str, status: str, message: str = None):
 STRATEGIES_DIR = Path("strategies") / "scripts"
 LOGS_DIR = Path("log") / "strategies"  # Using existing log folder
 CONFIG_FILE = Path("strategies") / "strategy_configs.json"
+OCS_STORE = ConfigStore(Path("strategies") / "configs")
 
 # Detect operating system
 OS_TYPE = platform.system().lower()  # 'windows', 'linux', 'darwin'
@@ -228,10 +237,11 @@ def verify_strategy_ownership(strategy_id, user_id, return_config=False):
 
 def ensure_directories():
     """Ensure all required directories exist"""
-    global STRATEGIES_DIR, LOGS_DIR
+    global STRATEGIES_DIR, LOGS_DIR, OCS_STORE
     try:
         STRATEGIES_DIR.mkdir(parents=True, exist_ok=True)
         LOGS_DIR.mkdir(parents=True, exist_ok=True)
+        OCS_STORE.ensure_dirs()
         logger.debug(f"Directories initialized on {OS_TYPE}")
     except PermissionError as e:
         # If we can't create directories, check if they exist
@@ -244,8 +254,10 @@ def ensure_directories():
             temp_base = Path(tempfile.gettempdir()) / "openalgo"
             STRATEGIES_DIR = temp_base / "strategies" / "scripts"
             LOGS_DIR = temp_base / "log" / "strategies"
+            OCS_STORE = ConfigStore(temp_base / "strategies" / "configs")
             STRATEGIES_DIR.mkdir(parents=True, exist_ok=True)
             LOGS_DIR.mkdir(parents=True, exist_ok=True)
+            OCS_STORE.ensure_dirs()
             logger.warning(f"Using temporary directories due to permission issues: {temp_base}")
     except Exception as e:
         logger.exception(f"Failed to create directories: {e}")
@@ -357,6 +369,225 @@ def create_subprocess_args():
     return args
 
 
+def inject_ocs_environment(strategy_env: dict, strategy_id: str):
+    """Inject OCS schema and resolved values into a strategy subprocess env."""
+    try:
+        schema = OCS_STORE.get_schema(strategy_id)
+        values = build_runtime_config(OCS_STORE, strategy_id)
+    except OCSValidationError as e:
+        logger.warning(f"OCS config invalid for strategy {strategy_id}: {e}")
+        values = {}
+        schema = {"ocs_version": "1.0", "strategy": strategy_id, "fields": []}
+    except Exception as e:
+        logger.warning(f"Could not load OCS config for strategy {strategy_id}: {e}")
+        values = {}
+        schema = {"ocs_version": "1.0", "strategy": strategy_id, "fields": []}
+
+    strategy_env["OPENALGO_CONFIG_JSON"] = json.dumps(values, ensure_ascii=False)
+    strategy_env["OPENALGO_CONFIG_SCHEMA_JSON"] = json.dumps(schema, ensure_ascii=False)
+
+    for key, value in values.items():
+        env_key = f"OPENALGO_CONFIG_{key.upper()}"
+        if isinstance(value, (dict, list)):
+            strategy_env[env_key] = json.dumps(value, ensure_ascii=False)
+        else:
+            strategy_env[env_key] = str(value)
+
+
+UI_FIELD_TYPES = {
+    "int": "int",
+    "float": "float",
+    "bool": "bool",
+    "string": "string",
+    "select": "select",
+    "symbol": "symbol",
+    "exchange": "exchange",
+    "product": "product",
+    "quantity": "quantity",
+}
+
+
+def _literal_node_value(node):
+    try:
+        return ast.literal_eval(node)
+    except (ValueError, SyntaxError):
+        return None
+
+
+def _extract_ui_schema_from_ast(module: ast.Module, strategy_name: str):
+    ui_names = {"ui"}
+    fields = []
+
+    for node in ast.walk(module):
+        if isinstance(node, ast.ImportFrom) and node.module in {
+            "openalgo.config",
+            "openalgo_config",
+            "openalgo_config.ui",
+        }:
+            for alias in node.names:
+                if alias.name == "ui":
+                    ui_names.add(alias.asname or alias.name)
+
+    ui_calls = []
+    for node in ast.walk(module):
+        if isinstance(node, ast.Assign) and isinstance(node.value, ast.Call):
+            assigned_name = None
+            for target in node.targets:
+                if isinstance(target, ast.Name):
+                    assigned_name = target.id
+                    break
+            ui_calls.append((node.value, assigned_name))
+        elif isinstance(node, ast.AnnAssign) and isinstance(node.value, ast.Call):
+            assigned_name = node.target.id if isinstance(node.target, ast.Name) else None
+            ui_calls.append((node.value, assigned_name))
+        elif isinstance(node, ast.Expr) and isinstance(node.value, ast.Call):
+            ui_calls.append((node.value, None))
+
+    for call_node, assigned_name in ui_calls:
+        if not isinstance(call_node, ast.Call):
+            continue
+        if not isinstance(call_node.func, ast.Attribute) or not isinstance(
+            call_node.func.value, ast.Name
+        ):
+            continue
+        if call_node.func.value.id not in ui_names:
+            continue
+
+        field_type = UI_FIELD_TYPES.get(call_node.func.attr)
+        if not field_type:
+            continue
+
+        key = None
+        if call_node.args:
+            key = _literal_node_value(call_node.args[0])
+        for keyword in call_node.keywords:
+            if keyword.arg in {"key", "name"}:
+                key = _literal_node_value(keyword.value)
+                break
+        if not isinstance(key, str) or not key:
+            continue
+
+        field = {"key": key, "type": field_type}
+        for keyword in call_node.keywords:
+            if keyword.arg in {
+                "default",
+                "label",
+                "required",
+                "min",
+                "max",
+                "step",
+                "options",
+                "description",
+                "placeholder",
+            }:
+                value = _literal_node_value(keyword.value)
+                if value is not None:
+                    field[keyword.arg] = value
+        fields.append(field)
+
+    if not fields:
+        return None
+
+    return {
+        "ocs_version": "1.0",
+        "strategy": strategy_name,
+        "title": strategy_name.replace("_", " ").title(),
+        "fields": fields,
+    }
+
+
+def extract_ocs_schema_from_strategy_file(file_path: Path):
+    """Safely extract SDK ui.* declarations or legacy literal schema from a script."""
+    try:
+        source = file_path.read_text(encoding="utf-8")
+        module = ast.parse(source, filename=str(file_path))
+    except (OSError, SyntaxError) as e:
+        logger.warning(f"Could not parse OCS schema from {file_path}: {e}")
+        return None
+
+    ui_schema = _extract_ui_schema_from_ast(module, file_path.stem)
+    if ui_schema:
+        return ui_schema
+
+    for node in module.body:
+        targets = []
+        value_node = None
+        if isinstance(node, ast.Assign):
+            targets = node.targets
+            value_node = node.value
+        elif isinstance(node, ast.AnnAssign):
+            targets = [node.target]
+            value_node = node.value
+
+        if not value_node:
+            continue
+
+        for target in targets:
+            if isinstance(target, ast.Name) and target.id in {"DEFAULT_OCS_SCHEMA", "OCS_SCHEMA"}:
+                try:
+                    schema = ast.literal_eval(value_node)
+                except (ValueError, SyntaxError) as e:
+                    logger.warning(f"OCS schema in {file_path} must be a literal dict: {e}")
+                    return None
+                return schema if isinstance(schema, dict) else None
+
+    return None
+
+
+def get_valid_strategy_file_path(config: dict):
+    """Return a valid strategy script path, or None for legacy/corrupt records."""
+    raw_path = str(config.get("file_path") or "").strip()
+    file_name = str(config.get("file_name") or "").strip()
+
+    if raw_path:
+        file_path = Path(raw_path)
+    elif file_name:
+        file_path = STRATEGIES_DIR / file_name
+    else:
+        return None
+
+    try:
+        resolved_path = file_path.resolve()
+        strategies_dir_resolved = STRATEGIES_DIR.resolve()
+    except OSError:
+        return None
+
+    if not resolved_path.is_file() or resolved_path.suffix.lower() != ".py":
+        return None
+
+    try:
+        resolved_path.relative_to(strategies_dir_resolved)
+    except ValueError:
+        return None
+
+    return resolved_path
+
+
+def sync_ocs_schema_from_strategy_file(strategy_id: str, config: dict):
+    """Save an embedded OCS schema for this strategy when the script exposes one."""
+    file_path = get_valid_strategy_file_path(config)
+    if not file_path:
+        return None
+
+    schema = extract_ocs_schema_from_strategy_file(file_path)
+    if not schema:
+        return None
+
+    try:
+        return OCS_STORE.save_schema(strategy_id, schema)
+    except OCSValidationError as e:
+        logger.warning(f"Invalid embedded OCS schema for strategy {strategy_id}: {e.errors}")
+        return None
+
+
+def get_or_sync_ocs_schema(strategy_id: str, config: dict):
+    """Load saved OCS schema, backfilling from script defaults if needed."""
+    schema = OCS_STORE.get_schema(strategy_id)
+    if schema.get("fields"):
+        return schema
+    return sync_ocs_schema_from_strategy_file(strategy_id, config) or schema
+
+
 # Resource limits for strategy processes (Unix only)
 # Prevents buggy strategies from crashing the system
 # Can be overridden via environment variable for low-memory containers
@@ -428,9 +659,9 @@ def start_strategy_process(strategy_id):
         if not config:
             return False, "Strategy configuration not found"
 
-        file_path = Path(config["file_path"])
-        if not file_path.exists():
-            return False, f"Strategy file not found: {file_path}"
+        file_path = get_valid_strategy_file_path(config)
+        if not file_path:
+            return False, "Strategy file not found or invalid"
 
         # Check file permissions
         if not IS_WINDOWS:
@@ -519,6 +750,7 @@ def start_strategy_process(strategy_id):
                         strategy_env["OPENALGO_API_KEY"] = _api_key
             except Exception as e:
                 logger.warning(f"Could not inject API key for strategy {strategy_id}: {e}")
+            inject_ocs_environment(strategy_env, strategy_id)
             subprocess_args["env"] = strategy_env
 
             # Start the process
@@ -1729,6 +1961,10 @@ def new_strategy():
                 "schedule_days": schedule_days,
             }
             save_configs()
+            ocs_schema = sync_ocs_schema_from_strategy_file(
+                strategy_id, STRATEGY_CONFIGS[strategy_id]
+            )
+            ocs_field_count = len(ocs_schema.get("fields", [])) if ocs_schema else 0
 
             # Setup scheduler jobs for the new strategy
             schedule_strategy(
@@ -1740,7 +1976,11 @@ def new_strategy():
                     {
                         "status": "success",
                         "message": f'Strategy "{strategy_name}" uploaded successfully',
-                        "data": {"strategy_id": strategy_id},
+                        "data": {
+                            "strategy_id": strategy_id,
+                            "has_config_schema": ocs_field_count > 0,
+                            "config_field_count": ocs_field_count,
+                        },
                     }
                 )
 
@@ -1988,14 +2228,19 @@ def delete_strategy(strategy_id):
 
         # Delete file
         if strategy_id in STRATEGY_CONFIGS:
-            file_path = Path(STRATEGY_CONFIGS[strategy_id].get("file_path", ""))
-            if file_path.exists():
+            file_path = get_valid_strategy_file_path(STRATEGY_CONFIGS[strategy_id])
+            if file_path:
                 try:
                     file_path.unlink()
                 except Exception as e:
                     logger.exception(f"Failed to delete file {file_path}: {e}")
+            else:
+                logger.warning(
+                    f"Skipping strategy file delete for {strategy_id}: missing or invalid file path"
+                )
 
             # Remove from configs
+            OCS_STORE.delete(strategy_id)
             del STRATEGY_CONFIGS[strategy_id]
             save_configs()
 
@@ -2277,6 +2522,191 @@ def get_schedule_status(config):
     return "scheduled", f"Active window: {schedule_start} - {schedule_stop} IST"
 
 
+def _json_body():
+    payload = request.get_json(silent=True)
+    return payload if isinstance(payload, dict) else {}
+
+
+def _ocs_error_response(error: OCSValidationError, status_code: int = 400):
+    return jsonify(
+        {
+            "status": "error",
+            "message": str(error),
+            "errors": error.errors,
+        }
+    ), status_code
+
+
+def _ocs_unexpected_error_response(error: Exception):
+    logger.exception(f"OCS API operation failed: {error}")
+    return jsonify(
+        {
+            "status": "error",
+            "message": "Configuration operation failed",
+        }
+    ), 500
+
+
+def _build_ocs_config_response_values(strategy_id: str):
+    """Return editable draft values plus runtime-valid values when available."""
+    values = OCS_STORE.get_values(strategy_id, allow_invalid=True)
+    try:
+        resolved_values = build_runtime_config(OCS_STORE, strategy_id)
+        validation_errors = []
+    except OCSValidationError as exc:
+        resolved_values = values
+        validation_errors = exc.errors
+    return values, resolved_values, validation_errors
+
+
+@python_strategy_bp.route("/api/config/<strategy_id>", methods=["GET"])
+@check_session_validity
+def api_get_ocs_config(strategy_id):
+    """API: Get OCS schema, raw values, and resolved runtime values."""
+    user_id = session.get("user")
+    if not user_id:
+        return jsonify({"status": "error", "message": "Session expired"}), 401
+
+    is_owner, error_response = verify_strategy_ownership(strategy_id, user_id)
+    if not is_owner:
+        return error_response
+
+    config = STRATEGY_CONFIGS[strategy_id]
+    try:
+        schema = get_or_sync_ocs_schema(strategy_id, config)
+        values, resolved_values, validation_errors = _build_ocs_config_response_values(strategy_id)
+    except OCSValidationError as e:
+        return _ocs_error_response(e)
+    except Exception as e:
+        return _ocs_unexpected_error_response(e)
+
+    return jsonify(
+        {
+            "status": "success",
+            "schema": schema,
+            "values": values,
+            "resolved_values": resolved_values,
+            "validation_errors": validation_errors,
+        }
+    )
+
+
+@python_strategy_bp.route("/api/config/<strategy_id>/schema", methods=["POST"])
+@check_session_validity
+def api_save_ocs_schema(strategy_id):
+    """API: Save an OCS schema for a Python strategy."""
+    user_id = session.get("user")
+    if not user_id:
+        return jsonify({"status": "error", "message": "Session expired"}), 401
+
+    is_owner, error_response = verify_strategy_ownership(strategy_id, user_id, True)
+    if not is_owner:
+        return error_response
+
+    config = error_response
+    if config.get("is_running"):
+        return jsonify(
+            {
+                "status": "error",
+                "message": "Stop the strategy before changing its configuration schema",
+            }
+        ), 409
+
+    payload = _json_body()
+    schema = payload.get("schema", payload)
+    try:
+        saved_schema = OCS_STORE.save_schema(strategy_id, schema)
+        values, resolved_values, validation_errors = _build_ocs_config_response_values(strategy_id)
+    except OCSValidationError as e:
+        return _ocs_error_response(e)
+    except Exception as e:
+        return _ocs_unexpected_error_response(e)
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": "Configuration schema saved",
+            "schema": saved_schema,
+            "values": values,
+            "resolved_values": resolved_values,
+            "validation_errors": validation_errors,
+            "data": {
+                "schema": saved_schema,
+                "values": values,
+                "resolved_values": resolved_values,
+                "validation_errors": validation_errors,
+            },
+        }
+    )
+
+
+@python_strategy_bp.route("/api/config/<strategy_id>/values", methods=["POST"])
+@check_session_validity
+def api_save_ocs_values(strategy_id):
+    """API: Save validated OCS values for a Python strategy."""
+    user_id = session.get("user")
+    if not user_id:
+        return jsonify({"status": "error", "message": "Session expired"}), 401
+
+    is_owner, error_response = verify_strategy_ownership(strategy_id, user_id, True)
+    if not is_owner:
+        return error_response
+
+    config = error_response
+    if config.get("is_running"):
+        return jsonify(
+            {
+                "status": "error",
+                "message": "Stop the strategy before changing its configuration values",
+            }
+        ), 409
+
+    payload = _json_body()
+    values = payload.get("values", payload)
+    try:
+        saved_values = OCS_STORE.save_values(strategy_id, values)
+    except OCSValidationError as e:
+        return _ocs_error_response(e)
+    except Exception as e:
+        return _ocs_unexpected_error_response(e)
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": "Configuration values saved",
+            "values": saved_values,
+            "resolved_values": saved_values,
+            "data": {"resolved_values": saved_values},
+        }
+    )
+
+
+@python_strategy_bp.route("/api/config/validate", methods=["POST"])
+@check_session_validity
+def api_validate_ocs_config():
+    """API: Validate a draft OCS schema/value payload without saving it."""
+    payload = _json_body()
+    schema = payload.get("schema", {})
+    values = payload.get("values", {})
+
+    try:
+        normalized_schema = normalize_schema(schema)
+        resolved_values = validate_values(normalized_schema, values)
+    except OCSValidationError as e:
+        return _ocs_error_response(e)
+    except Exception as e:
+        return _ocs_unexpected_error_response(e)
+
+    return jsonify(
+        {
+            "status": "success",
+            "message": "Configuration is valid",
+            "schema": normalized_schema,
+            "resolved_values": resolved_values,
+        }
+    )
+
+
 @python_strategy_bp.route("/api/strategies")
 @check_session_validity
 def api_get_strategies():
@@ -2285,6 +2715,12 @@ def api_get_strategies():
     strategies = []
 
     for strategy_id, config in STRATEGY_CONFIGS.items():
+        try:
+            config_schema = get_or_sync_ocs_schema(strategy_id, config)
+            config_field_count = len(config_schema.get("fields", []))
+        except OCSValidationError:
+            config_field_count = 0
+
         # Determine status with detailed schedule info
         if config.get("is_running"):
             status = "running"
@@ -2316,6 +2752,8 @@ def api_get_strategies():
                 "paused_message": config.get("paused_message"),
                 "process_id": config.get("process_id"),
                 "created_at": config.get("created_at"),
+                "has_config_schema": config_field_count > 0,
+                "config_field_count": config_field_count,
             }
         )
 
@@ -2378,6 +2816,11 @@ def api_get_strategy(strategy_id):
         return jsonify({"status": "error", "message": "Strategy not found"}), 404
 
     config = STRATEGY_CONFIGS[strategy_id]
+    try:
+        config_schema = get_or_sync_ocs_schema(strategy_id, config)
+        config_field_count = len(config_schema.get("fields", []))
+    except OCSValidationError:
+        config_field_count = 0
 
     # Determine status with detailed schedule info
     if config.get("is_running"):
@@ -2411,6 +2854,8 @@ def api_get_strategy(strategy_id):
                 "paused_message": config.get("paused_message"),
                 "process_id": config.get("process_id"),
                 "created_at": config.get("created_at"),
+                "has_config_schema": config_field_count > 0,
+                "config_field_count": config_field_count,
             }
         }
     )
@@ -2692,6 +3137,7 @@ def save_strategy(strategy_id):
         # Update config
         config["last_modified"] = get_ist_time().isoformat()
         save_configs()
+        sync_ocs_schema_from_strategy_file(strategy_id, config)
 
         logger.info(f"Strategy {strategy_id} saved successfully")
         return jsonify(

--- a/blueprints/react_app.py
+++ b/blueprints/react_app.py
@@ -4,6 +4,10 @@ Serves the pre-built React app for migrated routes.
 """
 
 import mimetypes
+import os
+import shutil
+import subprocess
+import threading
 from pathlib import Path
 
 from flask import Blueprint, request, send_file, send_from_directory
@@ -18,7 +22,98 @@ react_bp = Blueprint("react", __name__)
 _PRECOMPRESSED_ENCODINGS = ((".br", "br"), (".gz", "gzip"))
 
 # Path to the pre-built React frontend
-FRONTEND_DIST = Path(__file__).parent.parent / "frontend" / "dist"
+FRONTEND_DIR = Path(__file__).parent.parent / "frontend"
+FRONTEND_DIST = FRONTEND_DIR / "dist"
+FRONTEND_SRC = FRONTEND_DIR / "src"
+_BUILD_LOCK = threading.Lock()
+_BUILD_THREAD_STARTED = False
+
+
+def frontend_auto_build_enabled():
+    return os.getenv("OPENALGO_AUTO_BUILD_FRONTEND", "false").lower() in {
+        "1",
+        "true",
+        "yes",
+        "on",
+    }
+
+
+def _newest_mtime(path: Path):
+    if not path.exists():
+        return 0.0
+    if path.is_file():
+        return path.stat().st_mtime
+
+    newest = path.stat().st_mtime
+    for child in path.rglob("*"):
+        try:
+            if child.is_file():
+                newest = max(newest, child.stat().st_mtime)
+        except OSError:
+            continue
+    return newest
+
+
+def _frontend_source_mtime():
+    watched_paths = [
+        FRONTEND_SRC,
+        FRONTEND_DIR / "package.json",
+        FRONTEND_DIR / "package-lock.json",
+        FRONTEND_DIR / "vite.config.ts",
+        FRONTEND_DIR / "tsconfig.json",
+        FRONTEND_DIR / "tsconfig.app.json",
+        FRONTEND_DIR / "index.html",
+    ]
+    return max(_newest_mtime(path) for path in watched_paths)
+
+
+def _run_frontend_command(args, timeout):
+    subprocess.run(
+        args,
+        cwd=str(FRONTEND_DIR),
+        check=True,
+        timeout=timeout,
+    )
+
+
+def _build_frontend_if_needed():
+    """Build React once outside request handling when opt-in auto-build is enabled."""
+    with _BUILD_LOCK:
+        index_html = FRONTEND_DIST / "index.html"
+        dist_mtime = index_html.stat().st_mtime if index_html.exists() else 0.0
+        source_mtime = _frontend_source_mtime()
+
+        if index_html.exists() and dist_mtime >= source_mtime:
+            return
+
+        npm = shutil.which("npm")
+        if not npm:
+            print("WARNING: npm not found; cannot auto-build React frontend")
+            return
+
+        try:
+            if not (FRONTEND_DIR / "node_modules").exists():
+                install_command = [npm, "ci"] if (FRONTEND_DIR / "package-lock.json").exists() else [npm, "install"]
+                print("React frontend dependencies missing; running npm install step...")
+                _run_frontend_command(install_command, timeout=900)
+
+            print("React frontend is stale or missing; running npm run build...")
+            _run_frontend_command([npm, "run", "build"], timeout=900)
+            print("React frontend build complete")
+        except (subprocess.CalledProcessError, subprocess.TimeoutExpired) as exc:
+            print(f"WARNING: React frontend auto-build failed: {exc}")
+
+
+def start_frontend_auto_build():
+    """Start the optional frontend auto-build in a daemon thread."""
+    global _BUILD_THREAD_STARTED
+
+    if not frontend_auto_build_enabled() or _BUILD_THREAD_STARTED:
+        return
+
+    _BUILD_THREAD_STARTED = True
+    thread = threading.Thread(target=_build_frontend_if_needed, name="frontend-auto-build", daemon=True)
+    thread.start()
 
 
 def is_react_frontend_available():
@@ -357,8 +452,18 @@ def react_python_edit(strategy_id):
     return serve_react_app()
 
 
+@react_bp.route("/python/<strategy_id>/config", strict_slashes=False)
+def react_python_config(strategy_id):
+    return serve_react_app()
+
+
 @react_bp.route("/python/<strategy_id>/logs", strict_slashes=False)
 def react_python_logs(strategy_id):
+    return serve_react_app()
+
+
+@react_bp.route("/python/<strategy_id>/schedule", strict_slashes=False)
+def react_python_schedule(strategy_id):
     return serve_react_app()
 
 

--- a/docs/openalgo-configuration-sdk.md
+++ b/docs/openalgo-configuration-sdk.md
@@ -1,0 +1,311 @@
+# OpenAlgo Configuration SDK
+
+OpenAlgo Configuration SDK, or OCS, makes Python strategy inputs editable from the OpenAlgo web UI. A strategy declares configurable fields once, OpenAlgo discovers those declarations during upload, renders a configuration form, validates user input, stores the values, and injects the resolved runtime configuration when the strategy starts.
+
+This guide describes the implemented system for the Python Strategy Management feature and the intended SDK-native direction for OpenAlgo libraries.
+
+## Overview
+
+Before OCS, changing strategy parameters usually meant editing Python source code. OCS moves those parameters into a platform-managed configuration flow.
+
+```text
+Strategy script
+  -> ui.* declarations or legacy schema
+  -> OpenAlgo schema discovery
+  -> JSON schema and values storage
+  -> React configuration page
+  -> validated runtime values
+  -> strategy subprocess environment
+```
+
+The current implementation focuses on Python strategies under `/python`, with a shared schema contract designed to support future SDKs such as Python, Node.js, Go, Java, .NET, and Rust.
+
+## What Is Included
+
+| Area | Implementation |
+|---|---|
+| Backend core | `openalgo_config` schema normalization, validation, value coercion, JSON storage, and runtime config building |
+| Python strategy host | Upload-time schema discovery, config APIs, runtime injection, delete cleanup, and safe path handling |
+| Frontend | Generated React configuration page at `/python/:strategyId/config` |
+| Runtime | `OPENALGO_CONFIG_JSON`, `OPENALGO_CONFIG_SCHEMA_JSON`, and `OPENALGO_CONFIG_<KEY>` environment variables |
+| Storage | File-backed JSON under `strategies/configs/` |
+| Developer API | Local `openalgo_config.ui` helper, with the target public API being `from openalgo.config import ui` |
+| Frontend build behavior | Optional background auto-build only when `OPENALGO_AUTO_BUILD_FRONTEND=true` |
+
+## Storage Layout
+
+OCS stores runtime state beside Python strategy runtime files:
+
+```text
+strategies/
+|-- scripts/
+|   `-- <strategy_id>.py
+|-- strategy_configs.json
+`-- configs/
+    |-- schemas/
+    |   `-- <strategy_id>.json
+    `-- values/
+        `-- <strategy_id>.json
+```
+
+`strategies/configs/` is local runtime state and should not be committed.
+
+If the normal strategy directories cannot be created because of permissions, the Python strategy host falls back to a temporary OpenAlgo directory and moves the OCS store with it. This keeps strategy scripts, logs, schemas, and values in the same writable runtime area.
+
+## Authoring Strategy Inputs
+
+New strategy scripts should declare fields with explicit `ui.*` keys:
+
+```python
+try:
+    from openalgo.config import ui
+except ModuleNotFoundError:
+    from openalgo_config import ui
+
+strategy = ui.string("strategy", default="EMA Crossover Python", label="Strategy Name")
+symbol = ui.symbol("symbol", default="NHPC", label="Symbol", required=True)
+exchange = ui.exchange("exchange", default="BSE", label="Exchange")
+product = ui.product("product", default="MIS", options=["MIS", "NRML", "CNC"])
+quantity = ui.quantity("quantity", default=1, min=1)
+
+fast_period = ui.int("fast_period", default=5, min=1, max=200)
+slow_period = ui.int("slow_period", default=10, min=2, max=500)
+debug = ui.bool("debug", default=False)
+```
+
+Explicit keys are required for reliable upload-time discovery and runtime value lookup. Keyless declarations are ignored by static schema discovery because assignment-name inference can drift from runtime helper semantics.
+
+Legacy scripts can still expose a literal `DEFAULT_OCS_SCHEMA` or `OCS_SCHEMA` dictionary. That compatibility path is useful for older strategies, but new scripts should use `ui.*` declarations instead of hand-written schema dictionaries.
+
+## Upload Flow
+
+When a strategy is uploaded from `/python/new`, OpenAlgo:
+
+1. Saves the strategy script under `strategies/scripts/`.
+2. Parses the script with Python `ast`.
+3. Extracts explicit `ui.*` declarations without executing trading code.
+4. Falls back to literal `DEFAULT_OCS_SCHEMA` or `OCS_SCHEMA` only when needed.
+5. Normalizes and validates the schema.
+6. Stores the schema in `strategies/configs/schemas/`.
+7. Creates or updates editable values in `strategies/configs/values/`.
+8. Returns `has_config_schema` and `config_field_count` in the upload response.
+
+The React upload flow can navigate directly to the generated config page when fields are discovered. The strategy list also receives live config metadata from `/python/api/strategies`, so the config icon appears from API data without rebuilding React after every upload.
+
+## Configuration API
+
+| Method | Endpoint | Purpose |
+|---|---|---|
+| `GET` | `/python/api/config/<strategy_id>` | Load schema, editable values, runtime-resolved values, and validation errors |
+| `POST` | `/python/api/config/<strategy_id>/schema` | Save or replace a schema |
+| `POST` | `/python/api/config/<strategy_id>/values` | Save user-edited values |
+| `POST` | `/python/api/config/validate` | Validate draft schema and values without saving |
+
+The read API distinguishes between editable values and runtime values:
+
+| Field | Meaning |
+|---|---|
+| `values` | Safe editable draft values; available even when required fields are not filled yet |
+| `resolved_values` | Runtime-valid values when validation succeeds; falls back to draft values when incomplete |
+| `validation_errors` | Structured errors explaining why runtime values are not yet valid |
+
+This lets users add required fields first, then fill values in the UI, without breaking config page loading.
+
+## Runtime Injection
+
+When a Python strategy starts, OpenAlgo validates the saved values and injects the resolved configuration into the subprocess environment.
+
+| Environment variable | Description |
+|---|---|
+| `OPENALGO_CONFIG_JSON` | Full resolved value object as JSON |
+| `OPENALGO_CONFIG_SCHEMA_JSON` | Normalized schema as JSON |
+| `OPENALGO_CONFIG_<KEY>` | Per-field string convenience value |
+| `OPENALGO_STRATEGY_EXCHANGE` | Exchange selected for the strategy runner |
+| `OPENALGO_API_KEY` | User API key when available |
+| `OPENALGO_HOST` | OpenAlgo host URL |
+
+Strategies can read configuration through the `ui.*` helper or directly from `OPENALGO_CONFIG_JSON`.
+
+## Generated React UI
+
+The config page lives at:
+
+```text
+/python/<strategy_id>/config
+```
+
+It renders fields from the saved schema and supports:
+
+- Text-like fields, including `string`, `symbol`, `broker`, `timeframe`, `expiry`, and `session`.
+- Numeric fields, including `int`, `float`, `quantity`, `lot_size`, `percentage`, `price`, `trigger_price`, and `strike`.
+- Boolean switches.
+- Select and multi-select fields.
+- JSON text areas.
+- Date, time, color, and password inputs.
+- Field descriptions, placeholders, min, max, step, options, and grouping metadata.
+
+Number inputs preserve intermediate typing states such as `-`, `.`, and `1.` so users are not forced into invalid `NaN` or truncated values while editing. Running strategies cannot be edited until they are stopped.
+
+The config icon on the strategy card is icon-only but includes an accessible label for screen readers.
+
+## Validation Rules
+
+OCS validation is centralized in `openalgo_config/core.py`.
+
+| Validation area | Behavior |
+|---|---|
+| Schema shape | Schema must be an object; fields must be a list |
+| Field keys | Keys must be unique and match Python-style identifier rules |
+| Field types | Type must be one of the supported OCS field types |
+| Required fields | Required values are enforced when saving runtime values |
+| Defaults | Defaults are coerced and validated during schema normalization |
+| Numeric limits | `min` and `max` apply to numeric field types |
+| Options | `select` and `multi_select` enforce membership |
+| Option value types | Numeric and boolean option values are preserved during validation |
+| Regex | Regex syntax is validated at schema save time and applied after option matching |
+| Unknown values | Extra value keys are rejected |
+| Schema changes | Stale value keys are pruned when schemas change |
+
+Schema persistence is resilient when a new required field has no default. The schema can be saved first, the config UI can show an incomplete draft, and the user can fill the required value before strategy start.
+
+Bad disk I/O or unexpected runtime failures in OCS API handlers return structured API errors instead of leaking raw exceptions.
+
+## Supported Field Types
+
+| Category | Types |
+|---|---|
+| Basic | `int`, `float`, `bool`, `string`, `password` |
+| Choice | `select`, `multi_select` |
+| Trading | `symbol`, `exchange`, `product`, `broker`, `timeframe`, `quantity`, `lot_size`, `percentage`, `price`, `trigger_price`, `expiry`, `strike`, `option_type` |
+| UI and data | `color`, `date`, `time`, `session`, `json` |
+
+Additional UI metadata such as `label`, `description`, `placeholder`, `group`, `tab`, `section`, `min`, `max`, `step`, `regex`, `options`, `visible_if`, and `enabled_if` can be stored in the schema for current or future rendering behavior.
+
+## Frontend Build Behavior
+
+React is served from:
+
+```text
+frontend/dist/
+```
+
+OCS configuration discovery is runtime API behavior. Uploading a strategy does not require a frontend rebuild.
+
+Auto-build is disabled by default. If explicitly enabled, OpenAlgo starts a background build during app startup when the React bundle is stale or missing:
+
+```powershell
+set OPENALGO_AUTO_BUILD_FRONTEND=true
+uv run app.py
+```
+
+On Linux or macOS:
+
+```bash
+OPENALGO_AUTO_BUILD_FRONTEND=true uv run app.py
+```
+
+The auto-build path never runs inside a React route request handler, so page requests are not blocked by `npm install` or `npm run build`.
+
+## Included Example Strategy
+
+The maintained OCS example is:
+
+```text
+strategies/examples/simple_ema_strategy_config.py
+```
+
+It demonstrates:
+
+- Explicit `ui.*` field declarations.
+- Runtime values returned by the helper calls.
+- OpenAlgo API key and host injection.
+- `openalgo.ta` indicator usage.
+- EMA crossover signals using `ta.ema`, `ta.crossover`, `ta.crossunder`, and `ta.exrem`.
+
+Typical configurable fields include strategy name, symbol, exchange, product, quantity, fast EMA period, slow EMA period, interval, history window, and polling interval.
+
+## OpenAlgo Python Library Direction
+
+The current app includes `openalgo_config.ui` as a local helper for OpenAlgo-hosted strategies. The intended public developer experience is:
+
+```python
+from openalgo.config import ui
+
+symbol = ui.symbol("symbol", default="NHPC")
+ema = ui.int("ema", default=20, min=1, max=500, label="EMA Length")
+stop_loss = ui.float("stop_loss", default=2.0, min=0.1)
+debug = ui.bool("debug", default=False)
+```
+
+The OpenAlgo Python library should eventually provide:
+
+```text
+openalgo/
+`-- config/
+    |-- __init__.py
+    |-- ui.py
+    |-- registry.py
+    |-- runtime.py
+    `-- schema.py
+```
+
+Each helper call should:
+
+1. Register field metadata for schema generation.
+2. Read the configured runtime value from `OPENALGO_CONFIG_JSON`.
+3. Fall back to the default when no runtime value exists.
+4. Return a typed Python value.
+
+The host can keep using safe static AST discovery for simple literal declarations. A future schema-export mode can support dynamic declarations by running a script in a non-trading schema-only mode.
+
+## Multi-SDK Direction
+
+The OCS schema contract is language-neutral. Other SDKs can expose native helpers that emit the same JSON schema.
+
+```text
+Python    ui.int("ema", default=20)
+Node.js   ui.int("ema", { default: 20 })
+Go        ui.Int("ema", ui.Default(20))
+Rust      ui::int("ema").default(20).get()
+
+All produce the same OCS schema.
+```
+
+The OpenAlgo host should remain the validator, storage owner, and UI renderer. SDKs should focus on ergonomic declaration and runtime value access.
+
+## Operational Notes
+
+- Stop a running strategy before changing its schema or values.
+- Do not manually edit `strategies/configs/` unless repairing local runtime state.
+- Use explicit keys in all `ui.*` declarations.
+- Use literal defaults, options, labels, and limits when relying on static discovery.
+- Keep frontend rebuilds separate from strategy uploads.
+- Treat `DEFAULT_OCS_SCHEMA` and `OCS_SCHEMA` as compatibility paths, not the preferred authoring model.
+
+## Troubleshooting
+
+| Problem | Likely cause | Resolution |
+|---|---|---|
+| Config icon missing after upload | No explicit `ui.*` fields were discovered, or API metadata did not report fields | Check `/python/api/strategies` for `has_config_schema` and `config_field_count`; re-upload with explicit keys |
+| Config page is empty | Script has no discoverable schema | Add explicit `ui.*` declarations or a compatibility schema |
+| Required field blocks runtime | Field has no saved value yet | Open the config page, fill the value, and save |
+| Schema saves but runtime values are incomplete | Required fields were added before values existed | Use the returned `validation_errors` to guide the user to missing fields |
+| Numeric input behaves oddly while typing | Browser intermediate numeric text is not a final number | The UI preserves drafts; save only after entering a complete value |
+| Select value rejected unexpectedly | Option value type or regex does not match | Confirm options and regex syntax; numeric and boolean options are preserved |
+| Regex crashes validation | Invalid regex pattern | Schema normalization now returns structured regex errors |
+| Frontend route shows old UI after source changes | `frontend/dist` is stale | Run `cd frontend && npm run build`, or opt into background auto-build |
+| Warning mentions schema parsing from `.` | Legacy/corrupt strategy record has an empty path | The host ignores empty, directory, and out-of-scope paths |
+
+## Verification
+
+The OCS implementation is covered by focused backend and frontend checks:
+
+```powershell
+.\.venv\Scripts\python.exe -m pytest test\test_openalgo_config.py test\test_python_strategy_exchange_aware.py test\test_python_strategy_edge_cases.py -q
+.\.venv\Scripts\python.exe -m py_compile app.py blueprints\python_strategy.py blueprints\react_app.py openalgo_config\core.py openalgo_config\ui.py
+cd frontend
+npx tsc -b
+npm run lint
+```
+
+Some local test runs can print a Windows/colorama logging warning during Python `atexit` cleanup after tests pass. That warning is separate from OCS validation behavior.

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -83,6 +83,7 @@ const ConfigureSymbols = lazy(() => import('@/pages/strategy/ConfigureSymbols'))
 const PythonStrategyIndex = lazy(() => import('@/pages/python-strategy/PythonStrategyIndex'))
 const NewPythonStrategy = lazy(() => import('@/pages/python-strategy/NewPythonStrategy'))
 const EditPythonStrategy = lazy(() => import('@/pages/python-strategy/EditPythonStrategy'))
+const ConfigPythonStrategy = lazy(() => import('@/pages/python-strategy/ConfigPythonStrategy'))
 const PythonStrategyLogs = lazy(() => import('@/pages/python-strategy/PythonStrategyLogs'))
 const SchedulePythonStrategy = lazy(() => import('@/pages/python-strategy/SchedulePythonStrategy'))
 const PythonStrategyGuide = lazy(() => import('@/pages/python-strategy/PythonStrategyGuide'))
@@ -235,6 +236,7 @@ function App() {
                 <Route path="/python" element={<PythonStrategyIndex />} />
                 <Route path="/python/new" element={<NewPythonStrategy />} />
                 <Route path="/python/:strategyId/edit" element={<EditPythonStrategy />} />
+                <Route path="/python/:strategyId/config" element={<ConfigPythonStrategy />} />
                 <Route path="/python/:strategyId/logs" element={<PythonStrategyLogs />} />
                 <Route path="/python/:strategyId/schedule" element={<SchedulePythonStrategy />} />
                 <Route path="/python/guide" element={<PythonStrategyGuide />} />

--- a/frontend/src/api/python-strategy.ts
+++ b/frontend/src/api/python-strategy.ts
@@ -3,8 +3,11 @@ import type {
   LogContent,
   LogFile,
   MasterContractStatus,
+  OCSConfigResponse,
+  OCSSchema,
   PythonStrategy,
   PythonStrategyContent,
+  PythonStrategyUploadResult,
   ScheduleConfig,
 } from '@/types/python-strategy'
 import type { ApiResponse } from '@/types/trading'
@@ -51,7 +54,7 @@ export const pythonStrategyApi = {
       days: string[]
       exchange?: string
     }
-  ): Promise<ApiResponse<{ strategy_id: string }>> => {
+  ): Promise<ApiResponse<PythonStrategyUploadResult>> => {
     const formData = new FormData()
     formData.append('strategy_name', name)
     formData.append('strategy_file', file)
@@ -61,7 +64,7 @@ export const pythonStrategyApi = {
     formData.append('schedule_stop', schedule.stop_time)
     formData.append('schedule_days', JSON.stringify(schedule.days))
 
-    const response = await webClient.post<ApiResponse<{ strategy_id: string }>>(
+    const response = await webClient.post<ApiResponse<PythonStrategyUploadResult>>(
       '/python/new',
       formData,
       {
@@ -209,6 +212,42 @@ export const pythonStrategyApi = {
   checkAndStartPending: async (): Promise<ApiResponse<{ started: number }>> => {
     const response =
       await webClient.post<ApiResponse<{ started: number }>>('/python/check-contracts')
+    return response.data
+  },
+
+  /**
+   * Get OpenAlgo Configuration SDK schema and values
+   */
+  getConfig: async (strategyId: string): Promise<OCSConfigResponse> => {
+    const response = await webClient.get<OCSConfigResponse>(`/python/api/config/${strategyId}`)
+    return response.data
+  },
+
+  /**
+   * Save OpenAlgo Configuration SDK schema
+   */
+  saveConfigSchema: async (
+    strategyId: string,
+    schema: OCSSchema
+  ): Promise<ApiResponse<{ schema: OCSSchema }>> => {
+    const response = await webClient.post<ApiResponse<{ schema: OCSSchema }>>(
+      `/python/api/config/${strategyId}/schema`,
+      { schema }
+    )
+    return response.data
+  },
+
+  /**
+   * Save OpenAlgo Configuration SDK values
+   */
+  saveConfigValues: async (
+    strategyId: string,
+    values: Record<string, unknown>
+  ): Promise<ApiResponse<{ resolved_values: Record<string, unknown> }>> => {
+    const response = await webClient.post<ApiResponse<{ resolved_values: Record<string, unknown> }>>(
+      `/python/api/config/${strategyId}/values`,
+      { values }
+    )
     return response.data
   },
 }

--- a/frontend/src/pages/python-strategy/ConfigPythonStrategy.tsx
+++ b/frontend/src/pages/python-strategy/ConfigPythonStrategy.tsx
@@ -1,0 +1,418 @@
+import { ArrowLeft, Braces, Save, Settings2 } from 'lucide-react'
+import { useEffect, useMemo, useState } from 'react'
+import { Link, useNavigate, useParams } from 'react-router-dom'
+import { pythonStrategyApi } from '@/api/python-strategy'
+import { Alert, AlertDescription } from '@/components/ui/alert'
+import { Button } from '@/components/ui/button'
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '@/components/ui/card'
+import { Checkbox } from '@/components/ui/checkbox'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select'
+import { Skeleton } from '@/components/ui/skeleton'
+import { Switch } from '@/components/ui/switch'
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs'
+import { Textarea } from '@/components/ui/textarea'
+import type { OCSField, OCSOption, OCSSchema, PythonStrategy } from '@/types/python-strategy'
+import { showToast } from '@/utils/toast'
+
+const emptySchema = (strategyId: string): OCSSchema => ({
+  ocs_version: '1.0',
+  strategy: strategyId,
+  title: 'Strategy Configuration',
+  description: '',
+  fields: [],
+})
+
+const optionValue = (option: string | number | boolean | OCSOption) =>
+  typeof option === 'object' ? option.value : option
+
+const optionLabel = (option: string | number | boolean | OCSOption) =>
+  typeof option === 'object' ? option.label || String(option.value) : String(option)
+
+const fieldInputType = (field: OCSField) => {
+  if (field.type === 'password') return 'password'
+  if (['int', 'float', 'quantity', 'lot_size', 'percentage', 'price', 'trigger_price', 'strike'].includes(field.type)) {
+    return 'number'
+  }
+  if (field.type === 'date' || field.type === 'time' || field.type === 'color') return field.type
+  return 'text'
+}
+
+const coerceValue = (field: OCSField, value: string | boolean | string[]) => {
+  if (field.type === 'bool') return Boolean(value)
+  if (field.type === 'multi_select') return value
+  if (fieldInputType(field) === 'number') {
+    if (value === '') return ''
+    return field.type === 'int' || field.type === 'quantity' || field.type === 'lot_size' || field.type === 'strike'
+      ? Number.parseInt(String(value), 10)
+      : Number.parseFloat(String(value))
+  }
+  if (field.type === 'json') {
+    try {
+      return JSON.parse(String(value || '{}'))
+    } catch (_error) {
+      return value
+    }
+  }
+  return value
+}
+
+export default function ConfigPythonStrategy() {
+  const { strategyId } = useParams<{ strategyId: string }>()
+  const navigate = useNavigate()
+  const [strategy, setStrategy] = useState<PythonStrategy | null>(null)
+  const [schema, setSchema] = useState<OCSSchema | null>(null)
+  const [values, setValues] = useState<Record<string, unknown>>({})
+  const [draftValues, setDraftValues] = useState<Record<string, string>>({})
+  const [schemaText, setSchemaText] = useState('')
+  const [loading, setLoading] = useState(true)
+  const [savingValues, setSavingValues] = useState(false)
+  const [savingSchema, setSavingSchema] = useState(false)
+  const [error, setError] = useState('')
+
+  const isRunning = strategy?.status === 'running'
+
+  const groupedFields = useMemo(() => {
+    const fields = schema?.fields || []
+    return fields.reduce<Record<string, OCSField[]>>((groups, field) => {
+      const group = field.group || field.section || 'General'
+      groups[group] = [...(groups[group] || []), field]
+      return groups
+    }, {})
+  }, [schema])
+
+  const fetchData = async () => {
+    if (!strategyId) return
+    try {
+      setLoading(true)
+      const [strategyData, configData] = await Promise.all([
+        pythonStrategyApi.getStrategy(strategyId),
+        pythonStrategyApi.getConfig(strategyId),
+      ])
+      const loadedSchema = configData.schema || emptySchema(strategyId)
+      setStrategy(strategyData)
+      setSchema(loadedSchema)
+      setValues(configData.resolved_values || configData.values || {})
+      setDraftValues({})
+      setSchemaText(JSON.stringify(loadedSchema, null, 2))
+    } catch (_error) {
+      showToast.error('Failed to load configuration', 'pythonStrategy')
+      navigate('/python')
+    } finally {
+      setLoading(false)
+    }
+  }
+
+  // biome-ignore lint/correctness/useExhaustiveDependencies: one-time fetch for current route id
+  useEffect(() => {
+    fetchData()
+  }, [])
+
+  const updateValue = (field: OCSField, value: string | boolean | string[]) => {
+    setValues((current) => ({ ...current, [field.key]: coerceValue(field, value) }))
+  }
+
+  const updateNumberValue = (field: OCSField, value: string) => {
+    setDraftValues((current) => ({ ...current, [field.key]: value }))
+
+    if (value === '' || value === '-' || value === '.' || value === '-.' || value.endsWith('.')) {
+      return
+    }
+
+    const parsed =
+      field.type === 'int' || field.type === 'quantity' || field.type === 'lot_size' || field.type === 'strike'
+        ? Number.parseInt(value, 10)
+        : Number.parseFloat(value)
+
+    if (!Number.isNaN(parsed)) {
+      setValues((current) => ({ ...current, [field.key]: parsed }))
+    }
+  }
+
+  const saveValues = async () => {
+    if (!strategyId || isRunning) return
+    try {
+      setSavingValues(true)
+      setError('')
+      const response = await pythonStrategyApi.saveConfigValues(strategyId, values)
+      if (response.status === 'success') {
+        showToast.success('Configuration saved', 'pythonStrategy')
+      } else {
+        setError(response.message || 'Failed to save configuration')
+      }
+    } catch (err: unknown) {
+      const axiosError = err as { response?: { data?: { message?: string } } }
+      setError(axiosError.response?.data?.message || 'Failed to save configuration')
+    } finally {
+      setSavingValues(false)
+    }
+  }
+
+  const saveSchema = async () => {
+    if (!strategyId || isRunning) return
+    try {
+      setSavingSchema(true)
+      setError('')
+      const parsed = JSON.parse(schemaText) as OCSSchema
+      const response = await pythonStrategyApi.saveConfigSchema(strategyId, parsed)
+      if (response.status === 'success') {
+        const nextSchema = response.data?.schema || parsed
+        setSchema(nextSchema)
+        setSchemaText(JSON.stringify(nextSchema, null, 2))
+        showToast.success('Configuration schema saved', 'pythonStrategy')
+        fetchData()
+      } else {
+        setError(response.message || 'Failed to save schema')
+      }
+    } catch (err: unknown) {
+      if (err instanceof SyntaxError) {
+        setError('Schema JSON is invalid')
+      } else {
+        const axiosError = err as { response?: { data?: { message?: string } } }
+        setError(axiosError.response?.data?.message || 'Failed to save schema')
+      }
+    } finally {
+      setSavingSchema(false)
+    }
+  }
+
+  const renderField = (field: OCSField) => {
+    const currentValue = values[field.key]
+    const id = `ocs-${field.key}`
+
+    if (field.type === 'bool') {
+      return (
+        <div key={field.key} className="flex items-center justify-between gap-4 rounded border p-3">
+          <div className="space-y-1">
+            <Label htmlFor={id}>{field.label}</Label>
+            {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+          </div>
+          <Switch
+            id={id}
+            checked={Boolean(currentValue)}
+            onCheckedChange={(checked) => updateValue(field, checked)}
+            disabled={isRunning}
+          />
+        </div>
+      )
+    }
+
+    if (field.type === 'select' || field.type === 'exchange' || field.type === 'product' || field.type === 'option_type') {
+      return (
+        <div key={field.key} className="space-y-2">
+          <Label htmlFor={id}>{field.label}</Label>
+          <Select
+            value={currentValue == null ? '' : String(currentValue)}
+            onValueChange={(value) => updateValue(field, value)}
+            disabled={isRunning}
+          >
+            <SelectTrigger id={id}>
+              <SelectValue placeholder={field.placeholder || 'Select'} />
+            </SelectTrigger>
+            <SelectContent>
+              {(field.options || []).map((option) => (
+                <SelectItem key={String(optionValue(option))} value={String(optionValue(option))}>
+                  {optionLabel(option)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+          {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+        </div>
+      )
+    }
+
+    if (field.type === 'multi_select') {
+      const selected = Array.isArray(currentValue) ? currentValue.map(String) : []
+      return (
+        <div key={field.key} className="space-y-2">
+          <Label>{field.label}</Label>
+          <div className="grid gap-2 rounded border p-3 sm:grid-cols-2">
+            {(field.options || []).map((option) => {
+              const value = String(optionValue(option))
+              return (
+                <label key={value} className="flex items-center gap-2 text-sm">
+                  <Checkbox
+                    checked={selected.includes(value)}
+                    onCheckedChange={(checked) => {
+                      const next = checked
+                        ? [...selected, value]
+                        : selected.filter((item) => item !== value)
+                      updateValue(field, next)
+                    }}
+                    disabled={isRunning}
+                  />
+                  {optionLabel(option)}
+                </label>
+              )
+            })}
+          </div>
+          {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+        </div>
+      )
+    }
+
+    if (field.type === 'json') {
+      return (
+        <div key={field.key} className="space-y-2">
+          <Label htmlFor={id}>{field.label}</Label>
+          <Textarea
+            id={id}
+            value={typeof currentValue === 'string' ? currentValue : JSON.stringify(currentValue ?? {}, null, 2)}
+            onChange={(event) => updateValue(field, event.target.value)}
+            disabled={isRunning}
+            className="min-h-28 font-mono text-xs"
+          />
+          {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+        </div>
+      )
+    }
+
+    return (
+      <div key={field.key} className="space-y-2">
+        <Label htmlFor={id}>{field.label}</Label>
+        <Input
+          id={id}
+          type={fieldInputType(field)}
+          value={
+            fieldInputType(field) === 'number' && field.key in draftValues
+              ? draftValues[field.key]
+              : currentValue == null
+                ? ''
+                : String(currentValue)
+          }
+          min={field.min}
+          max={field.max}
+          step={field.step}
+          placeholder={field.placeholder}
+          onChange={(event) =>
+            fieldInputType(field) === 'number'
+              ? updateNumberValue(field, event.target.value)
+              : updateValue(field, event.target.value)
+          }
+          disabled={isRunning}
+        />
+        {field.description && <p className="text-xs text-muted-foreground">{field.description}</p>}
+      </div>
+    )
+  }
+
+  if (loading) {
+    return (
+      <div className="container mx-auto py-6 space-y-6">
+        <Skeleton className="h-8 w-40" />
+        <Skeleton className="h-64" />
+      </div>
+    )
+  }
+
+  if (!strategy || !schema || !strategyId) return null
+
+  return (
+    <div className="container mx-auto py-6 space-y-6 max-w-4xl">
+      <Button variant="ghost" asChild>
+        <Link to="/python">
+          <ArrowLeft className="h-4 w-4 mr-2" />
+          Back to Python Strategies
+        </Link>
+      </Button>
+
+      <div className="flex flex-col gap-4 sm:flex-row sm:items-center sm:justify-between">
+        <div>
+          <h1 className="text-2xl font-bold tracking-tight flex items-center gap-2">
+            <Settings2 className="h-6 w-6" />
+            Strategy Configuration
+          </h1>
+          <p className="text-muted-foreground">{strategy.name}</p>
+        </div>
+      </div>
+
+      {isRunning && (
+        <Alert>
+          <AlertDescription>
+            This strategy is running. Stop it before changing configuration.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {error && (
+        <Alert variant="destructive">
+          <AlertDescription>{error}</AlertDescription>
+        </Alert>
+      )}
+
+      <Tabs defaultValue="values">
+        <TabsList>
+          <TabsTrigger value="values">Values</TabsTrigger>
+          <TabsTrigger value="schema">Schema</TabsTrigger>
+        </TabsList>
+
+        <TabsContent value="values" className="space-y-4">
+          {schema.fields.length === 0 ? (
+            <Card>
+              <CardContent className="py-12 text-center">
+                <Braces className="h-10 w-10 mx-auto text-muted-foreground mb-3" />
+                <h2 className="font-semibold mb-1">No configuration fields</h2>
+                <p className="text-sm text-muted-foreground">
+                  Add fields in the Schema tab to generate this form.
+                </p>
+              </CardContent>
+            </Card>
+          ) : (
+            <>
+              {Object.entries(groupedFields).map(([group, fields]) => (
+                <Card key={group}>
+                  <CardHeader>
+                    <CardTitle className="text-base">{group}</CardTitle>
+                    {schema.description && group === 'General' && (
+                      <CardDescription>{schema.description}</CardDescription>
+                    )}
+                  </CardHeader>
+                  <CardContent className="grid gap-4">{fields.map(renderField)}</CardContent>
+                </Card>
+              ))}
+              <div className="flex justify-end">
+                <Button onClick={saveValues} disabled={savingValues || isRunning}>
+                  <Save className="h-4 w-4 mr-2" />
+                  {savingValues ? 'Saving...' : 'Save Values'}
+                </Button>
+              </div>
+            </>
+          )}
+        </TabsContent>
+
+        <TabsContent value="schema" className="space-y-4">
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-base">OCS Schema JSON</CardTitle>
+              <CardDescription>
+                Defines fields rendered in the generated configuration form.
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-4">
+              <Textarea
+                value={schemaText}
+                onChange={(event) => setSchemaText(event.target.value)}
+                disabled={isRunning}
+                className="min-h-[420px] font-mono text-xs"
+              />
+              <div className="flex justify-end">
+                <Button onClick={saveSchema} disabled={savingSchema || isRunning}>
+                  <Save className="h-4 w-4 mr-2" />
+                  {savingSchema ? 'Saving...' : 'Save Schema'}
+                </Button>
+              </div>
+            </CardContent>
+          </Card>
+        </TabsContent>
+      </Tabs>
+    </div>
+  )
+}

--- a/frontend/src/pages/python-strategy/NewPythonStrategy.tsx
+++ b/frontend/src/pages/python-strategy/NewPythonStrategy.tsx
@@ -167,8 +167,15 @@ export default function NewPythonStrategy() {
       })
 
       if (response.status === 'success') {
-        showToast.success('Strategy uploaded with schedule', 'pythonStrategy')
-        navigate('/python')
+        const strategyId = response.data?.strategy_id
+        const configFieldCount = response.data?.config_field_count || 0
+        showToast.success(
+          configFieldCount > 0
+            ? `Strategy uploaded with ${configFieldCount} config fields`
+            : 'Strategy uploaded with schedule',
+          'pythonStrategy'
+        )
+        navigate(strategyId && configFieldCount > 0 ? `/python/${strategyId}/config` : '/python')
       } else {
         showToast.error(response.message || 'Failed to upload strategy', 'pythonStrategy')
       }
@@ -236,9 +243,8 @@ export default function NewPythonStrategy() {
             <div className="space-y-2">
               <Label htmlFor="file">Python Script</Label>
               <div
-                className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer hover:border-primary transition-colors ${
-                  errors.file ? 'border-red-500' : ''
-                }`}
+                className={`border-2 border-dashed rounded-lg p-6 text-center cursor-pointer hover:border-primary transition-colors ${errors.file ? 'border-red-500' : ''
+                  }`}
                 onClick={() => fileInputRef.current?.click()}
               >
                 <input
@@ -342,19 +348,17 @@ export default function NewPythonStrategy() {
                     <button
                       type="button"
                       key={day.value}
-                      className={`flex items-center gap-2 px-3 py-2 border rounded-lg cursor-pointer transition-colors ${
-                        selectedDays.includes(day.value)
-                          ? 'bg-primary text-primary-foreground border-primary'
-                          : 'hover:bg-muted'
-                      }`}
+                      className={`flex items-center gap-2 px-3 py-2 border rounded-lg cursor-pointer transition-colors ${selectedDays.includes(day.value)
+                        ? 'bg-primary text-primary-foreground border-primary'
+                        : 'hover:bg-muted'
+                        }`}
                       onClick={() => handleDayToggle(day.value)}
                     >
                       <div
-                        className={`h-4 w-4 rounded border flex items-center justify-center ${
-                          selectedDays.includes(day.value)
-                            ? 'bg-primary-foreground border-primary-foreground'
-                            : 'border-current'
-                        }`}
+                        className={`h-4 w-4 rounded border flex items-center justify-center ${selectedDays.includes(day.value)
+                          ? 'bg-primary-foreground border-primary-foreground'
+                          : 'border-current'
+                          }`}
                       >
                         {selectedDays.includes(day.value) && (
                           <svg

--- a/frontend/src/pages/python-strategy/PythonStrategyIndex.tsx
+++ b/frontend/src/pages/python-strategy/PythonStrategyIndex.tsx
@@ -11,6 +11,7 @@ import {
   Play,
   Plus,
   RefreshCw,
+  Settings2,
   Square,
   Trash2,
 } from 'lucide-react'
@@ -405,6 +406,10 @@ export default function PythonStrategyIndex() {
                           <Download className="h-4 w-4 mr-2" />
                           Export
                         </DropdownMenuItem>
+                        <DropdownMenuItem onClick={() => navigate(`/python/${strategy.id}/config`)}>
+                          <Settings2 className="h-4 w-4 mr-2" />
+                          Config
+                        </DropdownMenuItem>
                         <DropdownMenuSeparator />
                         <DropdownMenuItem
                           className="text-red-500"
@@ -537,6 +542,24 @@ export default function PythonStrategyIndex() {
                       {strategy.schedule_start_time && strategy.schedule_stop_time
                         ? `${strategy.schedule_start_time} - ${strategy.schedule_stop_time}`
                         : 'Edit schedule'}
+                    </TooltipContent>
+                  </Tooltip>
+
+                  <Tooltip>
+                    <TooltipTrigger asChild>
+                      <Button variant="outline" size="sm" asChild>
+                        <Link
+                          to={`/python/${strategy.id}/config`}
+                          aria-label={`Configure ${strategy.name}`}
+                        >
+                          <Settings2 className="h-4 w-4" />
+                        </Link>
+                      </Button>
+                    </TooltipTrigger>
+                    <TooltipContent>
+                      {strategy.config_field_count
+                        ? `${strategy.config_field_count} config fields`
+                        : 'Configure inputs'}
                     </TooltipContent>
                   </Tooltip>
 

--- a/frontend/src/pages/python-strategy/index.ts
+++ b/frontend/src/pages/python-strategy/index.ts
@@ -1,3 +1,4 @@
+export { default as ConfigPythonStrategy } from './ConfigPythonStrategy'
 export { default as EditPythonStrategy } from './EditPythonStrategy'
 export { default as NewPythonStrategy } from './NewPythonStrategy'
 export { default as PythonStrategyIndex } from './PythonStrategyIndex'

--- a/frontend/src/types/python-strategy.ts
+++ b/frontend/src/types/python-strategy.ts
@@ -18,6 +18,8 @@ export interface PythonStrategy {
   schedule_days: string[]
   created_at: string
   updated_at: string
+  has_config_schema?: boolean
+  config_field_count?: number
 }
 
 export interface PythonStrategyContent {
@@ -28,6 +30,12 @@ export interface PythonStrategyContent {
   line_count: number
   size_kb: number
   last_modified: string
+}
+
+export interface PythonStrategyUploadResult {
+  strategy_id: string
+  has_config_schema?: boolean
+  config_field_count?: number
 }
 
 export interface LogFile {
@@ -54,6 +62,50 @@ export interface ScheduleConfig {
   stop_time: string
   days: string[]
   exchange?: string
+}
+
+export interface OCSOption {
+  label?: string
+  value: string | number | boolean
+}
+
+export interface OCSField {
+  key: string
+  type: string
+  label: string
+  required?: boolean
+  default?: unknown
+  description?: string
+  tooltip?: string
+  placeholder?: string
+  min?: number
+  max?: number
+  step?: number
+  regex?: string
+  options?: Array<string | number | boolean | OCSOption>
+  group?: string
+  tab?: string
+  section?: string
+}
+
+export interface OCSSchema {
+  ocs_version: string
+  strategy: string
+  title?: string
+  description?: string
+  fields: OCSField[]
+}
+
+export interface OCSConfigResponse {
+  status: string
+  schema: OCSSchema
+  values: Record<string, unknown>
+  resolved_values: Record<string, unknown>
+}
+
+export interface OCSValidationError {
+  field: string
+  message: string
 }
 
 // Exchanges that drive the strategy's calendar/holiday awareness in /python.

--- a/openalgo_config/__init__.py
+++ b/openalgo_config/__init__.py
@@ -1,0 +1,21 @@
+"""OpenAlgo Configuration SDK core primitives."""
+
+from .core import (
+    DEFAULT_OCS_VERSION,
+    ConfigStore,
+    OCSValidationError,
+    build_runtime_config,
+    normalize_schema,
+    validate_values,
+)
+from .ui import ui
+
+__all__ = [
+    "DEFAULT_OCS_VERSION",
+    "ConfigStore",
+    "OCSValidationError",
+    "build_runtime_config",
+    "normalize_schema",
+    "ui",
+    "validate_values",
+]

--- a/openalgo_config/core.py
+++ b/openalgo_config/core.py
@@ -1,0 +1,432 @@
+"""Schema, validation, and JSON persistence for OpenAlgo Configuration SDK.
+
+OCS intentionally starts as a language-neutral JSON contract. Python Strategy
+Host can use it today, and SDK bindings can emit the same shape later.
+"""
+
+from __future__ import annotations
+
+import json
+import os
+import re
+from copy import deepcopy
+from pathlib import Path
+from typing import Any
+
+DEFAULT_OCS_VERSION = "1.0"
+
+SUPPORTED_FIELD_TYPES = {
+    "int",
+    "float",
+    "bool",
+    "string",
+    "password",
+    "select",
+    "multi_select",
+    "symbol",
+    "exchange",
+    "product",
+    "broker",
+    "timeframe",
+    "quantity",
+    "lot_size",
+    "percentage",
+    "price",
+    "trigger_price",
+    "expiry",
+    "strike",
+    "option_type",
+    "color",
+    "date",
+    "time",
+    "session",
+    "json",
+}
+
+FIELD_KEY_RE = re.compile(r"^[A-Za-z_][A-Za-z0-9_]*$")
+
+
+class OCSValidationError(ValueError):
+    """Raised when an OCS schema or value payload is invalid."""
+
+    def __init__(self, message: str, errors: list[dict[str, str]] | None = None):
+        super().__init__(message)
+        self.errors = errors or [{"field": "_schema", "message": message}]
+
+
+def _as_list(value: Any) -> list[Any]:
+    if value is None:
+        return []
+    if isinstance(value, list):
+        return value
+    raise OCSValidationError("Expected a list")
+
+
+def _field_error(field: str, message: str) -> dict[str, str]:
+    return {"field": field, "message": message}
+
+
+def _option_value(option: Any) -> Any:
+    return option.get("value") if isinstance(option, dict) else option
+
+
+def _coerce_option_value(field: dict[str, Any], option: Any) -> Any:
+    option_value = _option_value(option)
+    option_field = {key: value for key, value in field.items() if key != "options"}
+    option_field["required"] = False
+    return _coerce_value(option_field, option_value)
+
+
+def _option_matches(value: Any, option_value: Any) -> bool:
+    if value == option_value:
+        return True
+    if isinstance(option_value, bool):
+        return str(value).strip().lower() == str(option_value).lower()
+    return str(value) == str(option_value)
+
+
+def _coerce_value(field: dict[str, Any], value: Any) -> Any:
+    field_type = field["type"]
+    key = field["key"]
+
+    if value is None or value == "":
+        if field.get("required"):
+            raise OCSValidationError(
+                f"{key} is required", [_field_error(key, "This field is required")]
+            )
+        return None
+
+    try:
+        if field_type in {"int", "quantity", "lot_size", "strike"}:
+            coerced = int(value)
+        elif field_type in {"float", "percentage", "price", "trigger_price"}:
+            coerced = float(value)
+        elif field_type == "bool":
+            if isinstance(value, bool):
+                coerced = value
+            elif isinstance(value, str):
+                coerced = value.strip().lower() in {"1", "true", "yes", "on"}
+            else:
+                coerced = bool(value)
+        elif field_type == "multi_select":
+            coerced = _as_list(value)
+        elif field_type == "select":
+            coerced = value
+        elif field_type == "json":
+            if isinstance(value, str):
+                coerced = json.loads(value)
+            else:
+                coerced = value
+        else:
+            coerced = str(value)
+    except (TypeError, ValueError, json.JSONDecodeError) as exc:
+        raise OCSValidationError(
+            f"{key} has invalid type",
+            [_field_error(key, f"Expected {field_type}: {exc}")],
+        ) from exc
+
+    if isinstance(coerced, (int, float)) and not isinstance(coerced, bool):
+        min_value = field.get("min")
+        max_value = field.get("max")
+        if min_value is not None and coerced < min_value:
+            raise OCSValidationError(
+                f"{key} is below minimum",
+                [_field_error(key, f"Must be at least {min_value}")],
+            )
+        if max_value is not None and coerced > max_value:
+            raise OCSValidationError(
+                f"{key} is above maximum",
+                [_field_error(key, f"Must be at most {max_value}")],
+            )
+
+    options = field.get("options")
+    if options:
+        raw_option_values = [_option_value(item) for item in options]
+        if field_type == "select":
+            for option_value in raw_option_values:
+                if _option_matches(coerced, option_value):
+                    coerced = option_value
+                    break
+            else:
+                raise OCSValidationError(
+                    f"{key} is not an allowed option",
+                    [_field_error(key, "Choose one of the allowed values")],
+                )
+
+        elif field_type == "multi_select":
+            matched_values = []
+            invalid = []
+            for item in coerced:
+                for option_value in raw_option_values:
+                    if _option_matches(item, option_value):
+                        matched_values.append(option_value)
+                        break
+                else:
+                    invalid.append(item)
+            if invalid:
+                raise OCSValidationError(
+                    f"{key} includes invalid option",
+                    [_field_error(key, f"Invalid option(s): {', '.join(map(str, invalid))}")],
+                )
+            coerced = matched_values
+        else:
+            option_values = [_coerce_option_value(field, item) for item in options]
+            if coerced not in option_values:
+                raise OCSValidationError(
+                    f"{key} is not an allowed option",
+                    [_field_error(key, "Choose one of the allowed values")],
+                )
+
+    pattern = field.get("regex")
+    if pattern and coerced is not None:
+        try:
+            matches_pattern = re.search(str(pattern), str(coerced))
+        except re.error as exc:
+            raise OCSValidationError(
+                f"{key} has invalid regex",
+                [_field_error(key, f"Invalid regex pattern: {exc}")],
+            ) from exc
+        if not matches_pattern:
+            raise OCSValidationError(
+                f"{key} does not match pattern",
+                [_field_error(key, "Value does not match the required pattern")],
+            )
+
+    return coerced
+
+
+def normalize_schema(schema: dict[str, Any] | None, strategy_id: str = "") -> dict[str, Any]:
+    """Validate and normalize a schema dict into the OCS v1 shape."""
+    raw_schema = deepcopy(schema or {})
+    errors: list[dict[str, str]] = []
+
+    if not isinstance(raw_schema, dict):
+        raise OCSValidationError("Schema must be a JSON object")
+
+    normalized = {
+        "ocs_version": str(raw_schema.get("ocs_version") or DEFAULT_OCS_VERSION),
+        "strategy": str(raw_schema.get("strategy") or strategy_id or ""),
+        "title": str(raw_schema.get("title") or raw_schema.get("strategy") or strategy_id or ""),
+        "description": str(raw_schema.get("description") or ""),
+        "fields": [],
+    }
+
+    fields = raw_schema.get("fields", [])
+    if not isinstance(fields, list):
+        errors.append(_field_error("fields", "Fields must be a list"))
+        fields = []
+
+    seen_keys: set[str] = set()
+    for idx, raw_field in enumerate(fields):
+        location = f"fields[{idx}]"
+        if not isinstance(raw_field, dict):
+            errors.append(_field_error(location, "Field must be an object"))
+            continue
+
+        key = str(raw_field.get("key") or "").strip()
+        field_type = str(raw_field.get("type") or "string").strip()
+
+        if not key or not FIELD_KEY_RE.match(key):
+            errors.append(
+                _field_error(f"{location}.key", "Use letters, numbers, and underscores; start with a letter or underscore")
+            )
+            continue
+        if key in seen_keys:
+            errors.append(_field_error(f"{location}.key", "Field keys must be unique"))
+            continue
+        if field_type not in SUPPORTED_FIELD_TYPES:
+            errors.append(_field_error(f"{location}.type", f"Unsupported type: {field_type}"))
+            continue
+
+        field = {
+            "key": key,
+            "type": field_type,
+            "label": str(raw_field.get("label") or raw_field.get("name") or key.replace("_", " ").title()),
+            "required": bool(raw_field.get("required", False)),
+        }
+
+        for optional_key in (
+            "default",
+            "description",
+            "tooltip",
+            "placeholder",
+            "group",
+            "tab",
+            "section",
+            "min",
+            "max",
+            "step",
+            "regex",
+            "options",
+            "visible_if",
+            "enabled_if",
+        ):
+            if optional_key in raw_field:
+                field[optional_key] = raw_field[optional_key]
+
+        if "regex" in field:
+            try:
+                re.compile(str(field["regex"]))
+            except re.error as exc:
+                errors.append(
+                    _field_error(f"{location}.regex", f"Invalid regex pattern: {exc}")
+                )
+                continue
+
+        if field_type in {"select", "multi_select", "exchange", "product", "option_type"}:
+            options = field.get("options")
+            if options is not None and not isinstance(options, list):
+                errors.append(_field_error(f"{location}.options", "Options must be a list"))
+                continue
+
+        if "default" in field:
+            try:
+                field["default"] = _coerce_value(field, field["default"])
+            except OCSValidationError as exc:
+                errors.extend(
+                    _field_error(f"{location}.default", err["message"]) for err in exc.errors
+                )
+                continue
+
+        seen_keys.add(key)
+        normalized["fields"].append(field)
+
+    if errors:
+        raise OCSValidationError("Schema validation failed", errors)
+
+    return normalized
+
+
+def validate_values(schema: dict[str, Any] | None, values: dict[str, Any] | None) -> dict[str, Any]:
+    """Return coerced values merged with field defaults."""
+    normalized_schema = normalize_schema(schema)
+    provided = values or {}
+    if not isinstance(provided, dict):
+        raise OCSValidationError("Values must be a JSON object")
+
+    errors: list[dict[str, str]] = []
+    result: dict[str, Any] = {}
+    fields = normalized_schema.get("fields", [])
+    field_keys = {field["key"] for field in fields}
+
+    for field in fields:
+        key = field["key"]
+        raw_value = provided.get(key, field.get("default"))
+        try:
+            coerced = _coerce_value(field, raw_value)
+        except OCSValidationError as exc:
+            errors.extend(exc.errors)
+            continue
+        if coerced is not None:
+            result[key] = coerced
+
+    for key in provided:
+        if key not in field_keys:
+            errors.append(_field_error(key, "Unknown configuration key"))
+
+    if errors:
+        raise OCSValidationError("Value validation failed", errors)
+
+    return result
+
+
+def default_values_for_schema(schema: dict[str, Any] | None) -> dict[str, Any]:
+    """Return best-effort defaults without enforcing required fields."""
+    normalized_schema = normalize_schema(schema)
+    defaults: dict[str, Any] = {}
+    for field in normalized_schema.get("fields", []):
+        if "default" in field:
+            defaults[field["key"]] = field["default"]
+    return defaults
+
+
+def merge_schema_defaults(schema: dict[str, Any] | None, values: dict[str, Any] | None) -> dict[str, Any]:
+    """Merge known values with defaults without requiring every field to exist."""
+    normalized_schema = normalize_schema(schema)
+    provided = values or {}
+    valid_keys = {field["key"] for field in normalized_schema.get("fields", [])}
+    merged = default_values_for_schema(normalized_schema)
+    merged.update({key: value for key, value in provided.items() if key in valid_keys})
+    return merged
+
+
+class ConfigStore:
+    """File-backed OCS schema/value store."""
+
+    def __init__(self, base_dir: str | Path = Path("strategies") / "configs"):
+        self.base_dir = Path(base_dir)
+        self.schema_dir = self.base_dir / "schemas"
+        self.values_dir = self.base_dir / "values"
+
+    def ensure_dirs(self) -> None:
+        self.schema_dir.mkdir(parents=True, exist_ok=True)
+        self.values_dir.mkdir(parents=True, exist_ok=True)
+
+    def _safe_id(self, strategy_id: str) -> str:
+        if not strategy_id or not FIELD_KEY_RE.match(strategy_id.replace("-", "_")):
+            raise OCSValidationError("Invalid strategy ID")
+        if "/" in strategy_id or "\\" in strategy_id or ".." in strategy_id:
+            raise OCSValidationError("Invalid strategy ID")
+        return strategy_id
+
+    def schema_path(self, strategy_id: str) -> Path:
+        return self.schema_dir / f"{self._safe_id(strategy_id)}.json"
+
+    def values_path(self, strategy_id: str) -> Path:
+        return self.values_dir / f"{self._safe_id(strategy_id)}.json"
+
+    def _read_json(self, path: Path, default: dict[str, Any]) -> dict[str, Any]:
+        if not path.exists():
+            return deepcopy(default)
+        with open(path, encoding="utf-8") as handle:
+            return json.load(handle)
+
+    def _write_json(self, path: Path, payload: dict[str, Any]) -> None:
+        path.parent.mkdir(parents=True, exist_ok=True)
+        tmp_path = path.with_suffix(path.suffix + ".tmp")
+        with open(tmp_path, "w", encoding="utf-8") as handle:
+            json.dump(payload, handle, indent=2, sort_keys=True, ensure_ascii=False)
+            handle.flush()
+            os.fsync(handle.fileno())
+        os.replace(tmp_path, path)
+
+    def get_schema(self, strategy_id: str) -> dict[str, Any]:
+        raw = self._read_json(self.schema_path(strategy_id), {"fields": []})
+        return normalize_schema(raw, strategy_id)
+
+    def save_schema(self, strategy_id: str, schema: dict[str, Any]) -> dict[str, Any]:
+        normalized = normalize_schema(schema, strategy_id)
+        self._write_json(self.schema_path(strategy_id), normalized)
+        current_values = self.get_values(strategy_id, allow_invalid=True)
+        current_values = merge_schema_defaults(normalized, current_values)
+        try:
+            self.save_values(strategy_id, current_values)
+        except OCSValidationError:
+            self._write_json(self.values_path(strategy_id), current_values)
+        return normalized
+
+    def get_values(self, strategy_id: str, allow_invalid: bool = False) -> dict[str, Any]:
+        raw = self._read_json(self.values_path(strategy_id), {})
+        if allow_invalid:
+            return merge_schema_defaults(self.get_schema(strategy_id), raw)
+        return validate_values(self.get_schema(strategy_id), raw)
+
+    def save_values(self, strategy_id: str, values: dict[str, Any]) -> dict[str, Any]:
+        schema = self.get_schema(strategy_id)
+        normalized_values = validate_values(schema, values)
+        self._write_json(self.values_path(strategy_id), normalized_values)
+        return normalized_values
+
+    def delete(self, strategy_id: str) -> None:
+        for path in (self.schema_path(strategy_id), self.values_path(strategy_id)):
+            try:
+                path.unlink()
+            except FileNotFoundError:
+                pass
+
+
+def build_runtime_config(store: ConfigStore, strategy_id: str) -> dict[str, Any]:
+    """Load schema defaults plus persisted values for strategy launch."""
+    schema = store.get_schema(strategy_id)
+    values = store.get_values(strategy_id)
+    return validate_values(schema, values)

--- a/openalgo_config/ui.py
+++ b/openalgo_config/ui.py
@@ -1,0 +1,74 @@
+"""Runtime helpers for OpenAlgo strategy configuration declarations.
+
+Strategy authors can declare editable settings with ``ui.*`` calls. The
+OpenAlgo host discovers those calls statically during upload, while this module
+returns the active runtime value when the strategy process is started.
+"""
+
+from __future__ import annotations
+
+import builtins
+import json
+import os
+from typing import Any
+
+
+def _runtime_values() -> dict[str, Any]:
+    raw = os.getenv("OPENALGO_CONFIG_JSON")
+    if not raw:
+        return {}
+    try:
+        values = json.loads(raw)
+    except json.JSONDecodeError:
+        return {}
+    return values if isinstance(values, dict) else {}
+
+
+class _UI:
+    def __init__(self) -> None:
+        self._values: dict[str, Any] | None = None
+
+    @property
+    def values(self) -> dict[str, Any]:
+        if self._values is None:
+            self._values = _runtime_values()
+        return self._values
+
+    def _get(self, key: str, default: Any = None) -> Any:
+        value = self.values.get(key, default)
+        return default if value is None else value
+
+    def int(self, key: str, *, default: int = 0, **_: Any) -> int:
+        return builtins.int(self._get(key, default))
+
+    def float(self, key: str, *, default: float = 0.0, **_: Any) -> float:
+        return builtins.float(self._get(key, default))
+
+    def bool(self, key: str, *, default: bool = False, **_: Any) -> bool:
+        value = self._get(key, default)
+        if isinstance(value, str):
+            return value.strip().lower() in {"1", "true", "yes", "on"}
+        return builtins.bool(value)
+
+    def string(self, key: str, *, default: str = "", **_: Any) -> str:
+        return str(self._get(key, default))
+
+    def select(self, key: str, *, default: Any = None, **_: Any) -> Any:
+        return self._get(key, default)
+
+    def symbol(self, key: str = "symbol", *, default: str = "", **_: Any) -> str:
+        return str(self._get(key, default))
+
+    def exchange(self, key: str = "exchange", *, default: str = "NSE", **_: Any) -> str:
+        return str(self._get(key, default))
+
+    def product(self, key: str = "product", *, default: str = "MIS", **_: Any) -> str:
+        return str(self._get(key, default))
+
+    def quantity(self, key: str = "quantity", *, default: int = 1, **_: Any) -> int:
+        return builtins.int(self._get(key, default))
+
+
+ui = _UI()
+
+__all__ = ["ui"]

--- a/strategies/.gitignore
+++ b/strategies/.gitignore
@@ -1,5 +1,6 @@
 # Strategy configuration file (contains user-specific data)
 strategy_configs.json
+configs/
 
 # Environment variables (contains sensitive data)
 strategy_env.json

--- a/strategies/README.md
+++ b/strategies/README.md
@@ -7,10 +7,10 @@ A complete web-based strategy hosting and scheduling system for OpenAlgo, access
 - **Upload & Manage**: Upload Python strategy scripts through web interface
 - **Start/Stop**: Control strategy execution with one click
 - **Schedule**: Set automatic start/stop times with day selection
-- **Exchange-aware calendar**: Each strategy is tagged with an exchange (NSE / BSE / NFO / BFO / MCX / BCD / CDS / CRYPTO) and the host gates start/stop using that exchange's holiday calendar — an MCX strategy keeps running on an NSE/BSE holiday during the MCX session, a CRYPTO strategy ignores all holidays, and SPECIAL_SESSION rows (Muhurat, DR-drill) override weekend rejects
+- **Exchange-aware calendar**: Each strategy is tagged with an exchange (NSE / BSE / NFO / BFO / MCX / BCD / CDS / CRYPTO) and the host gates start/stop using that exchange's holiday calendar - an MCX strategy keeps running on an NSE/BSE holiday during the MCX session, a CRYPTO strategy ignores all holidays, and SPECIAL_SESSION rows (Muhurat, DR-drill) override weekend rejects
 - **Process Isolation**: Each strategy runs in its own process
 - **Real-time Monitoring**: View logs and strategy status
-- **Parameter Configuration**: Pass custom parameters to strategies
+- **Parameter Configuration**: Configure strategy inputs through OCS-powered generated UI forms
 
 ## Installation
 
@@ -30,8 +30,8 @@ http://localhost:5000/python
 - Click "Add Strategy" button
 - Provide a name for your strategy
 - Select your Python script file
-- **Pick the exchange** the strategy trades on (NSE / BSE / NFO / BFO / MCX / BCD / CDS / CRYPTO). This drives which calendar the host uses to gate scheduled start/stop. Pick CRYPTO for 24/7 strategies — the host will skip all holiday checks and pre-fill the schedule to all 7 days
-- Add any parameters (will be available as environment variables)
+- **Pick the exchange** the strategy trades on (NSE / BSE / NFO / BFO / MCX / BCD / CDS / CRYPTO). This drives which calendar the host uses to gate scheduled start/stop. Pick CRYPTO for 24/7 strategies - the host will skip all holiday checks and pre-fill the schedule to all 7 days
+- If the script declares OCS fields with `ui.*`, OpenAlgo discovers them automatically and opens the generated configuration page after upload
 - Click "Upload Strategy"
 
 ### 2. Start/Stop Strategy
@@ -51,7 +51,7 @@ The effective trading window is the **intersection** of:
 1. Your `start..stop` time, and
 2. The exchange's session for that specific date (from the market calendar DB).
 
-So a 09:15-23:55 schedule on an MCX strategy on 14-Apr-2026 will only fire 17:00-23:55 (the partial holiday window the calendar publishes for that date), not 09:15. This is by design — you don't have to redo the schedule for every partial holiday.
+So a 09:15-23:55 schedule on an MCX strategy on 14-Apr-2026 will only fire 17:00-23:55 (the partial holiday window the calendar publishes for that date), not 09:15. This is by design - you don't have to redo the schedule for every partial holiday.
 
 ### 4. View Logs
 - Click "Logs" to view strategy output
@@ -72,7 +72,7 @@ from datetime import datetime
 # EXCHANGE prefers OPENALGO_STRATEGY_EXCHANGE (set by /python from your
 # strategy's exchange config) so the script trades on the same exchange
 # the host is gating its calendar against. Falls back to EXCHANGE env
-# var, then NSE — so the same script works standalone too.
+# var, then NSE - so the same script works standalone too.
 SYMBOL   = os.getenv('SYMBOL', 'RELIANCE')
 EXCHANGE = os.getenv(
     'OPENALGO_STRATEGY_EXCHANGE',
@@ -112,29 +112,29 @@ if __name__ == "__main__":
     main()
 ```
 
-> **Reading `OPENALGO_STRATEGY_EXCHANGE` is optional but strongly recommended.** If your script hardcodes `exchange = "NSE"`, the host will still gate it correctly per its config (e.g. host runs your script during MCX evening session because `exchange=MCX`), but your `client.placeorder(exchange="NSE", ...)` calls will still send NSE orders — and the broker will reject them. Wiring the env var keeps host calendar and script orders aligned.
+> **Reading `OPENALGO_STRATEGY_EXCHANGE` is optional but strongly recommended.** If your script hardcodes `exchange = "NSE"`, the host will still gate it correctly per its config (e.g. host runs your script during MCX evening session because `exchange=MCX`), but your `client.placeorder(exchange="NSE", ...)` calls will still send NSE orders - and the broker will reject them. Wiring the env var keeps host calendar and script orders aligned.
 
 ## Environment Variables
 
 ### Injected by the platform
 
-These are set directly on each strategy subprocess (only the ones below — the host does not inject host/port/websocket vars; see next section):
+These are set directly on each strategy subprocess (only the ones below - the host does not inject host/port/websocket vars; see next section):
 
-- `STRATEGY_ID` — unique identifier for the strategy
-- `STRATEGY_NAME` — name of the strategy
-- `OPENALGO_STRATEGY_EXCHANGE` — the exchange picked at upload/edit time (`NSE` / `BSE` / `NFO` / `BFO` / `MCX` / `BCD` / `CDS` / `CRYPTO`). Read this in your script so its trading calls match the calendar the host is gating against
-- `OPENALGO_API_KEY` — decrypted API key for this user
-- `OPENALGO_HOST` — OpenAlgo host URL, **set with `setdefault` to `http://127.0.0.1:5000`**. If `OPENALGO_HOST` is already present in `.env` (it usually isn't — `.env` uses `HOST_SERVER`), that value is kept. Treat this as a convenience fallback only
+- `STRATEGY_ID` - unique identifier for the strategy
+- `STRATEGY_NAME` - name of the strategy
+- `OPENALGO_STRATEGY_EXCHANGE` - the exchange picked at upload/edit time (`NSE` / `BSE` / `NFO` / `BFO` / `MCX` / `BCD` / `CDS` / `CRYPTO`). Read this in your script so its trading calls match the calendar the host is gating against
+- `OPENALGO_API_KEY` - decrypted API key for this user
+- `OPENALGO_HOST` - OpenAlgo host URL, **set with `setdefault` to `http://127.0.0.1:5000`**. If `OPENALGO_HOST` is already present in `.env` (it usually isn't - `.env` uses `HOST_SERVER`), that value is kept. Treat this as a convenience fallback only
 
 ### Inherited from `.env`
 
 Strategies are launched with `os.environ.copy()`, so they inherit **every** variable from OpenAlgo's `.env`. The relevant ones for connecting to OpenAlgo:
 
-- `HOST_SERVER` — REST host, e.g. `http://127.0.0.1:5000` (this is the canonical name in `.env`; **prefer this in your scripts**)
-- `WEBSOCKET_URL` — full WS URL, e.g. `ws://127.0.0.1:8765`
-- `WEBSOCKET_HOST` — e.g. `127.0.0.1` (raw component)
-- `WEBSOCKET_PORT` — e.g. `8765` (raw component)
-- `FLASK_HOST_IP` / `FLASK_PORT` — also present if you need them
+- `HOST_SERVER` - REST host, e.g. `http://127.0.0.1:5000` (this is the canonical name in `.env`; **prefer this in your scripts**)
+- `WEBSOCKET_URL` - full WS URL, e.g. `ws://127.0.0.1:8765`
+- `WEBSOCKET_HOST` - e.g. `127.0.0.1` (raw component)
+- `WEBSOCKET_PORT` - e.g. `8765` (raw component)
+- `FLASK_HOST_IP` / `FLASK_PORT` - also present if you need them
 - Any other key you've defined in `.env`
 
 > **Recommended pattern in scripts:**
@@ -149,21 +149,158 @@ Strategies are launched with `os.environ.copy()`, so they inherit **every** vari
 >
 > Note: there is **no `HOST_URL` variable** anywhere in OpenAlgo. Only `HOST_SERVER` (REST), `OPENALGO_HOST` (injected fallback alias), and `WEBSOCKET_URL` (WS).
 
-### Per-strategy parameters
+### Per-strategy configuration
 
-Plus any custom parameters you define in the strategy upload form — these become additional environment variables.
+Strategy-specific inputs should use OCS declarations in the script. OpenAlgo stores those values per strategy and injects them at runtime.
+
+### OpenAlgo Configuration SDK (OCS)
+
+Python strategies can receive structured configuration from the OpenAlgo Configuration SDK. OCS keeps user-editable values outside source code, validates them against a schema, renders a generated React form, stores values per strategy, and injects the resolved values into the strategy process at launch.
+
+The preferred authoring style is explicit `ui.*` declarations:
+
+```python
+try:
+    from openalgo.config import ui
+except ModuleNotFoundError:
+    from openalgo_config import ui
+
+strategy = ui.string("strategy", default="EMA Crossover Python", label="Strategy Name")
+symbol = ui.symbol("symbol", default="RELIANCE", label="Symbol", required=True)
+exchange = ui.exchange("exchange", default="NSE", label="Exchange")
+product = ui.product("product", default="MIS", options=["MIS", "NRML", "CNC"])
+quantity = ui.quantity("quantity", default=1, min=1)
+
+fast_ema = ui.int("fast_ema", default=9, min=1, max=200)
+slow_ema = ui.int("slow_ema", default=21, min=2, max=500)
+debug = ui.bool("debug", default=False)
+```
+
+Use explicit keys such as `"symbol"` and `"fast_ema"`. Keyless calls are not used for upload-time schema discovery because the runtime helper reads values by key.
+
+Legacy scripts can still expose a literal `DEFAULT_OCS_SCHEMA` or `OCS_SCHEMA`, but new strategies should use `ui.*` instead of hand-writing schema JSON.
+
+Files are stored per strategy:
+
+```text
+strategies/
+`-- configs/
+    |-- schemas/<strategy_id>.json
+    `-- values/<strategy_id>.json
+```
+
+The runner injects:
+
+- `OPENALGO_CONFIG_JSON` - resolved config values after defaults and validation
+- `OPENALGO_CONFIG_SCHEMA_JSON` - normalized OCS schema
+- `OPENALGO_CONFIG_<KEY>` - convenience aliases for each config key
+
+Runtime values can be read from `ui.*` return values or directly from `OPENALGO_CONFIG_JSON`:
+
+```python
+import json
+import os
+
+config = json.loads(os.getenv("OPENALGO_CONFIG_JSON", "{}"))
+
+SYMBOL = config.get("symbol", "RELIANCE")
+FAST_EMA = int(config.get("fast_ema", 9))
+SLOW_EMA = int(config.get("slow_ema", 21))
+```
+
+OpenAlgo discovers explicit `ui.*` fields during upload without executing trading logic. The React UI renders the form at `/python/<strategy_id>/config`; upload/list responses include config metadata so the config icon appears from live API data, not from a frontend rebuild.
+
+Backend endpoints:
+
+- `GET /python/api/config/<strategy_id>`
+- `POST /python/api/config/<strategy_id>/schema`
+- `POST /python/api/config/<strategy_id>/values`
+- `POST /python/api/config/validate`
+
+`GET /python/api/config/<strategy_id>` returns editable draft `values`, runtime-valid `resolved_values`, and `validation_errors` when required fields still need user input.
+
+OCS validation supports defaults, required fields, min/max limits, select and multi-select options, numeric and boolean option values, regex syntax validation, stale-key pruning, and structured API errors for storage/runtime failures.
+
+For a complete system guide, see `docs/openalgo-configuration-sdk.md`.
+
+### OpenAlgo Configuration SDK (OCS)
+
+Python strategies can also receive structured configuration generated by the OpenAlgo Configuration SDK. OCS keeps user-editable values outside source code, validates them against a JSON schema, and injects the resolved values into the strategy process at launch.
+
+Files are stored per strategy:
+
+```
+strategies/
+└── configs/
+    ├── schemas/<strategy_id>.json
+    └── values/<strategy_id>.json
+```
+
+The runner injects:
+
+- `OPENALGO_CONFIG_JSON` — resolved config values after defaults and validation
+- `OPENALGO_CONFIG_SCHEMA_JSON` — normalized OCS schema
+- `OPENALGO_CONFIG_<KEY>` — convenience aliases for each config key
+
+Example:
+
+```python
+import json
+import os
+
+config = json.loads(os.getenv("OPENALGO_CONFIG_JSON", "{}"))
+
+SYMBOL = config.get("symbol", "RELIANCE")
+FAST_EMA = int(config.get("fast_ema", 9))
+SLOW_EMA = int(config.get("slow_ema", 21))
+```
+
+Minimal schema:
+
+```json
+{
+  "ocs_version": "1.0",
+  "strategy": "ema_crossover",
+  "title": "EMA Crossover",
+  "fields": [
+    {
+      "key": "symbol",
+      "type": "symbol",
+      "label": "Symbol",
+      "default": "RELIANCE",
+      "required": true
+    },
+    {
+      "key": "fast_ema",
+      "type": "int",
+      "label": "Fast EMA",
+      "default": 9,
+      "min": 1,
+      "max": 200
+    }
+  ]
+}
+```
+
+The React UI renders the form from this schema at `/python/<strategy_id>/config`. Backend endpoints:
+
+- `GET /python/api/config/<strategy_id>`
+- `POST /python/api/config/<strategy_id>/schema`
+- `POST /python/api/config/<strategy_id>/values`
+- `POST /python/api/config/validate`
 
 ## Directory Structure
 
 ```
 strategies/
-├── scripts/          # Uploaded strategy files
-├── examples/         # Example strategies
-├── configs.json      # Strategy configurations
-└── requirements.txt  # Python dependencies
+|-- scripts/          # Uploaded strategy files
+|-- examples/         # Example strategies
+|-- configs/          # OCS runtime schema/value files
+|-- configs.json      # Strategy configurations
+`-- requirements.txt  # Python dependencies
 
 logs/
-└── strategies/       # Strategy log files
+`-- strategies/       # Strategy log files
 ```
 
 ## API Integration
@@ -207,26 +344,26 @@ Strategies can be scheduled to run automatically:
 - **Stop Time**: When to stop the strategy (optional, IST)
 - **Days**: Which days to run (Mon-Sun)
 
-Example: NSE EMA strategy → Start 09:15, stop 15:30, Monday-Friday.
-Example: MCX evening strategy → exchange=MCX, start 17:00, stop 23:55, Monday-Friday.
-Example: CRYPTO arb → exchange=CRYPTO, start 00:00, stop 23:59, all 7 days.
+Example: NSE EMA strategy -> Start 09:15, stop 15:30, Monday-Friday.
+Example: MCX evening strategy -> exchange=MCX, start 17:00, stop 23:55, Monday-Friday.
+Example: CRYPTO arb -> exchange=CRYPTO, start 00:00, stop 23:59, all 7 days.
 
 ### How exchange-aware gating works
 
 Three things run on the host:
 
-1. **Cron job** — fires `start_<sid>` at your `start_time` on each day in `schedule_days`.
-2. **Daily check** at 00:01 IST — for each scheduled strategy, looks up `get_market_status(config["exchange"])`. If the exchange has no session today (closed weekend / full holiday), the strategy is stopped and marked `paused_reason=holiday|weekend`.
-3. **Per-minute enforcer** — same per-strategy check. When the exchange reopens (or a special session starts), previously-paused strategies are auto-resumed (unless `manually_stopped`).
+1. **Cron job** - fires `start_<sid>` at your `start_time` on each day in `schedule_days`.
+2. **Daily check** at 00:01 IST - for each scheduled strategy, looks up `get_market_status(config["exchange"])`. If the exchange has no session today (closed weekend / full holiday), the strategy is stopped and marked `paused_reason=holiday|weekend`.
+3. **Per-minute enforcer** - same per-strategy check. When the exchange reopens (or a special session starts), previously-paused strategies are auto-resumed (unless `manually_stopped`).
 
-The "session today" lookup uses the same calendar DB that powers `/api/v1/market/holidays` — see admin → Holidays to add SPECIAL_SESSION rows for events like Muhurat trading or NSE DR-drill weekends.
+The "session today" lookup uses the same calendar DB that powers `/api/v1/market/holidays` - see admin -> Holidays to add SPECIAL_SESSION rows for events like Muhurat trading or NSE DR-drill weekends.
 
 ### Worked example: 14-Apr-2026 (Ambedkar Jayanti)
 
 | Exchange | Calendar says | Strategy behavior |
 |---|---|---|
 | NSE / BSE / NFO / BFO / CDS / BCD | Closed all day | All scheduled strategies stopped at 00:01 IST |
-| MCX | Open 17:00-23:55 IST (partial holiday) | MCX strategies stay armed; auto-start at 17:00, run within user's `start..stop ∩ 17:00-23:55` |
+| MCX | Open 17:00-23:55 IST (partial holiday) | MCX strategies stay armed; auto-start at 17:00, run within the overlap of the user's `start..stop` window and `17:00-23:55` |
 | CRYPTO | 24/7 | Unaffected |
 
 ### Worked example: 8-Nov-2026 (Sunday Diwali Muhurat)
@@ -252,11 +389,11 @@ The "session today" lookup uses the same calendar DB that powers `/api/v1/market
 3. **Can't stop strategy**: Process may be stuck, use system task manager if needed
 4. **Parameters not working**: Ensure parameter names are valid environment variable names
 5. **Strategy didn't run on a partial holiday (e.g., MCX evening on NSE holiday)**:
-   - Open the strategy → Schedule → confirm `Exchange` is set to the right market (legacy strategies default to `NSE` after the upgrade and need a one-time edit if they trade MCX/CRYPTO/etc.)
-   - Confirm the date has a row in admin → Holidays with the partial-open window for your exchange
-   - Confirm your `schedule_start..schedule_stop` overlaps the calendar window — they intersect, so a 09:15-15:30 schedule will NOT fire during a 17:00-23:55 partial session
-6. **Strategy ran on a Sunday/Saturday (special session)**: that's by design — the calendar's SPECIAL_SESSION row overrides the weekend reject. To opt out, remove the day from `schedule_days`
-7. **Strategy paused with `paused_reason=holiday`** but you think today is open: check `get_market_status(exchange)` — the exchange's session may differ from another exchange's. Each strategy is gated by its own exchange
+   - Open the strategy -> Schedule -> confirm `Exchange` is set to the right market (legacy strategies default to `NSE` after the upgrade and need a one-time edit if they trade MCX/CRYPTO/etc.)
+   - Confirm the date has a row in admin -> Holidays with the partial-open window for your exchange
+   - Confirm your `schedule_start..schedule_stop` overlaps the calendar window - they intersect, so a 09:15-15:30 schedule will NOT fire during a 17:00-23:55 partial session
+6. **Strategy ran on a Sunday/Saturday (special session)**: that's by design - the calendar's SPECIAL_SESSION row overrides the weekend reject. To opt out, remove the day from `schedule_days`
+7. **Strategy paused with `paused_reason=holiday`** but you think today is open: check `get_market_status(exchange)` - the exchange's session may differ from another exchange's. Each strategy is gated by its own exchange
 8. **Orders rejected with "market closed" while host says strategy is running**: your script's hardcoded `exchange="NSE"` doesn't match the host's `exchange="MCX"`. Read `OPENALGO_STRATEGY_EXCHANGE` in your script (see Strategy Template)
 
 ## Migration notes (existing deployments)
@@ -265,14 +402,15 @@ When upgrading to the exchange-aware /python:
 
 - **No data migration required.** `load_configs()` writes `"exchange": "NSE"` into any legacy entry missing the field, on the first read after restart.
 - **No strategy is force-restarted or force-stopped by the upgrade itself.** Running PIDs are reaped and re-evaluated normally.
-- Strategies that should trade something other than NSE need a one-time UI edit (Schedule → pick exchange → Save). Otherwise they'll behave exactly as before, gated on NSE's calendar.
-- `manually_stopped` strategies stay manually stopped — the upgrade does not auto-resume them.
+- Strategies that should trade something other than NSE need a one-time UI edit (Schedule -> pick exchange -> Save). Otherwise they'll behave exactly as before, gated on NSE's calendar.
+- `manually_stopped` strategies stay manually stopped - the upgrade does not auto-resume them.
 - Forward-compatible: rolling back to the previous code reads the same JSON and ignores the new `exchange` field.
 
 ## Example Strategy
 
-See `examples/simple_ema_strategy.py` for a complete working example that:
+See `examples/simple_ema_strategy_config.py` for a complete OCS-powered example that:
 - Implements EMA crossover logic
 - Integrates with OpenAlgo API
 - Handles errors gracefully
-- Uses environment parameters
+- Declares editable inputs with explicit `ui.*` keys
+- Uses OpenAlgo runtime configuration instead of hardcoded parameters

--- a/strategies/examples/simple_ema_strategy_config.py
+++ b/strategies/examples/simple_ema_strategy_config.py
@@ -6,6 +6,7 @@ This example declares editable OpenAlgo strategy settings with ui.* calls.
 OpenAlgo discovers these declarations on upload and injects runtime values.
 """
 
+import json
 import os
 import time
 from datetime import datetime, timedelta
@@ -174,5 +175,16 @@ def ema_strategy():
 
 if __name__ == "__main__":
     print(f"Starting {fast_period}/{slow_period} EMA Crossover Strategy...")
-    print("OCS config:", json.dumps(config, sort_keys=True))
+    print("OCS config:", json.dumps({
+        "strategy": strategy,
+        "symbol": symbol,
+        "exchange": exchange,
+        "product": product,
+        "quantity": quantity,
+        "fast_period": fast_period,
+        "slow_period": slow_period,
+        "interval": interval,
+        "history_days": history_days,
+        "poll_seconds": poll_seconds,
+    }, sort_keys=True))
     ema_strategy()

--- a/strategies/examples/simple_ema_strategy_config.py
+++ b/strategies/examples/simple_ema_strategy_config.py
@@ -1,0 +1,178 @@
+#!/usr/bin/env python
+"""
+Simple EMA Crossover Strategy Example
+
+This example declares editable OpenAlgo strategy settings with ui.* calls.
+OpenAlgo discovers these declarations on upload and injects runtime values.
+"""
+
+import os
+import time
+from datetime import datetime, timedelta
+
+import pandas as pd
+from openalgo import api, ta
+
+try:
+    from openalgo.config import ui
+except ModuleNotFoundError:
+    from openalgo_config import ui
+
+
+def normalize_history(df):
+    """Normalize OpenAlgo history data before indicator calculations."""
+    if "timestamp" in df.columns:
+        df["timestamp"] = pd.to_datetime(df["timestamp"])
+        df = df.set_index("timestamp")
+    else:
+        df.index = pd.to_datetime(df.index)
+    df = df.sort_index()
+    if df.index.tz is not None:
+        df.index = df.index.tz_convert(None)
+    return df
+
+
+api_key = os.getenv("OPENALGO_API_KEY")
+host = os.getenv("HOST_SERVER") or os.getenv("OPENALGO_HOST", "http://127.0.0.1:5000")
+ws_url = os.getenv("WEBSOCKET_URL", "ws://127.0.0.1:8765")
+
+if not api_key:
+    print("Error: OPENALGO_API_KEY environment variable not set")
+    raise SystemExit(1)
+
+strategy = ui.string("strategy", default="EMA Crossover Python", label="Strategy Name", required=True)
+symbol = ui.symbol("symbol", default="NHPC", label="Symbol", required=True)
+exchange = ui.exchange(
+    "exchange",
+    default="BSE",
+    label="Exchange",
+    options=["NSE", "BSE", "NFO", "BFO", "MCX", "CDS", "BCD", "CRYPTO"],
+    required=True,
+)
+product = ui.product("product", default="MIS", label="Product", options=["MIS", "NRML", "CNC"], required=True)
+quantity = ui.quantity("quantity", default=1, label="Quantity", min=1, required=True)
+fast_period = ui.int("fast_period", default=5, label="Fast EMA Period", min=1, max=200, required=True)
+slow_period = ui.int("slow_period", default=10, label="Slow EMA Period", min=2, max=500, required=True)
+interval = ui.string("interval", default="1m", label="Candle Interval", required=True)
+history_days = ui.int("history_days", default=7, label="History Days", min=1, max=365, required=True)
+poll_seconds = ui.int("poll_seconds", default=15, label="Poll Seconds", min=1, max=3600, required=True)
+
+if fast_period >= slow_period:
+    print("Error: fast_period must be lower than slow_period")
+    raise SystemExit(1)
+
+client = api(api_key=api_key, host=host, ws_url=ws_url)
+
+
+def calculate_ema_signals(df):
+    """Calculate EMA crossover signals using openalgo.ta."""
+    close = df["close"]
+
+    ema_fast = ta.ema(close, fast_period)
+    ema_slow = ta.ema(close, slow_period)
+
+    raw_buy = pd.Series(ta.crossover(ema_fast, ema_slow), index=df.index).fillna(False)
+    raw_sell = pd.Series(ta.crossunder(ema_fast, ema_slow), index=df.index).fillna(False)
+    buy_signal = pd.Series(ta.exrem(raw_buy, raw_sell), index=df.index).fillna(False)
+    sell_signal = pd.Series(ta.exrem(raw_sell, raw_buy), index=df.index).fillna(False)
+
+    return pd.DataFrame(
+        {
+            "EMA_Fast": ema_fast,
+            "EMA_Slow": ema_slow,
+            "Buy_Signal": buy_signal,
+            "Sell_Signal": sell_signal,
+        },
+        index=df.index,
+    )
+
+
+def ema_strategy():
+    """Run the EMA crossover trading strategy."""
+    position = 0
+
+    while True:
+        try:
+            end_date = datetime.now().strftime("%Y-%m-%d")
+            start_date = (datetime.now() - timedelta(days=history_days)).strftime("%Y-%m-%d")
+
+            df = client.history(
+                symbol=symbol,
+                exchange=exchange,
+                interval=interval,
+                start_date=start_date,
+                end_date=end_date,
+            )
+
+            if df.empty:
+                print("DataFrame is empty. Retrying...")
+                time.sleep(poll_seconds)
+                continue
+
+            if "close" not in df.columns:
+                raise KeyError("Missing 'close' column in DataFrame")
+
+            df = normalize_history(df)
+            df["close"] = df["close"].round(2)
+
+            signals = calculate_ema_signals(df)
+            if len(signals) < 2:
+                print("Not enough candles for signal confirmation. Retrying...")
+                time.sleep(poll_seconds)
+                continue
+
+            buy_signal = bool(signals["Buy_Signal"].iloc[-2])
+            sell_signal = bool(signals["Sell_Signal"].iloc[-2])
+
+            if buy_signal and position <= 0:
+                position = quantity
+                response = client.placesmartorder(
+                    strategy=strategy,
+                    symbol=symbol,
+                    action="BUY",
+                    exchange=exchange,
+                    price_type="MARKET",
+                    product=product,
+                    quantity=quantity,
+                    position_size=position,
+                )
+                print("Buy Order Response:", response)
+
+            elif sell_signal and position >= 0:
+                position = quantity * -1
+                response = client.placesmartorder(
+                    strategy=strategy,
+                    symbol=symbol,
+                    action="SELL",
+                    exchange=exchange,
+                    price_type="MARKET",
+                    product=product,
+                    quantity=quantity,
+                    position_size=position,
+                )
+                print("Sell Order Response:", response)
+
+            print("\nStrategy Status:")
+            print("-" * 50)
+            print(f"Strategy: {strategy}")
+            print(f"Symbol: {symbol} | Exchange: {exchange} | Product: {product}")
+            print(f"Position: {position}")
+            print(f"LTP: {df['close'].iloc[-1]}")
+            print(f"Fast EMA ({fast_period}): {signals['EMA_Fast'].iloc[-2]:.2f}")
+            print(f"Slow EMA ({slow_period}): {signals['EMA_Slow'].iloc[-2]:.2f}")
+            print(f"Buy Signal: {buy_signal}")
+            print(f"Sell Signal: {sell_signal}")
+            print("-" * 50)
+
+        except Exception as e:
+            print(f"Error in strategy: {str(e)}")
+            time.sleep(poll_seconds)
+            continue
+
+        time.sleep(poll_seconds)
+
+
+if __name__ == "__main__":
+    print(f"Starting {fast_period}/{slow_period} EMA Crossover Strategy...")
+    print("OCS config:", json.dumps(config, sort_keys=True))
+    ema_strategy()

--- a/test/test_openalgo_config.py
+++ b/test/test_openalgo_config.py
@@ -1,0 +1,329 @@
+import json
+import logging
+
+import pytest
+
+from openalgo_config import (
+    ConfigStore,
+    OCSValidationError,
+    build_runtime_config,
+    normalize_schema,
+    validate_values,
+)
+
+
+def test_normalize_schema_and_validate_values_coerces_supported_types():
+    schema = normalize_schema(
+        {
+            "strategy": "ema",
+            "fields": [
+                {"key": "symbol", "type": "symbol", "default": "RELIANCE"},
+                {"key": "fast_ema", "type": "int", "default": 9, "min": 1, "max": 200},
+                {"key": "risk", "type": "float", "default": 1.5, "min": 0.1},
+                {"key": "enabled", "type": "bool", "default": True},
+                {"key": "exchange", "type": "exchange", "default": "NSE", "options": ["NSE", "MCX"]},
+            ],
+        },
+        "ema",
+    )
+
+    values = validate_values(
+        schema,
+        {
+            "symbol": "SBIN",
+            "fast_ema": "21",
+            "risk": "2.25",
+            "enabled": "true",
+            "exchange": "MCX",
+        },
+    )
+
+    assert values == {
+        "symbol": "SBIN",
+        "fast_ema": 21,
+        "risk": 2.25,
+        "enabled": True,
+        "exchange": "MCX",
+    }
+
+
+def test_validate_values_rejects_unknown_and_out_of_range_values():
+    schema = normalize_schema(
+        {
+            "fields": [
+                {"key": "quantity", "type": "quantity", "default": 1, "min": 1, "max": 10},
+            ],
+        }
+    )
+
+    with pytest.raises(OCSValidationError) as exc:
+        validate_values(schema, {"quantity": 20, "extra": "nope"})
+
+    fields = {error["field"] for error in exc.value.errors}
+    assert fields == {"quantity", "extra"}
+
+
+def test_validate_values_preserves_select_option_value_types():
+    numeric_schema = normalize_schema(
+        {"fields": [{"key": "mode", "type": "select", "options": [1, 2]}]}
+    )
+    bool_schema = normalize_schema(
+        {"fields": [{"key": "enabled_mode", "type": "select", "options": [True, False]}]}
+    )
+    multi_schema = normalize_schema(
+        {"fields": [{"key": "legs", "type": "multi_select", "options": [1, 2]}]}
+    )
+
+    assert validate_values(numeric_schema, {"mode": "1"}) == {"mode": 1}
+    assert validate_values(bool_schema, {"enabled_mode": "true"}) == {"enabled_mode": True}
+    assert validate_values(multi_schema, {"legs": ["1", 2]}) == {"legs": [1, 2]}
+
+
+def test_validate_values_applies_regex_after_select_option_match():
+    schema = normalize_schema(
+        {
+            "fields": [
+                {
+                    "key": "code",
+                    "type": "select",
+                    "options": ["ABC", "abc"],
+                    "regex": "^[A-Z]+$",
+                }
+            ]
+        }
+    )
+
+    assert validate_values(schema, {"code": "ABC"}) == {"code": "ABC"}
+    with pytest.raises(OCSValidationError) as exc:
+        validate_values(schema, {"code": "abc"})
+
+    assert exc.value.errors[0]["field"] == "code"
+
+
+def test_normalize_schema_rejects_invalid_regex():
+    with pytest.raises(OCSValidationError) as exc:
+        normalize_schema(
+            {
+                "fields": [
+                    {
+                        "key": "code",
+                        "type": "select",
+                        "options": ["ABC"],
+                        "regex": "[",
+                    }
+                ]
+            }
+        )
+
+    assert exc.value.errors[0]["field"] == "fields[0].regex"
+
+
+def test_validate_values_wraps_persisted_invalid_regex():
+    with pytest.raises(OCSValidationError) as exc:
+        validate_values(
+            {
+                "fields": [
+                    {
+                        "key": "code",
+                        "type": "select",
+                        "options": ["ABC"],
+                        "regex": "[",
+                    }
+                ]
+            },
+            {"code": "ABC"},
+        )
+
+    assert exc.value.errors[0]["field"] == "fields[0].regex"
+
+
+def test_config_store_persists_schema_and_values(tmp_path):
+    store = ConfigStore(tmp_path)
+    schema = store.save_schema(
+        "ema_20260627",
+        {
+            "fields": [
+                {"key": "fast", "type": "int", "default": 9},
+                {"key": "slow", "type": "int", "default": 21},
+            ],
+        },
+    )
+    values = store.save_values("ema_20260627", {"fast": "13"})
+
+    assert schema["fields"][0]["key"] == "fast"
+    assert values == {"fast": 13, "slow": 21}
+    assert build_runtime_config(store, "ema_20260627") == {"fast": 13, "slow": 21}
+
+
+def test_config_store_prunes_stale_values_when_schema_changes(tmp_path):
+    store = ConfigStore(tmp_path)
+    store.save_schema(
+        "ema_20260627",
+        {"fields": [{"key": "fast", "type": "int", "default": 9}]},
+    )
+    store.save_values("ema_20260627", {"fast": "13"})
+
+    store.save_schema(
+        "ema_20260627",
+        {"fields": [{"key": "slow", "type": "int", "default": 21}]},
+    )
+
+    assert store.get_values("ema_20260627") == {"slow": 21}
+
+
+def test_config_store_saves_schema_when_required_field_has_no_default(tmp_path):
+    store = ConfigStore(tmp_path)
+    schema = store.save_schema(
+        "required_20260627",
+        {"fields": [{"key": "symbol", "type": "symbol", "required": True}]},
+    )
+
+    assert schema["fields"][0]["key"] == "symbol"
+    assert store.get_values("required_20260627", allow_invalid=True) == {}
+    with pytest.raises(OCSValidationError):
+        store.get_values("required_20260627")
+
+
+def test_python_strategy_injects_ocs_environment(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+    monkeypatch.setenv("LOG_FORMAT", "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from blueprints import python_strategy as ps
+
+    store = ConfigStore(tmp_path)
+    store.save_schema(
+        "ema_20260627",
+        {
+            "fields": [
+                {"key": "symbol", "type": "symbol", "default": "RELIANCE"},
+                {"key": "fast", "type": "int", "default": 9},
+            ],
+        },
+    )
+    store.save_values("ema_20260627", {"symbol": "SBIN", "fast": "13"})
+    monkeypatch.setattr(ps, "OCS_STORE", store)
+
+    env = {}
+    ps.inject_ocs_environment(env, "ema_20260627")
+
+    assert json.loads(env["OPENALGO_CONFIG_JSON"]) == {"symbol": "SBIN", "fast": 13}
+    assert json.loads(env["OPENALGO_CONFIG_SCHEMA_JSON"])["strategy"] == "ema_20260627"
+    assert env["OPENALGO_CONFIG_SYMBOL"] == "SBIN"
+    assert env["OPENALGO_CONFIG_FAST"] == "13"
+
+
+def test_python_strategy_config_response_values_keep_draft_when_runtime_invalid(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+    monkeypatch.setenv("LOG_FORMAT", "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from blueprints import python_strategy as ps
+
+    store = ConfigStore(tmp_path)
+    store.save_schema(
+        "required_20260627",
+        {"fields": [{"key": "symbol", "type": "symbol", "required": True}]},
+    )
+    monkeypatch.setattr(ps, "OCS_STORE", store)
+
+    values, resolved_values, validation_errors = ps._build_ocs_config_response_values(
+        "required_20260627"
+    )
+
+    assert values == {}
+    assert resolved_values == values
+    assert validation_errors[0]["field"] == "symbol"
+
+
+def test_python_strategy_syncs_embedded_default_ocs_schema(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+    monkeypatch.setenv("LOG_FORMAT", "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from blueprints import python_strategy as ps
+
+    strategy_file = tmp_path / "ema.py"
+    monkeypatch.setattr(ps, "STRATEGIES_DIR", tmp_path)
+    strategy_file.write_text(
+        """
+DEFAULT_OCS_SCHEMA = {
+    "strategy": "ema",
+    "fields": [
+        {"key": "symbol", "type": "symbol", "default": "NHPC"},
+        {"key": "fast_period", "type": "int", "default": 5},
+    ],
+}
+
+print("trading code must not execute during schema extraction")
+""",
+        encoding="utf-8",
+    )
+
+    store = ConfigStore(tmp_path / "configs")
+    monkeypatch.setattr(ps, "OCS_STORE", store)
+
+    schema = ps.sync_ocs_schema_from_strategy_file(
+        "ema_20260627", {"file_path": str(strategy_file)}
+    )
+
+    assert schema is not None
+    assert [field["key"] for field in schema["fields"]] == ["symbol", "fast_period"]
+    assert store.get_values("ema_20260627") == {"symbol": "NHPC", "fast_period": 5}
+
+
+def test_python_strategy_syncs_ui_declarations(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+    monkeypatch.setenv("LOG_FORMAT", "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from blueprints import python_strategy as ps
+
+    strategy_file = tmp_path / "ui_ema.py"
+    monkeypatch.setattr(ps, "STRATEGIES_DIR", tmp_path)
+    strategy_file.write_text(
+        """
+from openalgo_config import ui
+
+ignored_symbol = ui.symbol(default="IGNORED", label="Ignored Symbol")
+symbol = ui.symbol("symbol", default="NHPC", label="Symbol", required=True)
+ignored_fast = ui.int(default=3, label="Ignored Fast EMA")
+fast_period = ui.int("fast_period", default=5, min=1, max=200, label="Fast EMA")
+debug = ui.bool("debug", default=False)
+""",
+        encoding="utf-8",
+    )
+
+    store = ConfigStore(tmp_path / "configs")
+    monkeypatch.setattr(ps, "OCS_STORE", store)
+
+    schema = ps.sync_ocs_schema_from_strategy_file(
+        "ui_ema_20260627", {"file_path": str(strategy_file)}
+    )
+
+    assert schema is not None
+    assert [field["key"] for field in schema["fields"]] == [
+        "symbol",
+        "fast_period",
+        "debug",
+    ]
+    assert store.get_values("ui_ema_20260627") == {
+        "symbol": "NHPC",
+        "fast_period": 5,
+        "debug": False,
+    }
+
+
+def test_python_strategy_ignores_empty_or_directory_file_path(tmp_path, monkeypatch):
+    monkeypatch.setattr(logging, "raiseExceptions", False)
+    monkeypatch.setenv("LOG_FORMAT", "[%(asctime)s] %(levelname)s in %(module)s: %(message)s")
+    monkeypatch.setenv("DATABASE_URL", "sqlite:///:memory:")
+
+    from blueprints import python_strategy as ps
+
+    monkeypatch.setattr(ps, "STRATEGIES_DIR", tmp_path / "strategies" / "scripts")
+    ps.STRATEGIES_DIR.mkdir(parents=True)
+
+    assert ps.get_valid_strategy_file_path({"file_path": ""}) is None
+    assert ps.get_valid_strategy_file_path({"file_path": "."}) is None
+    assert ps.sync_ocs_schema_from_strategy_file("legacy", {"file_path": ""}) is None

--- a/test/test_python_strategy_edge_cases.py
+++ b/test/test_python_strategy_edge_cases.py
@@ -486,10 +486,12 @@ def test_subprocess_env_includes_strategy_exchange(ps_module, monkeypatch, tmp_p
     }
 
     captured_env = {}
+    captured_cwd = {}
 
     class FakeProc:
         def __init__(self, *a, **kw):
             captured_env.update(kw.get("env") or {})
+            captured_cwd["cwd"] = kw.get("cwd")
             self.pid = 12345
             self._stdout = a
 
@@ -507,6 +509,35 @@ def test_subprocess_env_includes_strategy_exchange(ps_module, monkeypatch, tmp_p
     assert captured_env.get("OPENALGO_STRATEGY_EXCHANGE") == "MCX"
     assert captured_env.get("STRATEGY_ID") == "envtest"
     assert captured_env.get("STRATEGY_NAME") == "EnvTest"
+    assert str(ps_module.APP_ROOT) in captured_env.get("PYTHONPATH", "").split(os.pathsep)
+    assert captured_cwd["cwd"] == str(ps_module.APP_ROOT)
+
+
+def test_ensure_directories_moves_ocs_store_with_temp_fallback(ps_module, monkeypatch, tmp_path):
+    """Permission fallback relocates OCS config storage with strategy files."""
+    from openalgo_config import ConfigStore
+
+    original_mkdir = Path.mkdir
+    blocked_strategies_dir = tmp_path / "blocked" / "strategies"
+    blocked_logs_dir = tmp_path / "blocked" / "logs"
+
+    ps_module.STRATEGIES_DIR = blocked_strategies_dir
+    ps_module.LOGS_DIR = blocked_logs_dir
+    ps_module.OCS_STORE = ConfigStore(tmp_path / "blocked" / "configs")
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == blocked_strategies_dir:
+            raise PermissionError("blocked")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    ps_module.ensure_directories()
+
+    temp_base = Path(tempfile.gettempdir()) / "openalgo"
+    assert ps_module.STRATEGIES_DIR == temp_base / "strategies" / "scripts"
+    assert ps_module.LOGS_DIR == temp_base / "log" / "strategies"
+    assert ps_module.OCS_STORE.base_dir == temp_base / "strategies" / "configs"
 
 
 def test_ensure_directories_moves_ocs_store_with_temp_fallback(ps_module, monkeypatch, tmp_path):

--- a/test/test_python_strategy_edge_cases.py
+++ b/test/test_python_strategy_edge_cases.py
@@ -13,7 +13,9 @@ Run:
 import json
 import os
 import sys
+import tempfile
 from datetime import date, datetime
+from pathlib import Path
 from unittest.mock import patch
 
 import pytest
@@ -474,6 +476,7 @@ def test_subprocess_env_includes_strategy_exchange(ps_module, monkeypatch, tmp_p
     # Build a noop strategy file
     strat = tmp_path / "noop.py"
     strat.write_text("import sys; sys.exit(0)\n")
+    monkeypatch.setattr(ps_module, "STRATEGIES_DIR", tmp_path)
 
     ps_module.STRATEGY_CONFIGS["envtest"] = {
         "name": "EnvTest",
@@ -504,6 +507,33 @@ def test_subprocess_env_includes_strategy_exchange(ps_module, monkeypatch, tmp_p
     assert captured_env.get("OPENALGO_STRATEGY_EXCHANGE") == "MCX"
     assert captured_env.get("STRATEGY_ID") == "envtest"
     assert captured_env.get("STRATEGY_NAME") == "EnvTest"
+
+
+def test_ensure_directories_moves_ocs_store_with_temp_fallback(ps_module, monkeypatch, tmp_path):
+    """Permission fallback relocates OCS config storage with strategy files."""
+    from openalgo_config import ConfigStore
+
+    original_mkdir = Path.mkdir
+    blocked_strategies_dir = tmp_path / "blocked" / "strategies"
+    blocked_logs_dir = tmp_path / "blocked" / "logs"
+
+    ps_module.STRATEGIES_DIR = blocked_strategies_dir
+    ps_module.LOGS_DIR = blocked_logs_dir
+    ps_module.OCS_STORE = ConfigStore(tmp_path / "blocked" / "configs")
+
+    def fake_mkdir(self, *args, **kwargs):
+        if self == blocked_strategies_dir:
+            raise PermissionError("blocked")
+        return original_mkdir(self, *args, **kwargs)
+
+    monkeypatch.setattr(Path, "mkdir", fake_mkdir)
+
+    ps_module.ensure_directories()
+
+    temp_base = Path(tempfile.gettempdir()) / "openalgo"
+    assert ps_module.STRATEGIES_DIR == temp_base / "strategies" / "scripts"
+    assert ps_module.LOGS_DIR == temp_base / "log" / "strategies"
+    assert ps_module.OCS_STORE.base_dir == temp_base / "strategies" / "configs"
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Introduces the OpenAlgo Configuration SDK (OCS) for Python so strategies declare inputs once and manage them via a generated UI. Values are validated, persisted, and injected at runtime so strategies run without source edits; also fixes strategy subprocess working directory and import path for reliable execution.

- New Features
  - Adds `openalgo_config` for schema normalize/validate and JSON persistence under `strategies/configs/`.
  - Discovers fields via static AST from `ui.*` calls (`from openalgo_config import ui`) or literal `DEFAULT_OCS_SCHEMA`/`OCS_SCHEMA`.
  - Injects `OPENALGO_CONFIG_JSON`, `OPENALGO_CONFIG_SCHEMA_JSON`, and `OPENALGO_CONFIG_<KEY>` env vars into strategy processes.
  - Endpoints: `GET /python/api/config/:id`, `POST /python/api/config/:id/schema`, `POST /python/api/config/:id/values`, `POST /python/api/config/validate`.
  - New React page at `/python/:strategyId/config` with form and raw schema editor; index shows config field counts and adds a Config action; upload response includes `has_config_schema` and `config_field_count` and auto-navigates to config when fields exist.
  - Blocks schema/value edits while running; deletes per-strategy schema/values on strategy delete; safer strategy file-path validation and temp fallback also relocate the OCS store.
  - Optional frontend auto-build (`OPENALGO_AUTO_BUILD_FRONTEND=true`) runs as a startup daemon; routes are available even if `frontend/dist` is missing.
  - Validation: preserves option value types, merges schema defaults, unified error responses, number inputs allow in-progress values, validates regex syntax in schemas, and applies regex after select option matching.
  - Strategy subprocesses start in the app root and include the app root on `PYTHONPATH` so uploaded scripts can import app-local packages.
  - Adds docs for OCS and an example strategy using `ui.*`.

- Migration
  - New strategies: `from openalgo_config import ui`; e.g. `symbol = ui.symbol(default="RELIANCE")`, `fast = ui.int("fast", default=9)`.
  - Existing strategies: add a `DEFAULT_OCS_SCHEMA` dict or author the schema from the config page.
  - Stop the strategy before changing its schema or values.

<sup>Written for commit 41207d924b02f8ad62f3506b8a4fb35c508b38ed. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1585?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

