### PR TITLE
fix(fyers): make master contract download race-safe and crash-safe

### DIFF
--- a/broker/fyers/database/master_contract_db.py
+++ b/broker/fyers/database/master_contract_db.py
@@ -6,6 +6,8 @@ import io
 import json
 import os
 import shutil
+import tempfile
+import threading
 from typing import Any, Dict, List, Optional, Tuple
 
 import httpx
@@ -695,29 +697,51 @@ def delete_fyers_temp_data(output_path):
                 logger.warning(f"Error deleting file {file_path}: {e}")
 
 
+# Serialize concurrent master-contract downloads. The login flow can trigger this
+# more than once in quick succession, and two runs sharing the temp dir + the
+# symtoken table race destructively: one run wipes the table and deletes the temp
+# CSVs the other is still reading, leaving an EMPTY catalog — after which every
+# symbol/token lookup (quotes, order placement, search) silently fails. A
+# process-wide lock makes runs strictly sequential.
+_master_contract_lock = threading.Lock()
+
+
 def master_contract_download():
+    # Hold the lock for the whole download so two invocations can never interleave.
+    with _master_contract_lock:
+        return _master_contract_download()
+
+
+def _master_contract_download():
     logger.info("Downloading Master Contract")
 
-    output_path = "tmp"
+    # Use a unique temp dir per run so a concurrent or previous run's cleanup can
+    # never delete this run's files (and vice-versa), and so temp files are always
+    # removed afterwards regardless of success or failure.
+    output_path = tempfile.mkdtemp(prefix="fyers_master_")
     try:
-        download_csv_fyers_data(output_path)
-        delete_symtoken_table()
-        token_df = process_fyers_nse_csv(output_path)
-        copy_from_dataframe(token_df)
-        token_df = process_fyers_bse_csv(output_path)
-        copy_from_dataframe(token_df)
-        token_df = process_fyers_bfo_csv(output_path)
-        copy_from_dataframe(token_df)
-        token_df = process_fyers_nfo_csv(output_path)
-        copy_from_dataframe(token_df)
-        token_df = process_fyers_cds_json(output_path)
-        copy_from_dataframe(token_df)
-        token_df = process_fyers_mcx_json(output_path)
-        copy_from_dataframe(token_df)
-        delete_fyers_temp_data(output_path)
-        # token_df['token'] = pd.to_numeric(token_df['token'], errors='coerce').fillna(-1).astype(int)
+        # Verify ALL master files downloaded BEFORE touching the table. If the
+        # download was incomplete, keep the existing (possibly stale) contract
+        # rather than wiping it and ending up with zero symbols.
+        success, _downloaded, error_msg = download_csv_fyers_data(output_path)
+        if not success:
+            raise RuntimeError(f"master contract download incomplete: {error_msg}")
 
-        # token_df = token_df.drop_duplicates(subset='symbol', keep='first')
+        # Parse every file into DataFrames BEFORE mutating the table, so a parse
+        # error can't leave the catalog empty. Delete as late as possible.
+        token_frames = [
+            process_fyers_nse_csv(output_path),
+            process_fyers_bse_csv(output_path),
+            process_fyers_bfo_csv(output_path),
+            process_fyers_nfo_csv(output_path),
+            process_fyers_cds_json(output_path),
+            process_fyers_mcx_json(output_path),
+        ]
+
+        # All data is validated in memory — now swap the table contents.
+        delete_symtoken_table()
+        for token_df in token_frames:
+            copy_from_dataframe(token_df)
 
         return socketio.emit(
             "master_contract_download", {"status": "success", "message": "Successfully Downloaded"}
@@ -726,6 +750,9 @@ def master_contract_download():
     except Exception as e:
         logger.exception(f"{e}")
         return socketio.emit("master_contract_download", {"status": "error", "message": f"{e}"})
+    finally:
+        # Always remove this run's isolated temp dir (files + the dir itself).
+        shutil.rmtree(output_path, ignore_errors=True)
 
 
 def search_symbols(symbol, exchange):


### PR DESCRIPTION
## Problem

`broker/fyers/database/master_contract_db.py::master_contract_download()` can leave the `symtoken` table **empty**. Once that happens, every symbol/token lookup — quotes, order placement, and `/search` — silently fails until the next successful download.

I hit this in practice after a login: the catalog went from ~131k rows to **0**, and `/search` returned nothing for every query. The logs showed two downloads running at once and stepping on each other:

```
Downloading Master Contract          <- run #1
Downloading Master Contract          <- run #2 (concurrent)
...
Deleted tmp/NSE_CM.csv (+ others)    <- run #1 cleans up temp files
ERROR: [Errno 2] No such file or directory: 'tmp/NSE_CM.csv'   <- run #2 mid-parse
Master contract download for fyers produced 0 symbols
```

## Root causes

1. **No concurrency guard.** The login flow can trigger the download more than once in quick succession. Two runs share the `tmp` directory and the `symtoken` table and race destructively — one run wipes the table and deletes the temp CSVs the other is still reading.
2. **Delete-before-verify.** `delete_symtoken_table()` runs *before* the downloaded CSVs are confirmed present/parseable, so a failed or incomplete download wipes the existing (working) catalog and leaves nothing.
3. **Ignored result.** `download_csv_fyers_data()` returns a success flag that was never checked, so processing proceeded even when downloads failed.

## Fix

- **Serialize** invocations with a process-wide lock so runs can't interleave.
- **Isolate temp files** in a unique per-run dir (`tempfile.mkdtemp`), always cleaned up in a `finally`, so a concurrent/previous run's cleanup can't delete this run's files.
- **Verify before delete**: check the download succeeded and abort otherwise, keeping the existing contract rather than wiping it.
- **Parse-before-delete**: parse every CSV/JSON into DataFrames first, *then* delete + insert, so a parse error can no longer leave the catalog empty (delete as late as possible).

## Testing

- Ran the reordered flow end-to-end: it parses all exchanges, then deletes, then bulk-inserts, rebuilding the full ~131k-row catalog.
- Simulated an incomplete download: the table is now left intact instead of being emptied.
- No functional change to the parsing/insert logic itself — only ordering, verification, temp-dir isolation, and locking.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Makes the Fyers master contract download race-safe and crash-safe. Prevents the `symtoken` table from being emptied by concurrent or failed downloads, keeping quotes/search/order lookups working.

- **Bug Fixes**
  - Serialize runs with a process-wide lock to stop interleaving.
  - Use a unique per-run temp dir via `tempfile.mkdtemp`; always clean up in `finally`.
  - Check `download_csv_fyers_data()` success; abort on incomplete downloads to preserve the current catalog.
  - Parse all files first, then delete the table and bulk-insert to avoid leaving it empty on errors.

<sup>Written for commit 51e97545f9cad498a32b98180b37609485838948. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

