### PR TITLE
fix(groww): unwrap (data, status) tuple in calculate_portfolio_statistics

### DIFF
--- a/broker/groww/mapping/order_data.py
+++ b/broker/groww/mapping/order_data.py
@@ -963,6 +963,14 @@ def calculate_portfolio_statistics(holdings_data):
             "totalprofitandloss": 0,
         }
 
+    # Handle tuple input (response, status_code) — get_holdings returns a
+    # (data, status_code) tuple, and it reaches here unchanged via
+    # map_portfolio_data. Unwrap it the same way transform_holdings_data does;
+    # otherwise the isinstance(list) check below fails and this returns all-zero
+    # statistics (and logs "Invalid holdings data format: tuple" on every call).
+    if isinstance(holdings_data, tuple):
+        holdings_data = holdings_data[0]
+
     # Extract holdings from the API response structure
     if isinstance(holdings_data, dict):
         # Check if statistics are already provided


### PR DESCRIPTION
## Problem

On Groww, the `/holdings` response's `statistics` block comes back all-zero:

```json
"statistics": {"totalholdingvalue": 0, "totalinvvalue": 0, "totalpnlpercentage": 0, "totalprofitandloss": 0}
```

and the log fills with this on **every** holdings call:

```
ERROR ... Invalid holdings data format: <class 'tuple'>
```

**Root cause:** Groww's `get_holdings()` returns a `(data, status_code)` **tuple**. That tuple reaches `calculate_portfolio_statistics()` unchanged (via `map_portfolio_data`, which passes non-error input straight through). `calculate_portfolio_statistics` handles a `dict` but not a `tuple`, so it falls through to the `if not isinstance(holdings_data, list)` branch — logging the error and returning all-zero statistics.

The holdings themselves still display, because the sibling `transform_holdings_data()` **already** unwraps the tuple (`if isinstance(holdings_data, tuple): holdings_data = holdings_data[0]`). Only `calculate_portfolio_statistics` was missing the same guard.

## Fix

Unwrap the tuple in `calculate_portfolio_statistics` the same way `transform_holdings_data` does, before the dict/list handling. After this, the `statistics` block reflects the real portfolio instead of zeros, and the per-call error log stops.

## Validation

- Before: `statistics` = all zeros; `Invalid holdings data format: tuple` logged every call.
- After: `statistics.totalholdingvalue` reflects the real holdings value; no more error log.

One-line, broker-local, mirrors an existing guard in the same file.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed Groww holdings stats returning all zeros by unwrapping the `(data, status_code)` tuple in `calculate_portfolio_statistics`. This restores correct totals and stops the “Invalid holdings data format: tuple” log on each call.

<sup>Written for commit 44824b80d7ffe593cd81d09be809fe207d1f6d05. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1594?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

