### PR TITLE
Fix AliceBlue NFO/CDS futures missing from master contract

### DIFF
--- a/broker/aliceblue/database/master_contract_db.py
+++ b/broker/aliceblue/database/master_contract_db.py
@@ -276,6 +276,12 @@ def process_aliceblue_nfo_csv(path):
 
         return f"{row['Symbol']}{date_str}{Strike_price}"
 
+    # Futures rows in the NFO master carry Instrument Type 'FUTSTK'/'FUTIDX'
+    # with a NaN Option Type. Map them to 'XX' so the futures symbol logic
+    # below picks them up (mirrors the BFO/MCX processors).
+    df.loc[df["Instrument Type"] == "FUTSTK", "Option Type"] = "XX"
+    df.loc[df["Instrument Type"] == "FUTIDX", "Option Type"] = "XX"
+
     # Apply the function to rows where 'Option Type' is 'XX'
     df.loc[df["Option Type"] == "XX", "symbol"] = df["Trading Symbol"] + "UT"
 
@@ -339,6 +345,10 @@ def process_aliceblue_cds_csv(path):
             date_str = "NOEXP"  # Use a placeholder for missing dates
 
         return f"{row['Symbol']}{date_str}{Strike_price}"
+
+    # Currency futures carry Instrument Type 'FUTCUR' with a NaN Option Type.
+    # Map them to 'XX' so the futures symbol logic below picks them up.
+    df.loc[df["Instrument Type"] == "FUTCUR", "Option Type"] = "XX"
 
     # Apply the function to rows where 'Option Type' is 'XX'
     df.loc[df["Option Type"] == "XX", "symbol"] = df["Trading Symbol"] + "UT"


### PR DESCRIPTION
AliceBlue V2 master CSVs identify futures by Instrument Type (FUTSTK/FUTIDX for NFO, FUTCUR for CDS) with a NaN Option Type, not Option Type 'XX'. The NFO and CDS processors only built symbols for Option Type 'XX', so all futures rows got a NaN symbol and were dropped by the final dropna. Map the futures Instrument Types to 'XX' before symbol construction, mirroring the existing BFO/MCX/BCD processors.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes missing NFO/CDS futures in AliceBlue V2 master contract. We map futures Instrument Types (`FUTSTK`, `FUTIDX`, `FUTCUR`) with NaN Option Type to `XX` so futures symbols are generated and not dropped.

- **Bug Fixes**
  - Map `FUTSTK`/`FUTIDX` (NFO) and `FUTCUR` (CDS) to Option Type `XX` before symbol construction.
  - Aligns with existing logic in BFO/MCX/BCD processors to prevent futures rows being removed by `dropna()`.

<sup>Written for commit e55e1de0b03ad8d86baf037aaee405561eccf17a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1604?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

