### PR TITLE
fix(indmoney): align broker with updated IndStocks API + fix option chain quotes, close WebSocket file-descriptor leaks in streaming, close second-order WS resource leaks in adapter and batch WebSocket subscriptions like Zerodha

### DIFF
--- a/broker/indmoney/api/data.py
+++ b/broker/indmoney/api/data.py
@@ -1,5 +1,6 @@
 import json
 import os
+import threading
 import time
 from datetime import datetime, timedelta
 
@@ -12,6 +13,71 @@ from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# --- Poison scrip-code cache ---------------------------------------------
+# IndStocks' /market/quotes/full 400-rejects the ENTIRE comma-separated batch
+# if any single scrip code is unquotable (e.g. a deep-ITM option strike the
+# server won't price). We isolate the offending code(s) via bisection and cache
+# them here so subsequent quote calls skip them and stay a single fast batch.
+# Cached codes are re-tested after a TTL in case they become quotable again.
+_BAD_SCRIP_CODES = {}          # scrip_code -> monotonic() time it was marked bad
+_BAD_SCRIP_TTL = 300.0         # seconds before a bad code is retried
+_bad_scrip_lock = threading.Lock()
+
+
+def _is_known_bad(scrip_code):
+    """True if scrip_code is currently cached as unquotable (within TTL)."""
+    with _bad_scrip_lock:
+        ts = _BAD_SCRIP_CODES.get(scrip_code)
+        if ts is None:
+            return False
+        if time.monotonic() - ts > _BAD_SCRIP_TTL:
+            _BAD_SCRIP_CODES.pop(scrip_code, None)
+            return False
+        return True
+
+
+def _mark_bad(scrip_code):
+    """Cache scrip_code as unquotable so future batches skip it."""
+    with _bad_scrip_lock:
+        _BAD_SCRIP_CODES[scrip_code] = time.monotonic()
+
+# 429 (rate-limit) retry configuration. IndStocks enforces per-category rate
+# limits (Data/Quote 5/s) and returns 429 on breach (docs 03-conventions /
+# 14-errors), so requests retry with backoff.
+_MAX_RETRIES = 3
+_RATE_LIMIT_BASE_DELAY = 1.0  # seconds; doubled each attempt (1s, 2s, 4s)
+
+
+def request_with_retry(client, method, url, **kwargs):
+    """
+    Perform an httpx request, retrying HTTP 429 with exponential backoff
+    (honouring Retry-After when present). Sets ``.status`` for compatibility
+    with the existing codebase.
+    """
+    response = None
+    for attempt in range(_MAX_RETRIES):
+        response = client.request(method.upper(), url, **kwargs)
+        if response.status_code == 429 and attempt < _MAX_RETRIES - 1:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                delay = (
+                    min(float(retry_after), 30.0)
+                    if retry_after
+                    else _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+                )
+            except (TypeError, ValueError):
+                delay = _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+            logger.warning(
+                f"Rate limit hit (429) on {url}, retrying in {delay:.1f}s "
+                f"(attempt {attempt + 1}/{_MAX_RETRIES})"
+            )
+            time.sleep(delay)
+            continue
+        break
+    if response is not None:
+        response.status = response.status_code
+    return response
 
 
 def get_api_response(endpoint, auth, method="GET", params=None):
@@ -49,12 +115,13 @@ def get_api_response(endpoint, auth, method="GET", params=None):
         logger.debug(f"Full URL: {url}")
 
     try:
+        # request_with_retry handles HTTP 429 with backoff and sets .status
         if method == "GET":
-            res = client.get(url, headers=headers, params=params)
+            res = request_with_retry(client, "GET", url, headers=headers, params=params)
         elif method == "POST":
-            res = client.post(url, headers=headers, json=params)
+            res = request_with_retry(client, "POST", url, headers=headers, json=params)
         else:
-            res = client.request(method, url, headers=headers, params=params)
+            res = request_with_retry(client, method, url, headers=headers, params=params)
 
         logger.debug(f"Request completed. Status code: {res.status_code}")
         logger.info(f"Actual request URL: {res.url}")
@@ -62,9 +129,6 @@ def get_api_response(endpoint, auth, method="GET", params=None):
     except Exception as req_error:
         logger.error(f"Request failed: {str(req_error)}")
         raise Exception(f"Failed to make request to Indmoney API: {str(req_error)}")
-
-    # Add status attribute for compatibility with existing codebase
-    res.status = res.status_code
 
     logger.debug(f"Response status: {res.status}")
     logger.debug(f"Raw response text: {res.text}")
@@ -453,6 +517,54 @@ class BrokerData:
             logger.exception("Error fetching multiquotes")
             raise Exception(f"Error fetching multiquotes: {e}")
 
+    def _fetch_full_quotes_map(self, scrip_codes):
+        """
+        Fetch /market/quotes/full for a list of scrip codes, tolerating
+        'poison' codes. IndStocks 400-rejects the whole batch if ANY single
+        code is unquotable, so on a 400 we bisect to isolate and drop the bad
+        code(s); valid codes still return data. Bad codes are cached (with TTL)
+        so later calls skip them and stay a single fast request.
+
+        Returns: {scrip_code: raw_quote_dict} for the codes that returned data.
+        """
+        if not scrip_codes:
+            return {}
+
+        # Skip codes already known to poison the batch (re-tested after TTL)
+        codes = [c for c in scrip_codes if not _is_known_bad(c)]
+        if not codes:
+            return {}
+
+        try:
+            params = {"scrip-codes": ",".join(codes)}
+            response = get_api_response("/market/quotes/full", self.auth_token, "GET", params)
+            return response.get("data", {}) or {}
+        except Exception as e:
+            msg = str(e)
+            # A 400 "Invalid scrip codes" means at least one code in this batch
+            # is unquotable. Only these are worth bisecting.
+            bad_batch = "400" in msg or "Invalid scrip" in msg
+
+            if len(codes) == 1:
+                if bad_batch:
+                    logger.warning(f"Marking unquotable scrip code as bad: {codes[0]}")
+                    _mark_bad(codes[0])
+                else:
+                    logger.error(f"Quote fetch failed for {codes[0]}: {e}")
+                return {}
+
+            if not bad_batch:
+                # Network/auth/other error - don't hammer the API by bisecting
+                logger.error(f"Quote fetch failed for {len(codes)} codes: {e}")
+                return {}
+
+            # Bisect to isolate the poison code(s)
+            mid = len(codes) // 2
+            left = self._fetch_full_quotes_map(codes[:mid])
+            right = self._fetch_full_quotes_map(codes[mid:])
+            left.update(right)
+            return left
+
     def _process_multiquotes_batch(self, symbols: list) -> list:
         """
         Process a single batch of symbols (internal method)
@@ -476,7 +588,6 @@ class BrokerData:
                     {
                         "symbol": symbol,
                         "exchange": exchange,
-                        "data": None,
                         "error": "Missing required symbol or exchange",
                     }
                 )
@@ -489,7 +600,7 @@ class BrokerData:
             except Exception as e:
                 logger.warning(f"Skipping symbol {symbol} on {exchange}: {str(e)}")
                 skipped_symbols.append(
-                    {"symbol": symbol, "exchange": exchange, "data": None, "error": str(e)}
+                    {"symbol": symbol, "exchange": exchange, "error": str(e)}
                 )
 
         # Return skipped symbols if no valid symbols
@@ -497,76 +608,53 @@ class BrokerData:
             logger.warning("No valid symbols to fetch quotes for")
             return skipped_symbols
 
-        # Join all scrip codes with comma
-        scrip_codes_param = ",".join(scrip_codes)
+        # Fetch quotes, tolerating poison codes that would otherwise 400 the
+        # whole batch. Returns {scrip_code: raw_quote} for codes with data.
+        quotes_data = self._fetch_full_quotes_map(scrip_codes)
+        logger.debug(f"Multiquotes returned data for {len(quotes_data)} of {len(scrip_codes)} codes")
 
-        try:
-            params = {"scrip-codes": scrip_codes_param}
-            response = get_api_response("/market/quotes/full", self.auth_token, "GET", params)
-            logger.debug("Indmoney multiquotes API response received")
+        succeeded = 0
+        for scrip_code, original in symbol_map.items():
+            quote = quotes_data.get(scrip_code, {})
 
-            quotes_data = response.get("data", {})
-            logger.debug(f"Multiquotes response keys: {list(quotes_data.keys())}")
-
-            # Process each scrip code in the response
-            for scrip_code, original in symbol_map.items():
-                quote = quotes_data.get(scrip_code, {})
-                logger.debug(
-                    f"Quote for {scrip_code}: keys={list(quote.keys()) if quote else 'None'}"
-                )
-
-                if quote and any(
-                    key in quote for key in ["ltp", "live_price", "day_open", "day_high", "day_low"]
-                ):
-                    results.append(
-                        {
-                            "symbol": original["symbol"],
-                            "exchange": original["exchange"],
-                            "data": {
-                                "bid": 0,  # Will be 0 unless we fetch depth
-                                "ask": 0,
-                                "open": self._clean_number(quote.get("day_open", 0)),
-                                "high": self._clean_number(quote.get("day_high", 0)),
-                                "low": self._clean_number(quote.get("day_low", 0)),
-                                "ltp": self._clean_number(
-                                    quote.get("live_price", quote.get("ltp", 0))
-                                ),
-                                "prev_close": self._clean_number(
-                                    quote.get("prev_close", quote.get("close", 0))
-                                ),
-                                "volume": self._clean_number(quote.get("volume", 0)),
-                                "oi": self._clean_number(
-                                    quote.get("oi", quote.get("open_interest", 0))
-                                ),
-                            },
-                        }
-                    )
-                else:
-                    results.append(
-                        {
-                            "symbol": original["symbol"],
-                            "exchange": original["exchange"],
-                            "data": None,
-                            "error": "No data received",
-                        }
-                    )
-
-        except Exception as e:
-            logger.error(f"Error calling quotes API: {str(e)}")
-            # Return error for all symbols in the batch
-            for scrip_code, original in symbol_map.items():
+            if quote and any(
+                key in quote for key in ["ltp", "live_price", "day_open", "day_high", "day_low"]
+            ):
+                succeeded += 1
                 results.append(
                     {
                         "symbol": original["symbol"],
                         "exchange": original["exchange"],
-                        "data": None,
-                        "error": str(e),
+                        "data": {
+                            "bid": 0,  # Will be 0 unless we fetch depth
+                            "ask": 0,
+                            "open": self._clean_number(quote.get("day_open", 0)),
+                            "high": self._clean_number(quote.get("day_high", 0)),
+                            "low": self._clean_number(quote.get("day_low", 0)),
+                            "ltp": self._clean_number(
+                                quote.get("live_price", quote.get("ltp", 0))
+                            ),
+                            "prev_close": self._clean_number(
+                                quote.get("prev_close", quote.get("close", 0))
+                            ),
+                            "volume": self._clean_number(quote.get("volume", 0)),
+                            "oi": self._clean_number(quote.get("oi", quote.get("open_interest", 0))),
+                        },
+                    }
+                )
+            else:
+                # No quote for this symbol (e.g. an unquotable strike). Omit the
+                # "data" key (and include "error") so downstream consumers treat
+                # it as missing and default to {} rather than hitting a None.
+                results.append(
+                    {
+                        "symbol": original["symbol"],
+                        "exchange": original["exchange"],
+                        "error": "No data received",
                     }
                 )
 
-        logger.info(
-            f"Retrieved quotes for {len([r for r in results if r.get('data')])} / {len(symbols)} symbols"
-        )
+        logger.info(f"Retrieved quotes for {succeeded} / {len(symbols)} symbols")
         return skipped_symbols + results
 
     def get_depth(self, symbol: str, exchange: str) -> dict:

--- a/broker/indmoney/api/funds.py
+++ b/broker/indmoney/api/funds.py
@@ -2,12 +2,50 @@
 
 import json
 import logging
+import time
 
 from broker.indmoney.api.baseurl import get_url
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# 429 (rate-limit) retry configuration. IndStocks enforces per-category rate
+# limits (Non-Trading 15/s) and returns 429 on breach (docs 03-conventions /
+# 14-errors), so requests retry with backoff.
+_MAX_RETRIES = 3
+_RATE_LIMIT_BASE_DELAY = 1.0  # seconds; doubled each attempt (1s, 2s, 4s)
+
+
+def request_with_retry(client, method, url, **kwargs):
+    """
+    Perform an httpx request, retrying HTTP 429 with exponential backoff
+    (honouring Retry-After when present). Sets ``.status`` for compatibility
+    with the existing codebase.
+    """
+    response = None
+    for attempt in range(_MAX_RETRIES):
+        response = client.request(method.upper(), url, **kwargs)
+        if response.status_code == 429 and attempt < _MAX_RETRIES - 1:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                delay = (
+                    min(float(retry_after), 30.0)
+                    if retry_after
+                    else _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+                )
+            except (TypeError, ValueError):
+                delay = _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+            logger.warning(
+                f"Rate limit hit (429) on {url}, retrying in {delay:.1f}s "
+                f"(attempt {attempt + 1}/{_MAX_RETRIES})"
+            )
+            time.sleep(delay)
+            continue
+        break
+    if response is not None:
+        response.status = response.status_code
+    return response
 
 # Default response format for margin data (OpenAlgo standard format)
 DEFAULT_MARGIN_RESPONSE = {
@@ -43,8 +81,8 @@ def get_margin_data(auth_token):
 
         logger.info(f"Making request to: {url}")
 
-        # Make the API request with standard timeout
-        response = client.get(url, headers=headers, timeout=30.0)
+        # Make the API request with standard timeout (429-aware)
+        response = request_with_retry(client, "GET", url, headers=headers, timeout=30.0)
 
         # Check if the request was successful
         if response.status_code != 200:

--- a/broker/indmoney/api/margin_api.py
+++ b/broker/indmoney/api/margin_api.py
@@ -1,5 +1,6 @@
 import json
 import os
+import time
 
 from broker.indmoney.api.baseurl import get_url
 from broker.indmoney.mapping.margin_data import parse_margin_response, transform_margin_positions
@@ -7,6 +8,43 @@ from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# 429 (rate-limit) retry configuration. IndStocks enforces per-category rate
+# limits (Data 5/s) and returns 429 on breach (docs 03-conventions /
+# 14-errors), so requests retry with backoff.
+_MAX_RETRIES = 3
+_RATE_LIMIT_BASE_DELAY = 1.0  # seconds; doubled each attempt (1s, 2s, 4s)
+
+
+def request_with_retry(client, method, url, **kwargs):
+    """
+    Perform an httpx request, retrying HTTP 429 with exponential backoff
+    (honouring Retry-After when present). Sets ``.status`` for compatibility
+    with the existing codebase.
+    """
+    response = None
+    for attempt in range(_MAX_RETRIES):
+        response = client.request(method.upper(), url, **kwargs)
+        if response.status_code == 429 and attempt < _MAX_RETRIES - 1:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                delay = (
+                    min(float(retry_after), 30.0)
+                    if retry_after
+                    else _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+                )
+            except (TypeError, ValueError):
+                delay = _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+            logger.warning(
+                f"Rate limit hit (429) on {url}, retrying in {delay:.1f}s "
+                f"(attempt {attempt + 1}/{_MAX_RETRIES})"
+            )
+            time.sleep(delay)
+            continue
+        break
+    if response is not None:
+        response.status = response.status_code
+    return response
 
 
 def calculate_margin_api(positions, auth):
@@ -66,13 +104,10 @@ def calculate_margin_api(positions, auth):
 
             logger.info(f"Margin calculation payload for {position.get('securityID')}: {payload}")
 
-            # Make the GET request with JSON body (as per IndMoney API spec)
-            response = client.request(
-                method="GET", url=get_url("/margin"), headers=headers, content=payload
+            # Make the GET request with JSON body (as per IndMoney API spec), 429-aware
+            response = request_with_retry(
+                client, "GET", get_url("/margin"), headers=headers, content=payload
             )
-
-            # Add status attribute for compatibility
-            response.status = response.status_code
 
             # Parse the JSON response
             try:

--- a/broker/indmoney/api/order_api.py
+++ b/broker/indmoney/api/order_api.py
@@ -6,6 +6,10 @@ import threading
 import time
 
 from broker.indmoney.api.baseurl import get_url
+from broker.indmoney.mapping.order_data import (
+    OPEN_STATUSES,
+    TRIGGER_PENDING_STATUSES,
+)
 from broker.indmoney.mapping.transform_data import (
     map_exchange,
     map_exchange_type,
@@ -21,6 +25,43 @@ from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# 429 (rate-limit) retry configuration. IndStocks enforces per-category rate
+# limits (Order 10/s, Data/Quote 5/s, Non-Trading 15/s) and returns 429 on
+# breach (docs 03-conventions / 14-errors), so requests retry with backoff.
+_MAX_RETRIES = 3
+_RATE_LIMIT_BASE_DELAY = 1.0  # seconds; doubled each attempt (1s, 2s, 4s)
+
+
+def request_with_retry(client, method, url, **kwargs):
+    """
+    Perform an httpx request, retrying HTTP 429 with exponential backoff
+    (honouring Retry-After when present). Sets ``.status`` for compatibility
+    with the existing codebase.
+    """
+    response = None
+    for attempt in range(_MAX_RETRIES):
+        response = client.request(method.upper(), url, **kwargs)
+        if response.status_code == 429 and attempt < _MAX_RETRIES - 1:
+            retry_after = response.headers.get("Retry-After")
+            try:
+                delay = (
+                    min(float(retry_after), 30.0)
+                    if retry_after
+                    else _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+                )
+            except (TypeError, ValueError):
+                delay = _RATE_LIMIT_BASE_DELAY * (2 ** attempt)
+            logger.warning(
+                f"Rate limit hit (429) on {url}, retrying in {delay:.1f}s "
+                f"(attempt {attempt + 1}/{_MAX_RETRIES})"
+            )
+            time.sleep(delay)
+            continue
+        break
+    if response is not None:
+        response.status = response.status_code
+    return response
 
 
 def get_api_response(endpoint, auth, method="GET", payload="", params=None):
@@ -39,15 +80,19 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
     url = get_url(endpoint)
 
     try:
+        # request_with_retry handles HTTP 429 with backoff and sets .status
         if method == "GET":
-            response = client.get(url, headers=headers, params=params)
+            response = request_with_retry(
+                client, "GET", url, headers=headers, params=params
+            )
         elif method == "POST":
-            response = client.post(url, headers=headers, content=payload, params=params)
+            response = request_with_retry(
+                client, "POST", url, headers=headers, content=payload, params=params
+            )
         else:
-            response = client.request(method, url, headers=headers, content=payload, params=params)
-
-        # Add status attribute for compatibility with existing codebase
-        response.status = response.status_code
+            response = request_with_retry(
+                client, method, url, headers=headers, content=payload, params=params
+            )
 
         # Check if response is successful
         if response.status_code not in [200, 201]:
@@ -151,27 +196,37 @@ def get_trade_book(auth):
         order_map = {}
 
         if order_book and isinstance(order_book, list):
-            # Create a mapping of exchange order IDs to order details
+            # Index each order under BOTH identifiers it may expose: the internal
+            # id (EQ-/DRV-/GTT-...) and the exchange order id. Trades join on the
+            # exchange order id (their exch_order_id), which the order book also
+            # carries in exch_order_id once the order reaches the exchange.
             for order in order_book:
                 if isinstance(order, dict):
-                    exch_order_id = order.get("exch_order_id") or order.get("id")
-                    if exch_order_id:
-                        order_map[exch_order_id] = {
-                            "txn_type": order.get("txn_type", ""),
-                            "product": order.get("product", ""),
-                            "segment": order.get("segment", ""),
-                        }
+                    order_info = {
+                        "txn_type": order.get("txn_type", ""),
+                        "product": order.get("product", ""),
+                        "segment": order.get("segment", ""),
+                    }
+                    for key in (order.get("exch_order_id"), order.get("id")):
+                        if key:
+                            order_map[str(key)] = order_info
 
         # Enrich trades with order book data
         for trade in all_trades:
             if isinstance(trade, dict):
+                # Trades carry the exchange order id in exch_order_id
                 exch_order_id = trade.get("exch_order_id")
-                if exch_order_id and exch_order_id in order_map:
-                    order_info = order_map[exch_order_id]
+                order_info = order_map.get(str(exch_order_id)) if exch_order_id else None
+                if order_info:
                     trade["txn_type"] = order_info["txn_type"]
                     trade["product"] = order_info["product"]
                     logger.debug(
                         f"Enriched trade {exch_order_id} with txn_type={order_info['txn_type']}, product={order_info['product']}"
+                    )
+                else:
+                    logger.debug(
+                        f"No matching order for trade exch_order_id={exch_order_id}; "
+                        f"txn_type/product left unenriched"
                     )
 
         logger.debug(
@@ -310,8 +365,42 @@ def _invalidate_position_cache(auth):
 
 
 
+def _map_exchange_segment(exchange_segment):
+    """
+    Map an IndMoney position ``exchange_segment`` (e.g. NSE_EQ, NSE_FNO, BSE_EQ)
+    or a legacy segment label (EQUITY, F&O, COMMODITY) to the OpenAlgo exchange code.
+    """
+    seg = str(exchange_segment or "").upper()
+    mapping = {
+        "NSE_EQ": "NSE",
+        "NSE_FNO": "NFO",
+        "NSE_FO": "NFO",
+        "BSE_EQ": "BSE",
+        "BSE_FNO": "BFO",
+        "BSE_FO": "BFO",
+        "MCX_FO": "MCX",
+        "MCX_COMM": "MCX",
+        # Legacy labels
+        "EQUITY": "NSE",
+        "F&O": "NFO",
+        "FUTURES": "NFO",
+        "COMMODITY": "MCX",
+    }
+    if seg in mapping:
+        return mapping[seg]
+    if seg.startswith("NSE"):
+        return "NSE"
+    if seg.startswith("BSE"):
+        return "BSE"
+    if seg.startswith("MCX"):
+        return "MCX"
+    return seg
+
+
 def get_open_position(tradingsymbol, exchange, product, auth):
-    # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
+    # Resolve the reliable security_id (token) for the requested symbol before
+    # converting to broker symbol format for the fallback name match.
+    target_token = str(get_token(tradingsymbol, exchange) or "")
     tradingsymbol = get_br_symbol(tradingsymbol, exchange)
     positions_response = _get_cached_positions(auth)
     net_qty = "0"
@@ -341,23 +430,24 @@ def get_open_position(tradingsymbol, exchange, product, auth):
             if not isinstance(position, dict):
                 continue
 
-            # Map the actual IndMoney API fields
-            position_symbol = position.get("symbol")  # Actual field name from API
-            position_segment = position.get("segment", "")
+            # Read documented IndMoney position fields (with legacy fallbacks)
+            position_token = str(position.get("security_id", "") or "")
+            position_symbol = position.get("trading_symbol") or position.get("symbol")
+            position_qty = position.get("net_quantity", position.get("net_qty", 0))
 
-            # Map segment to exchange format for comparison
-            if position_segment == "F&O" or position_segment == "FUTURES":
-                mapped_exchange = "NFO"
-            elif position_segment == "EQUITY":
-                mapped_exchange = "NSE"  # Default for equity
-            elif position_segment == "COMMODITY":
-                mapped_exchange = "MCX"
-            else:
-                mapped_exchange = position_segment
+            # Map exchange_segment (e.g. NSE_EQ, NSE_FNO, BSE_EQ) to the
+            # NSE/BSE/MCX root returned by map_exchange_type()
+            mapped_exchange = map_exchange_type(
+                _map_exchange_segment(
+                    position.get("exchange_segment", position.get("segment", ""))
+                )
+            )
 
-            # Check if this position matches our search criteria
-            if position_symbol == tradingsymbol and mapped_exchange == map_exchange_type(exchange):
-                net_qty = str(position.get("net_qty", 0))
+            # Prefer a reliable security_id match; fall back to symbol match
+            token_match = target_token and position_token == target_token
+            symbol_match = position_symbol == tradingsymbol
+            if (token_match or symbol_match) and mapped_exchange == map_exchange_type(exchange):
+                net_qty = str(position_qty)
                 break  # Return the first match
 
     return net_qty
@@ -388,9 +478,7 @@ def place_order_api(data, auth):
     client = get_httpx_client()
 
     url = get_url("/order")
-    res = client.post(url, headers=headers, content=payload)
-    # Add status attribute for compatibility with existing codebase
-    res.status = res.status_code
+    res = request_with_retry(client, "POST", url, headers=headers, content=payload)
 
     try:
         response_data = json.loads(res.text)
@@ -544,8 +632,8 @@ def close_all_positions(current_api_key, auth):
             if not isinstance(position, dict):
                 continue
 
-            # Skip if net quantity is zero - using actual API field name
-            net_qty = position.get("net_qty", 0)
+            # Skip if net quantity is zero - documented field with legacy fallback
+            net_qty = position.get("net_quantity", position.get("net_qty", 0))
             if int(net_qty) == 0:
                 continue
 
@@ -553,28 +641,26 @@ def close_all_positions(current_api_key, auth):
             action = "SELL" if int(net_qty) > 0 else "BUY"
             quantity = abs(int(net_qty))
 
-            # Map segment to standard exchange format - using actual API field name
-            segment = position.get("segment", "")
-            if segment == "F&O" or segment == "FUTURES":
-                exchange = "NFO"
-            elif segment == "EQUITY":
-                exchange = "NSE"
-            elif segment == "COMMODITY":
-                exchange = "MCX"
-            else:
-                exchange = segment
+            # Map exchange_segment (documented) to OpenAlgo exchange, legacy fallback
+            exchange = _map_exchange_segment(
+                position.get("exchange_segment", position.get("segment", ""))
+            )
 
             # get openalgo symbol to send to placeorder function
             symbol = get_symbol(position["security_id"], exchange)
             logger.debug(f"The Symbol is {symbol}")
 
-            # Determine product type based on actual API response
-            api_product = position.get("product", "")
+            # Determine product type. get_positions() tags each item with the
+            # query_product it was fetched under (cnc/intraday/margin); fall back
+            # to any product field the API returns.
+            api_product = str(
+                position.get("query_product", position.get("product", ""))
+            ).upper()
             if api_product == "INTRADAY":
                 product = "MIS"
-            elif api_product == "DELIVERY":
+            elif api_product in ("DELIVERY", "CNC"):
                 product = "CNC"
-            elif exchange in ["NFO", "MCX", "BFO", "CDS"]:
+            elif api_product == "MARGIN" or exchange in ["NFO", "MCX", "BFO", "CDS"]:
                 product = "NRML"
             else:
                 product = "MIS"
@@ -625,10 +711,7 @@ def cancel_order(orderid, auth):
 
     # Make the POST request to cancel order using httpx
     url = get_url("/order/cancel")
-    res = client.post(url, headers=headers, content=json.dumps(payload))
-
-    # Add status attribute for compatibility with existing codebase
-    res.status = res.status_code
+    res = request_with_retry(client, "POST", url, headers=headers, content=json.dumps(payload))
 
     # Parse the response
     data = json.loads(res.text)
@@ -675,10 +758,7 @@ def modify_order(data, auth):
     url = get_url("/order/modify")
 
     # Make the POST request using httpx
-    res = client.post(url, headers=headers, content=payload)
-
-    # Add status attribute for compatibility with existing codebase
-    res.status = res.status_code
+    res = request_with_retry(client, "POST", url, headers=headers, content=payload)
 
     # Parse the response
     data = json.loads(res.text)
@@ -704,11 +784,14 @@ def cancel_all_orders_api(data, auth):
     if order_book_response is None:
         return [], []  # Return empty lists indicating failure to retrieve the order book
 
-    # Filter orders that are in 'open' or 'trigger_pending' state
+    # Filter orders that are still open or trigger-pending (cancellable).
+    # Covers all live-order statuses per Indmoney docs (QUEUED, O-PENDING,
+    # PENDING, PROCESSING, INITIATED, MODIFIED, SL-PENDING, PARTIALLY FILLED).
+    cancellable_statuses = OPEN_STATUSES | TRIGGER_PENDING_STATUSES
     orders_to_cancel = [
         order
         for order in order_book_response
-        if order["status"] in ["PENDING", "O-PENDING", "SL-PENDING"]
+        if str(order.get("status", "")).upper().strip() in cancellable_statuses
     ]
     logger.debug(f"Orders to cancel: {orders_to_cancel}")
     canceled_orders = []

--- a/broker/indmoney/mapping/order_data.py
+++ b/broker/indmoney/mapping/order_data.py
@@ -7,6 +7,49 @@ from utils.logging import get_logger
 logger = get_logger(__name__)
 
 
+# Indmoney order status values (docs 09-order-management) normalized to the
+# OpenAlgo canonical statuses used by other brokers (e.g. Zerodha):
+# complete / open / trigger pending / rejected / cancelled.
+COMPLETED_STATUSES = {"SUCCESS", "TRADED", "COMPLETE", "EXECUTED"}
+OPEN_STATUSES = {
+    "QUEUED",
+    "O-PENDING",
+    "PENDING",
+    "PROCESSING",
+    "INITIATED",
+    "MODIFIED",
+    "PARTIALLY FILLED",
+}
+TRIGGER_PENDING_STATUSES = {"SL-PENDING"}
+REJECTED_STATUSES = {"REJECTED", "FAILED", "ABORTED"}
+CANCELLED_STATUSES = {
+    "CANCELLED",
+    "EXPIRED",
+    "PARTIALLY FILLED - CANCELLED",
+    "PARTIALLY FILLED - EXPIRED",
+}
+
+
+def normalize_order_status(status):
+    """
+    Normalize an Indmoney order status to an OpenAlgo canonical status.
+    Returns one of: complete, open, trigger pending, rejected, cancelled.
+    Unknown values are returned lower-cased unchanged.
+    """
+    status = str(status or "").upper().strip()
+    if status in COMPLETED_STATUSES:
+        return "complete"
+    if status in TRIGGER_PENDING_STATUSES:
+        return "trigger pending"
+    if status in OPEN_STATUSES:
+        return "open"
+    if status in REJECTED_STATUSES:
+        return "rejected"
+    if status in CANCELLED_STATUSES:
+        return "cancelled"
+    return status.lower()
+
+
 def map_order_data(order_data):
     """
     Processes and modifies a list of order dictionaries based on specific conditions.
@@ -139,19 +182,15 @@ def calculate_order_statistics(order_data):
             elif order.get("transactionType") == "SELL":
                 total_sell_orders += 1
 
-            # Count orders based on their status - handle new Indmoney status values
-            status = order.get("orderStatus", "").upper()
-            if status in ["SUCCESS", "TRADED"]:
+            # Normalize status to OpenAlgo canonical value and count it
+            normalized = normalize_order_status(order.get("orderStatus", ""))
+            order["orderStatus"] = normalized
+            if normalized == "complete":
                 total_completed_orders += 1
-                order["orderStatus"] = "complete"
-            elif status in ["O-PENDING", "PENDING"]:
+            elif normalized in ("open", "trigger pending"):
                 total_open_orders += 1
-                order["orderStatus"] = "open"
-            elif status in ["REJECTED"]:
+            elif normalized == "rejected":
                 total_rejected_orders += 1
-                order["orderStatus"] = "rejected"
-            elif status in ["CANCELLED"]:
-                order["orderStatus"] = "cancelled"
 
         # Compile and return the statistics
         return {
@@ -221,7 +260,7 @@ def transform_order_data(orders):
                 "pricetype": order.get("orderType", ""),
                 "product": order.get("productType", ""),
                 "orderid": order.get("orderId", ""),
-                "order_status": order.get("orderStatus", ""),
+                "order_status": normalize_order_status(order.get("orderStatus", "")),
                 "timestamp": order.get("updateTime", ""),
             }
 

--- a/broker/indmoney/mapping/transform_data.py
+++ b/broker/indmoney/mapping/transform_data.py
@@ -38,45 +38,61 @@ def transform_data(data, token):
     action = data["action"].upper()
 
     if data["pricetype"] == "MARKET":
-        # Get username from Flask session
+        # Get username from Flask session (never fall back to a hard-coded user
+        # — that would borrow another account's token). Without a session user
+        # we cannot fetch a quote, so send a native MARKET order instead.
         username = None
         if session and hasattr(session, "get"):
             username = session.get("username")
 
-        # Get auth token for market data using username
-        auth_token = get_auth_token(username if username else "kalaivani")
+        auth_token = get_auth_token(username) if username else None
 
-        logger.info(f"Using auth token for user: {username if username else 'kalaivani'}")
+        if not auth_token:
+            logger.warning(
+                "No session user/auth token available for market-order price "
+                "adjustment; sending a native MARKET order."
+            )
+        else:
+            logger.info(f"Using auth token for user: {username}")
 
-        # Create BrokerData instance to use get_quotes - only need auth_token
-        broker_data = BrokerData(auth_token)
+            # Create BrokerData instance to use get_quotes - only need auth_token
+            broker_data = BrokerData(auth_token)
 
-        # Fetch quotes for the symbol
-        quote_data = broker_data.get_quotes(data["symbol"], data["exchange"])
-        logger.info(f"Quote data for market order adjustment: {quote_data}")
+            # Fetch quotes for the symbol
+            quote_data = broker_data.get_quotes(data["symbol"], data["exchange"])
+            logger.info(f"Quote data for market order adjustment: {quote_data}")
 
-        # Adjust price based on action (BUY or SELL) using LTP
-        ltp = float(quote_data.get("ltp", 0))
-        if action == "BUY":
-            # Add 0.1% to LTP for BUY orders
-            adjusted_price = ltp * 1.001
-            price = str(round(adjusted_price, 2))
-            logger.info(f"Adjusted BUY price: LTP {ltp} + 0.1% = {price}")
-            # Change order type to LIMIT (uppercase required by API)
-            order_type = "LIMIT"
-        elif action == "SELL":
-            # Subtract 0.1% from LTP for SELL orders
-            adjusted_price = ltp * 0.999
-            price = str(round(adjusted_price, 2))
-            logger.info(f"Adjusted SELL price: LTP {ltp} - 0.1% = {price}")
-            # Change order type to LIMIT (uppercase required by API)
-            order_type = "LIMIT"
+            # Adjust price based on action (BUY or SELL) using LTP
+            ltp = float(quote_data.get("ltp", 0))
+            if ltp <= 0:
+                logger.warning(
+                    "LTP unavailable for market-order adjustment; sending a native MARKET order."
+                )
+            elif action == "BUY":
+                # Add 0.1% to LTP for BUY orders
+                adjusted_price = ltp * 1.001
+                price = str(round(adjusted_price, 2))
+                logger.info(f"Adjusted BUY price: LTP {ltp} + 0.1% = {price}")
+                # Change order type to LIMIT (uppercase required by API)
+                order_type = "LIMIT"
+            elif action == "SELL":
+                # Subtract 0.1% from LTP for SELL orders
+                adjusted_price = ltp * 0.999
+                price = str(round(adjusted_price, 2))
+                logger.info(f"Adjusted SELL price: LTP {ltp} - 0.1% = {price}")
+                # Change order type to LIMIT (uppercase required by API)
+                order_type = "LIMIT"
 
     # Basic mapping from OpenAlgo to Indmoney
     segment = map_segment(data["exchange"])
+    # Indmoney order API only accepts NSE/BSE for the exchange field; F&O
+    # exchanges (NFO/BFO/CDS/BCD) map to their NSE/BSE parent + DERIVATIVE segment.
+    api_exchange = map_exchange_type(data["exchange"].upper())
+    # algo_id is exchange-specific: 99999 for NSE, 9999999999999999 for BSE.
+    algo_id = "9999999999999999" if api_exchange == "BSE" else "99999"
     transformed = {
         "txn_type": action,  # BUY/SELL
-        "exchange": data["exchange"].upper(),  # NSE/BSE
+        "exchange": api_exchange,  # NSE/BSE
         "segment": segment,  # DERIVATIVE/EQUITY
         "product": map_product_type(data["product"]),  # MARGIN/INTRADAY/CNC
         "order_type": order_type,  # LIMIT/MARKET
@@ -84,7 +100,7 @@ def transform_data(data, token):
         "security_id": token,  # Security ID from token
         "qty": int(data["quantity"]),  # Order quantity
         "is_amo": data.get("is_amo", False),  # After market order flag
-        "algo_id": "99999",  # Required by API - use 99999 for regular orders
+        "algo_id": algo_id,  # Required by API - NSE: 99999, BSE: 9999999999999999
     }
 
     # Log the segment mapping for debugging

--- a/broker/indmoney/streaming/indWebSocket.py
+++ b/broker/indmoney/streaming/indWebSocket.py
@@ -16,7 +16,7 @@ class IndWebSocket:
 
     # WebSocket endpoints
     PRICE_FEED_URI = "wss://ws-prices.indstocks.com/api/v1/ws/prices"
-    ORDER_UPDATES_URI = "wss://ws-order-updates.indstocks.com"
+    ORDER_UPDATES_URI = "wss://ws-order-updates.indstocks.com/api/v1/ws/trades"
 
     HEART_BEAT_MESSAGE = "ping"
     HEART_BEAT_INTERVAL = 30  # 30 seconds

--- a/broker/indmoney/streaming/indWebSocket.py
+++ b/broker/indmoney/streaming/indWebSocket.py
@@ -30,6 +30,12 @@ class IndWebSocket:
     LTP_MODE = "ltp"
     QUOTE_MODE = "quote"
 
+    # Subscription batching. INDstocks allows up to 3000 instruments per
+    # connection; a single subscribe frame is chunked so a large subscription
+    # (e.g. a full option chain) is split across several frames.
+    MAX_INSTRUMENTS_PER_SUBSCRIBE = 1000
+    MAX_INSTRUMENTS_PER_CONNECTION = 3000
+
     def __init__(
         self,
         access_token,
@@ -167,32 +173,35 @@ class IndWebSocket:
                 logger.error(error_message)
                 raise ValueError(error_message)
 
-            request_data = {
-                "action": self.SUBSCRIBE_ACTION,
-                "mode": mode,
-                "instruments": instruments,
-            }
+            if not instruments:
+                return
 
-            # Log the subscription request for debugging
-            logger.info(">> SENDING SUBSCRIPTION REQUEST:")
-            logger.info(f"   Action: {request_data['action']}")
-            logger.info(f"   Mode: {request_data['mode']}")
-            logger.info(f"   Instruments: {request_data['instruments']}")
-            logger.info(f"   Full JSON: {json.dumps(request_data)}")
-
-            # Store subscription for reconnection
+            # Store subscription for reconnection (dedup)
             if mode not in self.input_request_dict:
                 self.input_request_dict[mode] = []
 
-            # Add instruments to subscription list (avoid duplicates)
-            for instrument in instruments:
-                if instrument not in self.input_request_dict[mode]:
-                    self.input_request_dict[mode].append(instrument)
+            new_instruments = [
+                i for i in instruments if i not in self.input_request_dict[mode]
+            ]
+            if not new_instruments:
+                logger.debug(f"All {len(instruments)} instruments already subscribed in {mode} mode")
+                return
 
-            # Send subscription request
+            # Enforce the per-connection instrument cap
+            current_total = sum(len(v) for v in self.input_request_dict.values())
+            if current_total + len(new_instruments) > self.MAX_INSTRUMENTS_PER_CONNECTION:
+                logger.error(
+                    f"Cannot subscribe {len(new_instruments)} instruments: would exceed the "
+                    f"{self.MAX_INSTRUMENTS_PER_CONNECTION}-instrument per-connection limit "
+                    f"(currently {current_total})"
+                )
+                raise ValueError("Per-connection instrument limit exceeded")
+
+            self.input_request_dict[mode].extend(new_instruments)
+
+            # Send the subscription in chunks
             if self.wsapp:
-                self.wsapp.send(json.dumps(request_data))
-                logger.info(f"[OK] Subscribed to {len(instruments)} instruments in {mode} mode")
+                self._send_subscribe_chunks(new_instruments, mode)
                 self.RESUBSCRIBE_FLAG = True
             else:
                 logger.warning(
@@ -202,6 +211,24 @@ class IndWebSocket:
         except Exception as e:
             logger.error(f"Error during subscribe: {e}")
             raise e
+
+    def _send_subscribe_chunks(self, instruments, mode):
+        """Send a subscribe request in chunks of MAX_INSTRUMENTS_PER_SUBSCRIBE."""
+        if not self.wsapp:
+            return
+        total = len(instruments)
+        for start in range(0, total, self.MAX_INSTRUMENTS_PER_SUBSCRIBE):
+            chunk = instruments[start : start + self.MAX_INSTRUMENTS_PER_SUBSCRIBE]
+            request_data = {
+                "action": self.SUBSCRIBE_ACTION,
+                "mode": mode,
+                "instruments": chunk,
+            }
+            self.wsapp.send(json.dumps(request_data))
+            logger.info(
+                f"[OK] Subscribed to {len(chunk)} instruments in {mode} mode "
+                f"(chunk {start // self.MAX_INSTRUMENTS_PER_SUBSCRIBE + 1}, {total} total)"
+            )
 
     def unsubscribe(self, instruments, mode="ltp"):
         """
@@ -237,16 +264,11 @@ class IndWebSocket:
             raise e
 
     def resubscribe(self):
-        """Resubscribe to all previously subscribed instruments"""
+        """Resubscribe to all previously subscribed instruments (chunked)."""
         try:
             for mode, instruments in self.input_request_dict.items():
                 if instruments:
-                    request_data = {
-                        "action": self.SUBSCRIBE_ACTION,
-                        "mode": mode,
-                        "instruments": instruments,
-                    }
-                    self.wsapp.send(json.dumps(request_data))
+                    self._send_subscribe_chunks(instruments, mode)
                     logger.info(f"Resubscribed to {len(instruments)} instruments in {mode} mode")
         except Exception as e:
             logger.error(f"Error during resubscribe: {e}")

--- a/broker/indmoney/streaming/indWebSocket.py
+++ b/broker/indmoney/streaming/indWebSocket.py
@@ -1,12 +1,12 @@
 import json
-import logging
-import os
 import ssl
 import time
 
-import logzero
 import websocket
-from logzero import logger
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
 
 
 class IndWebSocket:
@@ -20,7 +20,7 @@ class IndWebSocket:
 
     HEART_BEAT_MESSAGE = "ping"
     HEART_BEAT_INTERVAL = 30  # 30 seconds
-    RESUBSCRIBE_FLAG = False
+    HEART_BEAT_TIMEOUT = 10  # seconds to wait for a pong before dropping the socket
 
     # Available Actions
     SUBSCRIBE_ACTION = "subscribe"
@@ -29,10 +29,6 @@ class IndWebSocket:
     # Subscription Modes
     LTP_MODE = "ltp"
     QUOTE_MODE = "quote"
-
-    wsapp = None
-    input_request_dict = {}
-    current_retry_attempt = 0
 
     def __init__(
         self,
@@ -76,12 +72,13 @@ class IndWebSocket:
         self.retry_multiplier = retry_multiplier
         self.retry_duration = retry_duration
 
-        # Create log folder based on current date
-        log_folder = time.strftime("%Y-%m-%d", time.localtime())
-        log_folder_path = os.path.join("logs", log_folder)
-        os.makedirs(log_folder_path, exist_ok=True)
-        log_path = os.path.join(log_folder_path, "indmoney_ws.log")
-        logzero.logfile(log_path, loglevel=logging.INFO)
+        # Per-instance state (previously class-level mutable attrs, which leaked
+        # subscription state across users). Each client owns its own socket,
+        # subscription list, retry counter and resubscribe flag.
+        self.wsapp = None
+        self.input_request_dict = {}
+        self.current_retry_attempt = 0
+        self.RESUBSCRIBE_FLAG = False
 
         if not self._sanity_check():
             logger.error("Invalid initialization parameters. Provide valid access token.")
@@ -276,6 +273,15 @@ class IndWebSocket:
         """Establish WebSocket connection to price feed"""
         headers = {"Authorization": self.access_token}
 
+        # Close any existing socket first so we never leak an orphaned
+        # run_forever/socket by overwriting self.wsapp.
+        if self.wsapp is not None:
+            try:
+                self.wsapp.close()
+            except Exception as e:
+                logger.warning(f"Error closing previous WebSocket before reconnect: {e}")
+            self.wsapp = None
+
         try:
             self.wsapp = websocket.WebSocketApp(
                 self.PRICE_FEED_URI,
@@ -289,9 +295,13 @@ class IndWebSocket:
             )
 
             logger.info("Connecting to INDmoney WebSocket...")
+            # ping_timeout (< ping_interval) lets websocket-client detect a
+            # half-open connection and close the socket promptly instead of
+            # holding the FD until the OS TCP timeout.
             self.wsapp.run_forever(
                 sslopt={"cert_reqs": ssl.CERT_NONE},
                 ping_interval=self.HEART_BEAT_INTERVAL,
+                ping_timeout=self.HEART_BEAT_TIMEOUT,
                 ping_payload=self.HEART_BEAT_MESSAGE,
             )
 
@@ -304,53 +314,31 @@ class IndWebSocket:
         self.RESUBSCRIBE_FLAG = False
         self.DISCONNECT_FLAG = True
         if self.wsapp:
-            self.wsapp.close()
-            logger.info("WebSocket connection closed")
+            try:
+                self.wsapp.close()
+                logger.info("WebSocket connection closed")
+            except Exception as e:
+                logger.warning(f"Error closing WebSocket: {e}")
+            finally:
+                # Drop the reference so the socket/thread can be GC'd and a
+                # later connect() starts clean.
+                self.wsapp = None
 
     def _on_error(self, wsapp, error):
-        """Handle WebSocket errors with retry logic"""
+        """Handle WebSocket errors.
+
+        This callback runs *inside* run_forever's dispatch, so it must NOT call
+        connect()/run_forever() itself — doing so nested the run loops and
+        stacked live sockets on every error. Reconnection is owned by the
+        adapter (driven by the on_close callback); here we only flag the need
+        to resubscribe and surface the error to the adapter.
+        """
         self.RESUBSCRIBE_FLAG = True
         logger.error(f"WebSocket error: {error}")
-
-        if self.current_retry_attempt < self.MAX_RETRY_ATTEMPT:
-            logger.warning(f"Attempting to reconnect (Attempt {self.current_retry_attempt + 1})...")
-            self.current_retry_attempt += 1
-
-            # Calculate delay based on retry strategy
-            if self.retry_strategy == 0:  # Simple retry
-                time.sleep(self.retry_delay)
-            elif self.retry_strategy == 1:  # Exponential backoff
-                delay = self.retry_delay * (
-                    self.retry_multiplier ** (self.current_retry_attempt - 1)
-                )
-                time.sleep(delay)
-            else:
-                logger.error(f"Invalid retry strategy {self.retry_strategy}")
-                raise Exception(f"Invalid retry strategy {self.retry_strategy}")
-
-            try:
-                # Re-read a fresh token before reconnecting so a daily-rolled
-                # token (~3 AM IST) is used instead of the dead one.
-                self._refresh_access_token()
-                self.close_connection()
-                self.connect()
-            except Exception as e:
-                logger.error(f"Error during reconnect: {e}")
-                if hasattr(self, "on_error"):
-                    self.on_error("Reconnect Error", str(e) if str(e) else "Unknown error")
-        else:
-            self.close_connection()
-            if hasattr(self, "on_error"):
-                self.on_error("Max retry attempt reached", "Connection closed")
-
-            if (
-                self.retry_duration is not None
-                and self.last_pong_timestamp is not None
-                and time.time() - self.last_pong_timestamp > self.retry_duration * 60
-            ):
-                logger.warning("Connection closed due to inactivity.")
-            else:
-                logger.warning("Connection closed due to max retry attempts reached.")
+        try:
+            self.on_error(wsapp, error)
+        except Exception as e:
+            logger.error(f"Error in on_error callback: {e}")
 
     def _on_close(self, wsapp, close_status_code=None, close_msg=None):
         """Handle WebSocket connection close event"""

--- a/broker/indmoney/streaming/indmoney_adapter.py
+++ b/broker/indmoney/streaming/indmoney_adapter.py
@@ -42,6 +42,12 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Set on disconnect so the reconnect backoff sleep is interruptible and
         # the loop exits promptly instead of lingering up to max_reconnect_delay.
         self._stop_event = threading.Event()
+        # Batch subscription management: collect per-symbol subscribe() calls
+        # arriving in quick succession (e.g. a full option chain) and send them
+        # grouped by mode in a few frames instead of one frame per symbol.
+        self.subscription_queue = []
+        self.batch_timer = None
+        self.batch_delay = 0.5  # 500ms window to collect subscriptions into a batch
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -66,6 +72,9 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.info("Re-initializing: closing previous WebSocket client")
             self.running = False
             self._stop_event.set()
+            self._cancel_batch_timer()
+            with self.lock:
+                self.subscription_queue.clear()
             try:
                 self.ws_client.close_connection()
             except Exception as e:
@@ -200,11 +209,61 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.running = False
         # Wake an in-progress reconnect backoff so the loop exits promptly.
         self._stop_event.set()
+        # Cancel any pending batch-subscription timer so its thread doesn't fire
+        # after shutdown.
+        self._cancel_batch_timer()
         if hasattr(self, "ws_client") and self.ws_client:
             self.ws_client.close_connection()
 
         # Clean up ZeroMQ resources
         self.cleanup_zmq()
+
+    def _start_batch_timer(self) -> None:
+        """(Re)start the batch-collection timer. Caller must hold self.lock."""
+        if self.batch_timer:
+            self.batch_timer.cancel()
+        self.batch_timer = threading.Timer(self.batch_delay, self._process_batch_subscriptions)
+        self.batch_timer.daemon = True
+        self.batch_timer.start()
+
+    def _cancel_batch_timer(self) -> None:
+        """Cancel the batch timer if one is pending."""
+        with self.lock:
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+
+    def _process_batch_subscriptions(self) -> None:
+        """Flush queued subscriptions to the client, grouped by mode, so a burst
+        of per-symbol subscribe() calls becomes a few frames instead of one per
+        symbol."""
+        with self.lock:
+            if not self.subscription_queue:
+                self.batch_timer = None
+                return
+            # Group queued instruments by INDmoney mode (dedup within the batch)
+            mode_groups: dict[str, list[str]] = {}
+            for sub in self.subscription_queue:
+                mode = sub["mode"]
+                token = sub["instrument_token"]
+                bucket = mode_groups.setdefault(mode, [])
+                if token not in bucket:
+                    bucket.append(token)
+            self.subscription_queue.clear()
+            self.batch_timer = None
+
+        if not (self.connected and self.ws_client):
+            # Not connected: items remain in self.subscriptions and are
+            # resubscribed by _on_open when the socket opens.
+            self.logger.info("Batch flush skipped (not connected); will resubscribe on open")
+            return
+
+        for mode, instruments in mode_groups.items():
+            try:
+                self.logger.info(f"Batch subscribing {len(instruments)} instruments in {mode} mode")
+                self.ws_client.subscribe(instruments=instruments, mode=mode)
+            except Exception as e:
+                self.logger.error(f"Batch subscription failed for {mode} mode: {e}")
 
     def subscribe(
         self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 1
@@ -259,20 +318,18 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 "depth_level": depth_level,
             }
 
-        # Subscribe if connected
-        self.logger.info(
-            f"Checking connection status: connected={self.connected}, ws_client={self.ws_client is not None}"
-        )
+        # Queue for batch processing. If connected, the batch timer flushes the
+        # queue (grouped by mode) shortly; if not, _on_open resubscribes from
+        # self.subscriptions when the connection opens.
         if self.connected and self.ws_client:
-            try:
-                self.logger.info(
-                    f"ATTEMPTING SUBSCRIPTION: {symbol}.{exchange}, instrument_token={instrument_token}, mode={indmoney_mode}"
+            with self.lock:
+                self.subscription_queue.append(
+                    {"instrument_token": instrument_token, "mode": indmoney_mode}
                 )
-                self.ws_client.subscribe(instruments=[instrument_token], mode=indmoney_mode)
-                self.logger.info(f"SUBSCRIPTION SENT: {symbol}.{exchange} in {indmoney_mode} mode")
-            except Exception as e:
-                self.logger.error(f"SUBSCRIPTION ERROR for {symbol}.{exchange}: {e}", exc_info=True)
-                return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
+                # First item in an empty queue starts the collection window.
+                if len(self.subscription_queue) == 1:
+                    self._start_batch_timer()
+            self.logger.info(f"QUEUED SUBSCRIPTION: {symbol}.{exchange} in {indmoney_mode} mode")
         else:
             self.logger.warning(
                 "NOT CONNECTED YET - subscription will be sent when connection opens"

--- a/broker/indmoney/streaming/indmoney_adapter.py
+++ b/broker/indmoney/streaming/indmoney_adapter.py
@@ -39,6 +39,9 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # accumulating threads and sockets on a flapping feed.
         self._reconnect_lock = threading.Lock()
         self._reconnecting = False
+        # Set on disconnect so the reconnect backoff sleep is interruptible and
+        # the loop exits promptly instead of lingering up to max_reconnect_delay.
+        self._stop_event = threading.Event()
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -56,6 +59,18 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """
         self.user_id = user_id
         self.broker_name = broker_name
+
+        # If re-initializing a live adapter, tear down the previous client first
+        # so we don't orphan its open socket and reconnect thread.
+        if self.ws_client is not None:
+            self.logger.info("Re-initializing: closing previous WebSocket client")
+            self.running = False
+            self._stop_event.set()
+            try:
+                self.ws_client.close_connection()
+            except Exception as e:
+                self.logger.warning(f"Error closing previous ws_client on re-init: {e}")
+            self.ws_client = None
 
         # Get access token from database if not provided
         if not auth_data:
@@ -126,6 +141,8 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.logger.debug("Reconnect loop already running; not starting another")
                 return
             self._reconnecting = True
+            # Fresh loop: clear any stop signal left by a previous disconnect.
+            self._stop_event.clear()
 
         threading.Thread(target=self._connect_with_retry, daemon=True).start()
 
@@ -166,7 +183,11 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         self.max_reconnect_delay,
                     )
                     self.logger.warning(f"Disconnected; reconnecting in {delay} seconds...")
-                    time.sleep(delay)
+                    # Interruptible sleep: returns immediately if disconnect()
+                    # signals a stop, so the thread doesn't linger for up to
+                    # max_reconnect_delay after shutdown.
+                    if self._stop_event.wait(delay):
+                        break
 
             if self.running and self.reconnect_attempts >= self.max_reconnect_attempts:
                 self.logger.error("Max reconnection attempts reached. Giving up.")
@@ -177,6 +198,8 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def disconnect(self) -> None:
         """Disconnect from INDmoney WebSocket"""
         self.running = False
+        # Wake an in-progress reconnect backoff so the loop exits promptly.
+        self._stop_event.set()
         if hasattr(self, "ws_client") and self.ws_client:
             self.ws_client.close_connection()
 

--- a/broker/indmoney/streaming/indmoney_adapter.py
+++ b/broker/indmoney/streaming/indmoney_adapter.py
@@ -34,6 +34,11 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.running = False
         self.lock = threading.Lock()
         self.last_values = {}  # Cache for retaining last known values
+        # Guard so only one reconnect loop runs at a time. Without it, every
+        # on_close spawns a fresh thread (each blocking in its own run_forever),
+        # accumulating threads and sockets on a flapping feed.
+        self._reconnect_lock = threading.Lock()
+        self._reconnecting = False
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -104,34 +109,70 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.error("WebSocket client not initialized. Call initialize() first.")
             return
 
+        self._start_reconnect_thread()
+
+    def _start_reconnect_thread(self) -> None:
+        """Start the single (re)connect loop, ensuring only one runs at a time.
+
+        ws_client.connect() blocks in run_forever until the socket drops, so a
+        single thread owns the whole connect -> drop -> reconnect lifecycle. The
+        _reconnecting guard stops any second thread (and thus a second socket)
+        from ever being started.
+        """
+        with self._reconnect_lock:
+            if not self.running:
+                return
+            if self._reconnecting:
+                self.logger.debug("Reconnect loop already running; not starting another")
+                return
+            self._reconnecting = True
+
         threading.Thread(target=self._connect_with_retry, daemon=True).start()
 
     def _connect_with_retry(self) -> None:
-        """Connect to INDmoney WebSocket with retry logic"""
-        while self.running and self.reconnect_attempts < self.max_reconnect_attempts:
-            try:
-                # Refresh the client's token before connecting so a reconnect
-                # after the daily token rollover uses a live token.
-                if self.ws_client:
-                    self.ws_client._refresh_access_token()
+        """Own the connect/reconnect lifecycle in a single thread.
 
-                self.logger.info(
-                    f"Connecting to INDmoney WebSocket (attempt {self.reconnect_attempts + 1})"
-                )
-                self.ws_client.connect()
-                self.reconnect_attempts = 0  # Reset attempts on successful connection
-                break
+        connect() blocks until the socket drops; when it returns we reconnect
+        here (rather than spawning a new thread from on_close) so there is never
+        more than one live socket. reconnect_attempts is reset in _on_open when
+        a connection successfully opens.
+        """
+        try:
+            while self.running and self.reconnect_attempts < self.max_reconnect_attempts:
+                try:
+                    # Refresh the client's token before connecting so a reconnect
+                    # after the daily token rollover uses a live token.
+                    if self.ws_client:
+                        self.ws_client._refresh_access_token()
 
-            except Exception as e:
-                self.reconnect_attempts += 1
-                delay = min(
-                    self.reconnect_delay * (2**self.reconnect_attempts), self.max_reconnect_delay
-                )
-                self.logger.error(f"Connection failed: {e}. Retrying in {delay} seconds...")
-                time.sleep(delay)
+                    self.logger.info(
+                        f"Connecting to INDmoney WebSocket (attempt {self.reconnect_attempts + 1})"
+                    )
+                    # Blocks until the socket drops or an error is raised.
+                    self.ws_client.connect()
 
-        if self.reconnect_attempts >= self.max_reconnect_attempts:
-            self.logger.error("Max reconnection attempts reached. Giving up.")
+                    # connect() returned => socket closed. If we're shutting
+                    # down, exit; otherwise treat as an unexpected drop.
+                    if not self.running:
+                        break
+                    self.reconnect_attempts += 1
+                except Exception as e:
+                    self.reconnect_attempts += 1
+                    self.logger.error(f"Connection error: {e}")
+
+                if self.running and self.reconnect_attempts < self.max_reconnect_attempts:
+                    delay = min(
+                        self.reconnect_delay * (2**self.reconnect_attempts),
+                        self.max_reconnect_delay,
+                    )
+                    self.logger.warning(f"Disconnected; reconnecting in {delay} seconds...")
+                    time.sleep(delay)
+
+            if self.running and self.reconnect_attempts >= self.max_reconnect_attempts:
+                self.logger.error("Max reconnection attempts reached. Giving up.")
+        finally:
+            with self._reconnect_lock:
+                self._reconnecting = False
 
     def disconnect(self) -> None:
         """Disconnect from INDmoney WebSocket"""
@@ -290,6 +331,9 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info("==================== WEBSOCKET OPENED ====================")
         self.logger.info("Connection established to INDmoney WebSocket")
         self.connected = True
+        # A healthy open resets the retry budget so a long-lived connection that
+        # drops occasionally doesn't eventually exhaust max_reconnect_attempts.
+        self.reconnect_attempts = 0
 
         # Resubscribe to existing subscriptions if reconnecting
         with self.lock:
@@ -346,13 +390,19 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.error(f"INDmoney WebSocket error: {error}")
 
     def _on_close(self, wsapp) -> None:
-        """Callback when connection is closed"""
+        """Callback when connection is closed.
+
+        Do NOT spawn a reconnect thread here — that produced a second socket
+        while the connect loop was still active. The single _connect_with_retry
+        loop reconnects on its own when ws_client.connect() returns. If for any
+        reason no loop is running (e.g. connect() raised before blocking), the
+        guarded starter is a safe no-op when one is already active.
+        """
         self.logger.info("INDmoney WebSocket connection closed")
         self.connected = False
 
-        # Attempt to reconnect if we're still running
         if self.running:
-            threading.Thread(target=self._connect_with_retry, daemon=True).start()
+            self._start_reconnect_thread()
 
     def _on_message(self, wsapp, message) -> None:
         """Callback for text messages from the WebSocket"""


### PR DESCRIPTION
fix(indmoney): align broker with updated IndStocks API + fix option chain quotes, close WebSocket file-descriptor leaks in streaming, close second-order WS resource leaks in adapter and batch WebSocket subscriptions like Zerodha

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns the IndMoney broker with the latest IndStocks API, fixes option‑chain quotes, and hardens streaming with batched WebSocket subscriptions and leak‑free reconnects.

- **New Features**
  - Batch WebSocket subscriptions (chunked, deduped, capped per connection) for large lists like option chains; resubscribe uses the same chunking.
  - Auto‑retry HTTP 429 with exponential backoff (honors Retry‑After) across data, funds, margin, and order APIs.

- **Bug Fixes**
  - Option‑chain quotes: tolerate “poison” scrip codes via bisection + TTL cache; return entries with error (no data) for unquotable strikes so chains and OI views don’t stall.
  - API alignment: read documented position fields (security_id, net_quantity, trading_symbol, exchange_segment) and match by token; send NSE/BSE in orders (F&O maps to parent) with exchange‑specific algo_id; normalize full status set to canonical values so cancel‑all covers all open/trigger states; enrich trades by exch_order_id/internal id.
  - MARKET orders: drop hardcoded username fallback; only adjust price when a session auth token and valid LTP are available, otherwise send native MARKET.
  - Streaming: fix order‑updates URI; remove socket/thread leaks with a single guarded reconnect loop, close previous sockets before reconnect, set ping_timeout to clear half‑open FDs, keep per‑instance state, and make adapter backoff interruptible; no thread per on_close.

<sup>Written for commit 85a91e0daec93fd5cb6db8d61e1e894af960ff09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1610?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

