### PR TITLE
Use time.perf_counter() instead of time.time() for relative time calculations

### DIFF
--- a/app.py
+++ b/app.py
@@ -674,7 +674,7 @@ def setup_environment(app):
                 ("Strategy Portfolio DB", ensure_strategy_portfolio_tables_exists),
             ]
 
-            db_init_start = time.time()
+            db_init_start = time.perf_counter()
             with ThreadPoolExecutor(max_workers=15) as executor:
                 futures = {executor.submit(func): name for name, func in db_init_functions}
                 for future in as_completed(futures):
@@ -684,7 +684,7 @@ def setup_environment(app):
                     except Exception as e:
                         logger.error(f"Failed to initialize {db_name}: {e}")
 
-            db_init_time = (time.time() - db_init_start) * 1000
+            db_init_time = (time.perf_counter() - db_init_start) * 1000
             logger.debug(f"All databases initialized in parallel ({db_init_time:.0f}ms)")
 
             # Signal that DB tables are ready (unblocks cache restoration)

--- a/benchmark_api.py
+++ b/benchmark_api.py
@@ -36,9 +36,9 @@ ENDPOINTS = {
 
 
 def call(path, body):
-    t0 = time.time()
+    t0 = time.perf_counter()
     r = client.post(f"{BASE}/{path}", json={"apikey": APIKEY, **body})
-    dt = (time.time() - t0) * 1000
+    dt = (time.perf_counter() - t0) * 1000
     ok = False
     try:
         ok = r.status_code == 200 and r.json().get("status") == "success"
@@ -65,12 +65,12 @@ SAMPLES = {"intervals": 30, "quotes": 10, "history": 10, "multiquotes": 8}
 for ep, body in ENDPOINTS.items():
     n = SAMPLES[ep]
     times, ok = [], 0
-    t0 = time.time()
+    t0 = time.perf_counter()
     for _ in range(n):
         code, dt, good = call(ep, body)
         times.append(dt)
         ok += good
-    wall = time.time() - t0
+    wall = time.perf_counter() - t0
     print(f"  {ep:<14} {min(times):7.1f} {pct(times,50):7.1f} {pct(times,95):7.1f} "
           f"{pct(times,99):7.1f} {max(times):7.1f}  {ok:>2}/{n:<2}  {n/wall:5.2f}/s")
 
@@ -90,12 +90,12 @@ def burst(n):
             res[i] = "ERR"
 
     ts = [threading.Thread(target=fire, args=(i,)) for i in range(n)]
-    t0 = time.time()
+    t0 = time.perf_counter()
     for t in ts:
         t.start()
     for t in ts:
         t.join()
-    wall = time.time() - t0
+    wall = time.perf_counter() - t0
     ok = sum(1 for c in res if c == 200)
     rl = sum(1 for c in res if c == 429)
     other = sorted({str(c) for c in res if c not in (200, 429)})

--- a/broker/definedge/streaming/definedge_websocket.py
+++ b/broker/definedge/streaming/definedge_websocket.py
@@ -142,8 +142,8 @@ class DefinedGeWebSocket:
 
             # Wait for connection
             timeout = 10
-            start_time = time.time()
-            while not self.connected and (time.time() - start_time) < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and (time.perf_counter() - start_time) < timeout:
                 time.sleep(0.1)
 
             if not self.connected:

--- a/broker/dhan_sandbox/streaming/dhan_adapter.py
+++ b/broker/dhan_sandbox/streaming/dhan_adapter.py
@@ -1155,8 +1155,8 @@ class DhanWebSocketAdapter(BaseBrokerWebSocketAdapter):
                             self.subscribe(symbol, mode=mode)
 
                         # Wait for some ticks
-                        start_time = time.time()
-                        while time.time() - start_time < timeout / 4:  # Divide timeout by modes
+                        start_time = time.perf_counter()
+                        while time.perf_counter() - start_time < timeout / 4:  # Divide timeout by modes
                             if results["ticks_received"] > 0:
                                 self.logger.info(
                                     f"Received {results['ticks_received']} ticks for mode {mode}"

--- a/broker/dhan_sandbox/streaming/dhan_websocket.py
+++ b/broker/dhan_sandbox/streaming/dhan_websocket.py
@@ -139,8 +139,8 @@ class DhanWebSocket:
 
     def wait_for_connection(self, timeout: float = 5.0) -> bool:
         """Wait for WebSocket connection to be established"""
-        start_time = time.time()
-        while not self.connected and time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while not self.connected and time.perf_counter() - start_time < timeout:
             time.sleep(0.1)
         return self.connected
 
@@ -478,8 +478,8 @@ class DhanWebSocket:
                 logger.info(f"Waiting {sleep_time:.1f} seconds before next reconnection attempt...")
 
                 # Sleep with periodic checks for shutdown
-                start_time = time.time()
-                while time.time() - start_time < sleep_time:
+                start_time = time.perf_counter()
+                while time.perf_counter() - start_time < sleep_time:
                     if not self.running:
                         logger.info("Stopping reconnection attempts - client is shutting down")
                         return

--- a/broker/flattrade/api/data.py
+++ b/broker/flattrade/api/data.py
@@ -488,7 +488,7 @@ class BrokerData:
             return skipped_symbols
 
         # Step 2: Make concurrent API calls
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Runtime check: even if USE_ASYNC is True, asyncio.run() will crash
         # if called from within an already-running event loop
@@ -533,7 +533,7 @@ class BrokerData:
                             }
                         )
 
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
         logger.debug(
             f"Batch of {len(prepared_symbols)} symbols completed in {elapsed:.2f}s ({len(prepared_symbols) / max(elapsed, 0.001):.1f} symbols/sec)"
         )

--- a/broker/flattrade/streaming/flattrade_websocket.py
+++ b/broker/flattrade/streaming/flattrade_websocket.py
@@ -128,9 +128,9 @@ class FlattradeWebSocket:
         Returns:
             bool: True if connected within timeout, False otherwise
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
 
-        while time.time() - start_time < self.CONNECTION_TIMEOUT:
+        while time.perf_counter() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("WebSocket connected successfully")
                 return True

--- a/broker/fyers/streaming/fyers_adapter.py
+++ b/broker/fyers/streaming/fyers_adapter.py
@@ -108,8 +108,8 @@ class FyersAdapter:
 
             # Wait for authentication
             timeout = 15
-            start_time = time.time()
-            while not self.ws_client.is_connected() and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.ws_client.is_connected() and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if self.ws_client.is_connected():

--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -871,8 +871,8 @@ class FyersHSMWebSocket:
 
         # Wait for initial connection
         timeout = 15
-        start_time = time.time()
-        while not self.connected and time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while not self.connected and time.perf_counter() - start_time < timeout:
             if not self.running:
                 break
             time.sleep(0.1)
@@ -1070,8 +1070,8 @@ class FyersHSMWebSocket:
 
             # Wait for authentication
             timeout = 10
-            start_time = time.time()
-            while not self.authenticated and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.authenticated and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.authenticated:

--- a/broker/fyers/streaming/fyers_tbt_websocket.py
+++ b/broker/fyers/streaming/fyers_tbt_websocket.py
@@ -143,8 +143,8 @@ class FyersTbtWebSocket:
 
             # Wait for connection
             timeout = 15
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             return self.connected

--- a/broker/groww/api/data.py
+++ b/broker/groww/api/data.py
@@ -1176,7 +1176,7 @@ class BrokerData:
                     f"Requesting quote for {trading_symbol} on {groww_exchange} (segment: {segment})"
                 )
                 # Make direct API call to Groww quotes endpoint
-                start_time = time.time()
+                start_time = time.perf_counter()
 
                 # Safely convert values to float/int, handling None values
                 def safe_float(value, default=0.0):
@@ -1216,7 +1216,7 @@ class BrokerData:
                     )
 
                     logger.info(f"Groww API response: {response}")
-                    elapsed = time.time() - start_time
+                    elapsed = time.perf_counter() - start_time
                     logger.info(f"Got response from Groww API in {elapsed:.2f}s")
 
                     if response and not response.get("error"):

--- a/broker/groww/streaming/nats_websocket.py
+++ b/broker/groww/streaming/nats_websocket.py
@@ -144,8 +144,8 @@ class GrowwNATSWebSocket:
 
             # Wait for connection
             timeout = 10
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.connected:
@@ -153,8 +153,8 @@ class GrowwNATSWebSocket:
 
             # Wait for authentication
             timeout = 3
-            start_time = time.time()
-            while not self.authenticated and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.authenticated and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.authenticated:

--- a/broker/iiflcapital/streaming/iiflcapital_websocket.py
+++ b/broker/iiflcapital/streaming/iiflcapital_websocket.py
@@ -372,8 +372,8 @@ class IiflcapitalWebSocket:
         self.connected = False
 
     def wait_for_connection(self, timeout: float = 15.0) -> bool:
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline:
             if self.connected:
                 return True
             if self._fatal_error:

--- a/broker/pocketful/api/data.py
+++ b/broker/pocketful/api/data.py
@@ -801,14 +801,14 @@ class BrokerData:
         max_wait_time = min(
             max(num_instruments * 0.5, 3), 15
         )  # Between 3-15 seconds based on instrument count
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         logger.debug(
             f"Collecting data for up to {max_wait_time:.1f}s for {num_instruments} instruments..."
         )
 
         # Read continuously until we have all data or timeout
-        while time.time() - start_time < max_wait_time:
+        while time.perf_counter() - start_time < max_wait_time:
             detailed_data = self.ws_connection.read_detailed_marketdata()
 
             if detailed_data and isinstance(detailed_data, dict):

--- a/broker/samco/streaming/samcoWebSocket.py
+++ b/broker/samco/streaming/samcoWebSocket.py
@@ -207,9 +207,9 @@ class SamcoWebSocket:
 
     def _wait_for_connection(self) -> bool:
         """Wait for WebSocket connection to be established"""
-        start_time = time.time()
+        start_time = time.perf_counter()
 
-        while time.time() - start_time < self.CONNECTION_TIMEOUT:
+        while time.perf_counter() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("Samco WebSocket connected successfully")
                 return True

--- a/broker/shoonya/api/data.py
+++ b/broker/shoonya/api/data.py
@@ -413,7 +413,7 @@ class BrokerData:
             return skipped_symbols
 
         # Step 2: Make concurrent API calls
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Runtime check: even if USE_ASYNC is True, asyncio.run() will crash
         # if called from within an already-running event loop
@@ -458,7 +458,7 @@ class BrokerData:
                             }
                         )
 
-        elapsed = time.time() - start_time
+        elapsed = time.perf_counter() - start_time
         logger.debug(
             f"Batch of {len(prepared_symbols)} symbols completed in {elapsed:.2f}s ({len(prepared_symbols) / max(elapsed, 0.001):.1f} symbols/sec)"
         )

--- a/broker/shoonya/streaming/shoonya_websocket.py
+++ b/broker/shoonya/streaming/shoonya_websocket.py
@@ -176,9 +176,9 @@ class ShoonyaWebSocket:
             bool: True if connected within timeout, False otherwise
         """
         # Phase 8: interruptible poll. Bail immediately if shutdown is signaled.
-        start_time = time.time()
+        start_time = time.perf_counter()
 
-        while self.running and time.time() - start_time < self.CONNECTION_TIMEOUT:
+        while self.running and time.perf_counter() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("WebSocket connected successfully")
                 return True

--- a/broker/tradesmart/streaming/tradesmart_websocket.py
+++ b/broker/tradesmart/streaming/tradesmart_websocket.py
@@ -99,8 +99,8 @@ class TradeSmartWebSocket:
         self.ws_thread.start()
 
     def _wait_for_connection(self) -> bool:
-        start_time = time.time()
-        while time.time() - start_time < self.CONNECTION_TIMEOUT:
+        start_time = time.perf_counter()
+        while time.perf_counter() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("WebSocket connected successfully")
                 return True

--- a/broker/zebu/streaming/zebu_websocket.py
+++ b/broker/zebu/streaming/zebu_websocket.py
@@ -134,9 +134,9 @@ class ZebuWebSocket:
         Returns:
             bool: True if connected within timeout, False otherwise
         """
-        start_time = time.time()
+        start_time = time.perf_counter()
 
-        while time.time() - start_time < self.CONNECTION_TIMEOUT:
+        while time.perf_counter() - start_time < self.CONNECTION_TIMEOUT:
             if self.connected:
                 self.logger.info("WebSocket connected successfully")
                 return True

--- a/database/cache_restoration.py
+++ b/database/cache_restoration.py
@@ -43,7 +43,7 @@ def restore_symbol_cache() -> dict:
     """
     result = {"success": False, "symbols_loaded": 0, "broker": None, "time_ms": 0, "error": None}
 
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     try:
         from database.auth_db import Auth
@@ -67,7 +67,7 @@ def restore_symbol_cache() -> dict:
         if cache.cache_loaded and cache.stats.total_symbols > 0:
             result["success"] = True
             result["symbols_loaded"] = cache.stats.total_symbols
-            result["time_ms"] = (time.time() - start_time) * 1000
+            result["time_ms"] = (time.perf_counter() - start_time) * 1000
             logger.debug(f"Symbol cache already loaded: {cache.stats.total_symbols} symbols")
             return result
 
@@ -79,7 +79,7 @@ def restore_symbol_cache() -> dict:
             result["symbols_loaded"] = cache.stats.total_symbols
             logger.debug(
                 f"Symbol cache restored: {cache.stats.total_symbols} symbols "
-                f"for broker '{broker}' in {(time.time() - start_time) * 1000:.0f}ms"
+                f"for broker '{broker}' in {(time.perf_counter() - start_time) * 1000:.0f}ms"
             )
         else:
             result["error"] = "Failed to load symbols from database"
@@ -89,7 +89,7 @@ def restore_symbol_cache() -> dict:
         result["error"] = str(e)
         logger.exception(f"Error restoring symbol cache: {e}")
 
-    result["time_ms"] = (time.time() - start_time) * 1000
+    result["time_ms"] = (time.perf_counter() - start_time) * 1000
     return result
 
 
@@ -110,7 +110,7 @@ def restore_auth_cache() -> dict:
     """
     result = {"success": False, "tokens_loaded": 0, "users": [], "time_ms": 0, "error": None}
 
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     try:
         from database.auth_db import Auth, auth_cache, broker_cache, feed_token_cache
@@ -161,7 +161,7 @@ def restore_auth_cache() -> dict:
         result["error"] = str(e)
         logger.exception(f"Error restoring auth cache: {e}")
 
-    result["time_ms"] = (time.time() - start_time) * 1000
+    result["time_ms"] = (time.perf_counter() - start_time) * 1000
     return result
 
 
@@ -181,7 +181,7 @@ def restore_all_caches() -> dict:
     """
     logger.debug("Starting cache restoration from database...")
 
-    total_start = time.time()
+    total_start = time.perf_counter()
 
     result = {"success": False, "symbol_cache": None, "auth_cache": None, "total_time_ms": 0}
 
@@ -192,7 +192,7 @@ def restore_all_caches() -> dict:
     result["symbol_cache"] = restore_symbol_cache()
 
     # Calculate totals
-    result["total_time_ms"] = (time.time() - total_start) * 1000
+    result["total_time_ms"] = (time.perf_counter() - total_start) * 1000
 
     # Success if at least one cache was restored
     result["success"] = result["auth_cache"].get("success", False) or result["symbol_cache"].get(

--- a/database/master_contract_cache_hook.py
+++ b/database/master_contract_cache_hook.py
@@ -24,7 +24,7 @@ def load_symbols_to_cache(broker: str) -> bool:
     """
     try:
         logger.info(f"Starting cache load for broker: {broker}")
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         # Import the enhanced token_db module
         from database.token_db_enhanced import get_cache_stats, load_cache_for_broker
@@ -33,7 +33,7 @@ def load_symbols_to_cache(broker: str) -> bool:
         success = load_cache_for_broker(broker)
 
         if success:
-            load_time = time.time() - start_time
+            load_time = time.perf_counter() - start_time
             stats = get_cache_stats()
 
             logger.info(

--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -186,7 +186,7 @@ class BrokerSymbolCache:
         try:
             from database.symbol import SymToken
 
-            start_time = time.time()
+            start_time = time.perf_counter()
             logger.debug(f"Loading all symbols for broker: {broker}")
 
             # Clear existing cache
@@ -291,7 +291,7 @@ class BrokerSymbolCache:
                 len(self.symbols) * 500  # ~500 bytes per symbol
             ) / (1024 * 1024)
 
-            load_time = time.time() - start_time
+            load_time = time.perf_counter() - start_time
             logger.debug(
                 f"Successfully loaded {self.stats.total_symbols} symbols "
                 f"in {load_time:.2f} seconds. "

--- a/examples/python/test_2340_symbols.py
+++ b/examples/python/test_2340_symbols.py
@@ -99,9 +99,9 @@ def main():
 
     # Monitor for 30 seconds
     print("\nMonitoring for 30 seconds...")
-    monitor_start = time.time()
+    monitor_start = time.perf_counter()
 
-    while time.time() - monitor_start < 30:
+    while time.perf_counter() - monitor_start < 30:
         time.sleep(5)
         with stats["lock"]:
             print(

--- a/services/websocket_client.py
+++ b/services/websocket_client.py
@@ -102,8 +102,8 @@ class WebSocketClient:
 
             # Wait for connection
             timeout = 10
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.connected:
@@ -111,8 +111,8 @@ class WebSocketClient:
                 return False
 
             # Wait for authentication
-            start_time = time.time()
-            while not self.authenticated and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.authenticated and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.authenticated:

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ echo "[OpenAlgo] Starting up..."
 # ============================================
 
 # Determine writable .env location
-ENV_FILE="/app/.env"
+ENV_FILE="./.env"
 
 # Check if .env exists, is readable, and has content (not empty)
 if [ -f "$ENV_FILE" ] && [ -r "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then

--- a/start.sh
+++ b/start.sh
@@ -6,7 +6,7 @@ echo "[OpenAlgo] Starting up..."
 # ============================================
 
 # Determine writable .env location
-ENV_FILE="./.env"
+ENV_FILE="/app/.env"
 
 # Check if .env exists, is readable, and has content (not empty)
 if [ -f "$ENV_FILE" ] && [ -r "$ENV_FILE" ] && [ -s "$ENV_FILE" ]; then

--- a/test/ltp_example_test_1800 symbols.py
+++ b/test/ltp_example_test_1800 symbols.py
@@ -288,14 +288,14 @@ def main():
         print("🛑 Press Ctrl+C to stop\n")
 
         # Monitor with longer intervals for 1800 symbols
-        test_start_time = time.time()
+        test_start_time = time.perf_counter()
 
         while True:
             time.sleep(15)  # Print stats every 15 seconds for high volume
             print_statistics()
 
             # Check if we're receiving data
-            if update_count == 0 and time.time() - test_start_time > 60:
+            if update_count == 0 and time.perf_counter() - test_start_time > 60:
                 print("⚠️ No data received for 60 seconds.")
                 print("💡 This might be normal if market is closed or during low activity periods.")
 
@@ -304,7 +304,7 @@ def main():
                     response = input("Continue waiting? (y/n): ").lower().strip()
                     if response != "y":
                         break
-                    test_start_time = time.time()  # Reset timer
+                    test_start_time = time.perf_counter()  # Reset timer
                 except Exception:
                     break
 
@@ -319,7 +319,7 @@ def main():
 
     finally:
         print("\n🧹 Cleaning up...")
-        cleanup_start = time.time()
+        cleanup_start = time.perf_counter()
 
         try:
             print("📡 Unsubscribing from all symbols...")
@@ -335,7 +335,7 @@ def main():
         except Exception as e:
             print(f"❌ Error during disconnect: {e}")
 
-        cleanup_time = time.time() - cleanup_start
+        cleanup_time = time.perf_counter() - cleanup_start
 
         # Final comprehensive statistics
         print("\n" + "=" * 80)

--- a/test/simple_depth_test.py
+++ b/test/simple_depth_test.py
@@ -86,8 +86,8 @@ class SimpleFeed:
 
             # Wait for connection to establish
             timeout = 5
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.connected:
@@ -106,8 +106,8 @@ class SimpleFeed:
             self.ws.close()
             # Wait for websocket to close
             timeout = 2
-            start_time = time.time()
-            while self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
             self.ws = None
 
@@ -125,8 +125,8 @@ class SimpleFeed:
 
         # Wait for authentication response synchronously
         timeout = 5
-        start_time = time.time()
-        while not self.authenticated and time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while not self.authenticated and time.perf_counter() - start_time < timeout:
             # Process any messages in the queue
             try:
                 if not self.message_queue.empty():

--- a/test/simple_ltp_test.py
+++ b/test/simple_ltp_test.py
@@ -86,8 +86,8 @@ class SimpleFeed:
 
             # Wait for connection to establish
             timeout = 5
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.connected:
@@ -106,8 +106,8 @@ class SimpleFeed:
             self.ws.close()
             # Wait for websocket to close
             timeout = 2
-            start_time = time.time()
-            while self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
             self.ws = None
 
@@ -125,8 +125,8 @@ class SimpleFeed:
 
         # Wait for authentication response synchronously
         timeout = 5
-        start_time = time.time()
-        while not self.authenticated and time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while not self.authenticated and time.perf_counter() - start_time < timeout:
             # Process any messages in the queue
             try:
                 if not self.message_queue.empty():

--- a/test/simple_quote_test.py
+++ b/test/simple_quote_test.py
@@ -86,8 +86,8 @@ class SimpleFeed:
 
             # Wait for connection to establish
             timeout = 5
-            start_time = time.time()
-            while not self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while not self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
 
             if not self.connected:
@@ -106,8 +106,8 @@ class SimpleFeed:
             self.ws.close()
             # Wait for websocket to close
             timeout = 2
-            start_time = time.time()
-            while self.connected and time.time() - start_time < timeout:
+            start_time = time.perf_counter()
+            while self.connected and time.perf_counter() - start_time < timeout:
                 time.sleep(0.1)
             self.ws = None
 
@@ -125,8 +125,8 @@ class SimpleFeed:
 
         # Wait for authentication response synchronously
         timeout = 5
-        start_time = time.time()
-        while not self.authenticated and time.time() - start_time < timeout:
+        start_time = time.perf_counter()
+        while not self.authenticated and time.perf_counter() - start_time < timeout:
             # Process any messages in the queue
             try:
                 if not self.message_queue.empty():

--- a/test/test_broker_integration.py
+++ b/test/test_broker_integration.py
@@ -615,8 +615,8 @@ class _WSClient:
         t = threading.Thread(target=self.ws.run_forever, daemon=True)
         t.start()
 
-        deadline = time.time() + 8
-        while time.time() < deadline and not self.authenticated:
+        deadline = time.perf_counter() + 8
+        while time.perf_counter() < deadline and not self.authenticated:
             time.sleep(0.1)
         return self.authenticated
 
@@ -628,8 +628,8 @@ class _WSClient:
                                      "exchange": exchange, "mode": mode, "depth": 5}))
         except Exception:
             return False
-        deadline = time.time() + timeout
-        while time.time() < deadline:
+        deadline = time.perf_counter() + timeout
+        while time.perf_counter() < deadline:
             with self.lock:
                 if any(t[2] == mode and t[1] == symbol for t in self.ticks):
                     break

--- a/test/test_broker_protocol.py
+++ b/test/test_broker_protocol.py
@@ -42,18 +42,18 @@ def test_broker_apis():
             print(f"\n{name:25} ({url})")
 
             # First request (includes connection setup)
-            start = time.time()
+            start = time.perf_counter()
             response = client.head(url, follow_redirects=True)
-            first_time = (time.time() - start) * 1000
+            first_time = (time.perf_counter() - start) * 1000
 
             print(
                 f"  Protocol: {response.http_version:10} Status: {response.status_code:3}  First request: {first_time:.0f}ms"
             )
 
             # Second request (reuses connection)
-            start = time.time()
+            start = time.perf_counter()
             response = client.head(url, follow_redirects=True)
-            second_time = (time.time() - start) * 1000
+            second_time = (time.perf_counter() - start) * 1000
 
             print(
                 f"  Connection reused:                        Second request: {second_time:.0f}ms"
@@ -86,9 +86,9 @@ def test_broker_apis():
         try:
             print(f"\n{name:25} ({url})")
 
-            start = time.time()
+            start = time.perf_counter()
             response = client_http1.head(url, follow_redirects=True)
-            response_time = (time.time() - start) * 1000
+            response_time = (time.perf_counter() - start) * 1000
 
             print(
                 f"  Protocol: {response.http_version:10} Status: {response.status_code:3}  Time: {response_time:.0f}ms"

--- a/test/test_cache_performance.py
+++ b/test/test_cache_performance.py
@@ -73,9 +73,9 @@ def test_cache_performance():
             broker = "angel"  # Default broker for testing
             print(f"Loading cache for broker: {broker}")
 
-            start_time = time.time()
+            start_time = time.perf_counter()
             success = load_cache_for_broker(broker)
-            load_time = time.time() - start_time
+            load_time = time.perf_counter() - start_time
 
             if success:
                 print(f"[SUCCESS] Cache loaded in {load_time:.2f} seconds")
@@ -115,10 +115,10 @@ def test_cache_performance():
         cache_times = []
 
         for _ in range(3):  # Run 3 rounds
-            start = time.time()
+            start = time.perf_counter()
             for sym in test_symbols:
                 result = token_db.get_token(sym.symbol, sym.exchange)
-            end = time.time()
+            end = time.perf_counter()
             cache_times.append(end - start)
             print(f"  Round {_ + 1}: {cache_times[-1]:.4f} seconds")
 
@@ -162,9 +162,9 @@ def test_cache_performance():
         symbol_exchange_pairs = [(sym.symbol, sym.exchange) for sym in test_symbols[:50]]
 
         # Test bulk retrieval
-        start = time.time()
+        start = time.perf_counter()
         results = token_db.get_tokens_bulk(symbol_exchange_pairs)
-        bulk_time = time.time() - start
+        bulk_time = time.perf_counter() - start
 
         valid_results = [r for r in results if r is not None]
         print(f"Bulk retrieval of {len(symbol_exchange_pairs)} symbols")
@@ -180,9 +180,9 @@ def test_cache_performance():
         search_queries = ["RELIANCE", "NIFTY", "BANK", "TCS", "INFY"]
 
         for query in search_queries[:3]:  # Test first 3
-            start = time.time()
+            start = time.perf_counter()
             results = token_db.search_symbols(query, limit=10)
-            search_time = time.time() - start
+            search_time = time.perf_counter() - start
             print(f"Search '{query}': {len(results)} results in {search_time:.4f} seconds")
 
             if results and len(results) > 0:

--- a/test/test_flattrade_protocol.py
+++ b/test/test_flattrade_protocol.py
@@ -72,9 +72,9 @@ def test_broker_protocols():
     try:
         times = []
         for i in range(3):
-            start = time.time()
+            start = time.perf_counter()
             response = client_auto.head(flattrade_url, follow_redirects=True)
-            elapsed = (time.time() - start) * 1000
+            elapsed = (time.perf_counter() - start) * 1000
             times.append(elapsed)
             print(f"   Request {i + 1}: {response.http_version} - {elapsed:.0f}ms")
         print(f"   Average: {sum(times) / len(times):.0f}ms")
@@ -88,9 +88,9 @@ def test_broker_protocols():
     try:
         times = []
         for i in range(3):
-            start = time.time()
+            start = time.perf_counter()
             response = client_http1.head(flattrade_url, follow_redirects=True)
-            elapsed = (time.time() - start) * 1000
+            elapsed = (time.perf_counter() - start) * 1000
             times.append(elapsed)
             print(f"   Request {i + 1}: {response.http_version} - {elapsed:.0f}ms")
         print(f"   Average: {sum(times) / len(times):.0f}ms")

--- a/test/test_greeks_live.py
+++ b/test/test_greeks_live.py
@@ -36,9 +36,9 @@ STRIKE_INTERVAL = 50  # NIFTY=50, BANKNIFTY=100
 
 
 def api_call(endpoint, payload):
-    start = time.time()
+    start = time.perf_counter()
     resp = requests.post(f"{BASE_URL}{endpoint}", json=payload)
-    elapsed = time.time() - start
+    elapsed = time.perf_counter() - start
     return resp.status_code, resp.json(), elapsed
 
 

--- a/upgrade/migrate_all.py
+++ b/upgrade/migrate_all.py
@@ -117,7 +117,7 @@ def main():
     print("Already applied migrations will be automatically skipped.")
     print()
 
-    start_time = time.time()
+    start_time = time.perf_counter()
     success_count = 0
     fail_count = 0
 
@@ -127,7 +127,7 @@ def main():
         else:
             fail_count += 1
 
-    elapsed = time.time() - start_time
+    elapsed = time.perf_counter() - start_time
 
     # Summary
     print()

--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -275,7 +275,7 @@ def async_master_contract_download(broker):
 
     Tracks download duration and exchange-wise statistics for smart download feature.
     """
-    start_time = time.time()
+    start_time = time.perf_counter()
 
     # Update status to downloading
     update_status(broker, "downloading", "Master contract download in progress")
@@ -313,7 +313,7 @@ def async_master_contract_download(broker):
         logger.info(f"Master contract download completed for {broker}")
 
         # Calculate download duration and get exchange stats
-        duration_seconds = int(time.time() - start_time)
+        duration_seconds = int(time.perf_counter() - start_time)
         exchange_stats = get_exchange_stats_from_db()
 
         # Update download statistics for smart download tracking

--- a/utils/httpx_client.py
+++ b/utils/httpx_client.py
@@ -57,9 +57,9 @@ def request(method: str, url: str, **kwargs) -> httpx.Response:
     client = get_httpx_client()
 
     # Track actual broker API call time for latency monitoring
-    broker_api_start = time.time()
+    broker_api_start = time.perf_counter()
     response = client.request(method, url, **kwargs)
-    broker_api_end = time.time()
+    broker_api_end = time.perf_counter()
 
     # Store broker API time in Flask's g object for latency tracking
     if hasattr(g, "latency_tracker"):
@@ -147,7 +147,7 @@ def _create_http_client() -> httpx.Client:
     # Event hooks for tracking broker API timing
     def log_request(request):
         """Hook called before request is sent"""
-        request.extensions["start_time"] = time.time()
+        request.extensions["start_time"] = time.perf_counter()
         logger.debug(f"Starting request to {request.url}")
 
     def log_response(response):
@@ -155,7 +155,7 @@ def _create_http_client() -> httpx.Client:
         try:
             start_time = response.request.extensions.get("start_time")
             if start_time:
-                duration_ms = (time.time() - start_time) * 1000
+                duration_ms = (time.perf_counter() - start_time) * 1000
 
                 # Store broker API time in Flask's g object for latency tracking
                 try:

--- a/utils/latency_monitor.py
+++ b/utils/latency_monitor.py
@@ -51,7 +51,7 @@ class LatencyTracker:
         """
         Initialize the LatencyTracker instance.
         """
-        self.start_time = time.time()
+        self.start_time = time.perf_counter()
         self.stage_times = {}
         self.current_stage = None
         self.stage_start = None
@@ -61,14 +61,14 @@ class LatencyTracker:
     def start_stage(self, stage_name):
         """Start timing a new stage"""
         self.current_stage = stage_name
-        self.stage_start = time.time()
+        self.stage_start = time.perf_counter()
         if stage_name == "broker_request":
             self.request_start = self.stage_start
 
     def end_stage(self):
         """End timing the current stage"""
         if self.current_stage and self.stage_start:
-            current_time = time.time()
+            current_time = time.perf_counter()
             duration = (current_time - self.stage_start) * 1000  # Convert to milliseconds
             self.stage_times[self.current_stage] = duration
             if self.current_stage == "broker_request":
@@ -78,7 +78,7 @@ class LatencyTracker:
 
     def get_total_time(self):
         """Get total time since tracker was created"""
-        return (time.time() - self.start_time) * 1000  # Convert to milliseconds
+        return (time.perf_counter() - self.start_time) * 1000  # Convert to milliseconds
 
     def get_rtt(self):
         """Get round-trip time (comparable to Postman/Bruno)"""
@@ -123,7 +123,7 @@ def track_latency(api_type):
             try:
                 # Record the actual start time for overhead calculation
                 # (after Flask routing/middleware has completed)
-                endpoint_start_time = time.time()
+                endpoint_start_time = time.perf_counter()
                 g.endpoint_start_time = endpoint_start_time
 
                 # Start validation stage
@@ -172,7 +172,7 @@ def track_latency(api_type):
                 if broker_api_time is not None and endpoint_start_time is not None:
                     # Calculate total time from when endpoint actually started executing
                     # (excludes Flask routing/middleware overhead)
-                    current_time = time.time()
+                    current_time = time.perf_counter()
                     total_time = (current_time - endpoint_start_time) * 1000  # ms
 
                     # Broker API time is what the httpx hook captured
@@ -223,7 +223,7 @@ def track_latency(api_type):
                 endpoint_start_time = getattr(g, "endpoint_start_time", None)
 
                 if broker_api_time is not None and endpoint_start_time is not None:
-                    current_time = time.time()
+                    current_time = time.perf_counter()
                     total_time = (current_time - endpoint_start_time) * 1000
                     rtt = broker_api_time
                     overhead = total_time - broker_api_time

--- a/utils/traffic_logger.py
+++ b/utils/traffic_logger.py
@@ -46,14 +46,14 @@ class TrafficLoggerMiddleware:
             return self.app(environ, start_response)
 
         # Record start time
-        start_time = time.time()
+        start_time = time.perf_counter()
 
         def log_request(status_code, error=None):
             if not has_request_context():
                 return
 
             try:
-                duration_ms = (time.time() - start_time) * 1000
+                duration_ms = (time.perf_counter() - start_time) * 1000
                 # Capture request-context values now; the DB write happens on
                 # the executor thread where the Flask context is gone.
                 payload = {


### PR DESCRIPTION
Currently, the project uses `time.time()` for storing and benchmarking time elapsed between 2 events. But, `time.time()` is not monotonic, i.e. in case of an NTP sync or changes to the system clock, the output of `time.time()` does not come out to be accurate.

Instead,  `time.perf_counter()` uses a monotonic clock, and is resistant to NTP syncs or any other changes in the system time, helping to make the time/latency benchmarks more accurate.

This PR only changes the code where relative measurements of time is use, and not for code where `time.time()` actually stores the timestamp, since `time.perf_counter()` by itself, has no value. It is only useful when used to actually calculate difference in time between 2 events.

Since I do not have subscriptions to all supported broker APIs, I will request you to once verify the changes by running the code with the broker APIs where code has been updated.

Thanks,
Manan

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced relative timing code to use `time.perf_counter()` for monotonic elapsed-time calculations. This removes drift from system clock/NTP changes and improves accuracy of latency logs, connection waits, and benchmarks across the app.

- **Refactors**
  - Switched to `time.perf_counter()` in WebSocket connect/auth loops and backoff timers across broker clients and `services/websocket_client`.
  - Updated performance/latency tracking in cache restoration, DB init, `utils/latency_monitor`, `utils/httpx_client` (`httpx` hooks), `utils/traffic_logger`, benchmarks, and tests.
  - Kept `time.time()` where absolute timestamps are needed; only elapsed-time math changed.
  - Reverted prior `start.sh` change; no script changes included.

<sup>Written for commit f39ceac8168e1aa54adcdde2ff8c20a83058259e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1592?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

