### PR TITLE
fix(samco): batch subscribe queue + auth-fail short-circuit

### DIFF
--- a/broker/samco/streaming/samcoWebSocket.py
+++ b/broker/samco/streaming/samcoWebSocket.py
@@ -9,7 +9,6 @@ import logging
 import threading
 import time
 from collections.abc import Callable
-from typing import Any, Dict, List, Optional
 from urllib.parse import unquote
 
 import websocket
@@ -110,6 +109,9 @@ class SamcoWebSocket:
         self.current_retry_attempt = 0
         self.DISCONNECT_FLAG = False
 
+        # Auth-failure guard: once an auth error is detected, stop reconnecting
+        self._auth_failed = False
+
         # Logger
         self.logger = get_logger("samco_websocket")
 
@@ -177,6 +179,7 @@ class SamcoWebSocket:
         """Initialize WebSocket connection with authentication headers"""
         self.running = True
         self.DISCONNECT_FLAG = False
+        self._auth_failed = False
 
         # Build headers with session token
         # Log token info for debugging (first/last 4 chars only for security)
@@ -305,6 +308,19 @@ class SamcoWebSocket:
         try:
             # Try to parse as JSON
             data = json.loads(message)
+
+            # Short-circuit auth-failed messages before they reach the market-data path.
+            # Samco may wrap them in a response object or send them as top-level status.
+            from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
+
+            auth_check_payload = ""
+            if "response" in data and isinstance(data["response"], dict):
+                auth_check_payload = f"{data['response'].get('status', '')} {data['response'].get('message', '')}"
+            else:
+                auth_check_payload = f"{data.get('status', '')} {data.get('message', '')}"
+            if BaseBrokerWebSocketAdapter.is_auth_error(auth_check_payload):
+                self._handle_auth_failure(auth_check_payload.strip())
+                return
 
             # Check for response wrapper from Samco
             if "response" in data:
@@ -479,9 +495,37 @@ class SamcoWebSocket:
         except (ValueError, TypeError):
             return 0
 
+    def _handle_auth_failure(self, reason: str) -> None:
+        """Stop reconnect loops once an authentication failure has been detected."""
+        if self._auth_failed:
+            return
+
+        self._auth_failed = True
+        self.logger.error(f"Samco authentication failure: {reason}. Stopping reconnect.")
+
+        # Drop the connection so the adapter's _on_close can see _auth_failed
+        # and give up instead of reconnecting.
+        self.running = False
+        self.connected = False
+        self._stop_heartbeat()
+        self._close_websocket()
+
     def _on_error(self, ws, error) -> None:
         """Handle WebSocket connection errors — reconnection is handled by the adapter"""
-        self.logger.error(f"Samco WebSocket error: {error}")
+        error_msg = str(error)
+        self.logger.error(f"Samco WebSocket error: {error_msg}")
+
+        from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
+
+        if BaseBrokerWebSocketAdapter.is_auth_error(error_msg):
+            self._handle_auth_failure(error_msg)
+            # Propagate to the adapter so it can stop its retry loop immediately.
+            if self._on_error_callback:
+                try:
+                    self._on_error_callback(ws, error)
+                except Exception as e:
+                    self.logger.error(f"Error in on_error callback: {e}")
+            return
 
         if self._on_error_callback:
             try:
@@ -494,6 +538,19 @@ class SamcoWebSocket:
     ) -> None:
         """Handle WebSocket connection close event"""
         self.connected = False
+
+        # Auth failures may reach us through the close reason as well.
+        from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
+
+        close_reason = f"{close_status_code or ''} {close_msg or ''}".strip()
+        if close_reason and BaseBrokerWebSocketAdapter.is_auth_error(close_reason):
+            if not self._auth_failed:
+                self._auth_failed = True
+                self.logger.error(
+                    f"Samco authentication failure: {close_reason}. Stopping reconnect."
+                )
+            self.running = False
+
         self.logger.info(f"Samco WebSocket closed: {close_status_code} - {close_msg}")
 
         self._stop_heartbeat()

--- a/broker/samco/streaming/samco_adapter.py
+++ b/broker/samco/streaming/samco_adapter.py
@@ -4,8 +4,15 @@ import os
 import sys
 import threading
 import time
-from typing import Any, Dict, List, Optional
+from typing import Any
 from urllib.parse import unquote
+
+if "eventlet" in sys.modules:
+    import eventlet
+
+    _real_threading = eventlet.patcher.original("threading")
+else:
+    _real_threading = threading
 
 from broker.samco.api.data import BrokerData
 from broker.samco.streaming.samcoWebSocket import SamcoWebSocket
@@ -34,8 +41,13 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.reconnect_attempts = 0
         self.max_reconnect_attempts = 10
         self.running = False
-        self.lock = threading.Lock()
+        self.lock = _real_threading.Lock()
         self._reconnecting = False  # Guard against concurrent reconnect threads
+
+        # Batch subscription queueing (mirrors zerodha/dhan/flattrade/upstox/fyers)
+        self.subscription_queue = []
+        self.batch_timer = None
+        self.batch_delay = 0.5  # 500ms delay to collect more subscriptions in a batch
         self._broker_data = None  # Cached BrokerData for index listing lookups
         self._index_listing_cache = {}  # {symbol_exchange: listing_id}
 
@@ -160,6 +172,14 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def disconnect(self) -> None:
         """Disconnect from Samco WebSocket"""
         self.running = False
+
+        # Cancel any pending batch timer and clear the queue
+        if self.batch_timer:
+            self.batch_timer.cancel()
+            self.batch_timer = None
+        with self.lock:
+            self.subscription_queue.clear()
+
         if hasattr(self, "ws_client") and self.ws_client:
             self.ws_client.close_connection()
 
@@ -273,13 +293,24 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 "is_fallback": is_fallback,
             }
 
-        # Subscribe if connected
-        if self.connected and self.ws_client:
-            try:
-                self.ws_client.subscribe(correlation_id, mode, token_list)
-            except Exception as e:
-                self.logger.error(f"Error subscribing to {symbol}.{exchange}: {e}")
-                return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
+        # Queue subscription for batch processing instead of sending one message per call.
+        # On reconnection the _on_open path already resubscribes everything from
+        # self.subscriptions, so queued items only need to be flushed when connected.
+        with self.lock:
+            self.subscription_queue.append(
+                {
+                    "symbol": symbol,
+                    "exchange": exchange,
+                    "brexchange": brexchange,
+                    "token": token,
+                    "mode": mode,
+                    "token_list": token_list,
+                }
+            )
+
+            # Start the batch timer when the first queued item arrives
+            if len(self.subscription_queue) == 1:
+                self._start_batch_timer()
 
         # Return success with capability info
         return self._create_success_response(
@@ -293,6 +324,56 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
             actual_depth=actual_depth,
             is_fallback=is_fallback,
         )
+
+    def _start_batch_timer(self) -> None:
+        """Start a timer to process queued subscriptions in a single batch."""
+        if self.batch_timer:
+            self.batch_timer.cancel()
+
+        self.batch_timer = _real_threading.Timer(
+            self.batch_delay, self._process_batch_subscriptions
+        )
+        self.batch_timer.start()
+
+    def _process_batch_subscriptions(self) -> None:
+        """Flush queued subscriptions in one batched request per mode."""
+        with self.lock:
+            queue = self.subscription_queue[:]
+            self.subscription_queue.clear()
+            self.batch_timer = None
+
+        if not queue or not self.connected or not self.ws_client:
+            return
+
+        # Group by mode, then by exchange
+        mode_groups: dict[int, dict[str, list[str]]] = {}
+        for sub in queue:
+            mode = sub["mode"]
+            exchange = sub["brexchange"]
+            token = sub["token"]
+            if mode not in mode_groups:
+                mode_groups[mode] = {}
+            if exchange not in mode_groups[mode]:
+                mode_groups[mode][exchange] = []
+            mode_groups[mode][exchange].append(token)
+
+        for mode, exchange_tokens in mode_groups.items():
+            token_list = [
+                {
+                    "exchangeType": SamcoExchangeMapper.get_exchange_type(exchange),
+                    "tokens": list(set(tokens)),
+                }
+                for exchange, tokens in exchange_tokens.items()
+            ]
+
+            try:
+                self.ws_client.subscribe(f"batch_{mode}", mode, token_list)
+                self.logger.info(
+                    f"Batch subscribed {sum(len(g['tokens']) for g in token_list)} "
+                    f"symbol(s) in mode {mode}"
+                )
+            except Exception as e:
+                self.logger.error(f"Batch subscription failed for mode {mode}: {e}")
 
     def unsubscribe(self, symbol: str, exchange: str, mode: int = 2) -> dict[str, Any]:
         """
@@ -365,7 +446,7 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Group subscriptions by mode and batch them into single requests
         with self.lock:
             subscriptions_by_mode = {}
-            for correlation_id, sub in self.subscriptions.items():
+            for _correlation_id, sub in self.subscriptions.items():
                 mode = sub["mode"]
                 if mode not in subscriptions_by_mode:
                     subscriptions_by_mode[mode] = []
@@ -401,10 +482,22 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Callback for WebSocket errors"""
         self.logger.error(f"Samco WebSocket error: {error}")
 
+        # Short-circuit the reconnect loop on authentication failures so a
+        # stale token does not hammer the broker for the whole retry window.
+        if self.ws_client and getattr(self.ws_client, "_auth_failed", False):
+            self.logger.error("Authentication failure detected; stopping reconnect loop")
+            self.running = False
+
     def _on_close(self, wsapp) -> None:
         """Callback when connection is closed"""
         self.logger.info("Samco WebSocket connection closed")
         self.connected = False
+
+        # If the socket closed because of an auth failure, do not reconnect.
+        if self.ws_client and getattr(self.ws_client, "_auth_failed", False):
+            self.logger.error("Connection closed after authentication failure; not reconnecting")
+            self.running = False
+            return
 
         # Attempt to reconnect if we're still running
         if self.running:

--- a/test/test_samco_batch_queue.py
+++ b/test/test_samco_batch_queue.py
@@ -1,0 +1,118 @@
+"""Unit tests for the Samco WebSocket batch subscription and auth-fail short-circuit."""
+
+import os
+import sys
+import time
+from unittest.mock import MagicMock, patch
+
+# Make the project root importable when pytest runs from the test/ directory.
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+# The auth database requires these at import time.
+os.environ.setdefault("API_KEY_PEPPER", "a" * 64)
+os.environ.setdefault("DATABASE_URL", "sqlite:///test_openalgo.db")
+
+# Importing the package first bootstraps the broker adapters cleanly.
+import websocket_proxy  # noqa: E402
+from broker.samco.streaming.samco_adapter import SamcoWebSocketAdapter  # noqa: E402
+from broker.samco.streaming.samcoWebSocket import SamcoWebSocket  # noqa: E402
+
+
+def test_batch_subscriptions_are_queued_and_flushed():
+    """Multiple subscribe() calls should be coalesced into one batched request."""
+    from broker.samco.streaming import samco_adapter as adapter_module
+
+    adapter = SamcoWebSocketAdapter()
+    adapter.connected = True
+    adapter.ws_client = MagicMock()
+    adapter.user_id = "test_user"
+
+    # Reduce batch delay so the test runs fast.
+    adapter.batch_delay = 0.05
+
+    with patch.object(
+        adapter_module.SymbolMapper, "get_token_from_symbol"
+    ) as mock_get_token:
+        mock_get_token.return_value = {"token": "12345", "brexchange": "NSE"}
+        adapter.subscribe("RELIANCE", "NSE", mode=2)
+        adapter.subscribe("TCS", "NSE", mode=2)
+        adapter.subscribe("GOLD", "MCX", mode=1)
+
+    assert len(adapter.subscription_queue) == 3
+    assert adapter.batch_timer is not None
+
+    # Wait for the timer to fire.
+    time.sleep(adapter.batch_delay + 0.05)
+
+    assert len(adapter.subscription_queue) == 0
+    assert adapter.ws_client.subscribe.call_count >= 1
+
+    # The first call should batch the NSE symbols in mode 2.
+    first_call = adapter.ws_client.subscribe.call_args_list[0]
+    _, mode, token_list = first_call.args
+    assert mode == 2
+    exchanges = {g["exchangeType"]: g["tokens"] for g in token_list}
+    assert "NSE" in exchanges
+    assert set(exchanges["NSE"]) == {"12345"}
+
+
+def test_auth_error_stops_reconnect_from_ws_error():
+    """A 401/403 error from the WebSocket should set the auth-failed flag."""
+    ws = SamcoWebSocket(session_token="dummy", user_id="test_user")
+    ws.running = True
+    ws.connected = True
+
+    with patch.object(ws, "_close_websocket") as mock_close, patch.object(
+        ws, "_stop_heartbeat"
+    ) as mock_stop:
+        ws._on_error(None, "HTTP 401 unauthorized")
+
+    assert ws._auth_failed is True
+    assert ws.running is False
+    mock_close.assert_called_once()
+    mock_stop.assert_called_once()
+
+
+def test_auth_error_stops_reconnect_from_message():
+    """An auth failure message should short-circuit further processing."""
+    ws = SamcoWebSocket(session_token="dummy", user_id="test_user")
+    ws.running = True
+    ws.connected = True
+
+    with patch.object(ws, "_close_websocket") as mock_close, patch.object(
+        ws, "_stop_heartbeat"
+    ) as mock_stop:
+        ws._on_message(None, '{"status":"failed","message":"unauthenticated"}')
+
+    assert ws._auth_failed is True
+    assert ws.running is False
+    mock_close.assert_called_once()
+    mock_stop.assert_called_once()
+
+
+def test_auth_error_stops_reconnect_from_close_reason():
+    """A close reason containing an auth error should set the auth-failed flag."""
+    ws = SamcoWebSocket(session_token="dummy", user_id="test_user")
+    ws.running = True
+    ws.connected = True
+
+    with patch.object(ws, "_stop_heartbeat") as mock_stop:
+        ws._on_close(None, close_status_code=403, close_msg="forbidden")
+
+    assert ws._auth_failed is True
+    assert ws.running is False
+    mock_stop.assert_called_once()
+
+
+def test_adapter_on_close_does_not_reconnect_after_auth_failure():
+    """Once the client flags an auth failure, the adapter must not reconnect."""
+    adapter = SamcoWebSocketAdapter()
+    adapter.running = True
+    adapter.ws_client = MagicMock()
+    adapter.ws_client._auth_failed = True
+
+    with patch.object(adapter, "_connect_with_retry") as mock_reconnect:
+        adapter._on_close(None)
+
+    assert adapter.running is False
+    mock_reconnect.assert_not_called()

--- a/websocket_proxy/base_adapter.py
+++ b/websocket_proxy/base_adapter.py
@@ -503,7 +503,8 @@ class BaseBrokerWebSocketAdapter(ABC):
         except Exception as e:
             self.logger.exception(f"Error clearing auth cache for user {user_id}: {e}")
 
-    def is_auth_error(self, error_message: str) -> bool:
+    @staticmethod
+    def is_auth_error(error_message: str) -> bool:
         """
         Check if an error message indicates an authentication failure.
 
@@ -523,6 +524,7 @@ class BaseBrokerWebSocketAdapter(ABC):
             "401",
             "403",
             "unauthorized",
+            "unauthenticated",
             "forbidden",
             "authentication failed",
             "auth failed",


### PR DESCRIPTION
Closing this PR as superseded. PR #1783 (`feat(samco): migrate to Trade API v3.2 and fix market data, orders and streaming`, merged 2026-08-10) reworked the Samco integration and removed the batch queue feature this PR added; the current upstream `samco_adapter.subscribe()` sends one broker subscription message per call, same as before #1783. Issue #1343 remains open and the auth-fail short-circuit is also not present on current upstream. Happy to revive against #1783's surface if the maintainer signals that either fix is wanted.