### PR TITLE
docs: fix stale broker counts in CLAUDE.md and DOCKER_README.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -120,7 +120,7 @@ npm run format
 - `app.py` - Main Flask application entry point
 - `blueprints/` - Flask route handlers (UI and webhooks)
 - `restx_api/` - REST API endpoints (`/api/v1/`)
-- `broker/` - Broker integrations (30+ brokers), each with `api/`, `database/`, `mapping/`, `streaming/`, `plugin.json`
+- `broker/` - Broker integrations (34 brokers), each with `api/`, `database/`, `mapping/`, `streaming/`, `plugin.json`
 - `services/` - Business logic layer
 - `database/` - SQLAlchemy models and database utilities
 - `utils/` - Shared utilities and helpers
@@ -155,7 +155,7 @@ Broker API calls use `httpx` with HTTP/2 connection pooling (`utils/httpx_client
 
 ### Broker Integration Pattern
 
-All 30+ brokers follow a standardized structure in `broker/{broker_name}/`:
+All 34 brokers follow a standardized structure in `broker/{broker_name}/`:
 
 1. `api/auth_api.py` - OAuth2 or API key based authentication
 2. `api/order_api.py` - Place, modify, cancel orders
@@ -516,7 +516,7 @@ API keys are generated at `/apikey` and hashed with pepper before storage.
 
 ### Symbol Format
 
-OpenAlgo uses a standardized symbol format across all 30+ brokers. Broker-specific symbols are mapped via `broker/*/mapping/` modules and stored in the `SymToken` table.
+OpenAlgo uses a standardized symbol format across all 34 brokers. Broker-specific symbols are mapped via `broker/*/mapping/` modules and stored in the `SymToken` table.
 
 **Equity:** Just the base symbol — `INFY`, `SBIN`, `TATAMOTORS`
 

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,6 @@
 # OpenAlgo - Algorithmic Trading Platform
 
-OpenAlgo is a production-ready algorithmic trading platform providing a unified API layer across 24+ Indian brokers. Seamlessly integrate with TradingView, Amibroker, Excel, Python, and AI agents.
+OpenAlgo is a production-ready algorithmic trading platform providing a unified API layer across 34 Indian brokers. Seamlessly integrate with TradingView, Amibroker, Excel, Python, and AI agents.
 
 ## Quick Start
 


### PR DESCRIPTION
## Description
`CLAUDE.md` says "30+ brokers" in three places, and `DOCKER_README.md` says "24+ Indian brokers" once — both stale. The `broker/` directory currently contains 34 broker integrations, and `README.md` ("34 broker plugins"), `docs/INDEX.md` ("Broker integration (34 plugins)"), and `CONTRIBUTING.md` (per the pending #1651) already use the verified count of 34.

This follows the same reconciliation lane as #1651, extended to the two remaining docs that hadn't been updated to the current count.

This is a documentation-only change — no code, config, or behavior is touched.

## Related Issues
None — self-sourced via a documentation-accuracy pass; a follow-on to #1651.

## Screenshots
Not applicable (text-only doc fix, no UI change).

## Testing
- Counted actual broker integrations: `ls broker/` → 34 directories (excluding `__init__.py`).
- Cross-checked against `README.md` ("34 broker plugins: 33 securities integrations and Delta Exchange") and `docs/INDEX.md` ("Broker integration (34 plugins)"), both already accurate.
- Searched open/closed PRs referencing these files/claims — no existing fix in flight for these specific lines.
- Diff is a plain text substitution across two files; no build or test run needed.

## Checklist
- [x] My code follows the style guidelines of this project (N/A — docs only)
- [x] I have performed a self-review of my own changes
- [x] I have made corresponding changes to the documentation (this PR *is* the documentation fix)
- [x] My changes generate no new warnings
- [x] This is a single, focused fix (one logical change per PR)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated stale broker counts in CLAUDE.md and DOCKER_README.md to reflect 34 broker integrations. Replaced “30+ brokers” and “24+ Indian brokers” with “34” to match the current `broker/` directory and keep docs consistent with README and docs/INDEX.

<sup>Written for commit bf26f14ee71f80a71d8c59b55b4b91decd580aa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1653?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

