### PR TITLE
fix(dhan): rest SL-M orders as protective STOP_LOSS under live MPP AND fix(dhan): parse live order-update camelCase payload

### DIFF
--- a/broker/dhan/mapping/transform_data.py
+++ b/broker/dhan/mapping/transform_data.py
@@ -1,11 +1,31 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Upstox Broking Parameters https://dhanhq.co/docs/v2/orders/
 
+import math
+from decimal import Decimal
+
 from database.token_db import get_symbol_info
 from utils.logging import get_logger
-from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
+from utils.mpp_slab import get_instrument_type_from_symbol, get_mpp_percentage
 
 logger = get_logger(__name__)
+
+
+def _tick_decimals(tick: float) -> int:
+    """Number of decimal places implied by a tick size (0.05 -> 2, 0.0025 -> 4)."""
+    return max(0, -Decimal(str(tick)).as_tuple().exponent)
+
+
+def _snap_to_tick(value: float, tick: float, direction: str) -> float:
+    """Snap ``value`` to a multiple of ``tick``.
+
+    direction ``"floor"`` rounds down, ``"ceil"`` rounds up — used to keep the
+    protective limit strictly on the required side of the trigger after snapping
+    (nearest-tick rounding could otherwise land it back on the trigger).
+    """
+    ratio = round(value / tick, 6)  # tame float noise before the floor/ceil
+    k = math.floor(ratio) if direction == "floor" else math.ceil(ratio)
+    return round(k * tick, _tick_decimals(tick))
 
 
 def _slm_protected_price(symbol, exchange, action, trigger_price):
@@ -23,23 +43,50 @@ def _slm_protected_price(symbol, exchange, action, trigger_price):
     direction (SELL below the trigger, BUY above it) so it stays marketable once
     triggered. This mirrors the shared MPP handling used by the other Noren/MPP
     brokers (e.g. samco).
+
+    The limit is snapped to the instrument's exchange tick in the beyond-trigger
+    direction (SELL floors, BUY ceils) and forced at least one tick past the
+    trigger, so it can never round back onto/through the trigger (which would
+    re-trip DH-906) or collapse to zero on low-priced options. Fails closed if the
+    tick size can't be resolved — a 2-decimal guess risks a tick-size rejection.
     """
     instrument_type = get_instrument_type_from_symbol(symbol)
-    tick_size = None
-    try:
-        symbol_info = get_symbol_info(symbol, exchange)
-        if symbol_info and getattr(symbol_info, "tick_size", None):
-            tick_size = float(symbol_info.tick_size)
-    except Exception as e:
-        logger.warning(f"Dhan SL-M: tick size lookup failed for {symbol}/{exchange}: {e}")
 
-    return calculate_protected_price(
-        price=trigger_price,
-        action=action,
-        symbol=symbol,
-        instrument_type=instrument_type,
-        tick_size=tick_size,
-    )
+    # Tick size is fetched from the SymToken DB (populated by Dhan's master
+    # contract, SEM_TICK_SIZE/100) via the cache-then-DB get_symbol_info helper —
+    # the same DB-backed source the flattrade/samco MPP paths use. Validate it is a
+    # finite, positive number (master-contract rows can coerce to NaN) and fail
+    # closed if absent, rather than emit a 2-decimal guess Dhan would reject.
+    symbol_info = get_symbol_info(symbol, exchange)
+    try:
+        tick_size = float(getattr(symbol_info, "tick_size", None)) if symbol_info else 0.0
+    except (TypeError, ValueError):
+        tick_size = 0.0
+    if not math.isfinite(tick_size) or tick_size <= 0:
+        raise ValueError(
+            f"Cannot resolve tick size from DB for {symbol}/{exchange}; required to "
+            f"build a valid SL-M protective limit price"
+        )
+
+    pct = (get_mpp_percentage(trigger_price, instrument_type) or 0) / 100.0
+
+    if action.upper() == "SELL":
+        # Strictly BELOW trigger (DH-906: trigger > price), >= one tick away,
+        # tick-aligned (floor), and strictly positive.
+        raw = min(trigger_price * (1 - pct), trigger_price - tick_size)
+        limit = _snap_to_tick(raw, tick_size, "floor")
+        if limit <= 0:
+            raise ValueError(
+                f"SL-M SELL trigger {trigger_price} for {symbol}/{exchange} is too low "
+                f"to derive a positive protective limit at tick {tick_size}"
+            )
+    else:
+        # Strictly ABOVE trigger (DH-906: price > trigger), >= one tick away,
+        # tick-aligned (ceil).
+        raw = max(trigger_price * (1 + pct), trigger_price + tick_size)
+        limit = _snap_to_tick(raw, tick_size, "ceil")
+
+    return limit
 
 
 def transform_data(data, token):
@@ -139,24 +186,28 @@ def transform_modify_order_data(data):
     if disclosed_qty > 0:
         modified["disclosedQuantity"] = disclosed_qty
 
-    # Handle trigger price for SL orders
+    # Handle trigger price for SL orders. Reject a non-positive trigger up front
+    # (matching placement) — otherwise an SL-M modify would fall through with
+    # orderType STOP_LOSS_MARKET and no limit price, the exact broken state the
+    # protective conversion exists to avoid.
     if data["pricetype"] in ["SL", "SL-M"]:
         trigger_price = float(data.get("trigger_price", 0))
-        if trigger_price > 0:
-            modified["triggerPrice"] = float(trigger_price)
+        if trigger_price <= 0:
+            raise ValueError("Trigger price is required for Stop Loss orders")
+        modified["triggerPrice"] = float(trigger_price)
 
-            # Same SL-M -> protective STOP_LOSS conversion as placement (see
-            # _slm_protected_price / issue #1647), so a modified SL-M also rests.
-            if data["pricetype"] == "SL-M":
-                protected_price = _slm_protected_price(
-                    data["symbol"], data["exchange"], data["action"], trigger_price
-                )
-                modified["orderType"] = "STOP_LOSS"
-                modified["price"] = float(protected_price)
-                logger.info(
-                    f"Dhan SL-M modify -> STOP_LOSS: Symbol={data['symbol']}, "
-                    f"Action={data['action']}, Trigger={trigger_price}, ProtectedLimit={protected_price}"
-                )
+        # Same SL-M -> protective STOP_LOSS conversion as placement (see
+        # _slm_protected_price / issue #1647), so a modified SL-M also rests.
+        if data["pricetype"] == "SL-M":
+            protected_price = _slm_protected_price(
+                data["symbol"], data["exchange"], data["action"], trigger_price
+            )
+            modified["orderType"] = "STOP_LOSS"
+            modified["price"] = float(protected_price)
+            logger.info(
+                f"Dhan SL-M modify -> STOP_LOSS: Symbol={data['symbol']}, "
+                f"Action={data['action']}, Trigger={trigger_price}, ProtectedLimit={protected_price}"
+            )
 
     return modified
 

--- a/broker/dhan/mapping/transform_data.py
+++ b/broker/dhan/mapping/transform_data.py
@@ -1,6 +1,46 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Upstox Broking Parameters https://dhanhq.co/docs/v2/orders/
 
+from database.token_db import get_symbol_info
+from utils.logging import get_logger
+from utils.mpp_slab import calculate_protected_price, get_instrument_type_from_symbol
+
+logger = get_logger(__name__)
+
+
+def _slm_protected_price(symbol, exchange, action, trigger_price):
+    """
+    Derive a protective stop-limit price for an SL-M order from its trigger price.
+
+    Dhan's live API does not honor a bare STOP_LOSS_MARKET as a resting market stop
+    under the SEBI MPP regime: it either drops the trigger and fills immediately as a
+    LIMIT, or rejects the order with DH-906 "Trigger Price should be greater than
+    Price" (the limit price it substitutes via MPP lands on the wrong side of the
+    trigger). See GitHub issue #1647.
+
+    To place a stop that actually rests, SL-M is mapped to Dhan's STOP_LOSS
+    (stop-limit) with a limit price offset MPP% beyond the trigger in the fill
+    direction (SELL below the trigger, BUY above it) so it stays marketable once
+    triggered. This mirrors the shared MPP handling used by the other Noren/MPP
+    brokers (e.g. samco).
+    """
+    instrument_type = get_instrument_type_from_symbol(symbol)
+    tick_size = None
+    try:
+        symbol_info = get_symbol_info(symbol, exchange)
+        if symbol_info and getattr(symbol_info, "tick_size", None):
+            tick_size = float(symbol_info.tick_size)
+    except Exception as e:
+        logger.warning(f"Dhan SL-M: tick size lookup failed for {symbol}/{exchange}: {e}")
+
+    return calculate_protected_price(
+        price=trigger_price,
+        action=action,
+        symbol=symbol,
+        instrument_type=instrument_type,
+        tick_size=tick_size,
+    )
+
 
 def transform_data(data, token):
     """
@@ -24,8 +64,10 @@ def transform_data(data, token):
     if correlation_id:
         transformed["correlationId"] = correlation_id
 
-    # Set price for non-market orders
-    if data["pricetype"] != "MARKET":
+    # Set price for limit-priced orders (LIMIT and SL). MARKET carries no price —
+    # Dhan applies its own MPP (market->limit) conversion server-side. SL-M is
+    # handled below (converted to a protective STOP_LOSS with a derived limit).
+    if data["pricetype"] in ["LIMIT", "SL"]:
         price = float(data.get("price", 0))
         transformed["price"] = float(price)
 
@@ -37,10 +79,22 @@ def transform_data(data, token):
     # Set trigger price for SL orders
     if data["pricetype"] in ["SL", "SL-M"]:
         trigger_price = float(data.get("trigger_price", 0))
-        if trigger_price > 0:
-            transformed["triggerPrice"] = float(trigger_price)
-        else:
+        if trigger_price <= 0:
             raise ValueError("Trigger price is required for Stop Loss orders")
+        transformed["triggerPrice"] = float(trigger_price)
+
+        # Map SL-M -> STOP_LOSS with an MPP-protected limit price so the stop rests
+        # instead of being mangled/rejected by Dhan's live MPP. See _slm_protected_price.
+        if data["pricetype"] == "SL-M":
+            protected_price = _slm_protected_price(
+                data["symbol"], data["exchange"], data["action"], trigger_price
+            )
+            transformed["orderType"] = "STOP_LOSS"
+            transformed["price"] = float(protected_price)
+            logger.info(
+                f"Dhan SL-M -> STOP_LOSS: Symbol={data['symbol']}, Action={data['action']}, "
+                f"Trigger={trigger_price}, ProtectedLimit={protected_price}"
+            )
 
     # Handle after market orders
     after_market = data.get("after_market_order", False)
@@ -76,8 +130,8 @@ def transform_modify_order_data(data):
         "validity": "DAY",
     }
 
-    # Set price for non-market orders
-    if data.get("pricetype") != "MARKET":
+    # Set price for limit-priced orders (LIMIT and SL). SL-M is handled below.
+    if data.get("pricetype") in ["LIMIT", "SL"]:
         modified["price"] = float(data["price"])
 
     # Set disclosed quantity if provided
@@ -90,6 +144,19 @@ def transform_modify_order_data(data):
         trigger_price = float(data.get("trigger_price", 0))
         if trigger_price > 0:
             modified["triggerPrice"] = float(trigger_price)
+
+            # Same SL-M -> protective STOP_LOSS conversion as placement (see
+            # _slm_protected_price / issue #1647), so a modified SL-M also rests.
+            if data["pricetype"] == "SL-M":
+                protected_price = _slm_protected_price(
+                    data["symbol"], data["exchange"], data["action"], trigger_price
+                )
+                modified["orderType"] = "STOP_LOSS"
+                modified["price"] = float(protected_price)
+                logger.info(
+                    f"Dhan SL-M modify -> STOP_LOSS: Symbol={data['symbol']}, "
+                    f"Action={data['action']}, Trigger={trigger_price}, ProtectedLimit={protected_price}"
+                )
 
     return modified
 

--- a/broker/dhan/streaming/dhan_order_adapter.py
+++ b/broker/dhan/streaming/dhan_order_adapter.py
@@ -63,6 +63,21 @@ _EXCHANGE_SEGMENT_MAP = {
 }
 
 
+def _field(data: dict, *keys, default=None):
+    """Return the first present key from `keys`.
+
+    Dhan's live order-update payload sends camelCase keys (orderNo, txnType,
+    tradedQty, ...) even though docs/13-live-order-update.md documents PascalCase
+    (OrderNo, TxnType, TradedQty, ...). Read camelCase first and fall back to the
+    documented PascalCase so the adapter is correct against the real feed and
+    stays correct if Dhan ever aligns the wire format with its docs.
+    """
+    for k in keys:
+        if k in data:
+            return data[k]
+    return default
+
+
 class DhanOrderUpdateAdapter(BaseOrderUpdateAdapter):
     """Dedicated order-update WebSocket adapter for Dhan (individual-user flow)."""
 
@@ -99,37 +114,50 @@ class DhanOrderUpdateAdapter(BaseOrderUpdateAdapter):
             return None  # ignore login-ack / other frame types
 
         data = message.get("Data") or {}
-        raw_status = str(data.get("Status", "")).upper()
+
+        # Dhan's live status values are Title-case ("Pending"/"Traded"); upper() to
+        # match the _STATUS_MAP keys (which mirror the REST orderbook vocabulary).
+        raw_status = str(_field(data, "status", "Status", default="")).upper()
         order_status = _STATUS_MAP.get(raw_status, raw_status.lower())
 
-        quantity = int(data.get("Quantity") or 0)
-        traded_qty = int(data.get("TradedQty") or 0)
+        quantity = int(_field(data, "quantity", "Quantity", default=0) or 0)
+        traded_qty = int(_field(data, "tradedQty", "TradedQty", default=0) or 0)
 
-        # OpenAlgo exchange from (Exchange, Segment); symbol via SecurityId —
+        # OpenAlgo exchange from (exchange, segment); symbol via securityId —
         # the same get_symbol(token, exchange) lookup the REST orderbook
-        # mapping uses — falling back to Dhan's Symbol field.
-        exchange = _EXCHANGE_SEGMENT_MAP.get(
-            (data.get("Exchange", ""), data.get("Segment", "")), data.get("Exchange", "")
-        )
+        # mapping uses — falling back to Dhan's symbol field.
+        exch = _field(data, "exchange", "Exchange", default="")
+        seg = _field(data, "segment", "Segment", default="")
+        exchange = _EXCHANGE_SEGMENT_MAP.get((exch, seg), exch)
         symbol = to_openalgo_symbol(
-            data.get("Symbol", ""), exchange, token=data.get("SecurityId")
+            _field(data, "symbol", "Symbol", default=""),
+            exchange,
+            token=_field(data, "securityId", "SecurityId"),
         )
+
+        txn_type = _field(data, "txnType", "TxnType", default="")
+        order_type = _field(data, "orderType", "OrderType", default="")
+        product_code = _field(data, "product", "Product", default="")
 
         return {
-            "orderid": data.get("OrderNo", ""),
+            "orderid": _field(data, "orderNo", "OrderNo", default=""),
             "symbol": symbol,
             "exchange": exchange,
-            "action": _ACTION_MAP.get(data.get("TxnType", ""), data.get("TxnType", "")),
+            "action": _ACTION_MAP.get(txn_type, txn_type),
             "quantity": quantity,
-            "price": float(data.get("Price") or 0),
-            "trigger_price": float(data.get("TriggerPrice") or 0),
-            "pricetype": _PRICETYPE_MAP.get(data.get("OrderType", ""), data.get("OrderType", "")),
-            "product": _PRODUCT_MAP.get(data.get("Product", ""), data.get("Product", "")),
+            "price": float(_field(data, "price", "Price", default=0) or 0),
+            "trigger_price": float(_field(data, "triggerPrice", "TriggerPrice", default=0) or 0),
+            "pricetype": _PRICETYPE_MAP.get(order_type, order_type),
+            "product": _PRODUCT_MAP.get(product_code, product_code),
             "order_status": order_status,
             "filled_quantity": traded_qty,
             "pending_quantity": max(quantity - traded_qty, 0),
-            "average_price": float(data.get("AvgTradedPrice") or 0),
-            "rejection_reason": data.get("ReasonDescription", "") if raw_status == "REJECTED" else "",
+            "average_price": float(_field(data, "avgTradedPrice", "AvgTradedPrice", default=0) or 0),
+            "rejection_reason": (
+                _field(data, "reasonDescription", "ReasonDescription", default="")
+                if raw_status == "REJECTED"
+                else ""
+            ),
         }
 
 


### PR DESCRIPTION
Dhan's live API does not honor a bare STOP_LOSS_MARKET as a resting market stop under the SEBI MPP regime — it drops the trigger and fills immediately as a LIMIT, or rejects with DH-906 'Trigger Price should be greater than Price'.

Map SL-M to Dhan's STOP_LOSS (stop-limit) with a limit price derived from the trigger via utils/mpp_slab.py (SELL: trigger-MPP%, BUY: trigger+MPP%), snapped to tick size. Applied to both placement and modify. Mirrors the shared MPP handling used by the other Noren/MPP brokers (e.g. samco).

Fixes #1647

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Ensure Dhan `SL-M` stops rest under SEBI MPP by converting to protective `STOP_LOSS` with an MPP-offset, tick-aligned limit that stays beyond the trigger. Also fix live order-update parsing so order rows show correct status, quantities, and prices.

- **Bug Fixes**
  - Map `SL-M` to `STOP_LOSS` with limit from trigger via MPP slab (SELL: trigger − MPP%, BUY: trigger + MPP%), tick-aligned beyond the trigger (SELL floor, BUY ceil), ≥1 tick away, and >0; tick size from SymToken DB and validated; reject non‑positive trigger on modify. Applied on place/modify. Prevents instant fills, DH-906, and rounding/tick edge cases; `LIMIT`/`SL` unchanged.
  - Parse Live Order Update camelCase payload with PascalCase fallback and normalize Title-case status; fixes blank rows (qty 0/0) in the streaming feed.

<sup>Written for commit 943e39912e9eacac81c104fc1080edfd6eb0e68b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1649?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

