### PR TITLE
fix(definedge): show Cancel/Modify for SL-M orders in TRIGGER PENDING

### DIFF
--- a/broker/definedge/mapping/order_data.py
+++ b/broker/definedge/mapping/order_data.py
@@ -88,10 +88,19 @@ def calculate_order_statistics(order_data):
 
             # Count orders based on their status
             # API order_status values: CANCELED / COMPLETE / NEW / OPEN / REJECTED / REPLACED
+            # SL/SL-M orders additionally rest in TRIGGER PENDING until the trigger
+            # fires - they are still live at the exchange, so count them as open.
             status = order.get("order_status", "").upper()
             if status in ["COMPLETE", "EXECUTED"]:
                 total_completed_orders += 1
-            elif status in ["OPEN", "NEW", "REPLACED", "PENDING"]:
+            elif status in [
+                "OPEN",
+                "NEW",
+                "REPLACED",
+                "PENDING",
+                "TRIGGER PENDING",
+                "TRIGGER_PENDING",
+            ]:
                 total_open_orders += 1
             elif status in ["REJECTED", "CANCELED", "CANCELLED"]:
                 total_rejected_orders += 1
@@ -134,9 +143,17 @@ def transform_order_data(orders):
             order_status = "complete"
         elif status in ["REJECTED"]:
             order_status = "rejected"
-        elif status in ["TRIGGER PENDING", "TRIGGER_PENDING"]:
-            order_status = "trigger pending"
-        elif status in ["OPEN", "NEW", "REPLACED", "PENDING"]:
+        elif status in [
+            "OPEN",
+            "NEW",
+            "REPLACED",
+            "PENDING",
+            "TRIGGER PENDING",
+            "TRIGGER_PENDING",
+        ]:
+            # TRIGGER PENDING is an SL/SL-M order resting at the exchange waiting
+            # for its trigger. It is still cancellable and modifiable, so report it
+            # as "open" - the order book only exposes Cancel/Modify for "open".
             order_status = "open"
         elif status in ["CANCELED", "CANCELLED"]:
             order_status = "cancelled"


### PR DESCRIPTION
DefinEdge returns TRIGGER PENDING for an SL/SL-M order resting at the exchange awaiting its trigger. transform_order_data() mapped that to the literal "trigger pending", but the order book only renders the Cancel and Modify actions for order_status == 'open' (and its status badge falls back to "open" for unrecognised values, so the row looked open while the buttons were missing). calculate_order_statistics() ignored it too, so the Open card read 0.

Fold TRIGGER PENDING / TRIGGER_PENDING into "open" in both places - the order is still live at the exchange and is cancellable and modifiable, matching how shoonya (the other Noren broker) already maps it. cancel_all_orders_api() already accepted trigger-pending orders.

The streaming adapter is deliberately left alone: the order book refetches over REST on every order event, so the WS status never drives those buttons, and /websocket/test keeps reporting "trigger pending" in parity with the aliceblue, angel, arrow, upstox, zerodha and nubra adapters.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Treat DefinEdge SL/SL-M orders in TRIGGER PENDING/TRIGGER_PENDING as "open" so Cancel/Modify buttons appear and the Open count includes them. Matches `shoonya`; streaming adapter unchanged since the order book refetches over REST.

<sup>Written for commit 72e398a3bed9d7a4f491896a00355c53ae88fe23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1650?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

