### PR TITLE
fix(groww): interpolate status code in margin-error log (f-string double-brace)

### DIFF
--- a/broker/groww/api/funds.py
+++ b/broker/groww/api/funds.py
@@ -31,7 +31,7 @@ def get_margin_data(auth_token):
         # Check if the request was successful
         if response.status_code != 200:
             logger.error(
-                f"Error fetching margin data: HTTP {{response.status_code}} - {response.text}"
+                f"Error fetching margin data: HTTP {response.status_code} - {response.text}"
             )
             return {}
 


### PR DESCRIPTION
### Problem

The non-200 error branch of `get_margin_data()` in `broker/groww/api/funds.py` logs:

```python
f"Error fetching margin data: HTTP {{response.status_code}} - {response.text}"
```

The double braces `{{ }}` are the f-string escape for a **literal** brace, so this logs the useless text `HTTP {response.status_code}` instead of the real status (e.g. `HTTP 401`). The sibling `{response.text}` uses single braces and interpolates correctly, which makes the bug easy to miss.

Observed in a real log when a Groww session expired:

```
funds | Error fetching margin data: HTTP {response.status_code} - {"errorCode":401,...}
```

The literal `{response.status_code}` obscures the actual HTTP status, making it harder to distinguish a `401` (expired session) from a `429` (rate-limit) when diagnosing a failing funds call.

### Fix

Use single braces so the status code is interpolated:

```python
f"Error fetching margin data: HTTP {response.status_code} - {response.text}"
```

One-line, log-message-only change; no behavioral change to the returned value (`{}` on error is unchanged).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the margin error log to interpolate the HTTP status code in `get_margin_data()` by replacing f-string double braces, so logs show the real code (e.g., 401) instead of `{response.status_code}`. No runtime behavior change; only clearer diagnostics.

<sup>Written for commit 9fa9af081cd7fc91a286fa8b5c327ebd1be7351f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1600?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

