### PR TITLE
fix(upstox): resolve equity symbol/token collision with debt/rights rows

### DIFF
--- a/broker/upstox/database/master_contract_db.py
+++ b/broker/upstox/database/master_contract_db.py
@@ -336,7 +336,23 @@ def master_contract_download():
         delete_upstox_temp_data(input_path, output_path)
         # token_df['token'] = pd.to_numeric(token_df['token'], errors='coerce').fillna(-1).astype(int)
 
-        # token_df = token_df.drop_duplicates(subset='symbol', keep='first')
+        # Upstox's contract file can list more than one row for the same
+        # (symbol, exchange) — an equity's rights-entitlement or NCD/debt
+        # tranche sharing the underlying's display symbol (confirmed live for
+        # MOTHERSON, CHOLAFIN, AARTISURF, ELECTCAST on NSE: an EQ row plus a
+        # D1/P1/W1 row). Left unresolved, symbol/token lookups elsewhere
+        # (get_token_dbquery, the in-memory symbol cache) silently pick
+        # whichever row happens to load last — for MOTHERSON that meant the
+        # WS feed subscribed to a dead debt instrument (zero ticks, no error)
+        # instead of the actual equity. A bare drop_duplicates(subset='symbol')
+        # (previously here, commented out) ignored exchange entirely and would
+        # have wrongly collapsed the same symbol name across different
+        # exchanges (e.g. RELIANCE on NSE vs BSE) into one row. Scope the
+        # dedup to (symbol, exchange) and prefer instrumenttype='EQ' so the
+        # cash-equity instrument always wins a collision, not an arbitrary row.
+        token_df = token_df.sort_values(
+            "instrumenttype", key=lambda s: s.ne("EQ")
+        ).drop_duplicates(subset=["symbol", "exchange"], keep="first")
 
         delete_symtoken_table()  # Consider the implications of this action
         copy_from_dataframe(token_df)

--- a/database/token_db_enhanced.py
+++ b/database/token_db_enhanced.py
@@ -251,7 +251,20 @@ class BrokerSymbolCache:
                 self.symbols[sym.token] = symbol_data
 
                 # Build indexes
-                self.by_symbol_exchange[(sym.symbol, sym.exchange)] = symbol_data
+                # A master contract can contain more than one row for the same
+                # (symbol, exchange) — e.g. an equity's rights-entitlement or
+                # NCD/debt tranche sharing the underlying's display symbol
+                # (confirmed for MOTHERSON, CHOLAFIN, AARTISURF, ELECTCAST on
+                # NSE: an EQ row plus a D1/P1/W1 row). SymToken.query.all() has
+                # no ORDER BY, so plain last-write-wins here is undefined —
+                # whichever row the DB happens to return last for a given key
+                # silently decides which real-world instrument every quote /
+                # order / WS subscription for that symbol resolves to. Prefer
+                # the EQ row deterministically: never let a non-EQ row
+                # overwrite an EQ one already stored for the same key.
+                existing = self.by_symbol_exchange.get((sym.symbol, sym.exchange))
+                if existing is None or existing.instrumenttype != "EQ" or sym.instrumenttype == "EQ":
+                    self.by_symbol_exchange[(sym.symbol, sym.exchange)] = symbol_data
                 self.by_token_exchange[(sym.token, sym.exchange)] = symbol_data
                 self.by_brsymbol_exchange[(sym.brsymbol, sym.exchange)] = symbol_data
                 self.by_token[sym.token] = symbol_data
@@ -799,12 +812,26 @@ def get_symbol_info(symbol: str, exchange: str) -> SymbolData | None:
 
 
 # Database fallback functions (imported from original token_db)
+def _query_symtoken_preferring_eq(symbol: str, exchange: str):
+    """Look up a SymToken row for (symbol, exchange), preferring instrumenttype='EQ'
+    when more than one row shares the same (symbol, exchange) — a master contract
+    can legitimately contain an equity's rights-entitlement or NCD/debt tranche
+    under the same display symbol (confirmed for MOTHERSON, CHOLAFIN, AARTISURF,
+    ELECTCAST on NSE). Without this, plain .filter_by(...).first() picks whichever
+    row the DB happens to return first — undefined, and can silently resolve a
+    cash-equity symbol to a dead debt/rights instrument (zero quotes/ticks)."""
+    from database.symbol import SymToken
+
+    sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange, instrumenttype="EQ").first()
+    if sym_token is None:
+        sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange).first()
+    return sym_token
+
+
 def get_token_dbquery(symbol: str, exchange: str) -> str | None:
     """Query database for token by symbol and exchange"""
     try:
-        from database.symbol import SymToken
-
-        sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange).first()
+        sym_token = _query_symtoken_preferring_eq(symbol, exchange)
         if sym_token:
             return sym_token.token
         else:
@@ -832,9 +859,7 @@ def get_symbol_dbquery(token: str, exchange: str) -> str | None:
 def get_br_symbol_dbquery(symbol: str, exchange: str) -> str | None:
     """Query database for broker symbol"""
     try:
-        from database.symbol import SymToken
-
-        sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange).first()
+        sym_token = _query_symtoken_preferring_eq(symbol, exchange)
         if sym_token:
             return sym_token.brsymbol
         else:
@@ -862,9 +887,7 @@ def get_oa_symbol_dbquery(brsymbol: str, exchange: str) -> str | None:
 def get_brexchange_dbquery(symbol: str, exchange: str) -> str | None:
     """Query database for broker exchange"""
     try:
-        from database.symbol import SymToken
-
-        sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange).first()
+        sym_token = _query_symtoken_preferring_eq(symbol, exchange)
         if sym_token:
             return sym_token.brexchange
         else:
@@ -877,9 +900,7 @@ def get_brexchange_dbquery(symbol: str, exchange: str) -> str | None:
 def get_symbol_info_dbquery(symbol: str, exchange: str) -> SymbolData | None:
     """Query database for full symbol information, returns SymbolData object"""
     try:
-        from database.symbol import SymToken
-
-        sym_token = SymToken.query.filter_by(symbol=symbol, exchange=exchange).first()
+        sym_token = _query_symtoken_preferring_eq(symbol, exchange)
         if sym_token:
             # Convert SymToken database object to SymbolData
             return SymbolData(


### PR DESCRIPTION
## Bug report

**Symptom**: A subset of NSE equity symbols silently receive zero WebSocket ticks (and can return empty/wrong quote & history data) despite a successful subscription — no error anywhere in the logs. Reproduced identically across two independent OpenAlgo processes with separate Upstox broker sessions, ruling out a per-connection WebSocket fluke.

**Root cause**: Upstox's master contract file can list more than one row for the same `(symbol, exchange)` — an equity's rights-entitlement or NCD/debt tranche sharing the underlying's display symbol name. Confirmed live on NSE for:

| symbol | rows in `symtoken` |
|---|---|
| MOTHERSON | `EQ` (token `...INE775A01035`) **+** `D1` (token `...INE775A08105`) |
| CHOLAFIN | `EQ` + `D1` |
| AARTISURF | `EQ` + `P1` |
| ELECTCAST | `EQ` + `W1` |

Neither symbol-resolution path disambiguates by `instrumenttype`:
- `get_token_dbquery()` (and its `br_symbol`/`brexchange`/`symbol_info` siblings in `database/token_db_enhanced.py`) do a bare `SymToken.query.filter_by(symbol=, exchange=).first()` — arbitrary row order decides which instrument wins.
- The in-memory symbol cache's `by_symbol_exchange` dict is keyed only by `(symbol, exchange)`; `SymToken.query.all()` has no `ORDER BY`, so last-write-wins during cache build is undefined.

**Confirmed impact in production**: directly queried OpenAlgo's live token resolver and it returned the `D1` (debt) token for `MOTHERSON` instead of the `EQ` token — every quote/order/WebSocket subscription for "MOTHERSON" was hitting a bond that essentially never trades on this feed, a successful subscription with zero ticks.

There's also a **pre-existing, disabled fix** for part of this: `broker/upstox/database/master_contract_db.py` has a commented-out `token_df.drop_duplicates(subset='symbol', keep='first')` at the point the contract is written to `symtoken`. That line ignored `exchange` entirely, so re-enabling it as-is would have wrongly collapsed the same symbol name across different exchanges (e.g. RELIANCE on NSE vs BSE) into a single row — likely why it was disabled rather than fixed.

## Fix

Two layers:

1. **`database/token_db_enhanced.py`**: both the cache-build step (`by_symbol_exchange`) and the four affected `*_dbquery()` functions now prefer `instrumenttype='EQ'` when a `(symbol, exchange)` collision exists, falling back to whatever's available if no `EQ` row is present. Added a shared `_query_symtoken_preferring_eq()` helper to avoid duplicating the fallback logic four times.
2. **`broker/upstox/database/master_contract_db.py`**: re-enable the dedup step at import time so the bad rows are cleaned before they ever reach `symtoken`, on every master contract refresh — scoped to `(symbol, exchange)` (not just `symbol`) and sorted so `instrumenttype='EQ'` rows are kept over any competing row for the same key.

## Verification

Ran against the live `symtoken` table (both the DB-query fallback and the in-memory cache):

```
MOTHERSON  -> NSE_EQ|INE775A01035   (was: NSE_EQ|INE775A08105, the D1/debt token)
CHOLAFIN   -> NSE_EQ|INE121A01024   (already correct, now deterministic instead of lucky)
AARTISURF  -> NSE_EQ|INE09EO01013
ELECTCAST  -> NSE_EQ|INE086A01029
```

Ordinary non-colliding symbols are unaffected (spot-checked RELIANCE, TCS, INFY, HDFCBANK, SBIN, FORTIS, and index symbols under `NSE_INDEX`).

No existing automated tests cover `token_db_enhanced.py`'s symbol resolution or the Upstox master-contract import step, so this was verified manually as above rather than via `pytest`.

## Test plan

- [ ] Run a fresh Upstox master contract download and confirm `symtoken` no longer contains duplicate `(symbol, exchange)` rows for any equity symbol
- [ ] Subscribe to a previously-affected symbol (MOTHERSON) over the WebSocket proxy and confirm live ticks arrive
- [ ] Spot-check quote/history endpoints for MOTHERSON, CHOLAFIN, AARTISURF, ELECTCAST return equity data (not debt/rights instrument data)
- [ ] Confirm no regression for ordinary symbols across a few brokers

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes equity symbols resolving to debt/rights instruments when `(symbol, exchange)` rows collide in the Upstox master contract. Ensures quotes, orders, and WebSocket subscriptions resolve to the correct equity token and receive ticks.

- **Bug Fixes**
  - Prefer `instrumenttype='EQ'` in the in-memory cache and DB lookups when multiple rows share `(symbol, exchange)`, using a shared `_query_symtoken_preferring_eq` helper.
  - Deduplicate the Upstox master contract on `(symbol, exchange)` during import, keeping `EQ` rows via sort + `drop_duplicates`.

<sup>Written for commit bc346ebd9e4c9ec23367a392a7292103a281808c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1634?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

