### PR TITLE
fix(indmoney): address cubic review findings

### DIFF
--- a/broker/indmoney/api/data.py
+++ b/broker/indmoney/api/data.py
@@ -40,7 +40,13 @@ def _is_known_bad(scrip_code):
 def _mark_bad(scrip_code):
     """Cache scrip_code as unquotable so future batches skip it."""
     with _bad_scrip_lock:
-        _BAD_SCRIP_CODES[scrip_code] = time.monotonic()
+        now = time.monotonic()
+        _BAD_SCRIP_CODES[scrip_code] = now
+        # Prune expired entries so the cache stays bounded on a long-running
+        # worker that sees many one-off unquotable strikes over the day.
+        for code, ts in list(_BAD_SCRIP_CODES.items()):
+            if now - ts > _BAD_SCRIP_TTL:
+                _BAD_SCRIP_CODES.pop(code, None)
 
 # 429 (rate-limit) retry configuration. IndStocks enforces per-category rate
 # limits (Data/Quote 5/s) and returns 429 on breach (docs 03-conventions /
@@ -541,9 +547,12 @@ class BrokerData:
             return response.get("data", {}) or {}
         except Exception as e:
             msg = str(e)
-            # A 400 "Invalid scrip codes" means at least one code in this batch
-            # is unquotable. Only these are worth bisecting.
-            bad_batch = "400" in msg or "Invalid scrip" in msg
+            # A 400 carrying the server's "Invalid scrip codes or mode" text
+            # means at least one code in this batch is unquotable — only those
+            # are worth bisecting. Match the phrase specifically (not any "400")
+            # so an unrelated 400 (bad param, etc.) doesn't blacklist valid
+            # codes for the whole TTL.
+            bad_batch = "Invalid scrip" in msg
 
             if len(codes) == 1:
                 if bad_batch:

--- a/broker/indmoney/mapping/transform_data.py
+++ b/broker/indmoney/mapping/transform_data.py
@@ -87,7 +87,19 @@ def transform_data(data, token):
     segment = map_segment(data["exchange"])
     # Indmoney order API only accepts NSE/BSE for the exchange field; F&O
     # exchanges (NFO/BFO/CDS/BCD) map to their NSE/BSE parent + DERIVATIVE segment.
-    api_exchange = map_exchange_type(data["exchange"].upper())
+    raw_exchange = data["exchange"].upper()
+    api_exchange = map_exchange_type(raw_exchange)
+    # Fail fast on exchanges the order API can't place, instead of letting the
+    # default NSE mapping silently misroute the order. Only NSE/BSE and the F&O
+    # exchanges that map onto them are placeable; MCX (maps to MCX) and any
+    # unrecognised code are rejected.
+    if raw_exchange not in {"NSE", "BSE", "NFO", "BFO", "CDS", "BCD"} or api_exchange not in {
+        "NSE",
+        "BSE",
+    }:
+        raise ValueError(
+            f"Unsupported exchange for IndMoney order placement: {data['exchange']}"
+        )
     # algo_id is exchange-specific: 99999 for NSE, 9999999999999999 for BSE.
     algo_id = "9999999999999999" if api_exchange == "BSE" else "99999"
     transformed = {

--- a/broker/indmoney/streaming/indWebSocket.py
+++ b/broker/indmoney/streaming/indWebSocket.py
@@ -136,10 +136,15 @@ class IndWebSocket:
     def _on_open(self, wsapp):
         """Handle WebSocket connection open event"""
         logger.info("WebSocket connection opened")
+        # Always notify the adapter's on_open so it marks the socket connected
+        # and resets its reconnect budget on EVERY open, not just the first.
+        # (Previously a reconnect took the resubscribe-only branch, so the
+        # adapter never saw the open: connected stayed False and the retry
+        # budget was never replenished, eventually exhausting the reconnect
+        # attempts on a long-lived but occasionally-flapping feed.)
+        self.on_open(wsapp)
         if self.RESUBSCRIBE_FLAG:
             self.resubscribe()
-        else:
-            self.on_open(wsapp)
 
     def _on_pong(self, wsapp, data):
         """Handle pong response from heartbeat"""
@@ -180,8 +185,13 @@ class IndWebSocket:
             if mode not in self.input_request_dict:
                 self.input_request_dict[mode] = []
 
+            # Collapse duplicates within this batch (dict.fromkeys preserves
+            # order) as well as against already-subscribed instruments, so a
+            # repeated token isn't sent twice or double-counted against the
+            # per-connection cap.
+            existing = set(self.input_request_dict[mode])
             new_instruments = [
-                i for i in instruments if i not in self.input_request_dict[mode]
+                i for i in dict.fromkeys(instruments) if i not in existing
             ]
             if not new_instruments:
                 logger.debug(f"All {len(instruments)} instruments already subscribed in {mode} mode")

--- a/broker/indmoney/streaming/indmoney_adapter.py
+++ b/broker/indmoney/streaming/indmoney_adapter.py
@@ -39,6 +39,9 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # accumulating threads and sockets on a flapping feed.
         self._reconnect_lock = threading.Lock()
         self._reconnecting = False
+        # Handle to the running reconnect loop so a re-initialize can wait for
+        # it to finish (and clear _reconnecting) before starting a fresh one.
+        self._reconnect_thread = None
         # Set on disconnect so the reconnect backoff sleep is interruptible and
         # the loop exits promptly instead of lingering up to max_reconnect_delay.
         self._stop_event = threading.Event()
@@ -80,6 +83,14 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
             except Exception as e:
                 self.logger.warning(f"Error closing previous ws_client on re-init: {e}")
             self.ws_client = None
+            # Wait for the previous reconnect loop to unwind so its _reconnecting
+            # guard is cleared before a fresh connect() starts a new loop.
+            # Otherwise the next connect() would see the guard still set, no-op,
+            # and leave the new client permanently unconnected.
+            prev_thread = self._reconnect_thread
+            if prev_thread is not None and prev_thread.is_alive():
+                prev_thread.join(timeout=10)
+            self._reconnect_thread = None
 
         # Get access token from database if not provided
         if not auth_data:
@@ -152,8 +163,10 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self._reconnecting = True
             # Fresh loop: clear any stop signal left by a previous disconnect.
             self._stop_event.clear()
-
-        threading.Thread(target=self._connect_with_retry, daemon=True).start()
+            self._reconnect_thread = threading.Thread(
+                target=self._connect_with_retry, daemon=True
+            )
+            self._reconnect_thread.start()
 
     def _connect_with_retry(self) -> None:
         """Own the connect/reconnect lifecycle in a single thread.
@@ -380,6 +393,16 @@ class IndmoneyWebSocketAdapter(BaseBrokerWebSocketAdapter):
         with self.lock:
             if correlation_id in self.subscriptions:
                 del self.subscriptions[correlation_id]
+            # Drop any still-queued (not-yet-flushed) subscription for this
+            # instrument+mode so a subscribe→unsubscribe within the 500ms batch
+            # window doesn't end up subscribing after the unsubscribe.
+            self.subscription_queue = [
+                s
+                for s in self.subscription_queue
+                if not (
+                    s["instrument_token"] == instrument_token and s["mode"] == indmoney_mode
+                )
+            ]
             # Check if all subscriptions are removed
             if len(self.subscriptions) == 0:
                 should_disconnect = True


### PR DESCRIPTION
- transform_data: reject unsupported exchanges (MCX/unknown) before order placement instead of silently defaulting to NSE (order API accepts NSE/BSE only)
- indWebSocket: _on_open always notifies adapter so connected + reconnect budget reset on every open, not just the first (reconnect no longer leaves connected=False / exhausts retries)
- indWebSocket: dedup instruments within a single subscribe batch
- adapter: unsubscribe drops still-queued entries so a subscribe->unsubscribe inside the batch window doesn't subscribe afterward
- adapter: re-init joins the previous reconnect loop so its guard clears before a fresh connect() starts
- data.py: narrow poison-batch detection to the 'Invalid scrip' phrase so an unrelated 400 doesn't blacklist valid codes; prune expired poison entries

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Tightens INDmoney exchange validation and hardens the streaming lifecycle. Prevents misrouted orders, stuck reconnects, duplicate subscriptions, and accidental blacklisting.

- **Bug Fixes**
  - Reject unsupported exchanges (`MCX`/unknown) in `transform_data` instead of falling back to `NSE`.
  - Always notify the adapter on WebSocket open so `connected` and retry budget reset on every reconnect.
  - De-duplicate instruments within a single subscribe batch.
  - Unsubscribe drops matching entries still queued in the batch window to avoid re-subscribing after an unsubscribe.
  - Narrow bad-batch detection to the server phrase "Invalid scrip" to avoid blacklisting valid codes on unrelated 400s.

- **Stability**
  - Prune expired entries from the bad-scrip cache to bound memory on long-running workers.
  - On re-init, join the previous reconnect loop so its guard clears before starting a fresh connection.

<sup>Written for commit 96a64da0bbe52b949d76bf29420eb7b3a79dfd9f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1613?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

