### PR TITLE
fix(sandbox): honor Delta expiry settlement time

### DIFF
--- a/sandbox/position_manager.py
+++ b/sandbox/position_manager.py
@@ -14,6 +14,7 @@ import os
 import sys
 import time
 from datetime import datetime
+from datetime import time as datetime_time
 from decimal import Decimal
 
 import pytz
@@ -33,6 +34,12 @@ logger = get_logger(__name__)
 
 # Maximum age (seconds) for WebSocket data to be considered fresh
 WEBSOCKET_DATA_MAX_AGE = 5
+IST = pytz.timezone("Asia/Kolkata")
+
+# Delta Exchange settles dated crypto options at 17:30 IST (12:00 UTC).  Keep
+# this explicit and exchange-scoped: a calendar expiry date is not enough to
+# decide that a contract has reached its terminal settlement point.
+CRYPTO_EXPIRY_SETTLEMENT_TIME = datetime_time(17, 30)
 
 
 def parse_expiry_from_symbol(symbol, exchange):
@@ -167,6 +174,38 @@ def get_contract_expiry(symbol, exchange):
     return get_expiry_from_database(symbol, exchange)
 
 
+def is_contract_expired(symbol, exchange, *, now=None):
+    """Return whether a dated contract has reached its settlement boundary.
+
+    Delta crypto contracts remain tradable on their calendar expiry date until
+    the 17:30 IST settlement point.  Other exchanges retain the existing
+    date-only behavior because their expiry/settlement clocks are not uniform.
+
+    ``now`` is injectable so the boundary can be tested without sleeping or
+    changing the host clock.  Naive datetimes are interpreted as IST for
+    compatibility with the sandbox's existing naive-IST timestamps.
+    """
+
+    expiry_date = get_contract_expiry(symbol, exchange)
+    if expiry_date is None:
+        return False
+
+    if now is None:
+        current = datetime.now(IST)
+    elif now.tzinfo is None:
+        current = IST.localize(now)
+    else:
+        current = now.astimezone(IST)
+
+    if str(exchange).upper() == "CRYPTO":
+        settlement_at = IST.localize(
+            datetime.combine(expiry_date, CRYPTO_EXPIRY_SETTLEMENT_TIME)
+        )
+        return current >= settlement_at
+
+    return current.date() > expiry_date
+
+
 class PositionManager:
     """Manages positions and MTM calculations"""
 
@@ -205,9 +244,7 @@ class PositionManager:
         Returns:
             list: All positions (expired ones settled, others unchanged)
         """
-        from datetime import date
-
-        today = date.today()
+        now = datetime.now(IST)
         valid_positions = []
         expired_count = 0
 
@@ -221,7 +258,7 @@ class PositionManager:
                 continue
 
             # Check if contract has expired
-            is_expired = today > expiry_date
+            is_expired = is_contract_expired(position.symbol, position.exchange, now=now)
 
             # For already closed positions (qty=0), just keep them
             # These are today's closed trades - show them regardless of expiry
@@ -234,7 +271,7 @@ class PositionManager:
                 # Contract has expired - auto-close it
                 logger.info(
                     f"Expired contract detected: {position.symbol} "
-                    f"(expiry: {expiry_date}, today: {today}, user: {position.user_id})"
+                    f"(expiry: {expiry_date}, now: {now.isoformat()}, user: {position.user_id})"
                 )
 
                 try:
@@ -1214,13 +1251,12 @@ def cleanup_expired_contracts():
     - P&L calculated and added to realized P&L
     - Position quantity set to 0
     """
-    from datetime import date
     from decimal import Decimal
 
     from sandbox.fund_manager import FundManager
 
     try:
-        today = date.today()
+        now = datetime.now(IST)
 
         # Find all open positions in F&O exchanges
         fo_exchanges = ["NFO", "BFO", "MCX", "CDS", "BCD", "NCDEX", "CRYPTO"]
@@ -1242,11 +1278,13 @@ def cleanup_expired_contracts():
         for position in all_fo_positions:
             expiry_date = get_contract_expiry(position.symbol, position.exchange)
 
-            if expiry_date and today > expiry_date:
+            if expiry_date and is_contract_expired(
+                position.symbol, position.exchange, now=now
+            ):
                 expired_positions.append(position)
                 logger.debug(
                     f"Found expired contract: {position.symbol} "
-                    f"(expiry: {expiry_date}, user: {position.user_id})"
+                    f"(expiry: {expiry_date}, now: {now.isoformat()}, user: {position.user_id})"
                 )
 
         if not expired_positions:

--- a/test/test_position_expiry.py
+++ b/test/test_position_expiry.py
@@ -1,0 +1,55 @@
+"""Regression tests for sandbox contract settlement boundaries."""
+
+import sys
+from datetime import datetime
+from pathlib import Path
+
+import pytz
+
+# ``test/sandbox`` is a legacy test package and can shadow the production
+# ``sandbox`` package during pytest collection.  Make this regression import
+# the application module explicitly without changing the test harness globally.
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+sys.path.insert(0, str(PROJECT_ROOT))
+shadowed_sandbox = sys.modules.get("sandbox")
+if shadowed_sandbox is not None and not str(
+    getattr(shadowed_sandbox, "__file__", "")
+).startswith(str(PROJECT_ROOT / "sandbox")):
+    for module_name in tuple(sys.modules):
+        if module_name == "sandbox" or module_name.startswith("sandbox."):
+            sys.modules.pop(module_name, None)
+
+from sandbox.position_manager import is_contract_expired
+
+IST = pytz.timezone("Asia/Kolkata")
+
+
+def _ist(*, hour: int, minute: int, second: int = 0) -> datetime:
+    return IST.localize(datetime(2026, 7, 22, hour, minute, second))
+
+
+def test_delta_contract_is_not_expired_before_its_1730_ist_settlement():
+    assert not is_contract_expired(
+        "ETH22JUL261920CE", "CRYPTO", now=_ist(hour=17, minute=29, second=59)
+    )
+
+
+def test_delta_contract_expires_at_its_1730_ist_settlement():
+    assert is_contract_expired(
+        "ETH22JUL261920CE", "CRYPTO", now=_ist(hour=17, minute=30)
+    )
+
+
+def test_delta_contract_remains_expired_after_settlement_day():
+    next_day = IST.localize(datetime(2026, 7, 23, 0, 0))
+    assert is_contract_expired("ETH22JUL261920CE", "CRYPTO", now=next_day)
+
+
+def test_non_crypto_contract_keeps_existing_next_day_boundary():
+    expiry_day = IST.localize(datetime(2026, 7, 22, 23, 59, 59))
+    next_day = IST.localize(datetime(2026, 7, 23, 0, 0))
+
+    assert not is_contract_expired(
+        "NIFTY22JUL2624000CE", "NFO", now=expiry_day
+    )
+    assert is_contract_expired("NIFTY22JUL2624000CE", "NFO", now=next_day)


### PR DESCRIPTION
## Summary

- honor Delta Exchange's 17:30 IST settlement boundary on the contract's calendar expiry date
- apply the boundary consistently to position reads and background expiry cleanup
- preserve the existing next-calendar-day behavior for exchanges whose settlement clocks are not uniform
- add deterministic tests for the pre-boundary, exact-boundary, next-day, and non-crypto cases

## Problem

The sandbox used `today > expiry_date`, so a Delta contract remained open throughout its expiry date, including after Delta's 17:30 IST settlement point. A market close submitted after the contract expired could then remain working indefinitely when no valid quote was available.

Delta's product metadata reports settlement at `12:00 UTC` (`17:30 IST`) for the affected contract family.

## Verification

- `uv run pytest test/test_position_expiry.py -q` — 4 passed
- CI-safe backend subset — 7 passed
- `uv run ruff check sandbox/position_manager.py test/test_position_expiry.py --select I` — passed
- `git diff --check` — passed


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Honor Delta Exchange’s 17:30 IST settlement cutoff on the calendar expiry date so crypto contracts stop trading at the correct time and don’t linger past expiry. Applies the cutoff to position reads and background cleanup, with tests to prevent regressions.

- **Bug Fixes**
  - Added `is_contract_expired(symbol, exchange, now=...)`: for `CRYPTO`, expire at 17:30 IST on the expiry date; others keep date-only expiry.
  - Switched position checks and expiry cleanup to use the new boundary and IST-aware timestamps.
  - Added deterministic tests for pre-boundary, exact-boundary, next-day, and non-crypto cases.

<sup>Written for commit 5d6cf585d8d871359cce99259c68fc58a5d3b0f4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1659?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

