### PR TITLE
fix(angel): guard non-JSON responses so a rate-limit can't crash the API

### DIFF
--- a/broker/angel/api/auth_api.py
+++ b/broker/angel/api/auth_api.py
@@ -38,7 +38,33 @@ def authenticate_broker(clientcode, broker_pin, totp_code):
         response.status = response.status_code
 
         data = response.text
-        data_dict = json.loads(data)
+        # Angel can return a NON-JSON body on some errors — e.g. an HTTP 403
+        # rate-limit ("Access denied because of exceeding access rate"), or an F5
+        # Web Application Firewall page ("Request Rejected … Your support ID is: …")
+        # / a bare "not found" (HTTP 404) when the gateway blocks the caller's IP. A
+        # bare json.loads() on that raises JSONDecodeError, which the caller surfaces
+        # as the cryptic "Expecting value: line 1 column 1 (char 0)" — making a
+        # broker-side block look like a credentials bug. Guard the parse and return a
+        # clear, actionable message instead.
+        try:
+            data_dict = json.loads(data)
+        except json.JSONDecodeError:
+            body = (data or "").strip()
+            waf = "request rejected" in body.lower() or "support id" in body.lower()
+            if waf or response.status_code in (403, 404):
+                msg = (
+                    f"Angel rejected the login request (HTTP {response.status_code}) with a "
+                    "non-JSON response — this is a gateway block (WAF / rate-limit / IP block), "
+                    "not a credentials error. The server's public IP may be temporarily blocked "
+                    "(often from repeated automated logins); try again from a different IP, the "
+                    "block usually clears within a few hours."
+                )
+            else:
+                msg = (
+                    f"Angel returned a non-JSON login response (HTTP {response.status_code}): "
+                    f"{body[:200]}"
+                )
+            return None, None, msg
 
         if "data" in data_dict and "jwtToken" in data_dict["data"]:
             # Return both JWT token and feed token if available (None if not)

--- a/broker/angel/api/funds.py
+++ b/broker/angel/api/funds.py
@@ -38,7 +38,19 @@ def get_margin_data(auth_token):
     # Add status attribute for compatibility with the existing codebase
     response.status = response.status_code
 
-    margin_data = json.loads(response.text)
+    # Angel can return a NON-JSON body on some errors — notably an HTTP 403
+    # rate-limit ("Access denied because of exceeding access rate"). Calling
+    # json.loads() on that raises a JSONDecodeError that crashes the funds flow
+    # (surfaced to the caller as a 500 "Expecting value: line 1 column 1"). Guard
+    # the parse and treat an unparseable/error response as "no margin data",
+    # consistent with the empty-data path below.
+    try:
+        margin_data = json.loads(response.text)
+    except json.JSONDecodeError:
+        logger.error(
+            f"Non-JSON margin response (HTTP {response.status_code}): {response.text[:200]}"
+        )
+        return {}
 
     logger.info(f"Margin Data: {margin_data}")
 

--- a/broker/angel/api/order_api.py
+++ b/broker/angel/api/order_api.py
@@ -215,8 +215,21 @@ def place_order_api(data, auth):
     # as the rest of the codebase expects .status instead of .status_code
     response.status = response.status_code
 
-    # Parse the JSON response
-    response_data = response.json()
+    # Parse the JSON response. Angel can return a NON-JSON body under an HTTP 403
+    # rate-limit ("Access denied because of exceeding access rate"); .json() would
+    # then raise and crash order placement. Guard it and treat a non-JSON body as a
+    # failed order. Do NOT retry here — a placeOrder that reached the exchange
+    # before the error must never be re-sent (double-order risk).
+    try:
+        response_data = response.json()
+    except (json.JSONDecodeError, ValueError):
+        logger.error(
+            f"Non-JSON placeOrder response (HTTP {response.status_code}): {response.text[:200]}"
+        )
+        response_data = {
+            "status": False,
+            "message": f"Invalid JSON response (HTTP {response.status_code})",
+        }
 
     # Use .get() so a malformed / non-conforming response (gateway error
     # envelope, partial response, network blip) returns a clean
@@ -413,7 +426,19 @@ def cancel_order(orderid, auth):
     # Add status attribute for compatibility with the existing codebase
     response.status = response.status_code
 
-    data = json.loads(response.text)
+    # Guard against a non-JSON body (e.g. an HTTP 403 rate-limit "Access denied
+    # because of exceeding access rate"), which would otherwise raise. No retry —
+    # surface a clean error to the caller.
+    try:
+        data = json.loads(response.text)
+    except json.JSONDecodeError:
+        logger.error(
+            f"Non-JSON cancelOrder response (HTTP {response.status_code}): {response.text[:200]}"
+        )
+        return {
+            "status": "error",
+            "message": f"Invalid JSON response (HTTP {response.status_code})",
+        }, response.status
 
     # Check if the request was successful
     if data.get("status"):
@@ -465,7 +490,18 @@ def modify_order(data, auth):
     # Add status attribute for compatibility with the existing codebase
     response.status = response.status_code
 
-    data = json.loads(response.text)
+    # Guard against a non-JSON body (e.g. an HTTP 403 rate-limit), which would
+    # otherwise raise. No retry — surface a clean error to the caller.
+    try:
+        data = json.loads(response.text)
+    except json.JSONDecodeError:
+        logger.error(
+            f"Non-JSON modifyOrder response (HTTP {response.status_code}): {response.text[:200]}"
+        )
+        return {
+            "status": "error",
+            "message": f"Invalid JSON response (HTTP {response.status_code})",
+        }, response.status
 
     if data.get("status") == "true" or data.get("message") == "SUCCESS":
         return {"status": "success", "orderid": data["data"]["orderid"]}, 200


### PR DESCRIPTION
## Problem

Angel returns a **non-JSON** body under an HTTP 403 rate-limit:

```
Access denied because of exceeding access rate
```

Several Angel API call sites parse the body with `json.loads(response.text)` / `response.json()` **without checking the status**, so a rate-limit raises a `JSONDecodeError`:

- **`funds.py::get_margin_data`** — surfaced by `funds_service` as HTTP 500 `{"status":"error","message":"Expecting value: line 1 column 1 (char 0)"}`. The 403 + rate-limit message are lost. (This is the one that most visibly bites, since funds/`getRMS` is hit several times around login.)
- **`order_api.py::place_order_api`** (`.json()`), **`cancel_order`**, **`modify_order`** — crash the order placement / cancel / modify flows.

The read helper `get_api_response()` **already** handles this rate-limit (it retries on "exceeding access rate"), and the holdings/positions/orderbook/tradebook readers all go through it; quotes (`data.py`) already guard their parse. Only the four sites above were left unguarded.

## Fix

Guard each unguarded parse:

- **Reads** (`get_margin_data`) → return `{}` on a non-JSON body, consistent with the function's existing empty-data path.
- **Order writes** (`place_order_api` / `cancel_order` / `modify_order`) → return a clean `{"status":"error", ...}` envelope via each function's existing error path.

**Writes intentionally do NOT retry.** A `placeOrder` that reached the exchange *before* the error must never be auto-resent — retrying risks a **double order**. So writes fail cleanly and let the caller's existing error handling take over, rather than being routed through the retrying `get_api_response`.

## Validation

Simulated a non-JSON 403 (`"Access denied because of exceeding access rate"`) at each site:

- `get_margin_data` → `{}` (no exception)
- `place_order_api` → `(response, {"status": False, ...}, orderid=None)` (no exception, no order)
- `cancel_order` / `modify_order` → `({"status":"error","message":"Invalid JSON response (HTTP 403)"}, 403)` (no exception)

Valid-JSON happy paths are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guard non-JSON Angel responses (403 rate-limit, WAF/IP blocks) in login, funds, and order APIs to prevent JSON decode crashes. Reads return `{}`; writes return clean errors without retry to avoid double orders; login returns a clear gateway-block message.

- **Bug Fixes**
  - `auth_api.authenticate_broker`: handle non-JSON (403/404/WAF); return actionable gateway-block message instead of JSON decode error.
  - `funds.get_margin_data`: on non-JSON, return `{}`; log status/text.
  - `order_api.place_order_api`: guard `.json()`, return `{"status": False, "message": "Invalid JSON response (HTTP status)"}`; no retry.
  - `order_api.cancel_order` / `modify_order`: guard parse, return `({"status":"error","message":"Invalid JSON response (HTTP status)"}, status)`; no retry.

<sup>Written for commit 1d262d3b92c0a4dcf5a3c6c278e75fcadba14a9d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1595?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

