### PR TITLE
fix(funds): treat empty broker funds response as an error, not success

### DIFF
--- a/services/funds_service.py
+++ b/services/funds_service.py
@@ -73,6 +73,25 @@ def get_funds_with_auth(
         # Get funds data using broker's implementation
         funds = broker_module.get_margin_data(auth_token)
 
+        # An empty result means the broker returned no funds/margin data — the
+        # broker session is invalid or expired (all brokers return a POPULATED
+        # dict on success, even for a zero-balance account, e.g.
+        # availablecash="0.00"; they return {} only on the error/no-data path).
+        # Reporting this as success with empty data is misleading: it lets an
+        # expired session look "live" (callers such as the dashboard already
+        # compensate by re-checking `if not margin_data`). Surface it as a failure
+        # so every caller gets a consistent signal.
+        if not funds:
+            logger.warning("Empty funds/margin data — broker session likely invalid or expired")
+            return (
+                False,
+                {
+                    "status": "error",
+                    "message": "No funds data returned — broker session may be invalid or expired",
+                },
+                500,
+            )
+
         return True, {"status": "success", "data": funds}, 200
     except Exception as e:
         logger.exception(f"Error in broker_module.get_margin_data: {e}")


### PR DESCRIPTION
## Problem

`get_funds_with_auth` wraps **any** `get_margin_data()` result — including `{}` — as a success envelope:

```python
funds = broker_module.get_margin_data(auth_token)
return True, {"status": "success", "data": funds}, 200
```

But brokers return `{}` **only** on the error / no-data path (an invalid or expired broker session). A *successful* funds call always returns a populated dict — even a zero-balance account returns `availablecash="0.00"`. So an **expired broker session is currently reported as a successful funds call with empty data**.

That's misleading for every consumer: they can't tell "live session, genuinely empty" from "dead session". In practice callers already compensate — e.g. `blueprints/dashboard.py`:

```python
margin_data = response.get("data", {})
if not margin_data:
    logger.error("... authentication may have expired")
    return redirect(url_for("auth.logout"))
```

— which shows the intended semantic is "empty ⇒ failure"; `funds_service` just labels it wrong, forcing every caller to re-check emptiness.

## Fix

If `get_margin_data()` returns an empty result, return `(False, error, 500)` instead of a success envelope, so all callers get a consistent signal.

## Safety (cross-broker)

Checked the broker `get_margin_data` implementations: on success they return a **populated** dict (a zero-balance account still carries `availablecash`, etc.); `{}` is used only on the error/no-data path. So this only trips on the genuine no-data/expired case and does not affect legitimate zero-balance accounts.

## Validation

- Empty `{}` → `(False, {"status":"error",...}, 500)`
- Zero-balance populated dict (`availablecash="0.00"`) → `(True, success, 200)`
- Real balance → `(True, success, 200)`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat empty broker funds responses as errors so expired/invalid sessions no longer appear as successful funds calls. Callers now get a clear failure signal instead of an empty success.

- **Bug Fixes**
  - In `get_funds_with_auth`, return `(False, {"status":"error", ...}, 500)` and log a warning when `get_margin_data()` returns `{}`.
  - Aligns with broker behavior: `{}` only on error/no-data; zero-balance accounts still return a populated dict and succeed.

<sup>Written for commit ca6b96992602961cecd76c14d187ddd768c7a86e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

