### PR TITLE
docs: point contributors to supported API documentation

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -197,7 +197,7 @@ uv run gunicorn --worker-class eventlet -w 1 app:app
 
 - **Main app**: http://127.0.0.1:5000
 - **React frontend**: http://127.0.0.1:5000/react
-- **Swagger API docs**: http://127.0.0.1:5000/api/docs
+- **REST API documentation**: [docs/api/README.md](docs/api/README.md)
 - **API Analyzer**: http://127.0.0.1:5000/analyzer
 
 ---
@@ -248,7 +248,7 @@ openalgo/
 
 - **`frontend/`**: React 19 SPA with TypeScript, built with Vite and served by Flask via `blueprints/react_app.py`
 - **`broker/`**: Each subdirectory contains a complete broker integration with `api/`, `database/`, `mapping/`, `streaming/`, and `plugin.json`
-- **`restx_api/`**: RESTful API endpoints with automatic Swagger documentation at `/api/docs`
+- **`restx_api/`**: RESTful API endpoints under `/api/v1`; request contracts are maintained in [docs/api/README.md](docs/api/README.md)
 - **`blueprints/`**: Flask route handlers for UI pages and webhooks
 - **`services/`**: Business logic separated from route handlers
 - **`websocket_proxy/`**: Real-time market data streaming via unified WebSocket proxy
@@ -389,7 +389,7 @@ npm run e2e
 # Manual testing:
 # 1. Web UI: http://127.0.0.1:5000
 # 2. React UI: http://127.0.0.1:5000/react
-# 3. API Docs: http://127.0.0.1:5000/api/docs
+# 3. REST API documentation: docs/api/README.md
 # 4. API Analyzer: http://127.0.0.1:5000/analyzer
 ```
 
@@ -743,7 +743,7 @@ def get_historical_data(symbol, interval, start_date, end_date):
 1. Add broker to `VALID_BROKERS` in `.env`
 2. Configure broker credentials in `.env`
 3. Test authentication flow
-4. Test each API endpoint via Swagger UI at `/api/docs`
+4. Test each API endpoint against the request and response contracts in `docs/api/`
 5. Test WebSocket streaming (if supported)
 6. Validate error handling
 


### PR DESCRIPTION
## What does this PR do?

Removes four stale `/api/docs` Swagger references from `CONTRIBUTING.md`. OpenAlgo configures Flask-RESTX with `doc=False`, so `/api/docs` is not a supported route. The guide now points contributors to the maintained request/response contracts in `docs/api/`.

## Why

Following the current contributor guide sends contributors to an unsupported route during setup, manual testing, and broker integration work. This aligns the guide with the current source and canonical design documentation without changing runtime behavior.

## Changes

- Updated the access-points section to link `docs/api/README.md`.
- Corrected the `restx_api/` project-structure description.
- Updated the manual-testing checklist.
- Updated the broker-integration testing instruction.

## Verification

- Confirmed `docs/api/README.md` exists.
- Confirmed `/api/docs` no longer appears in `CONTRIBUTING.md`.
- Ran `git diff --check`.
- Re-read `restx_api/__init__.py` and the canonical REST API design docs, which both confirm Swagger UI is intentionally disabled.

This is a documentation-only, single-file change.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced `/api/docs` Swagger references in `CONTRIBUTING.md` with `docs/api/README.md` since Swagger UI is disabled in `Flask-RESTX`. This prevents dead links during setup, manual testing, and broker integration.

<sup>Written for commit 40d5b68e396309230077240ceff18235a23f9d20. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1654?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

