### PR TITLE
fix(arrow): send app-level PONG heartbeat so the data stream delivers ticks

### DIFF
--- a/broker/arrow/streaming/arrow_websocket.py
+++ b/broker/arrow/streaming/arrow_websocket.py
@@ -3,7 +3,11 @@
 Adapted from the Zerodha client. Uses sync `websocket-client` in a daemon
 thread (NOT asyncio) to stay compatible with gunicorn+eventlet. Implements the
 same resilience patterns:
-  - keepalive via run_forever ping/pong + a data-stall health-check watchdog
+  - keepalive via an app-level text "PONG" heartbeat + a data-stall watchdog.
+    Arrow's server tracks client liveness through the text heartbeat (the
+    official pyarrow-client SDK sends "PONG" every 3s and never uses
+    protocol-level ping frames); a client that stays silent gets no tick
+    delivery and is reaped without a close frame (close code 1006).
   - automatic reconnection with interruptible exponential backoff
   - bounded auth-refresh on token failure (re-reads a fresh JWT from the DB for
     the ~3 AM IST daily token rollover) instead of dying until a restart
@@ -58,9 +62,12 @@ class ArrowWebSocket:
     # layout; the parser handles both (per the official pyarrow-client SDK).
     _SIZE_TO_MODE = {13: MODE_LTP, 17: MODE_LTPC, 93: MODE_QUOTE, 249: MODE_FULL, 241: MODE_FULL}
 
-    PING_INTERVAL = 30
-    PING_TIMEOUT = 10
-    KEEPALIVE_INTERVAL = 30
+    # App-level heartbeat: the server expects the literal text "PONG" every
+    # few seconds (official SDK: ping_interval=3). Protocol ping frames are
+    # NOT honored by the server, so a websocket-client ping_timeout would
+    # kill healthy connections -- do not reintroduce run_forever ping args.
+    HEARTBEAT_INTERVAL = 3
+    HEARTBEAT_TEXT = "PONG"
     DATA_TIMEOUT = 90  # force reconnect if no data for this long
 
     # Batching. Standard-stream per-connection / per-request caps are not
@@ -195,10 +202,12 @@ class ArrowWebSocket:
                 # CERT_REQUIRED: credentials (appID + JWT) ride in the WS URL,
                 # so accepting arbitrary certificates would hand them to any
                 # MITM. Matches the deltaexchange adapter's verification.
+                # No ping_interval/ping_timeout: Arrow's server does not answer
+                # protocol-level pings (liveness is the text heartbeat sent by
+                # _health_check_loop), so a pong timeout here would tear down
+                # healthy connections ~40s after connect.
                 self.ws.run_forever(
                     sslopt={"cert_reqs": ssl.CERT_REQUIRED},
-                    ping_interval=self.PING_INTERVAL,
-                    ping_timeout=self.PING_TIMEOUT,
                 )
             except Exception as e:
                 self.logger.error(f"WebSocket run_forever error: {e}")
@@ -462,10 +471,17 @@ class ArrowWebSocket:
 
     def _health_check_loop(self):
         while self.running and self.connected:
-            if self._stop_event.wait(self.KEEPALIVE_INTERVAL):
+            if self._stop_event.wait(self.HEARTBEAT_INTERVAL):
                 break
             if not self.running or not self.connected:
                 break
+            # Server-liveness heartbeat: without this text frame the server
+            # delivers no ticks and drops the connection (1006).
+            try:
+                if self.ws:
+                    self.ws.send(self.HEARTBEAT_TEXT)
+            except Exception as e:
+                self.logger.debug(f"Heartbeat send failed: {e}")
             if (
                 self.last_message_time
                 and (time.time() - self.last_message_time) > self.DATA_TIMEOUT


### PR DESCRIPTION
## Symptom (#1583)

The Arrow adapter connects to `wss://ds.arrow.trade`, authenticates, and subscribes successfully — but **no ticks are ever delivered**, and the connection is eventually dropped with **close code 1006** (no close frame). REST quotes on the same account work fine, which rules out auth/tokens/symbol mapping. Reported in #1583 (and the same symptom reported in-thread by another user).

## Root cause

Arrow's standard data server tracks client liveness with an **application-level text `"PONG"` heartbeat** — the official `pyarrow-client` SDK sends the literal text `PONG` every 3 seconds from `BaseSocket._start_ping_timer` (see `pyarrow_client/sockets.py` in the sdist), and never uses protocol-level ping frames.

The OpenAlgo adapter sent no text heartbeat and instead relied on websocket-client protocol pings (`run_forever(ping_interval=30, ping_timeout=10)`), which Arrow's server does not honor. Two failure modes result:

1. The server treats the silent client as dead → accepts the subscribe but delivers no ticks, then reaps the connection without a close frame (the 1006).
2. Because the server never answers protocol pings, `ping_timeout=10` makes websocket-client itself tear down otherwise-healthy connections ~40s after connect.

## Fix

In `broker/arrow/streaming/arrow_websocket.py`:

- Send the text `"PONG"` every 3 seconds from the existing health-check loop (matching the official SDK's `ping_interval=3`).
- Drop `ping_interval`/`ping_timeout` from `run_forever` — protocol pings are not honored by the server, so a pong timeout only kills healthy connections.
- Everything else is unchanged: the 90s data-stall watchdog, reconnect/backoff, resubscribe-on-reconnect, and the daily ~3 AM token-rollover refresh all still apply.

## Verification

Running live in market on an Arrow account since 2026-07-04 — ticks flow immediately after subscribe (BFO options, LTP mode) and the connection stays up through the session. Before the fix the same setup showed the exact #1583 behavior (subscribe OK, zero ticks, 1006 after ~40s).

Closes #1583

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix Arrow WebSocket streaming by sending the required app-level PONG heartbeat and removing protocol ping/pong so subscriptions deliver ticks and connections stay stable. Fixes #1583.

- **Bug Fixes**
  - Send text "PONG" every 3s from the health-check loop (matches the official SDK).
  - Remove `ping_interval`/`ping_timeout` from `websocket-client` `run_forever`; the server ignores protocol pings.
  - Keep the 90s data-stall watchdog and reconnect/backoff logic unchanged.

<sup>Written for commit 44532dd40d75f38edab4739126ccad93b4347227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

