### PR TITLE
fix(master-contract): fail a download that produced 0 symbols

### DIFF
--- a/utils/auth_utils.py
+++ b/utils/auth_utils.py
@@ -298,13 +298,28 @@ def async_master_contract_download(broker):
         # Most brokers return the socketio.emit result, we need to check completion
         # by looking at the module's actual completion
 
-        # Try to get the symbol count from the database
+        # Verify the download actually populated the symbol table. Distinguish two
+        # distinct failure modes so incident response isn't misled:
+        #   - the count query itself failed  -> we can't verify; error out, but say so
+        #   - the count is genuinely 0        -> the download produced no symbols
+        # Either way we must NOT mark this success/is_ready=True: that would leave
+        # every symbol->token lookup (quotes, order placement) silently broken with
+        # nothing signalling the contract is empty. Fail closed so the smart-download
+        # logic re-fetches next time. (A False is_ready self-heals via re-download; a
+        # wrong True does not.)
         try:
             from database.token_db import get_symbol_count
 
             total_symbols = get_symbol_count()
-        except Exception:
-            total_symbols = None
+        except Exception as count_error:
+            logger.exception(f"Failed to verify symbol count for {broker}: {count_error}")
+            update_status(broker, "error", f"Failed to verify master contract symbol count: {count_error}")
+            return {"status": "error", "message": "Failed to verify master contract symbol count"}
+
+        if total_symbols == 0:
+            logger.error(f"Master contract download for {broker} produced 0 symbols")
+            update_status(broker, "error", "Master contract download produced 0 symbols", 0)
+            return {"status": "error", "message": "Master contract download produced 0 symbols"}
 
         # Since socketio.emit doesn't return a meaningful value, we check if no exception was raised
         update_status(


### PR DESCRIPTION
## Problem

`async_master_contract_download` (in `utils/auth_utils.py`, runs for **every** broker) marks the download successful without checking that any symbols were actually stored:

```python
total_symbols = get_symbol_count()
...
update_status(broker, "success", "Master contract download completed successfully", total_symbols)
```

So a download that inserted **0 rows** — an empty/failed CSV parse, a bulk-insert that rolled back, a broker returning nothing — is still recorded as `status="success"` / `is_ready=True`. The result: every subsequent symbol→token lookup fails (quotes, order placement) and there is **no signal** that the master contract is empty. The smart-download logic also sees "success" and won't re-fetch.

(Observed with Groww: a bulk-insert rollback left `symtoken` empty, yet the status was `success` with `total_symbols = 0`.)

## Fix

Fail closed — if the download produced no symbols, mark the status `error` and return, so the smart-download logic re-fetches on the next login instead of trusting an empty table:

```python
if not total_symbols:
    logger.error(f"Master contract download for {broker} produced 0 symbols")
    update_status(broker, "error", "Master contract download produced 0 symbols", 0)
    return {"status": "error", "message": "Master contract download produced 0 symbols"}
```

A `False` `is_ready` self-heals (triggers a re-download); a wrong `True` silently breaks data lookups.

## Scope

Broker-agnostic — this is in the shared post-download path, so it protects all brokers regardless of *why* a download came back empty. Independent of any single broker's data-parsing fix.

## Validation

- `get_symbol_count() == 0` → status recorded `error`, function returns `{"status":"error",...}`.
- `get_symbol_count() > 0` → unchanged, status `success`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark master contract downloads that produce 0 symbols or when the symbol count can’t be verified as errors, preventing is_ready=true on empty or unverifiable tables. This triggers re-downloads and avoids broken symbol→token lookups across all brokers.

- **Bug Fixes**
  - If count verification fails or returns 0, set status "error" with a clear message and return early.
  - Success path unchanged when symbols > 0; broker-agnostic safeguard.

<sup>Written for commit 97862e07fab9bd03bc160deb2bd227ac1958f467. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1596?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

