### PR TITLE
fix(ws): per-mode subscriptions, Depth-only terminal (#1664) + event-driven sandbox MTM

### DIFF
--- a/broker/iiflcapital/streaming/iiflcapital_adapter.py
+++ b/broker/iiflcapital/streaming/iiflcapital_adapter.py
@@ -253,23 +253,35 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
         segment = brexchange.strip()  # store uppercase; lower-casing happens in the feed client
 
         is_index = is_index_exchange(exchange)
-        feed_mode = self._MODE_OA_TO_IIFL[mode]
-        # OI is only meaningful for derivatives — see iiflcapital_mapping.
-        include_oi = mode != 1 and supports_open_interest(exchange) and not is_index
 
         key = f"{exchange}:{symbol}"
         topic_suffix = f"{normalize_segment(segment)}/{token}"
 
         with self.lock:
+            # Track modes as a set (issue #1664): the protocol lets a client
+            # hold LTP and Depth on the same symbol at once. A single "mode"
+            # field made the second subscribe overwrite the first, so
+            # _handle_ticks stopped publishing the overwritten mode's topic.
+            existing = self.subscribed_symbols.get(key)
+            modes = set(existing["modes"]) if existing else set()
+            modes.add(mode)
             self.subscribed_symbols[key] = {
                 "exchange": exchange,
                 "symbol": symbol,
                 "segment": segment,
                 "token": token,
-                "mode": mode,
+                "modes": modes,
                 "is_index": is_index,
             }
             self._key_to_symbol[topic_suffix] = (symbol, exchange)
+
+        # Subscribe the broker stream at the HIGHEST subscribed mode -- its
+        # packet is a superset and _handle_ticks fans out per mode. Without
+        # the max(), a later LTP subscribe would downgrade an active feed.
+        effective_mode = max(modes)
+        feed_mode = self._MODE_OA_TO_IIFL[effective_mode]
+        # OI is only meaningful for derivatives — see iiflcapital_mapping.
+        include_oi = effective_mode != 1 and supports_open_interest(exchange) and not is_index
 
         try:
             self.ws_client.subscribe_instruments(
@@ -301,7 +313,22 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
     ) -> dict[str, Any]:
         key = f"{exchange}:{symbol}"
         with self.lock:
-            sub = self.subscribed_symbols.pop(key, None)
+            sub = self.subscribed_symbols.get(key)
+            if sub is None:
+                pass
+            elif mode is not None and sub["modes"] - {mode}:
+                # Mode-specific unsubscribe with other modes still active:
+                # drop just that mode and keep the broker stream up (its
+                # packet is a superset; _handle_ticks fans out per remaining
+                # mode). See issue #1664.
+                sub["modes"].discard(mode)
+                self.logger.info(
+                    f"Unsubscribed IIFL {exchange}:{symbol} mode {mode}; "
+                    f"stream retained for modes {sorted(sub['modes'])}"
+                )
+                return {"status": "success", "message": f"Unsubscribed from {symbol}"}
+            else:
+                self.subscribed_symbols.pop(key, None)
         if sub is None:
             return {"status": "error", "message": f"Not subscribed to {symbol}"}
 
@@ -346,10 +373,12 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     continue
 
                 symbol, exchange = symbol_info
-                sub_mode = sub_info["mode"]
+                sub_modes = sub_info["modes"]
 
                 # The feed client always returns the full decoded packet; we
-                # produce per-mode payloads from the same source dict.
+                # produce per-mode payloads from the same source dict -- one
+                # publish per SUBSCRIBED mode (issue #1664), not just the
+                # last mode that happened to subscribe.
                 base = {
                     "symbol": symbol,
                     "exchange": exchange,
@@ -358,9 +387,10 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     "timestamp": tick.get("timestamp", int(time.time() * 1000)),
                 }
 
-                if sub_mode == 1:
+                if 1 in sub_modes:
                     payload = {**base, "mode": "ltp"}
                     self._publish(symbol, exchange, "LTP", payload)
+                if sub_modes == {1}:
                     continue
 
                 # Quote / Depth share the OHLC + bid/ask + volume block.
@@ -388,13 +418,13 @@ class IiflcapitalWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     payload["oi"] = tick["open_interest"]
                     payload["open_interest"] = tick["open_interest"]
 
-                if sub_mode == 2:
-                    payload["mode"] = "quote"
-                    self._publish(symbol, exchange, "QUOTE", payload)
-                else:  # mode 3 — depth
-                    payload["mode"] = "full"
-                    payload["depth"] = tick.get("depth", {"buy": [], "sell": []})
-                    self._publish(symbol, exchange, "DEPTH", payload)
+                if 2 in sub_modes:
+                    quote_payload = {**payload, "mode": "quote"}
+                    self._publish(symbol, exchange, "QUOTE", quote_payload)
+                if 3 in sub_modes:
+                    depth_payload = {**payload, "mode": "full"}
+                    depth_payload["depth"] = tick.get("depth", {"buy": [], "sell": []})
+                    self._publish(symbol, exchange, "DEPTH", depth_payload)
 
             except Exception as e:
                 self.logger.exception(f"Error processing IIFL tick: {e}")

--- a/broker/nubra/streaming/nubra_adapter.py
+++ b/broker/nubra/streaming/nubra_adapter.py
@@ -809,13 +809,47 @@ class NubraWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 key = f"{exchange}:{symbol}"
                 modes = self.symbol_modes.get(key, set()).copy()
 
-            if not modes or 3 not in modes:
+            if not modes:
                 return
 
             # Extract common data
             ltp = obj.ltp / 100.0 if obj.ltp else 0
             volume = obj.volume if obj.volume else 0
             timestamp = obj.timestamp if obj.timestamp else int(time.time() * 1000)
+
+            # The orderbook channel is the ONLY feed for non-index
+            # instruments, so fan out every subscribed mode from it
+            # (issue #1664). The old early-return on "3 not in modes"
+            # starved LTP/Quote subscribers entirely for stocks.
+            if 1 in modes:
+                self.publish_market_data(
+                    f"{exchange}_{symbol}_LTP",
+                    {
+                        "symbol": symbol,
+                        "exchange": exchange,
+                        "mode": "ltp",
+                        "ltp": ltp,
+                        "timestamp": timestamp,
+                    },
+                )
+            if 2 in modes:
+                bid0 = obj.bids[0].price / 100.0 if obj.bids and obj.bids[0].price else 0
+                ask0 = obj.asks[0].price / 100.0 if obj.asks and obj.asks[0].price else 0
+                self.publish_market_data(
+                    f"{exchange}_{symbol}_QUOTE",
+                    {
+                        "symbol": symbol,
+                        "exchange": exchange,
+                        "mode": "quote",
+                        "ltp": ltp,
+                        "volume": volume,
+                        "bid": bid0,
+                        "ask": ask0,
+                        "timestamp": timestamp,
+                    },
+                )
+            if 3 not in modes:
+                return
 
             # Build depth data
             bids = [

--- a/broker/zerodha/streaming/zerodha_adapter.py
+++ b/broker/zerodha/streaming/zerodha_adapter.py
@@ -304,9 +304,6 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             except ValueError:
                 return {"status": "error", "message": f"Invalid token format: {token}"}
 
-            # Map mode to Zerodha format
-            zerodha_mode = self.mode_map.get(mode, ZerodhaWebSocket.MODE_QUOTE)
-
             # Check if WebSocket is actually connected
             if not self.ws_client.is_connected():
                 self.logger.warning("WebSocket not connected, waiting for connection...")
@@ -317,26 +314,15 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # Track subscription with mapped exchange for consistency
             subscription_exchange = "NSE" if exchange == "NSE_INDEX" else exchange
 
-            # Add to queue for batch processing
             with self.lock:
-                self.subscription_queue.append(
-                    {
-                        "token": token,
-                        "mode": zerodha_mode,
-                        "symbol": symbol,
-                        "exchange": exchange,
-                        "subscription_exchange": subscription_exchange,
-                        "mode_int": mode,
-                    }
-                )
-
-                # If this is the first subscription in queue, start the batch timer
-                if len(self.subscription_queue) == 1:
-                    self._start_batch_timer()
-
-            # Immediately track subscription (even before actual WebSocket subscription)
-            with self.lock:
-                self.subscribed_symbols[f"{exchange}:{symbol}"] = {
+                # Per-mode subscription tracking (issue #1664). The protocol
+                # subscribes/unsubscribes per (symbol, mode) -- a client can
+                # legitimately hold LTP and Depth on the same symbol at once.
+                # The old symbol-only key made the second mode overwrite the
+                # first, so _handle_ticks stopped publishing the overwritten
+                # mode's topic and LTP consumers (the /trading chart) froze
+                # while depth kept flowing.
+                self.subscribed_symbols[f"{exchange}:{symbol}:{mode}"] = {
                     "exchange": exchange,  # Original exchange for unsubscribe
                     "symbol": symbol,
                     "token": token,
@@ -344,6 +330,33 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     "mapped_exchange": subscription_exchange,  # Mapped exchange for data matching
                 }
                 self.token_to_symbol[token] = (symbol, exchange)
+
+                # The kite stream itself carries ONE mode per token, so request
+                # the highest subscribed mode -- its payload is a superset of
+                # the lower modes and _handle_ticks fans it out per mode.
+                # Without the max(), a later LTP subscribe would downgrade an
+                # active full-depth stream at the broker.
+                highest_mode = max(
+                    info["mode"]
+                    for info in self.subscribed_symbols.values()
+                    if info["token"] == token
+                )
+                zerodha_mode = self.mode_map.get(highest_mode, ZerodhaWebSocket.MODE_QUOTE)
+
+                self.subscription_queue.append(
+                    {
+                        "token": token,
+                        "mode": zerodha_mode,
+                        "symbol": symbol,
+                        "exchange": exchange,
+                        "subscription_exchange": subscription_exchange,
+                        "mode_int": highest_mode,
+                    }
+                )
+
+                # If this is the first subscription in queue, start the batch timer
+                if len(self.subscription_queue) == 1:
+                    self._start_batch_timer()
 
             self.logger.info(
                 f"Subscribed to {exchange}:{symbol} (token: [REDACTED], mode: {zerodha_mode})"
@@ -366,24 +379,39 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             depth_level: Optional depth level parameter (for compatibility)
         """
         try:
-            key = f"{exchange}:{symbol}"
-
             with self.lock:
-                if key not in self.subscribed_symbols:
+                # Per-mode keys (issue #1664). A mode-specific unsubscribe
+                # removes only that mode; mode=None (legacy callers) removes
+                # every mode for the symbol.
+                prefix = f"{exchange}:{symbol}:"
+                if mode is not None:
+                    keys = [k for k in self.subscribed_symbols if k == f"{prefix}{mode}"]
+                else:
+                    keys = [k for k in self.subscribed_symbols if k.startswith(prefix)]
+
+                if not keys:
                     return {"status": "error", "message": f"Not subscribed to {symbol}"}
 
-                subscription = self.subscribed_symbols[key]
-                token = subscription["token"]
+                token = self.subscribed_symbols[keys[0]]["token"]
+                for k in keys:
+                    del self.subscribed_symbols[k]
 
-                # Unsubscribe using WebSocket client
-                if self.ws_client:
-                    self.ws_client.unsubscribe([token])
+                # Only drop the kite-level stream when NO mode still needs the
+                # token. If lower modes remain we keep the existing (possibly
+                # higher-mode) stream -- its payload is a superset, and
+                # _handle_ticks fans out per remaining mode.
+                still_needed = any(
+                    info["token"] == token for info in self.subscribed_symbols.values()
+                )
+                if not still_needed:
+                    if self.ws_client:
+                        self.ws_client.unsubscribe([token])
+                    self.token_to_symbol.pop(token, None)
 
-                # Remove from tracking
-                del self.subscribed_symbols[key]
-                self.token_to_symbol.pop(token, None)
-
-            self.logger.info(f"Unsubscribed from {exchange}:{symbol}")
+            self.logger.info(
+                f"Unsubscribed from {exchange}:{symbol}"
+                f"{f' (mode {mode})' if mode is not None else ''}"
+            )
             return {"status": "success", "message": f"Unsubscribed from {symbol}"}
 
         except Exception as e:
@@ -501,7 +529,7 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                                 f"LTP Data should be available for polling: {subscription_exchange}:{symbol}"
                             )
                     else:
-                        # For non-full modes, just publish as-is
+                        # For non-full modes, publish as-is
                         mode_str = {"ltp": "LTP", "quote": "QUOTE", "full": "DEPTH"}.get(
                             original_tick_mode, "LTP"
                         )
@@ -512,6 +540,24 @@ class ZerodhaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
                         # Publish to ZeroMQ
                         self.publish_market_data(topic, transformed_tick)
+
+                        # Quote ticks are a superset of LTP: when the kite
+                        # stream runs in quote mode because modes 1 and 2 are
+                        # both subscribed, fan the LTP topic out too --
+                        # otherwise the mode-1 subscriber starves exactly like
+                        # the depth case above (issue #1664).
+                        if original_tick_mode == "quote" and 1 in subscribed_modes:
+                            ltp_tick = {
+                                "symbol": symbol,
+                                "exchange": data_exchange,
+                                "mode": "ltp",
+                                "ltp": transformed_tick.get("ltp", 0),
+                                "timestamp": transformed_tick.get(
+                                    "timestamp", int(time.time() * 1000)
+                                ),
+                            }
+                            ltp_topic = self._generate_topic(symbol, subscription_exchange, "LTP")
+                            self.publish_market_data(ltp_topic, ltp_tick)
 
         except Exception as e:
             self.logger.error(f"Error handling ticks: {e}")

--- a/frontend/src/lib/trading/terminal.ts
+++ b/frontend/src/lib/trading/terminal.ts
@@ -757,9 +757,25 @@ export class TradingTerminal {
         this.depthActive = true
         if (this.tradeBtns) this.tradeBtns.setPrices(bid, ask)
       }
+      // Depth is the terminal's ONLY subscription for tradeable instruments,
+      // so the chart ticks off depth.ltp -- a first-class field in every mode-3
+      // payload per the WebSocket protocol (docs/prompt/websockets-format.md).
+      // This replaced the old dual LTP+Depth subscribe, which broke on brokers
+      // whose adapters track one mode per symbol (Depth overwrote LTP and the
+      // chart froze while depth kept flowing -- issue #1664).
+      if (typeof depth.ltp === 'number' && depth.ltp > 0) {
+        this.cb.onWsState('live')
+        this.stopLtpFallback()
+        this.onTick({ ltp: depth.ltp })
+      }
     })
-    this.ws.subscribe('LTP', this.sym.symbol, this.sym.exchange)
-    if (!this.sym.quoteOnly) this.ws.subscribe('Depth', this.sym.symbol, this.sym.exchange, 5)
+    // One subscription per symbol, mode picked by instrument type: indices
+    // have no order book (LTP), tradeables get Depth which embeds ltp.
+    if (this.sym.quoteOnly) {
+      this.ws.subscribe('LTP', this.sym.symbol, this.sym.exchange)
+    } else {
+      this.ws.subscribe('Depth', this.sym.symbol, this.sym.exchange, 5)
+    }
   }
 
   /* periodic history reconcile: snap completed bars to broker OHLC/volume */
@@ -806,13 +822,14 @@ export class TradingTerminal {
       this.sym &&
       (this.sym.symbol !== pick.symbol || this.sym.exchange !== pick.exchange)
     ) {
+      // Mirror connectLive's single-subscription model: the outgoing symbol
+      // holds exactly one mode -- LTP when quote-only, Depth otherwise.
       try {
-        this.ws.unsubscribe('LTP', this.sym.symbol, this.sym.exchange)
-      } catch {
-        /* not subscribed */
-      }
-      try {
-        this.ws.unsubscribe('Depth', this.sym.symbol, this.sym.exchange)
+        if (this.sym.quoteOnly) {
+          this.ws.unsubscribe('LTP', this.sym.symbol, this.sym.exchange)
+        } else {
+          this.ws.unsubscribe('Depth', this.sym.symbol, this.sym.exchange)
+        }
       } catch {
         /* not subscribed */
       }

--- a/sandbox/execution_engine.py
+++ b/sandbox/execution_engine.py
@@ -789,6 +789,39 @@ class ExecutionEngine:
 
             db_session.commit()
 
+            # Event-driven MTM: keep the WS engine's position-feed refs in
+            # sync with the position book. After any fill, either the symbol
+            # has open quantity (subscribe so MarketDataService stays warm and
+            # the MTM loop reads ticks instead of REST) or it just went flat
+            # (release the subscription). Never allowed to break a fill.
+            try:
+                from sandbox.websocket_execution_engine import (
+                    get_websocket_execution_engine,
+                )
+
+                ws_engine = get_websocket_execution_engine()
+                if ws_engine is not None:
+                    has_open = (
+                        SandboxPositions.query.filter_by(
+                            user_id=order.user_id,
+                            symbol=order.symbol,
+                            exchange=order.exchange,
+                        )
+                        .filter(SandboxPositions.quantity != 0)
+                        .count()
+                        > 0
+                    )
+                    if has_open:
+                        ws_engine.notify_position_opened(
+                            order.user_id, order.symbol, order.exchange
+                        )
+                    else:
+                        ws_engine.notify_position_closed(
+                            order.user_id, order.symbol, order.exchange
+                        )
+            except Exception:
+                logger.debug("Position feed notify failed (non-fatal)", exc_info=True)
+
             # Validate margin consistency after position update
             is_consistent, discrepancy = validate_margin_consistency(order.user_id)
             if not is_consistent:

--- a/sandbox/position_manager.py
+++ b/sandbox/position_manager.py
@@ -182,6 +182,22 @@ EXCHANGE_CLOSE_TIMES = {
 DEFAULT_CLOSE_TIME = dt_time(15, 30)
 
 
+def _notify_position_feed_closed(user_id, symbol, exchange):
+    """Tell the WS engine a settled position no longer needs its MTM feed.
+
+    Best-effort by design (event-driven MTM is an enhancement): failure to
+    release a subscription costs a few stray ticks, never correctness.
+    """
+    try:
+        from sandbox.websocket_execution_engine import get_websocket_execution_engine
+
+        engine = get_websocket_execution_engine()
+        if engine is not None:
+            engine.notify_position_closed(user_id, symbol, exchange)
+    except Exception:
+        logger.debug("Position feed release failed (non-fatal)", exc_info=True)
+
+
 def is_contract_expired_now(expiry_date, exchange, now=None):
     """Return True when an F&O contract should be treated as expired right now.
 
@@ -416,6 +432,10 @@ class PositionManager:
             db_session.commit()
 
         logger.info(f"Expired position {symbol} settled successfully for user {position.user_id}")
+
+        # Release the position's MTM feed subscription (event-driven MTM);
+        # the contract is dead, no further ticks are wanted.
+        _notify_position_feed_closed(position.user_id, symbol, position.exchange)
 
     def get_open_positions(self, update_mtm=True):
         """
@@ -1409,6 +1429,7 @@ def cleanup_expired_contracts():
                         db_session.commit()
 
                         logger.info(f"Expired contract {symbol} cleaned up for user {user_id}")
+                        _notify_position_feed_closed(user_id, symbol, position.exchange)
 
                     except Exception as e:
                         db_session.rollback()

--- a/sandbox/websocket_execution_engine.py
+++ b/sandbox/websocket_execution_engine.py
@@ -51,6 +51,14 @@ class WebSocketExecutionEngine:
         # {user_id: {symbol_key: count}}
         self._user_symbol_refcounts: dict[str, dict[str, int]] = {}
 
+        # Event-driven MTM: open POSITIONS hold a feed subscription just like
+        # open orders do, so the proxy keeps MarketDataService warm and the
+        # MTM loop reads tick-fresh prices instead of falling back to REST
+        # multiquotes for unwatched symbols. One ref per (user_id, symbol_key)
+        # regardless of how many products hold the symbol; the ref is released
+        # only when every product's position is flat.
+        self._position_refs: set[tuple[str, str]] = set()
+
         # Fallback settings
         self.fallback_enabled = os.getenv("SANDBOX_ENGINE_FALLBACK", "true").lower() == "true"
         self.stale_data_threshold = 30  # seconds
@@ -122,6 +130,7 @@ class WebSocketExecutionEngine:
             self._pending_orders_index.clear()
             self._monitored_symbols.clear()
             self._user_symbol_refcounts.clear()
+            self._position_refs.clear()
 
             try:
                 pending_orders = SandboxOrders.query.filter_by(order_status="open").all()
@@ -158,6 +167,35 @@ class WebSocketExecutionEngine:
                 logger.debug(
                     f"Built order index: {len(pending_orders)} orders across {len(self._monitored_symbols)} symbols"
                 )
+
+                # Event-driven MTM: open positions hold feed subscriptions too,
+                # so a restart re-warms MarketDataService for every held symbol
+                # (the poll loop then reads ticks instead of REST-fetching).
+                # Contracts already past expiry are skipped -- their positions
+                # are awaiting settlement, and the symbol may already be gone
+                # from the master contract.
+                from datetime import date
+
+                from database.sandbox_db import SandboxPositions
+                from sandbox.position_manager import get_contract_expiry
+
+                open_positions = SandboxPositions.query.filter(
+                    SandboxPositions.quantity != 0
+                ).all()
+                pos_subscribed = 0
+                for pos in open_positions:
+                    expiry = get_contract_expiry(pos.symbol, pos.exchange)
+                    if expiry is not None and date.today() > expiry:
+                        continue
+                    key = f"{pos.exchange}:{pos.symbol}"
+                    if (pos.user_id, key) not in self._position_refs:
+                        self._position_refs.add((pos.user_id, key))
+                        self._increment_user_symbol_refcount(pos.user_id, key)
+                        pos_subscribed += 1
+                if pos_subscribed:
+                    logger.info(
+                        f"Position feed: {pos_subscribed} open-position symbols added to index"
+                    )
 
             except Exception as e:
                 logger.exception(f"Error building order index: {e}")
@@ -228,6 +266,61 @@ class WebSocketExecutionEngine:
         if unsubscribe_user and unsubscribe_symbol:
             exchange, symbol = unsubscribe_symbol.split(":", 1)
             self._unsubscribe_ws_symbols(unsubscribe_user, [(symbol, exchange)])
+
+    def notify_position_opened(self, user_id: str, symbol: str, exchange: str):
+        """Hold a feed subscription for an open position (event-driven MTM).
+
+        Called after a fill leaves a non-zero position. Idempotent per
+        (user, symbol): repeat fills on an already-referenced symbol are
+        no-ops, and a symbol some open order already subscribed just gains
+        a second refcount -- the pool sees one subscription either way.
+        """
+        if not self._running:
+            return
+        symbol_key = f"{exchange}:{symbol}"
+        subscribe = False
+        with self._lock:
+            if (user_id, symbol_key) not in self._position_refs:
+                self._position_refs.add((user_id, symbol_key))
+                subscribe = self._increment_user_symbol_refcount(user_id, symbol_key)
+        if subscribe:
+            logger.info(f"Position feed: subscribing {symbol_key} for MTM (user {user_id})")
+            self._subscribe_ws_symbols(user_id, [(symbol, exchange)])
+
+    def notify_position_closed(self, user_id: str, symbol: str, exchange: str):
+        """Release the position's feed subscription once the symbol is flat.
+
+        Flat means NO product (MIS/NRML/CNC) still holds quantity -- an MIS
+        close while an NRML position remains must keep the feed up. On any
+        doubt (query failure) the subscription is kept; a stray subscription
+        costs a few ticks, a dropped one costs live MTM.
+        """
+        if not self._running:
+            return
+        try:
+            from database.sandbox_db import SandboxPositions
+
+            remaining = (
+                SandboxPositions.query.filter_by(
+                    user_id=user_id, symbol=symbol, exchange=exchange
+                )
+                .filter(SandboxPositions.quantity != 0)
+                .count()
+            )
+        except Exception:
+            logger.debug("Position feed: flatness check failed; keeping subscription")
+            return
+        if remaining:
+            return
+        symbol_key = f"{exchange}:{symbol}"
+        unsubscribe = False
+        with self._lock:
+            if (user_id, symbol_key) in self._position_refs:
+                self._position_refs.discard((user_id, symbol_key))
+                unsubscribe = self._decrement_user_symbol_refcount(user_id, symbol_key)
+        if unsubscribe:
+            logger.info(f"Position feed: releasing {symbol_key} (user {user_id}, flat)")
+            self._unsubscribe_ws_symbols(user_id, [(symbol, exchange)])
 
     def _on_market_data(self, data: dict):
         """


### PR DESCRIPTION
## Summary

Two related WebSocket-architecture changes, both tested live on Fyers; the broker adapter fixes need community verification on their brokers.

### 1. Per-mode WS subscriptions + Depth-only trading terminal (fixes #1664)

The /trading chart froze for derivatives on Zerodha while depth messages kept arriving. The terminal subscribed the same symbol in two modes (LTP for the chart, Depth for the buttons); the Zerodha adapter keyed subscriptions by symbol only, so the Depth subscribe overwrote the LTP entry and the LTP topic stopped publishing. The protocol subscribes/unsubscribes per (symbol, mode), so symbol-only tracking is out of spec.

- **Terminal (all brokers):** one subscription per symbol -- Depth for tradeables (chart ticks off `depth.ltp`, a first-class protocol field), LTP for quote-only indices. The dual-subscribe no longer exists.
- **Zerodha:** per-symbol:mode keys; kite stream requested at the highest subscribed mode; mode-aware unsubscribe; quote-tick to LTP-topic fan-out.
- **IIFL Capital:** modes tracked as a set; per-mode topic fan-out from the full packet; mode-aware unsubscribe.
- **Nubra:** the orderbook channel (only feed for non-index instruments) published nothing unless mode 3 was subscribed -- LTP/Quote subscribers on stocks starved entirely. Now fans out LTP and QUOTE alongside DEPTH.

The adapter fixes also stop /scalping and /positions from freezing when /trading holds Depth on the same symbol in another tab (server-side subscription state is global per symbol).

### 2. Event-driven sandbox MTM

Open positions were valued by REST polling every 5s; the WebSocket cache only helped if some browser tab happened to watch the symbol. Positions now hold feed subscriptions exactly like open orders do (shared refcounts, boot rebuild, release on flat across all products, release on expiry settlement). The proxy already feeds ticks into MarketDataService and the MTM loop already reads it first, so REST multiquotes degrades to a true fallback. DB write cadence unchanged.

## Testing

- Live on Fyers: /trading chart ticks via depth.ltp, buttons update, indices unaffected; boot logs `Position feed: 2 open-position symbols added to index`; per-cycle multiquotes REST calls stopped; positionbook LTPs track ticks.
- Behavioural tests: idempotent opens, order/position refcount sharing, non-flat close retention, last-ref release, stopped-engine no-ops.
- All adapters compile, ruff at baseline, frontend tsc + vite clean.
- **Needs verification on Zerodha/IIFL/Nubra** -- @<reporter of #1664> your repro is the acceptance test for the Zerodha path.

Fixes #1664

🤖 Generated with [Claude Code](https://claude.com/claude-code)
