### PR TITLE
docs: fix stale Python version requirement in INSTALL.md

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -5,7 +5,7 @@
 Before installing OpenAlgo, ensure you have the following prerequisites installed:
 
 - **Visual Studio Code (VS Code)** installed on Windows.
-- **Python** version 3.10 or 3.11 installed.
+- **Python** version 3.12 or newer installed.
 - **Git** for cloning the repository (Download from [https://git-scm.com/downloads](https://git-scm.com/downloads)).
 - **Node.js** for CSS compilation (Download from [https://nodejs.org/](https://nodejs.org/)).
 
@@ -105,7 +105,7 @@ If you encounter any issues during installation:
 
 2. **Python dependencies**:
    - Use a virtual environment
-   - Ensure you're using Python 3.10 or 3.11
+   - Ensure you're using Python 3.12 or newer
    - Try upgrading pip: `pip install --upgrade pip`
 
 3. **WebSocket issues**:


### PR DESCRIPTION
## Description
`INSTALL.md` lists **Python 3.10 or 3.11** as the required version, in both the Prerequisites section and the Troubleshooting section. This is stale — `pyproject.toml` declares `requires-python = ">=3.12"`, and `README.md` ("Requires Python 3.12 or newer"), `CONTRIBUTING.md` ("Python 3.12+"), and `CLAUDE.md` ("Python 3.12+ (required per pyproject.toml)") all already state the correct requirement. `INSTALL.md` was the one file still pointing new contributors at an unsupported Python version.

This is a documentation-only change — no code, config, or behavior is touched.

## Related Issues
None — found via a documentation-accuracy pass, not tied to a filed issue.

## Screenshots
Not applicable (text-only doc fix, no UI change).

## Testing
- Verified the actual requirement in `pyproject.toml`: `requires-python = ">=3.12"`.
- Cross-checked against `README.md`, `CONTRIBUTING.md`, and `CLAUDE.md`, which all already state 3.12+.
- Searched open/closed PRs for any existing fix to this file — none found (only unrelated historical PRs #108 and #318 touch `INSTALL.md`).
- Diff is a plain text substitution in two lines; no build or test run needed.

## Checklist
- [x] My code follows the style guidelines of this project (N/A — docs only)
- [x] I have performed a self-review of my own changes
- [x] I have made corresponding changes to the documentation (this PR *is* the documentation fix)
- [x] My changes generate no new warnings
- [x] This is a single, focused fix (one logical change per PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update INSTALL.md to require Python 3.12 or newer, aligning with `pyproject.toml` and the rest of the docs. Removes stale 3.10/3.11 references in prerequisites and troubleshooting to prevent installs on unsupported versions.

<sup>Written for commit 37facc03193ef5d92356ecf0b9c837463f8dcbc6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1652?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

