### PR TITLE
fix(groww): don't let one NULL-symbol row wipe the master contract

### DIFF
--- a/broker/groww/database/master_contract_db.py
+++ b/broker/groww/database/master_contract_db.py
@@ -58,6 +58,24 @@ def delete_symtoken_table():
 
 def copy_from_dataframe(df):
     logger.info("Performing Bulk Insert")
+
+    # Drop rows missing a NOT NULL column (symbol / brsymbol). The Groww
+    # instruments CSV can contain a malformed row — e.g. an index with an empty
+    # trading_symbol (which becomes the OpenAlgo `symbol`) — and without this
+    # guard a single such row raises "NOT NULL constraint failed: symtoken.symbol"
+    # mid-insert, whose rollback discards EVERY batch and leaves symtoken empty
+    # (breaking all symbol->token lookups, hence quotes). Filtering them keeps the
+    # rest of the master contract intact.
+    before = len(df)
+    df = df.dropna(subset=["symbol", "brsymbol"])
+    df = df[
+        (df["symbol"].astype(str).str.strip() != "")
+        & (df["brsymbol"].astype(str).str.strip() != "")
+    ]
+    dropped = before - len(df)
+    if dropped:
+        logger.warning(f"Skipped {dropped} instrument(s) with empty symbol/brsymbol")
+
     # Convert DataFrame to a list of dictionaries
     data_dict = df.to_dict(orient="records")
 


### PR DESCRIPTION
## Problem

On Groww, the master-contract download completes but leaves the `symtoken` table **empty (0 rows)**, so every symbol→token lookup fails and `/quotes` / `/multiquotes` return **"Symbol not found"** for all Groww symbols — no market data can be fetched.

Root cause is in `broker/groww/database/master_contract_db.py::copy_from_dataframe`. The Groww instruments CSV contains a malformed row — an index (`BSE FOCUSED IT`) with an **empty `trading_symbol`**, which becomes the OpenAlgo `symbol`. That row is inserted with a NULL `symbol`, so one batch raises:

```
sqlite3.IntegrityError: NOT NULL constraint failed: symtoken.symbol
```

The `except` clause calls `db_session.rollback()`, and because the `commit()` only happens **after all batches**, the rollback discards **every** previously-inserted batch — leaving the table empty.

Log excerpt:

```
Processed 138630 instruments
Inserting 138630 new records ... in batches of 10000
Inserted batch 9 (90000/138630 records)
ERROR: Error during bulk insert: (sqlite3.IntegrityError) NOT NULL constraint failed: symtoken.symbol
```

## Fix

Drop rows with an empty/NULL `symbol` or `brsymbol` (both `NOT NULL` columns) **before** the bulk insert, so a single malformed instrument can't abort the whole master contract. The number skipped is logged.

## Validation

Against the current Groww instruments CSV:

- **Before:** `symtoken` = 0 rows; `/quotes RELIANCE NSE` → "Symbol not found".
- **After:** `symtoken` = **138,629 rows** (the single bad `BSE FOCUSED IT` row skipped and logged); `RELIANCE`, `LT`, `HDFCBANK` resolve to tokens; the "Symbol not found" error is gone.

The change is minimal, broker-local, and touches only the Groww master-contract insert path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents a malformed Groww instrument with an empty symbol from wiping the master contract. We now filter out rows with empty or NULL `symbol`/`brsymbol` before bulk insert, restoring `/quotes` and `/multiquotes`.

- **Bug Fixes**
  - Drop rows with NULL/empty `symbol` or `brsymbol` before bulk insert to avoid a rollback that emptied `symtoken`. Log the number skipped.
  - Verified with current CSV: `symtoken` = 138,629 rows; `/quotes` no longer returns "Symbol not found".

<sup>Written for commit eb716aef9c8277418354cdf3ec2e8120922014e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1593?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

