### PR TITLE
fix: expose pre-premium-credit margin total in Zerodha basket response

### DIFF
--- a/broker/zerodha/mapping/margin_data.py
+++ b/broker/zerodha/mapping/margin_data.py
@@ -163,6 +163,8 @@ def parse_margin_response(response_data):
         span_margin = 0
         exposure_margin = 0
         margin_benefit = 0
+        initial_total_margin = 0
+        option_premium_credit = 0
 
         if isinstance(data, dict) and "final" in data:
             # Basket response - use final values which include spread benefit
@@ -193,6 +195,14 @@ def parse_margin_response(response_data):
             initial_option_premium = initial.get("option_premium", 0)
 
             final_total = final.get("total", 0)
+
+            # initial.total is the margin required BEFORE the premium credit from
+            # selling the short legs is netted in — that credit only lands once the
+            # sell orders actually fill, so it's the safer figure for callers sizing
+            # a position ahead of placing orders (see total_margin_required's docstring
+            # note above: initial.total - final.total = option_premium).
+            initial_total_margin = initial_total
+            option_premium_credit = option_premium
 
             # Calculate margin benefit (savings from spread/hedge recognition)
             # Formula: Margin Benefit = Sum of Individual Margins - Optimized Combined Margin
@@ -274,6 +284,12 @@ def parse_margin_response(response_data):
                 f"Orders margin: total={total_margin_required}, span={span_margin}, exposure={exposure_margin}"
             )
 
+        # Non-basket (single/aggregated orders) responses have no separate
+        # pre-optimization figure — total_margin_required is already the
+        # standalone total, so it doubles as initial_total_margin here.
+        if not (isinstance(data, dict) and "final" in data):
+            initial_total_margin = total_margin_required
+
         # Return standardized format matching OpenAlgo API specification
         response_data = {
             "status": "success",
@@ -281,6 +297,8 @@ def parse_margin_response(response_data):
                 "total_margin_required": total_margin_required,
                 "span_margin": span_margin,
                 "exposure_margin": exposure_margin,
+                "initial_total_margin": initial_total_margin,
+                "option_premium_credit": option_premium_credit,
             },
         }
 

--- a/broker/zerodha/mapping/margin_data.py
+++ b/broker/zerodha/mapping/margin_data.py
@@ -164,7 +164,6 @@ def parse_margin_response(response_data):
         exposure_margin = 0
         margin_benefit = 0
         initial_total_margin = 0
-        option_premium_credit = 0
 
         if isinstance(data, dict) and "final" in data:
             # Basket response - use final values which include spread benefit
@@ -202,7 +201,6 @@ def parse_margin_response(response_data):
             # a position ahead of placing orders (see total_margin_required's docstring
             # note above: initial.total - final.total = option_premium).
             initial_total_margin = initial_total
-            option_premium_credit = option_premium
 
             # Calculate margin benefit (savings from spread/hedge recognition)
             # Formula: Margin Benefit = Sum of Individual Margins - Optimized Combined Margin
@@ -298,7 +296,6 @@ def parse_margin_response(response_data):
                 "span_margin": span_margin,
                 "exposure_margin": exposure_margin,
                 "initial_total_margin": initial_total_margin,
-                "option_premium_credit": option_premium_credit,
             },
         }
 

--- a/test/test_zerodha_margin_api.py
+++ b/test/test_zerodha_margin_api.py
@@ -1,0 +1,73 @@
+import os
+import sys
+from pathlib import Path
+
+os.environ.setdefault("API_KEY_PEPPER", "test-pepper-value-at-least-32-chars")
+os.environ.setdefault("DATABASE_URL", "sqlite:///:memory:")
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+import broker.zerodha.mapping.margin_data as margin_data  # noqa: E402
+
+
+def test_basket_response_exposes_pre_credit_total_alongside_optimized_total():
+    """final.total already nets the option premium collected from the short
+    legs; initial_total_margin is the pre-credit figure a caller should use
+    to size a position before that premium has actually been received."""
+    response = {
+        "status": "success",
+        "data": {
+            "initial": {
+                "total": 258139.0,
+                "span": 258139.0,
+                "exposure": 0.0,
+                "option_premium": 0.0,
+            },
+            "final": {
+                "total": 191119.0,
+                "span": 191119.0,
+                "exposure": 0.0,
+                "option_premium": 67020.0,
+            },
+            "orders": [],
+        },
+    }
+
+    result = margin_data.parse_margin_response(response)
+
+    assert result["status"] == "success"
+    data = result["data"]
+    assert data["total_margin_required"] == 191119.0
+    assert data["initial_total_margin"] == 258139.0
+    assert data["option_premium_credit"] == 67020.0
+    # The relationship the fix is built on: initial - final == option_premium
+    assert (
+        data["initial_total_margin"] - data["total_margin_required"]
+        == data["option_premium_credit"]
+    )
+
+
+def test_non_basket_response_uses_total_as_initial_with_zero_credit():
+    """Single/aggregated-order responses have no initial/final split, so
+    initial_total_margin should just fall back to total_margin_required."""
+    response = {
+        "status": "success",
+        "data": [
+            {"total": 50000.0, "span": 40000.0, "exposure": 10000.0},
+            {"total": 30000.0, "span": 25000.0, "exposure": 5000.0},
+        ],
+    }
+
+    result = margin_data.parse_margin_response(response)
+
+    data = result["data"]
+    assert data["total_margin_required"] == 80000.0
+    assert data["initial_total_margin"] == 80000.0
+    assert data["option_premium_credit"] == 0
+
+
+def test_error_response_passes_through_unchanged():
+    response = {"status": "error", "message": "Invalid session"}
+
+    result = margin_data.parse_margin_response(response)
+
+    assert result == {"status": "error", "message": "Invalid session"}

--- a/test/test_zerodha_margin_api.py
+++ b/test/test_zerodha_margin_api.py
@@ -38,15 +38,9 @@ def test_basket_response_exposes_pre_credit_total_alongside_optimized_total():
     data = result["data"]
     assert data["total_margin_required"] == 191119.0
     assert data["initial_total_margin"] == 258139.0
-    assert data["option_premium_credit"] == 67020.0
-    # The relationship the fix is built on: initial - final == option_premium
-    assert (
-        data["initial_total_margin"] - data["total_margin_required"]
-        == data["option_premium_credit"]
-    )
 
 
-def test_non_basket_response_uses_total_as_initial_with_zero_credit():
+def test_non_basket_response_uses_total_as_initial():
     """Single/aggregated-order responses have no initial/final split, so
     initial_total_margin should just fall back to total_margin_required."""
     response = {
@@ -62,7 +56,6 @@ def test_non_basket_response_uses_total_as_initial_with_zero_credit():
     data = result["data"]
     assert data["total_margin_required"] == 80000.0
     assert data["initial_total_margin"] == 80000.0
-    assert data["option_premium_credit"] == 0
 
 
 def test_error_response_passes_through_unchanged():


### PR DESCRIPTION
## What this does

`parse_margin_response()` in `broker/zerodha/mapping/margin_data.py` computes both `initial.total` and `final.total` from Zerodha's basket margin API, but only ever returned `final.total` as `total_margin_required` — silently discarding the pre-premium-credit figure.

`final.total` already nets out the option premium you'd collect from selling the short legs (see the existing inline comment: `initial.total - final.total = option_premium`). That premium isn't actually available until the sell orders fill, so anyone using `client.margin()` to size a position *before* placing orders is working off an optimistic number.

Closes #1620.

## Change

Purely additive — no existing field changes shape or value:

```python
"data": {
    "total_margin_required": total_margin_required,   # unchanged
    "span_margin": span_margin,                          # unchanged
    "exposure_margin": exposure_margin,                   # unchanged
    "initial_total_margin": initial_total_margin,        # NEW
    "option_premium_credit": option_premium_credit,      # NEW
}
```

For non-basket (single/aggregated order) responses, `initial_total_margin` falls back to `total_margin_required` since there's no initial/final split in that path.

## Note for maintainers

While looking into this I noticed Shoonya, Flattrade, and Firstock's margin mappings each have a comment claiming Zerodha's `total_margin_required` maps to `initial.total` (the conservative figure) — e.g. Shoonya: *"Parallels Zerodha's initial.total vs final.total... matches Zerodha impl using initial.total"*. That's not what the current Zerodha code does (it uses `final.total`), so those three brokers already behave conservatively while Zerodha doesn't. I kept this PR additive/non-breaking rather than changing `total_margin_required`'s existing meaning, but flagging the inconsistency in case it's worth a follow-up decision on your end.

## Testing

- New `test/test_zerodha_margin_api.py` — 3 tests covering the basket-response case, the non-basket fallback, and error passthrough. All pass.
- `uv run pytest test/test_zerodha_margin_api.py test/test_dhan_margin_api.py -v` — 8/8 pass, no regressions in the sibling Dhan margin tests.
- `uv run ruff check` / `uv run ruff format --check` — clean.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose `initial_total_margin` in Zerodha basket margin responses so clients can size positions conservatively before fills. `total_margin_required` is unchanged; dropped the misleading `option_premium_credit`.

- **Bug Fixes**
  - Zerodha: `parse_margin_response()` now returns `initial_total_margin` (pre-premium-credit) alongside `total_margin_required`.
  - Non-basket responses set `initial_total_margin` = `total_margin_required`.
  - Dropped `option_premium_credit` due to inconsistent semantics in real responses.
  - Added tests in `test/test_zerodha_margin_api.py`; no changes to existing field shapes or values.

<sup>Written for commit d48461e4ae30264aff3d5af189dbdf1b16d4f57c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1621?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

