### PR TITLE
feat(kotak): live order-update WebSocket feed, perf(kotak): batch WebSocket unsubscribes and order them with subscribes and fix(kotak): close orphanable WebSocket clients on re-init and double connect

### DIFF
--- a/.claude/skills/broker-integration/references/order-updates.md
+++ b/.claude/skills/broker-integration/references/order-updates.md
@@ -9,7 +9,7 @@ much smaller. Do not confuse the two:
 | Subscription | per symbol + mode (1/2/3) | one `subscribe_orders` for the whole account |
 | Registered in | `websocket_proxy/__init__.py` (`register_adapter`) | `services/order_update_service.py` (`_BROKER_FACTORIES`) |
 | You implement | connect, subscribe, unsubscribe, disconnect, parsing | **3 methods** |
-| Optional? | effectively required | yes — 11 of 35 brokers have one |
+| Optional? | effectively required | yes — 12 of 35 brokers have one |
 
 Client-facing protocol (see `docs/prompt/websockets-format.md`): the client
 sends `{"action": "subscribe_orders"}` after authenticating and receives

--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -147,8 +147,16 @@ def place_order_api(data, auth_token):
     # Get the shared httpx client with connection pooling
     client = get_httpx_client()
 
-    token_id = get_token(data["symbol"], data["exchange"])
-    newdata = transform_data(data, token_id)
+    # Payload construction can reject the order before any network call — an
+    # SL-M with no trigger, or one whose tick size is unresolvable (see
+    # mapping/transform_data.py::_slm_protected_price). Return the same error
+    # shape as the request failures below instead of raising past the caller.
+    try:
+        token_id = get_token(data["symbol"], data["exchange"])
+        newdata = transform_data(data, token_id)
+    except Exception as e:
+        logger.error(f"Error building Kotak order payload: {e}")
+        return None, {"stat": "Not_Ok", "emsg": str(e)}, None
 
     json_string = json.dumps(newdata)
     payload = f"jData={urllib.parse.quote(json_string)}"
@@ -380,8 +388,14 @@ def modify_order(data, auth_token):
     # Get the shared httpx client with connection pooling
     client = get_httpx_client()
 
-    token_id = get_token(data["symbol"], data["exchange"])
-    newdata = transform_modify_order_data(data, token_id)
+    # Same pre-flight rejection as placement (SL-M without a usable trigger or
+    # tick size) — surface it as an error response, not an exception.
+    try:
+        token_id = get_token(data["symbol"], data["exchange"])
+        newdata = transform_modify_order_data(data, token_id)
+    except Exception as e:
+        logger.error(f"Error building Kotak modify payload: {e}")
+        return {"status": "error", "message": str(e)}, 400
 
     logger.debug(f"MODIFY ORDER - Transformed data: {newdata}")
 

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -1,10 +1,38 @@
-import json
-
 from broker.kotak.mapping.transform_data import map_exchange
 from database.token_db import get_oa_symbol, get_symbol
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+
+def _openalgo_symbol(row, exchange):
+    """Resolve one Kotak row to its OpenAlgo symbol.
+
+    Token first, then the broker trading symbol. The fallback is not
+    belt-and-braces: Kotak populates "tok" on orderbook rows but leaves it as
+    an empty string on tradebook rows, so a token-only lookup silently leaks
+    the raw broker symbol ("YESBANK-EQ") into the UI, which then fails every
+    downstream lookup that expects an OpenAlgo symbol. brsymbol in the master
+    contract is pTrdSymbol (master_contract_db.py:155), i.e. exactly the value
+    Kotak sends as trdSym.
+    """
+    token = str(row.get("tok") or "").strip()
+    if token:
+        mapped = get_symbol(token, exchange)
+        if mapped:
+            return mapped
+
+    broker_symbol = row.get("trdSym") or row.get("sym") or ""
+    if broker_symbol:
+        mapped = get_oa_symbol(broker_symbol, exchange)
+        if mapped:
+            return mapped
+
+    logger.debug(
+        f"No OpenAlgo symbol for token '{token}' / symbol '{broker_symbol}' on {exchange}. "
+        "Keeping the broker trading symbol."
+    )
+    return None
 
 
 def map_order_data(order_data):
@@ -21,7 +49,7 @@ def map_order_data(order_data):
     # if order_data has key 'data' and its value is None
 
     if order_data["stat"] == "Not_Ok":
-        logger.info("No data available.")
+        logger.debug("No data available.")
         order_data = {}  # or set it to an empty list if it's supposed to be a list
         return order_data
 
@@ -29,28 +57,19 @@ def map_order_data(order_data):
         # Handle the case where there is no data
         # For example, you might want to display a message to the user
         # or pass an empty list or dictionary to the template.
-        logger.info("No data available.")
+        logger.debug("No data available.")
         order_data = {}  # or set it to an empty list if it's supposed to be a list
     else:
         order_data = order_data["data"]
 
     if order_data:
         for order in order_data:
-            # Extract the instrument_token and exchange for the current order
-            symboltoken = order["tok"]
             exchange = map_exchange(order["exSeg"])
             order["exSeg"] = exchange
 
-            # Use the get_symbol function to fetch the symbol from the database
-            symbol_from_db = get_symbol(symboltoken, exchange)
-
-            # Check if a symbol was found; if so, update the trading_symbol in the current order
+            symbol_from_db = _openalgo_symbol(order, exchange)
             if symbol_from_db:
                 order["trdSym"] = symbol_from_db
-            else:
-                logger.info(
-                    f"Symbol not found for token {symboltoken} and exchange {exchange}. Keeping original trading symbol."
-                )
     return order_data
 
 
@@ -163,7 +182,7 @@ def map_trade_data(trade_data):
     - The modified order_data with updated 'tradingsymbol' and 'product' fields.
     """
     if trade_data["stat"] == "Not_Ok":
-        logger.info("No data available.")
+        logger.debug("No data available.")
         trade_data = {}  # or set it to an empty list if it's supposed to be a list
         return trade_data
         # Check if 'data' is None
@@ -171,36 +190,26 @@ def map_trade_data(trade_data):
         # Handle the case where there is no data
         # For example, you might want to display a message to the user
         # or pass an empty list or dictionary to the template.
-        logger.info("No data available.")
+        logger.debug("No data available.")
         trade_data = {}  # or set it to an empty list if it's supposed to be a list
     else:
         trade_data = trade_data["data"]
 
     if trade_data:
         for order in trade_data:
-            # Extract the instrument_token and exchange for the current order
-            symbol = order["tok"]
             exchange = map_exchange(order["exSeg"])
             order["exSeg"] = exchange
-            logger.info(f"{symbol}")
-            logger.info(f"{exchange}")
-            # Use the get_symbol function to fetch the symbol from the database
-            symbol_from_db = get_symbol(symbol, exchange)
-            logger.info(f"{symbol_from_db}")
-            # Check if a symbol was found; if so, update the trading_symbol in the current order
+
+            symbol_from_db = _openalgo_symbol(order, exchange)
             if symbol_from_db:
                 order["trdSym"] = symbol_from_db
-            else:
-                logger.info(
-                    f"Unable to find the symbol {symbol} and exchange {exchange}. Keeping original trading symbol."
-                )
 
             # Map transaction type regardless of symbol lookup result
             if order["trnsTp"] == "B":
                 order["trnsTp"] = "BUY"
             elif order["trnsTp"] == "S":
                 order["trnsTp"] = "SELL"
-    logger.info(f"{trade_data}")
+    logger.debug(f"Mapped Kotak tradebook: {trade_data}")
     return trade_data
 
 
@@ -259,8 +268,8 @@ def transform_positions_data(positions_data):
 
 def transform_holdings_data(holdings_data):
     transformed_data = []
-    logger.info("Holdings Data")
-    logger.info(f"{holdings_data}")
+    logger.debug("Holdings Data")
+    logger.debug(f"{holdings_data}")
     for holding in holdings_data:
         transformed_position = {
             "symbol": holding.get("displaySymbol", ""),
@@ -283,8 +292,8 @@ def transform_holdings_data(holdings_data):
         }
 
         transformed_data.append(transformed_position)
-    logger.info("Holdings Data")
-    logger.info(f"{transformed_data}")
+    logger.debug("Holdings Data")
+    logger.debug(f"{transformed_data}")
     return transformed_data
 
 
@@ -302,7 +311,7 @@ def map_portfolio_data(portfolio_data):
     """
     # Check if 'data' is None or doesn't contain 'holdings'
     if portfolio_data.get("data") is None:
-        logger.info("No data available.")
+        logger.debug("No data available.")
         # Return an empty structure or handle this scenario as needed
         return {}
 
@@ -324,7 +333,7 @@ def map_portfolio_data(portfolio_data):
         if portfolio["instrumentType"] == "Equity":
             portfolio["instrumentType"] = "CNC"  # Modify 'product' field
         else:
-            logger.info("Kotak Portfolio - Product Value for Delivery Not Found or Changed.")
+            logger.debug("Kotak Portfolio - Product Value for Delivery Not Found or Changed.")
 
     # The function already works with 'data', which includes 'holdings' and 'totalholding',
     # so we can return 'data' directly without additional modifications.

--- a/broker/kotak/mapping/transform_data.py
+++ b/broker/kotak/mapping/transform_data.py
@@ -1,10 +1,132 @@
 # Mapping OpenAlgo API Request https://openalgo.in/docs
 # Mapping Kotak Neo API Parameters
 
-from database.token_db import get_br_symbol
+import math
+from decimal import Decimal
+
+from database.token_db import get_br_symbol, get_symbol_info
 from utils.logging import get_logger
+from utils.mpp_slab import get_instrument_type_from_symbol
 
 logger = get_logger(__name__)
+
+# Kotak's published Market Price Protection grid
+# (broker-api-docs/kotak-api-docs/03-static-ip-whitelisting.md:134-144).
+# EQ/FUT matches utils/mpp_slab.py exactly; the OPT grid does not — Kotak adds
+# two extra bands below 5 and an ABSOLUTE 0.10 floor below 1, which a
+# percentage-only table cannot express. Kept local so the shared slabs stay
+# broker-neutral.
+_KOTAK_EQ_FUT_MPP = [(100, 2.0), (500, 1.0), (float("inf"), 0.5)]
+_KOTAK_OPT_MPP = [(5, 10.0), (10, 5.0), (100, 3.0), (500, 2.0), (float("inf"), 1.0)]
+
+# Below this price Kotak protects options by an absolute rupee amount, not a
+# percentage (a 10% band on a 0.50 option is smaller than one tick).
+_KOTAK_OPT_ABSOLUTE_BELOW = 1.0
+_KOTAK_OPT_ABSOLUTE_OFFSET = 0.10
+
+
+def _mpp_offset(price, instrument_type):
+    """Kotak's protection offset (in rupees) for a price and instrument type."""
+    if instrument_type in ("CE", "PE"):
+        if price < _KOTAK_OPT_ABSOLUTE_BELOW:
+            return _KOTAK_OPT_ABSOLUTE_OFFSET
+        slabs = _KOTAK_OPT_MPP
+    else:
+        slabs = _KOTAK_EQ_FUT_MPP
+
+    for max_price, percentage in slabs:
+        if price < max_price:
+            return price * percentage / 100.0
+    return 0.0
+
+
+def _tick_decimals(tick):
+    """Number of decimal places implied by a tick size (0.05 -> 2, 0.0025 -> 4)."""
+    return max(0, -Decimal(str(tick)).as_tuple().exponent)
+
+
+def _snap_to_tick(value, tick, direction):
+    """Snap to a multiple of ``tick``, away from the trigger.
+
+    Nearest-tick rounding could land the limit back on the trigger, so the
+    direction is forced: "floor" for SELL, "ceil" for BUY.
+    """
+    ratio = round(value / tick, 6)  # tame float noise before the floor/ceil
+    k = math.floor(ratio) if direction == "floor" else math.ceil(ratio)
+    return round(k * tick, _tick_decimals(tick))
+
+
+def _slm_protected_price(symbol, exchange, action, trigger_price):
+    """
+    Derive the protective limit price that turns an SL-M into a Kotak SL.
+
+    Kotak rejects SL-M from API sessions outright: "Market order with Algo Id
+    not allowed" (observed live 2026-07-28, order 260728000251866). Per SEBI,
+    market orders are not permitted for retail algos, and Kotak's APIs append
+    an exchange-compliant Algo ID to every order automatically
+    (03-static-ip-whitelisting.md:130,154). Plain MKT survives because Kotak
+    substitutes its own protection limit server-side; a stop-market has no LTP
+    to protect against at placement time, so it is refused instead.
+
+    The fix mirrors the Dhan SL-M path (issue #1647): send pt="SL" with a limit
+    offset one MPP band beyond the trigger in the fill direction — BUY above,
+    SELL below — so the stop still rests and stays marketable once triggered.
+
+    The limit is snapped to the instrument's exchange tick away from the
+    trigger and forced at least one tick past it, so it can never round back
+    onto the trigger. Fails closed when the tick size is unresolvable rather
+    than guessing 2 decimals, which Kotak would reject.
+    """
+    instrument_type = get_instrument_type_from_symbol(symbol)
+
+    symbol_info = get_symbol_info(symbol, exchange)
+    try:
+        tick_size = float(getattr(symbol_info, "tick_size", None)) if symbol_info else 0.0
+    except (TypeError, ValueError):
+        tick_size = 0.0
+    if not math.isfinite(tick_size) or tick_size <= 0:
+        raise ValueError(
+            f"Cannot resolve tick size from DB for {symbol}/{exchange}; required to "
+            f"build a valid SL-M protective limit price"
+        )
+
+    offset = _mpp_offset(trigger_price, instrument_type)
+
+    if action.upper() == "SELL":
+        # Strictly BELOW the trigger, at least one tick away, tick-aligned.
+        raw = min(trigger_price - offset, trigger_price - tick_size)
+        limit = _snap_to_tick(raw, tick_size, "floor")
+        if limit <= 0:
+            raise ValueError(
+                f"SL-M SELL trigger {trigger_price} for {symbol}/{exchange} is too low "
+                f"to derive a positive protective limit at tick {tick_size}"
+            )
+    else:
+        # Strictly ABOVE the trigger, at least one tick away, tick-aligned.
+        raw = max(trigger_price + offset, trigger_price + tick_size)
+        limit = _snap_to_tick(raw, tick_size, "ceil")
+
+    return limit
+
+
+def _apply_slm_conversion(transformed, data):
+    """Rewrite an SL-M payload in place as a protective Kotak SL order."""
+    if data.get("pricetype") != "SL-M":
+        return
+
+    trigger_price = float(data.get("trigger_price", 0) or 0)
+    if trigger_price <= 0:
+        raise ValueError("Trigger price is required and must be positive for SL-M orders")
+
+    protected_price = _slm_protected_price(
+        data["symbol"], data["exchange"], data["action"], trigger_price
+    )
+    transformed["pt"] = "SL"
+    transformed["pr"] = _fmt_price(protected_price)
+    logger.debug(
+        f"Kotak SL-M -> SL: Symbol={data['symbol']}, Action={data['action']}, "
+        f"Trigger={trigger_price}, ProtectedLimit={protected_price}"
+    )
 
 
 def _fmt_price(value):
@@ -44,7 +166,9 @@ def transform_data(data, token):
         "tt": "B" if action == "BUY" else ("S" if action == "SELL" else "None"),
     }
 
-    logger.info(f"Transformed order data: {transformed}")
+    _apply_slm_conversion(transformed, data)
+
+    logger.debug(f"Transformed order data: {transformed}")
     return transformed
 
 
@@ -66,6 +190,11 @@ def transform_modify_order_data(data, token):
         "no": str(data["orderid"]),
         "tt": "B" if data["action"] == "BUY" else ("S" if data["action"] == "SELL" else "None"),
     }
+
+    # A modify must carry the same conversion as the placement, or an SL-M
+    # modify would hand Kotak back the pt it already rejected.
+    _apply_slm_conversion(transformed, data)
+
     return transformed
 
 

--- a/broker/kotak/streaming/kotak_adapter.py
+++ b/broker/kotak/streaming/kotak_adapter.py
@@ -14,6 +14,18 @@ from .kotak_websocket import KotakWebSocket
 
 logger = get_logger(__name__)
 
+# HSI scrip operations: sub_type -> (feed family, is_unsubscribe). The family
+# groups a subscribe with its matching unsubscribe so the batcher can collapse
+# them per scrip, while leaving quote/depth/index independent of each other.
+_SCRIP_OPS = {
+    "mws": ("quote", False),
+    "mwu": ("quote", True),
+    "dps": ("depth", False),
+    "dpu": ("depth", True),
+    "ifs": ("index", False),
+    "ifu": ("index", True),
+}
+
 
 class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """
@@ -56,7 +68,9 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self._symbol_modes = {}  # {(kotak_exchange, token): set of active modes}
 
         # Batch subscription management - debounced fan-in so a burst of
-        # subscribe() calls collapses into one HSI frame per sub_type.
+        # subscribe()/unsubscribe() calls collapses into one HSI frame per
+        # sub_type. Subscribes and unsubscribes share one queue so their
+        # relative order per scrip is preserved (see _process_batch_subscriptions).
         # Each entry: {"kotak_exchange": str, "token": str, "sub_type": str, "channelnum": str}
         self._subscription_queue = []
         self._batch_timer = None
@@ -508,15 +522,25 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
             if not self._subscription_queue:
                 return
 
-            # Group by (sub_type, channelnum) and dedupe per group so we
-            # never send the same scrip twice in one frame.
-            groups = {}
+            # Collapse to the LAST operation per scrip per feed family. A
+            # subscribe and an unsubscribe for the same scrip land in separate
+            # frames, and emitting both would apply them in group order rather
+            # than call order — "sub, unsub, sub" within one window would leave
+            # the scrip unsubscribed. Keeping only the final op per family is
+            # both correct and fewer frames. Families are independent: the same
+            # scrip can hold a quote and a depth subscription at once.
+            # dict preserves the first-appearance position while the value is
+            # overwritten, so frame order still follows call order.
+            latest = {}
             for sub in self._subscription_queue:
-                key = (sub["sub_type"], sub["channelnum"])
-                groups.setdefault(key, [])
-                pair = (sub["kotak_exchange"], sub["token"])
-                if pair not in groups[key]:
-                    groups[key].append(pair)
+                family, _ = _SCRIP_OPS.get(sub["sub_type"], (sub["sub_type"], False))
+                key = (sub["kotak_exchange"], sub["token"], sub["channelnum"], family)
+                latest[key] = sub["sub_type"]
+
+            groups = {}
+            for (kotak_exchange, token, channelnum, _family), sub_type in latest.items():
+                groups.setdefault((sub_type, channelnum), []).append((kotak_exchange, token))
+
             self._subscription_queue.clear()
             ws = self._ws_client
 
@@ -525,17 +549,20 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
             return
 
         for (sub_type, channelnum), scrips in groups.items():
+            _, is_unsub = _SCRIP_OPS.get(sub_type, (sub_type, False))
+            send = ws.unsubscribe_batch if is_unsub else ws.subscribe_batch
+            verb = "unsubscribing" if is_unsub else "subscribing"
             for i in range(0, len(scrips), self._max_batch_size):
                 chunk = scrips[i : i + self._max_batch_size]
                 try:
                     logger.info(
-                        f"Batch subscribing {len(chunk)} scrips "
+                        f"Batch {verb} {len(chunk)} scrips "
                         f"(sub_type={sub_type}, channel={channelnum})"
                     )
-                    ws.subscribe_batch(chunk, sub_type=sub_type, channelnum=channelnum)
+                    send(chunk, sub_type=sub_type, channelnum=channelnum)
                 except Exception as e:
                     logger.error(
-                        f"Batch subscribe failed for sub_type={sub_type}: {e}"
+                        f"Batch {verb} failed for sub_type={sub_type}: {e}"
                     )
 
     def connect(self):
@@ -575,7 +602,9 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self._reconnect_timer = None
                 logger.debug("Cancelled pending reconnection timer")
 
-            # Cancel any pending batch subscription timer and drop unsent items
+            # Cancel any pending batch timer and drop unsent items. Safe for
+            # queued unsubscribes too: the socket is closing, which drops every
+            # subscription on it anyway.
             if self._batch_timer:
                 self._batch_timer.cancel()
                 self._batch_timer = None
@@ -1023,12 +1052,11 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         self._symbol_state.pop(symbol_key, None)
                         logger.debug(f"Cleaned up mapping for: {exchange}:{symbol}")
 
-            # Send unsubscribe outside lock to avoid deadlock
+            # Enqueue outside lock — batched by _process_batch_subscriptions,
+            # so tearing down a large watchlist costs one frame, not one each.
             if should_unsub_broker:
-                ws = self._ws_client
-                if ws:
-                    ws.unsubscribe(kotak_exchange, token, sub_type="mwu")
-                    logger.debug(f"Unsubscribed from broker: {exchange}:{symbol}")
+                self._enqueue_subscription(kotak_exchange, token, sub_type="mwu")
+                logger.debug(f"Queued broker unsubscribe: {exchange}:{symbol}")
 
         except Exception as e:
             logger.error(f"Error unsubscribing from quote for {exchange}:{symbol}: {e}")
@@ -1116,12 +1144,10 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         self._symbol_state.pop(symbol_key, None)
                         logger.debug(f"Cleaned up mapping for: {exchange}:{symbol}")
 
-            # Send unsubscribe outside lock to avoid deadlock
+            # Enqueue outside lock — batched by _process_batch_subscriptions.
             if should_unsub_broker:
-                ws = self._ws_client
-                if ws:
-                    ws.unsubscribe(kotak_exchange, token, sub_type="dpu")
-                    logger.debug(f"Unsubscribed from broker depth: {exchange}:{symbol}")
+                self._enqueue_subscription(kotak_exchange, token, sub_type="dpu")
+                logger.debug(f"Queued broker depth unsubscribe: {exchange}:{symbol}")
 
         except Exception as e:
             logger.error(f"Error unsubscribing from depth for {exchange}:{symbol}: {e}")

--- a/broker/kotak/streaming/kotak_adapter.py
+++ b/broker/kotak/streaming/kotak_adapter.py
@@ -80,9 +80,26 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self._max_batch_size = 100  # HSI MAX_SCRIPS limit per frame
 
     def initialize(self, broker_name: str, user_id: str, auth_data=None):
-        """Initialize adapter for a specific user/session - following AliceBlue pattern."""
+        """Initialize adapter for a specific user/session - following AliceBlue pattern.
+
+        Safe to call again on a live adapter: any existing client is closed
+        first. Without that, a re-initialisation would rebind _ws_client and
+        orphan the previous WebSocketApp with its socket and run thread still
+        alive, and nothing would ever close them.
+        """
         self._broker_name = broker_name.lower()
         self._user_id = user_id
+
+        # Close outside the adapter lock — close() joins the run thread, whose
+        # callbacks take that same lock (mirrors _attempt_reconnection).
+        old_client = self._ws_client
+        if old_client is not None:
+            logger.debug("initialize() called with an existing client — closing it first")
+            self._ws_client = None
+            try:
+                old_client.close()
+            except Exception as e:
+                logger.warning(f"Error closing previous WebSocket client on re-initialize: {e}")
 
         # Load authentication from DB
         auth_string = get_auth_token(user_id, bypass_cache=True)

--- a/broker/kotak/streaming/kotak_order_adapter.py
+++ b/broker/kotak/streaming/kotak_order_adapter.py
@@ -1,0 +1,323 @@
+"""
+Kotak Neo order-update adapter — dedicated Order & Position streaming socket.
+
+Docs: broker-api-docs/kotak-api-docs/13-order-position-streaming-websocket.md
+(12-neo-websocket.md calls the same stream "HSI", the order feed that sits
+alongside the "HSM" market feed driven by kotak_websocket.py).
+
+Endpoint: wss://<baseurl>/realtime — <baseurl> is the value /tradeApiValidate
+returns, already stored as the 3rd ":::"-separated component of the DB auth
+token (broker/kotak/api/auth_api.py builds
+"trading_token:::trading_sid:::base_url:::access_token").
+
+Auth: the first frame after onopen carries the session credentials —
+    {"type":"cn","Authorization":<token>,"Sid":<sid>,"src":"WEB"}
+and the server replies {"ak":"ok","type":"cn","msg":"connected"}.
+
+The two sources disagree on the encoding: doc 13 insists on a RAW, non-JSON
+string ({type:cn,Authorization:...}), while Kotak's own HSI client vendored
+here (HSWebSocketLib.HSIWebSocket.send) json.dumps() the same dict. Kotak
+dropped the connection immediately on the raw form in live testing, so JSON is
+tried first and the encoding alternates on any attempt that opens without a
+"cn" ack — whichever Kotak accepts sticks.
+
+An unacked attempt does not always announce itself: dropping the socket is one
+failure mode, but silently holding it open and never authenticating is the
+other, and that one looks exactly like a healthy connection on an idle market.
+The ack watchdog below closes any attempt that goes KOTAK_CONNECT_ACK_TIMEOUT_
+SECONDS without an ack, which both surfaces the state in the log and lets the
+reconnect flip the encoding.
+
+Frames are JSON: {"type":"order","data":{...}} and {"type":"position",...}.
+Only order frames are published — OpenAlgo has no position-update event, so
+position frames are ignored. Multiple frames arrive per order as it walks the
+lifecycle (put order req received -> validation pending -> open pending ->
+open -> complete), which is exactly the intermediate detail the client stream
+wants; each is published as its own OrderUpdateEvent.
+"""
+
+import json
+import threading
+import time
+
+from broker.kotak.mapping.transform_data import map_exchange
+from database.auth_db import get_auth_token
+from utils.logging import get_logger
+from websocket_proxy.order_adapter import BaseOrderUpdateAdapter, to_openalgo_symbol
+
+logger = get_logger(__name__)
+
+# Kotak's own HSI client (HSWebSocketLib.StartHSIServer) runs a 30s protocol
+# ping; there is no app-level heartbeat frame in the protocol.
+KOTAK_WS_PING_INTERVAL_SECONDS = 30
+
+# How long to wait for the "cn" ack before treating the attempt as failed. The
+# ack arrives in one round trip when it arrives at all, so this only has to
+# clear a slow link.
+KOTAK_CONNECT_ACK_TIMEOUT_SECONDS = 10
+
+# Kotak ordSt values (lowercase free text) -> OpenAlgo's lowercase
+# order_status vocabulary. Every in-flight OMS state collapses to "open".
+_STATUS_MAP = {
+    "complete": "complete",
+    "rejected": "rejected",
+    "cancelled": "cancelled",
+    "canceled": "cancelled",
+    "open": "open",
+    "trigger pending": "trigger pending",
+    "put order req received": "open",
+    "validation pending": "open",
+    "open pending": "open",
+    "modified": "open",
+    "modify validation pending": "open",
+    "modify pending": "open",
+    "cancel pending": "open",
+    "after market order req received": "open",
+    "modify after market order req received": "open",
+    "cancelled after market order": "cancelled",
+}
+
+# Kotak prcTp codes -> OpenAlgo pricetype constants. "L" is what
+# mapping/transform_data.py::map_order_type sends on placement; the stream
+# docs also show "MKT"/"LMT".
+_PRICETYPE_MAP = {
+    "MKT": "MARKET",
+    "MARKET": "MARKET",
+    "L": "LIMIT",
+    "LMT": "LIMIT",
+    "LIMIT": "LIMIT",
+    "SL": "SL",
+    "SL-M": "SL-M",
+}
+
+_ACTION_MAP = {"B": "BUY", "S": "SELL"}
+
+
+def _num(value, cast=float, default=0):
+    """Parse Kotak's string-typed numeric fields ("0.00", "", None) safely."""
+    try:
+        return cast(float(value))
+    except (TypeError, ValueError):
+        return default
+
+
+def _realtime_ws_url(base_url: str) -> str:
+    """Build wss://<baseurl>/realtime from the stored tradeApiValidate baseUrl.
+
+    The stored value is an https origin (order_api.py uses it as
+    f"{base_url}/quick/user/orders"), so only the scheme needs swapping.
+    """
+    base = (base_url or "").strip().rstrip("/")
+    if base.startswith("https://"):
+        base = "wss://" + base[len("https://") :]
+    elif base.startswith("http://"):
+        base = "ws://" + base[len("http://") :]
+    elif not base.startswith(("wss://", "ws://")):
+        base = "wss://" + base
+    return f"{base}/realtime"
+
+
+class KotakOrderUpdateAdapter(BaseOrderUpdateAdapter):
+    """Dedicated order-update WebSocket adapter for Kotak Neo."""
+
+    def __init__(self, user_id: str, base_url: str, session_token: str, session_sid: str):
+        super().__init__(broker_name="kotak", user_id=user_id)
+        self.base_url = base_url
+        self.session_token = session_token
+        self.session_sid = session_sid
+        # Handshake-encoding state, see on_open_extra() and the module docstring.
+        self._use_json_handshake = True
+        self._connect_attempted = False
+        self._connect_acked = False
+
+    def get_ws_url(self) -> str:
+        return _realtime_ws_url(self.base_url)
+
+    def get_headers(self):
+        return None  # auth is the post-connect "cn" frame, not a header
+
+    def ws_ping_interval(self) -> int:
+        return KOTAK_WS_PING_INTERVAL_SECONDS
+
+    def on_open_extra(self, ws) -> None:
+        # If the previous attempt opened but was dropped without a "cn" ack,
+        # the encoding was wrong — alternate for the next try (see below).
+        if self._connect_attempted and not self._connect_acked:
+            self._use_json_handshake = not self._use_json_handshake
+        self._connect_attempted = True
+        self._connect_acked = False
+
+        if self._use_json_handshake:
+            # Kotak's own HSI client (HSWebSocketLib.HSIWebSocket.send) sends
+            # this frame as JSON, contradicting doc 13's "NOT JSON" note.
+            frame = json.dumps(
+                {
+                    "type": "cn",
+                    "Authorization": self.session_token,
+                    "Sid": self.session_sid,
+                    "src": "WEB",
+                }
+            )
+        else:
+            # Doc 13's literal raw-string form.
+            frame = f"{{type:cn,Authorization:{self.session_token},Sid:{self.session_sid},src:WEB}}"
+
+        ws.send(frame)
+        encoding = "json" if self._use_json_handshake else "raw"
+        self.logger.info(
+            f"Sent Kotak realtime connect frame ({encoding}) for sid {self.session_sid}"
+        )
+        self._start_ack_watchdog(ws, encoding)
+
+    def _start_ack_watchdog(self, ws, encoding: str) -> None:
+        """Close the socket if Kotak never acks the connect frame.
+
+        A rejected handshake is sometimes a drop and sometimes silence — an
+        unauthenticated socket that Kotak simply holds open pushes nothing and
+        is indistinguishable from a quiet market. Closing it here turns that
+        case into a logged failure plus a reconnect, which alternates the
+        encoding via on_open_extra().
+        """
+
+        def watch():
+            deadline = time.monotonic() + KOTAK_CONNECT_ACK_TIMEOUT_SECONDS
+            while time.monotonic() < deadline:
+                time.sleep(0.5)
+                # Bound to the socket it was started for: a reconnect replaces
+                # self._ws, and this thread must not close its successor.
+                if self._connect_acked or self._shutting_down or self._ws is not ws:
+                    return
+            self.logger.warning(
+                f"No Kotak realtime 'cn' ack within {KOTAK_CONNECT_ACK_TIMEOUT_SECONDS}s of the "
+                f"{encoding} connect frame — closing so the next attempt tries the other encoding"
+            )
+            try:
+                ws.close()
+            except Exception:
+                pass
+
+        threading.Thread(
+            target=watch,
+            daemon=True,
+            name=f"order-adapter-ack-kotak-{self.user_id}",
+        ).start()
+
+    def normalize(self, raw_message):
+        if isinstance(raw_message, (bytes, bytearray)):
+            return None
+
+        try:
+            message = json.loads(raw_message)
+        except (json.JSONDecodeError, TypeError):
+            self.logger.info(f"Kotak realtime text frame: {raw_message}")
+            return None  # non-JSON acks / keepalive text
+
+        if not isinstance(message, dict):
+            return None
+
+        msg_type = message.get("type")
+        if msg_type in ("order", "position"):
+            # Live data proves the session authenticated, whatever the ack
+            # looked like — stop the watchdog from closing a working socket.
+            self._connect_acked = True
+
+        if msg_type != "order":
+            # "cn" ack, "position" frames and broker notices. Log them — the
+            # ack confirms which handshake encoding Kotak accepted, and a
+            # failure notice carries the reason it is about to close.
+            if msg_type == "cn" or "ak" in message:
+                self._connect_acked = str(message.get("ak", "")).lower() == "ok"
+                self.logger.info(f"Kotak realtime connect response: {message}")
+            elif msg_type != "position":
+                self.logger.info(f"Kotak realtime notice: {message}")
+            return None
+
+        data = message.get("data") or {}
+        if not data.get("nOrdNo"):
+            return None
+
+        self.logger.debug(f"Kotak order frame: {data}")
+
+        raw_status = str(data.get("ordSt", "")).strip().lower()
+        order_status = _STATUS_MAP.get(raw_status, raw_status or "open")
+
+        # exSeg is Kotak's segment code ("nse_cm"); map_exchange returns the
+        # canonical OpenAlgo exchange, same as mapping/order_data.py does for
+        # the REST orderbook. Unknown segments fall through as-is.
+        raw_segment = data.get("exSeg", "")
+        exchange = map_exchange(raw_segment) or raw_segment
+
+        # Token-keyed lookup first (tok + mapped exchange), falling back to the
+        # series-suffixed trading symbol ("ITBEES-EQ" -> "ITBEES").
+        symbol = to_openalgo_symbol(
+            data.get("trdSym") or data.get("sym", ""), exchange, token=data.get("tok")
+        )
+
+        quantity = _num(data.get("qty"), int)
+        filled = _num(data.get("fldQty"), int)
+        pending = _num(data.get("unFldSz"), int, default=max(quantity - filled, 0))
+
+        raw_pricetype = str(data.get("prcTp", "")).upper()
+        action = _ACTION_MAP.get(data.get("trnsTp", ""), str(data.get("trnsTp", "")).upper())
+
+        # One line per lifecycle transition (put order req received -> ... ->
+        # complete), so the log shows an order's full progression.
+        self.logger.info(
+            f"Kotak order update: {data.get('nOrdNo')} {action} {symbol} [{exchange}] "
+            f"{order_status} qty={quantity} filled={filled} avg={_num(data.get('avgPrc'))}"
+            + (f" reason={data.get('rejRsn')}" if order_status == "rejected" else "")
+        )
+
+        return {
+            "orderid": str(data.get("nOrdNo", "")),
+            "symbol": symbol,
+            "exchange": exchange,
+            "action": action,
+            "quantity": quantity,
+            "price": _num(data.get("prc")),
+            "trigger_price": _num(data.get("trgPrc")),
+            "pricetype": _PRICETYPE_MAP.get(raw_pricetype, raw_pricetype),
+            "product": data.get("prod", ""),  # NRML/MIS/CNC already match OpenAlgo
+            "order_status": order_status,
+            "filled_quantity": filled,
+            "pending_quantity": pending,
+            "average_price": _num(data.get("avgPrc")),
+            "rejection_reason": data.get("rejRsn", "") if order_status == "rejected" else "",
+        }
+
+
+def create_kotak_order_adapter(user_id: str) -> "KotakOrderUpdateAdapter | None":
+    """
+    Factory: build a KotakOrderUpdateAdapter for user_id. The stored DB token
+    is the composite "trading_token:::trading_sid:::base_url:::access_token"
+    (same split kotak_adapter.py and api/order_api.py use); the realtime socket
+    needs the token, the sid and the baseUrl.
+    """
+    auth_token = get_auth_token(user_id, bypass_cache=True)
+    if not auth_token:
+        logger.warning(
+            f"No Kotak auth token found for user {user_id}; order-update adapter not started"
+        )
+        return None
+
+    parts = auth_token.split(":::")
+    if len(parts) != 4:
+        logger.warning(
+            f"Unexpected Kotak auth token format for user {user_id}; "
+            "order-update adapter not started"
+        )
+        return None
+
+    session_token, session_sid, base_url = parts[0], parts[1], parts[2]
+    if not (session_token and session_sid and base_url):
+        logger.warning(
+            f"Incomplete Kotak credentials for user {user_id}; order-update adapter not started"
+        )
+        return None
+
+    return KotakOrderUpdateAdapter(
+        user_id=user_id,
+        base_url=base_url,
+        session_token=session_token,
+        session_sid=session_sid,
+    )

--- a/broker/kotak/streaming/kotak_websocket.py
+++ b/broker/kotak/streaming/kotak_websocket.py
@@ -64,11 +64,7 @@ class KotakWebSocket:
         self._on_close = on_close
 
     def connect(self):
-        """Start the websocket connection in a new thread."""
-        with self._lock:
-            if not self._should_run:
-                logger.warning("connect() called on a closed KotakWebSocket, ignoring")
-                return
+        """Start the websocket connection in a new thread. Idempotent."""
 
         def _run():
             try:
@@ -87,8 +83,23 @@ class KotakWebSocket:
                     self._on_error(e)
 
         thread = threading.Thread(target=_run, daemon=True)
+
+        # Check and claim the thread slot atomically. is_connected() is still
+        # False while the handshake is in flight, so callers cannot guard this
+        # themselves — a second connect() during that window would start a
+        # second run thread and orphan the first WebSocketApp along with its
+        # socket, which nothing would ever close.
         with self._lock:
+            if not self._should_run:
+                logger.warning("connect() called on a closed KotakWebSocket, ignoring")
+                return
+            if self._thread is not None and self._thread.is_alive():
+                logger.warning(
+                    "connect() called while a connection thread is already running, ignoring"
+                )
+                return
             self._thread = thread
+
         thread.start()
 
     def close(self):

--- a/docs/api/websocket-streaming/order-updates.md
+++ b/docs/api/websocket-streaming/order-updates.md
@@ -111,8 +111,9 @@ A live rejection example (pushed by the broker's own order feed):
 ## Sources and Broker Coverage
 
 - **Dedicated order feed / ticker postback**: Zerodha, Dhan, Fyers, Upstox,
-  AliceBlue, Definedge, IndMoney, Angel One, Nubra, Arrow stream natively via
-  each broker's push channel (`broker/*/streaming/*_order_adapter.py`).
+  AliceBlue, Definedge, IndMoney, Angel One, Nubra, Arrow, IIFL Capital, Kotak
+  stream natively via each broker's push channel
+  (`broker/*/streaming/*_order_adapter.py`).
 - **REST polling fallback**: brokers with no push mechanism (e.g. Groww) are
   covered by server-side orderbook polling (`ORDER_POLL_INTERVAL`, default 5s).
 - **HTTPS postbacks**: `/postback/<broker>` webhook receivers feed the same

--- a/docs/prompt/websockets-format.md
+++ b/docs/prompt/websockets-format.md
@@ -247,8 +247,9 @@ MARKET/LIMIT/SL/SL-M, `product` CNC/NRML/MIS; `order_status` is lowercase
 rejected; `mode` is `live` (broker) or `analyze` (sandbox).
 
 Sources: dedicated broker order feeds (Zerodha, Dhan, Fyers, Upstox,
-AliceBlue, Definedge, IndMoney, Angel One, Nubra, Arrow), REST-orderbook
-polling for brokers without push (Groww), and `/postback/<broker>` HTTPS
+AliceBlue, Definedge, IndMoney, Angel One, Nubra, Arrow, IIFL Capital, Kotak),
+REST-orderbook polling for brokers without push (Groww), and
+`/postback/<broker>` HTTPS
 webhooks on production deployments. If both a broker feed and a postback are
 configured, deduplicate on `orderid` + `order_status` + `filled_quantity`.
 

--- a/services/order_update_service.py
+++ b/services/order_update_service.py
@@ -53,6 +53,7 @@ _BROKER_FACTORIES: dict[str, tuple[str, str]] = {
     "zerodha": ("broker.zerodha.streaming.zerodha_order_adapter", "create_zerodha_order_adapter"),
     "nubra": ("broker.nubra.streaming.nubra_order_adapter", "create_nubra_order_adapter"),
     "arrow": ("broker.arrow.streaming.arrow_order_adapter", "create_arrow_order_adapter"),
+    "kotak": ("broker.kotak.streaming.kotak_order_adapter", "create_kotak_order_adapter"),
     "iiflcapital": (
         "broker.iiflcapital.streaming.iiflcapital_order_adapter",
         "create_iiflcapital_order_adapter",


### PR DESCRIPTION
feat(kotak): live order-update WebSocket feed, perf(kotak): batch WebSocket unsubscribes and order them with subscribes and fix(kotak): close orphanable WebSocket clients on re-init and double connect

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a live Kotak order-update WebSocket feed and auto‑converts SL‑M to protected SL to avoid broker rejections. Improves streaming reliability by batching and ordering unsubscribes with subscribes and by closing orphan WebSocket clients.

- **New Features**
  - Live order updates: dedicated realtime WebSocket publishes each lifecycle step; `kotak` registered in the order-update service; docs updated.
  - SL-M handling: convert to `SL` using Kotak MPP offsets with tick snapping on place/modify; fails fast if tick size is missing.

- **Bug Fixes**
  - Batching/unsub order: unsubscribes are batched and ordered with subscribes, keeping only the last op per scrip per feed; fixes race where unsub could overtake sub and cuts frames on large lists.
  - WebSocket stability: close existing client on re-init and make `connect()` idempotent to prevent double threads and orphaned sockets.
  - Symbol mapping: fall back to `trdSym` when `tok` is blank in tradebook/orderbook to resolve OpenAlgo symbols correctly; lower noisy logs to debug.
  - Error handling: pre-flight payload build errors in place/modify now return structured broker errors instead of raising.

<sup>Written for commit 73e4ef7e2ec5fd84da7478616a078e83878db0c1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1689?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

