### PR TITLE
docs: reconcile CONTRIBUTING.md broker and database counts with current codebase

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -228,7 +228,7 @@ openalgo/
 │   ├── auth.py               # Authentication routes
 │   ├── react_app.py          # Serves React SPA from frontend/dist/
 │   └── ...
-├── broker/                   # Broker integrations (24+ brokers)
+├── broker/                   # Broker integrations (34 brokers)
 │   ├── zerodha/              # Reference implementation
 │   ├── dhan/                 # Modern API design
 │   ├── angel/                # AngelOne integration
@@ -252,7 +252,7 @@ openalgo/
 - **`blueprints/`**: Flask route handlers for UI pages and webhooks
 - **`services/`**: Business logic separated from route handlers
 - **`websocket_proxy/`**: Real-time market data streaming via unified WebSocket proxy
-- **`database/`**: 5 separate databases for isolation (main, logs, latency, sandbox, historify)
+- **`database/`**: 6 separate databases for isolation (main, logs, latency, health, sandbox, historify)
 
 ---
 


### PR DESCRIPTION
## Description

`CONTRIBUTING.md`'s Project Structure section had drifted from the actual codebase on two counts:

1. **Broker count** — said "24+ brokers". There are currently **34** broker plugin directories under `broker/`, each with its own `plugin.json` (verified by counting both). `README.md`, `DISCOVERY_MAP.md`, and `docs/design/*` already say 34 — this line in CONTRIBUTING.md just hadn't been updated to match.
2. **Database count** — said "5 separate databases for isolation (main, logs, latency, sandbox, historify)". There are actually **6**, and the list silently omitted `health.db`. `.sample.env` defines all six URLs (`DATABASE_URL`, `LOGS_DATABASE_URL`, `LATENCY_DATABASE_URL`, `HEALTH_DATABASE_URL`, `SANDBOX_DATABASE_URL`, `HISTORIFY_DATABASE_URL`), and `CLAUDE.md`'s own architecture section already documents all 6 under "OpenAlgo uses **6 separate databases** for isolation." This PR brings CONTRIBUTING.md in line with what CLAUDE.md and the actual config already say.

Docs-only, no code or behavior changes. `README.md` and `CLAUDE.md` were already accurate on both counts and are left untouched.

## Related Issues

None — found via direct comparison of documented claims against the current codebase (`.sample.env`, `broker/` directory listing, `database/` module), not from a filed issue.

## Screenshots

N/A — docs-only change, no UI impact.

## Testing

- Counted broker plugin directories and `plugin.json` files: both = 34.
- Cross-checked `.sample.env` for every `*_DATABASE_URL` definition: 6 present, matching `CLAUDE.md`'s existing architecture section exactly.
- Confirmed no other open PR touches `CONTRIBUTING.md` before opening this one.
- No tests applicable — markdown-only diff, verified by direct text comparison (see `git diff`, two lines changed).

## Checklist

- [x] New feature works as expected — N/A, docs-only
- [x] Python tests pass — N/A, no Python changed
- [x] Frontend tests pass — N/A, no frontend changed
- [x] No TypeScript errors — N/A
- [x] No linting errors — N/A, markdown only
- [x] API endpoints return correct responses — N/A
- [x] WebSocket connections work — N/A


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated CONTRIBUTING.md to match the current project structure: 34 broker integrations and 6 databases (including health). Docs-only correction to remove stale counts and reduce confusion.

<sup>Written for commit 4abca2d836a0c1ba762f61a6b12bb0af09a75b53. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1651?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

