### PR TITLE
fix(sandbox): scale simulated margin by contract_value to match P&L ledger

### DIFF
--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -894,6 +894,10 @@ def get_symbol_info_dbquery(symbol: str, exchange: str) -> SymbolData | None:
                 lotsize=sym_token.lotsize,
                 instrumenttype=sym_token.instrumenttype,
                 tick_size=sym_token.tick_size,
+                # Carry contract_value so the DB-fallback path (cold/expired cache) scales
+                # margin and P&L identically to the cache path; without it crypto
+                # derivatives silently fall back to an unscaled 1.0 multiplier.
+                contract_value=getattr(sym_token, "contract_value", None),
             )
         else:
             return None

--- a/sandbox/fund_manager.py
+++ b/sandbox/fund_manager.py
@@ -393,8 +393,22 @@ class FundManager:
                 logger.error(f"Symbol {symbol} not found on {exchange}")
                 return None, "Symbol not found"
 
-            # Calculate trade value (quantity × price)
-            trade_value = quantity * price
+            # contract_value scales notional for instruments where one contract is not one
+            # unit of the underlying (e.g. crypto derivatives: 0.001 BTC or 0.01 ETH per
+            # contract). It is 1.0 for equities and standard F&O, so this is a no-op there.
+            # This mirrors the contract_value scaling already applied to realized and
+            # unrealized P&L in position_manager, keeping the margin/funds ledger consistent
+            # with the P&L ledger. Without it, margin is over-blocked by 1/contract_value
+            # (e.g. ~1000x for BTC), inflating used_margin and understating available cash.
+            contract_value = Decimal("1.0")
+            try:
+                if symbol_obj.contract_value and float(symbol_obj.contract_value) != 1.0:
+                    contract_value = Decimal(str(symbol_obj.contract_value))
+            except (TypeError, ValueError):
+                pass
+
+            # Calculate trade value (quantity × price × contract_value)
+            trade_value = quantity * price * contract_value
 
             # Determine leverage based on action, product and symbol type
             leverage = self._get_leverage(exchange, product, symbol, action)

--- a/sandbox/fund_manager.py
+++ b/sandbox/fund_manager.py
@@ -35,7 +35,7 @@ from database.sandbox_db import (
 )
 from database.token_db import get_symbol_info
 from utils.logging import get_logger
-from utils.symbol_utils import is_future, is_option
+from utils.symbol_utils import is_future, is_option, normalize_contract_value
 
 logger = get_logger(__name__)
 
@@ -396,16 +396,11 @@ class FundManager:
             # contract_value scales notional for instruments where one contract is not one
             # unit of the underlying (e.g. crypto derivatives: 0.001 BTC or 0.01 ETH per
             # contract). It is 1.0 for equities and standard F&O, so this is a no-op there.
-            # This mirrors the contract_value scaling already applied to realized and
-            # unrealized P&L in position_manager, keeping the margin/funds ledger consistent
-            # with the P&L ledger. Without it, margin is over-blocked by 1/contract_value
-            # (e.g. ~1000x for BTC), inflating used_margin and understating available cash.
-            contract_value = Decimal("1.0")
-            try:
-                if symbol_obj.contract_value and float(symbol_obj.contract_value) != 1.0:
-                    contract_value = Decimal(str(symbol_obj.contract_value))
-            except (TypeError, ValueError):
-                pass
+            # The same normalizer scales realized/unrealized P&L in position_manager, so the
+            # margin/funds ledger stays consistent with the P&L ledger. Without it, margin is
+            # over-blocked by 1/contract_value (e.g. ~1000x for BTC), inflating used_margin
+            # and understating available cash.
+            contract_value = normalize_contract_value(symbol_obj.contract_value)
 
             # Calculate trade value (quantity × price × contract_value)
             trade_value = quantity * price * contract_value

--- a/sandbox/position_manager.py
+++ b/sandbox/position_manager.py
@@ -23,6 +23,7 @@ sys.path.append(os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
 from database.sandbox_db import SandboxPositions, SandboxTrades, db_session, get_config
 from database.token_db import get_symbol_info
+from utils.symbol_utils import normalize_contract_value
 from sandbox.fund_manager import FundManager
 from sandbox.holdings_manager import HoldingsManager
 from services.market_data_service import get_market_data_service
@@ -175,15 +176,14 @@ class PositionManager:
         self.fund_manager = FundManager(user_id)
 
     def _get_contract_value(self, symbol: str, exchange: str) -> Decimal:
-        """Look up contract_value multiplier for a symbol (e.g. 0.01 for ETHUSD.P).
-        Returns 1.0 for normal equity instruments."""
+        """Look up the contract_value multiplier for a symbol (e.g. 0.01 for ETHUSD.P).
+        Returns 1.0 for normal equity instruments. Shares normalize_contract_value with the
+        sandbox margin path (fund_manager) so the P&L and margin ledgers cannot diverge."""
         try:
             sym_info = get_symbol_info(symbol, exchange)
-            if sym_info and sym_info.contract_value and float(sym_info.contract_value) != 1.0:
-                return Decimal(str(sym_info.contract_value))
+            return normalize_contract_value(sym_info.contract_value if sym_info else None)
         except Exception:
-            pass
-        return Decimal("1.0")
+            return Decimal("1.0")
 
     def _check_and_close_expired_positions(self, positions):
         """

--- a/test/sandbox/test_margin_contract_value.py
+++ b/test/sandbox/test_margin_contract_value.py
@@ -9,6 +9,10 @@ calculation must apply the same multiplier, otherwise margin/used-margin is
 over-blocked by 1/contract_value (e.g. ~1000x for BTC) while P&L stays correct,
 leaving the funds ledger inconsistent with the position ledger.
 
+Both paths share ``utils.symbol_utils.normalize_contract_value`` so they cannot
+diverge, and the normalizer rejects non-finite / non-positive multipliers so a
+bad value can never turn margin negative.
+
 These tests isolate ``FundManager.calculate_margin_required`` by mocking the
 symbol lookup and leverage so no database is required.
 """
@@ -19,10 +23,11 @@ from decimal import Decimal
 from unittest.mock import patch
 
 # Add repo root to the front of the path so the project's own packages
-# (sandbox/, database/) take precedence over any similarly named modules.
+# (sandbox/, database/, utils/) take precedence over any similarly named modules.
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
 
 from sandbox.fund_manager import FundManager
+from utils.symbol_utils import normalize_contract_value
 
 
 class _Sym:
@@ -36,6 +41,29 @@ def _fund_manager():
     # Avoid DB access in FundManager.__init__ (reads starting_capital from config)
     with patch("sandbox.fund_manager.get_config", return_value="10000000.00"):
         return FundManager("TEST_CV_USER")
+
+
+# --- normalize_contract_value: shared validation ---------------------------------
+
+
+def test_normalize_valid_multipliers():
+    assert normalize_contract_value(0.001) == Decimal("0.001")
+    assert normalize_contract_value(0.01) == Decimal("0.01")
+    assert normalize_contract_value(1.0) == Decimal("1.0")
+    assert normalize_contract_value("0.001") == Decimal("0.001")
+
+
+def test_normalize_rejects_missing_or_bad_values():
+    # Missing / non-positive / non-finite all fall back to 1.0 (never corrupt margin).
+    assert normalize_contract_value(None) == Decimal("1.0")
+    assert normalize_contract_value(0) == Decimal("1.0")
+    assert normalize_contract_value(-0.001) == Decimal("1.0")
+    assert normalize_contract_value("nan") == Decimal("1.0")
+    assert normalize_contract_value("inf") == Decimal("1.0")
+    assert normalize_contract_value("not-a-number") == Decimal("1.0")
+
+
+# --- calculate_margin_required: contract_value applied ---------------------------
 
 
 @patch.object(FundManager, "_get_leverage", return_value=Decimal("1"))
@@ -95,9 +123,28 @@ def test_leverage_still_applied_on_top_of_contract_value(mock_sym, _lev):
     assert margin == expected, f"expected {expected}, got {margin} ({msg})"
 
 
+@patch.object(FundManager, "_get_leverage", return_value=Decimal("1"))
+@patch("sandbox.fund_manager.get_symbol_info")
+def test_bad_contract_value_never_yields_negative_margin(mock_sym, _lev):
+    """A negative/invalid multiplier must fall back to 1.0, never produce negative margin
+    (which would credit available_balance when block_margin subtracts it)."""
+    mock_sym.return_value = _Sym(-0.001)
+    fm = _fund_manager()
+
+    margin, msg = fm.calculate_margin_required(
+        "BTC12JUL2663800PE", "CRYPTO", "NRML", 4, 123.4, action="BUY"
+    )
+
+    assert margin is not None and margin > 0, f"margin should be positive, got {margin} ({msg})"
+    assert margin == Decimal("4") * Decimal("123.4"), "should fall back to unscaled (cv=1.0)"
+
+
 if __name__ == "__main__":
+    test_normalize_valid_multipliers()
+    test_normalize_rejects_missing_or_bad_values()
     test_equity_margin_unaffected_by_contract_value()
     test_btc_option_margin_scaled_by_contract_value()
     test_eth_option_margin_scaled_by_contract_value()
     test_leverage_still_applied_on_top_of_contract_value()
+    test_bad_contract_value_never_yields_negative_margin()
     print("ALL contract_value margin tests passed")

--- a/test/sandbox/test_margin_contract_value.py
+++ b/test/sandbox/test_margin_contract_value.py
@@ -1,0 +1,103 @@
+# test/sandbox/test_margin_contract_value.py
+"""
+Regression tests for contract_value scaling in sandbox margin calculation.
+
+Sandbox P&L (realized + unrealized) is scaled by a per-symbol ``contract_value``
+multiplier for instruments where one contract is not one unit of the underlying
+(e.g. crypto derivatives: 0.001 BTC or 0.01 ETH per contract). The margin
+calculation must apply the same multiplier, otherwise margin/used-margin is
+over-blocked by 1/contract_value (e.g. ~1000x for BTC) while P&L stays correct,
+leaving the funds ledger inconsistent with the position ledger.
+
+These tests isolate ``FundManager.calculate_margin_required`` by mocking the
+symbol lookup and leverage so no database is required.
+"""
+
+import os
+import sys
+from decimal import Decimal
+from unittest.mock import patch
+
+# Add repo root to the front of the path so the project's own packages
+# (sandbox/, database/) take precedence over any similarly named modules.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.dirname(os.path.abspath(__file__)))))
+
+from sandbox.fund_manager import FundManager
+
+
+class _Sym:
+    """Minimal stand-in for a symtoken row."""
+
+    def __init__(self, contract_value):
+        self.contract_value = contract_value
+
+
+def _fund_manager():
+    # Avoid DB access in FundManager.__init__ (reads starting_capital from config)
+    with patch("sandbox.fund_manager.get_config", return_value="10000000.00"):
+        return FundManager("TEST_CV_USER")
+
+
+@patch.object(FundManager, "_get_leverage", return_value=Decimal("1"))
+@patch("sandbox.fund_manager.get_symbol_info")
+def test_equity_margin_unaffected_by_contract_value(mock_sym, _lev):
+    """contract_value = 1.0 (equity/standard F&O) => margin = qty * price / leverage."""
+    mock_sym.return_value = _Sym(1.0)
+    fm = _fund_manager()
+
+    margin, msg = fm.calculate_margin_required("RELIANCE", "NSE", "MIS", 100, 1500, action="BUY")
+
+    assert margin == Decimal("150000"), f"expected 150000, got {margin} ({msg})"
+
+
+@patch.object(FundManager, "_get_leverage", return_value=Decimal("1"))
+@patch("sandbox.fund_manager.get_symbol_info")
+def test_btc_option_margin_scaled_by_contract_value(mock_sym, _lev):
+    """BTC contract_value = 0.001 => margin scaled down 1000x vs raw premium * qty."""
+    mock_sym.return_value = _Sym(0.001)
+    fm = _fund_manager()
+
+    margin, msg = fm.calculate_margin_required(
+        "BTC12JUL2663800PE", "CRYPTO", "NRML", 4, 123.4, action="BUY"
+    )
+
+    expected = Decimal("4") * Decimal("123.4") * Decimal("0.001")  # 0.4936
+    assert margin == expected, f"expected {expected}, got {margin} ({msg})"
+    # Guard against the pre-fix behaviour (raw, unscaled premium * qty).
+    assert margin != Decimal("4") * Decimal("123.4"), "margin was not scaled by contract_value"
+
+
+@patch.object(FundManager, "_get_leverage", return_value=Decimal("1"))
+@patch("sandbox.fund_manager.get_symbol_info")
+def test_eth_option_margin_scaled_by_contract_value(mock_sym, _lev):
+    """ETH contract_value = 0.01 => margin scaled down 100x vs raw premium * qty."""
+    mock_sym.return_value = _Sym(0.01)
+    fm = _fund_manager()
+
+    margin, msg = fm.calculate_margin_required(
+        "ETH12JUL261810PE", "CRYPTO", "NRML", 2, 7.7, action="BUY"
+    )
+
+    expected = Decimal("2") * Decimal("7.7") * Decimal("0.01")  # 0.154
+    assert margin == expected, f"expected {expected}, got {margin} ({msg})"
+
+
+@patch.object(FundManager, "_get_leverage", return_value=Decimal("10"))
+@patch("sandbox.fund_manager.get_symbol_info")
+def test_leverage_still_applied_on_top_of_contract_value(mock_sym, _lev):
+    """Leverage divides the contract_value-scaled notional (e.g. crypto futures)."""
+    mock_sym.return_value = _Sym(0.001)
+    fm = _fund_manager()
+
+    margin, msg = fm.calculate_margin_required("BTCUSDFUT", "CRYPTO", "NRML", 4, 78000, action="BUY")
+
+    expected = (Decimal("4") * Decimal("78000") * Decimal("0.001")) / Decimal("10")  # 31.2
+    assert margin == expected, f"expected {expected}, got {margin} ({msg})"
+
+
+if __name__ == "__main__":
+    test_equity_margin_unaffected_by_contract_value()
+    test_btc_option_margin_scaled_by_contract_value()
+    test_eth_option_margin_scaled_by_contract_value()
+    test_leverage_still_applied_on_top_of_contract_value()
+    print("ALL contract_value margin tests passed")

--- a/utils/symbol_utils.py
+++ b/utils/symbol_utils.py
@@ -3,9 +3,31 @@
 Shared symbol classification helpers used across the sandbox and other modules.
 """
 
+from decimal import Decimal
+
 from utils.constants import CRYPTO_EXCHANGES, FNO_EXCHANGES
 from database.token_db_enhanced import fno_search_symbols
 from utils.constants import INSTRUMENT_PERPFUT
+
+
+def normalize_contract_value(raw) -> Decimal:
+    """Validate a raw ``contract_value`` into a positive, finite ``Decimal`` multiplier.
+
+    ``contract_value`` scales notional and P&L for instruments where one contract is a
+    fraction of the underlying (e.g. 0.001 BTC or 0.01 ETH per crypto contract). Both the
+    sandbox margin path (``fund_manager``) and the P&L path (``position_manager``) use this
+    single normalizer so their ledgers cannot diverge. Returns ``Decimal('1.0')`` when the
+    value is missing, non-finite, or non-positive, so a bad multiplier can never turn
+    margin or P&L negative or zero.
+    """
+    try:
+        if raw is not None:
+            candidate = Decimal(str(raw))
+            if candidate.is_finite() and candidate > 0:
+                return candidate
+    except (ArithmeticError, TypeError, ValueError):
+        pass
+    return Decimal("1.0")
 
 
 def get_underlying_quote_symbol(base_symbol: str, exchange: str) -> str:


### PR DESCRIPTION
## Summary

Sandbox realized/unrealized P&L is scaled by a per-symbol `contract_value` multiplier, but the margin calculation ignores it. For instruments where one contract is a fraction of the underlying (e.g. crypto derivatives on Delta Exchange — `0.001` BTC or `0.01` ETH per contract), margin is over-blocked by a factor of `1/contract_value` (~1000× for BTC, ~100× for ETH). This inflates `used_margin` and understates available cash while P&L stays correct, leaving the funds ledger inconsistent with the position ledger.

## Root cause

`PositionManager` already scales P&L by `contract_value`:

- `PositionManager._get_contract_value()` looks up `symtoken.contract_value`
- `_calculate_position_pnl()` / `_calculate_realized_pnl()` multiply by it

But `FundManager.calculate_margin_required()` computed:

```python
trade_value = quantity * price          # contract_value ignored
margin = trade_value / leverage
```

So P&L and margin end up on different scales for fractional-contract instruments.

### Observed (Delta Exchange, sandbox)

A `BTC…PE` position of 4 contracts @ premium 123.4 (`contract_value = 0.001`):

| Field | Before | Correct |
|---|---|---|
| Position P&L (unrealized) | `0.12` ✅ | `0.12` |
| `margin_blocked` / `used_margin` | `526.53` ❌ | `~0.49` |

The premium is quoted per unit of underlying, so 4 contracts = `0.004` BTC of exposure; the real premium outlay is `123.4 × 4 × 0.001 ≈ $0.49`, not `$526`.

## Fix

Multiply `trade_value` by `contract_value` in `calculate_margin_required()`. It is `1.0` for equities and standard F&O, so this is a **no-op** for those instruments — only fractional-contract instruments change. All margin flow (block/release, proportional release on partial close, `position.margin_blocked`) derives from this one function, so the fix is localized.

```python
trade_value = quantity * price * contract_value
margin = trade_value / leverage
```

## Tests

`test/sandbox/test_margin_contract_value.py` (mock-based, no DB) covers:

- Equity (`contract_value = 1.0`) — margin unchanged
- BTC option (`0.001`) — margin scaled 1000×
- ETH option (`0.01`) — margin scaled 100×
- Leverage still applied on top of the scaled notional (crypto futures)

## Compatibility

No behavior change for NSE/BSE/NFO/BFO/MCX/CDS instruments (all `contract_value = 1.0`). Only affects instruments that already rely on `contract_value` scaling for P&L, bringing their margin onto the same basis.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scale sandbox margin by per-symbol `contract_value` and harden multiplier handling so margin and P&L stay in sync across all paths, including cold-cache DB fallback. Fixes over-blocked margin for fractional-contract instruments; no change for equities and standard F&O.

- **Bug Fixes**
  - Apply `contract_value` in `FundManager.calculate_margin_required`; keep leverage on the scaled notional.
  - Share `utils/symbol_utils.normalize_contract_value` with `PositionManager` so P&L and margin use the same, validated multiplier; fallback to `1.0` for missing/negative/NaN.
  - Include `contract_value` in DB-fallback `get_symbol_info_dbquery` to prevent unscaled margin/P&L when cache is cold.
  - Expand tests: equity (`1.0`) unchanged, BTC (`0.001`) and ETH (`0.01`) scaled, leverage on top, and bad-multiplier safety.

<sup>Written for commit 2dda8e9879e96fa307b1aa54c72720ae4c2a3e14. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

