### PR TITLE
fix(flow): repair price alerts, guard execution paths, and land the strategy P&L work on main

### DIFF
--- a/app.py
+++ b/app.py
@@ -959,6 +959,7 @@ def shutdown_database_sessions(exception=None):
         ("database.market_calendar_db", "db_session"),
         ("database.telegram_db", "db_session"),
         ("database.symbol", "db_session"),
+        ("database.strategy_book_db", "db_session"),
     ]
 
     for module_name, session_attr in _sessions:

--- a/app.py
+++ b/app.py
@@ -411,9 +411,7 @@ def create_app():
                 "can immediately complete OAuth without admin review."
             )
 
-        logger.info(
-            "Remote MCP blueprints registered (OAuth + JSON-RPC dispatch + SSE)."
-        )
+        logger.info("Remote MCP blueprints registered (OAuth + JSON-RPC dispatch + SSE).")
 
     # Exempt webhook endpoints from CSRF protection after app initialization
     with app.app_context():
@@ -484,10 +482,7 @@ def create_app():
         from flask import request
 
         # Static assets don't need DB
-        if (
-            request.path.startswith("/static/")
-            or request.path.startswith("/assets/")
-        ):
+        if request.path.startswith("/static/") or request.path.startswith("/assets/"):
             return
 
         # Wait up to 30s for DB init (typically ~3.5s)
@@ -582,9 +577,15 @@ def create_app():
 
         # Skip tracking for common browser/crawler requests that are not attack probes
         safe_prefixes = (
-            "/favicon", "/robots.txt", "/sitemap", "/manifest",
-            "/sw.js", "/.well-known", "/apple-touch-icon",
-            "/service-worker", "/workbox",
+            "/favicon",
+            "/robots.txt",
+            "/sitemap",
+            "/manifest",
+            "/sw.js",
+            "/.well-known",
+            "/apple-touch-icon",
+            "/service-worker",
+            "/workbox",
         )
 
         if not is_authenticated and not path.startswith(safe_prefixes):
@@ -716,6 +717,20 @@ def setup_environment(app):
             db_init_time = (time.time() - db_init_start) * 1000
             logger.debug(f"All databases initialized in parallel ({db_init_time:.0f}ms)")
 
+            # The strategy book must be listening before any order can be
+            # accepted: order.placed carries the only copy of the strategy tag,
+            # so an order placed before this registration loses its attribution
+            # permanently. Registered ahead of db_ready for that reason.
+            try:
+                from database.strategy_book_db import init_strategy_book_db
+                from subscribers.strategy_book_subscriber import register as register_strategy_book
+                from utils.event_bus import bus as _bus
+
+                init_strategy_book_db()
+                register_strategy_book(_bus)
+            except Exception:
+                logger.exception("Failed to initialize strategy book")
+
             # Signal that DB tables are ready (unblocks cache restoration)
             app.db_ready.set()
 
@@ -740,18 +755,8 @@ def setup_environment(app):
                 )
 
                 restore_order_update_watches()
-            except Exception as e:
-                logger.error(f"Failed to restore Flow order-update watches: {e}")
-
-            try:
-                from database.strategy_book_db import init_strategy_book_db
-                from subscribers.strategy_book_subscriber import register as register_strategy_book
-                from utils.event_bus import bus as _bus
-
-                init_strategy_book_db()
-                register_strategy_book(_bus)
-            except Exception as e:
-                logger.error(f"Failed to initialize strategy book: {e}")
+            except Exception:
+                logger.exception("Failed to restore Flow order-update watches")
 
             try:
                 from services.historify_scheduler_service import init_historify_scheduler
@@ -795,6 +800,7 @@ def setup_environment(app):
                     logger.exception("WhatsApp bot auto-start crashed")
 
             import threading as _threading
+
             _threading.Thread(
                 target=_autostart_whatsapp_bot,
                 daemon=True,
@@ -819,6 +825,7 @@ def setup_environment(app):
 
                     def run_catchup():
                         from sandbox.position_manager import catchup_missed_settlements
+
                         catchup_missed_settlements()
                         return ("catchup_settlement", True, "Completed")
 
@@ -833,14 +840,22 @@ def setup_environment(app):
                                 service_name, success, message = future.result()
                                 if service_name == "execution_engine":
                                     if success:
-                                        logger.debug("Execution engine auto-started (Analyzer mode is ON)")
+                                        logger.debug(
+                                            "Execution engine auto-started (Analyzer mode is ON)"
+                                        )
                                     else:
-                                        logger.warning(f"Failed to auto-start execution engine: {message}")
+                                        logger.warning(
+                                            f"Failed to auto-start execution engine: {message}"
+                                        )
                                 elif service_name == "squareoff_scheduler":
                                     if success:
-                                        logger.debug("Square-off scheduler auto-started (Analyzer mode is ON)")
+                                        logger.debug(
+                                            "Square-off scheduler auto-started (Analyzer mode is ON)"
+                                        )
                                     else:
-                                        logger.warning(f"Failed to auto-start square-off scheduler: {message}")
+                                        logger.warning(
+                                            f"Failed to auto-start square-off scheduler: {message}"
+                                        )
                                 elif service_name == "catchup_settlement":
                                     logger.debug("Catch-up settlement check completed on startup")
                             except Exception as e:
@@ -886,7 +901,9 @@ def setup_environment(app):
                             if success:
                                 success, message = telegram_bot_service.start_bot()
                                 if success:
-                                    logger.debug(f"Telegram bot auto-started successfully: {message}")
+                                    logger.debug(
+                                        f"Telegram bot auto-started successfully: {message}"
+                                    )
                                 else:
                                     logger.error(f"Failed to auto-start Telegram bot: {message}")
                             else:
@@ -921,9 +938,12 @@ def _restore_caches_background():
                 symbol_count = cache_result["symbol_cache"].get("symbols_loaded", 0)
                 auth_count = cache_result["auth_cache"].get("tokens_loaded", 0)
                 if symbol_count > 0 or auth_count > 0:
-                    logger.debug(f"Cache restoration: {symbol_count} symbols, {auth_count} auth tokens")
+                    logger.debug(
+                        f"Cache restoration: {symbol_count} symbols, {auth_count} auth tokens"
+                    )
         except Exception as e:
             logger.debug(f"Cache restoration skipped: {e}")
+
 
 threading.Thread(target=_restore_caches_background, daemon=True).start()
 
@@ -931,46 +951,15 @@ threading.Thread(target=_restore_caches_background, daemon=True).start()
 # Database session cleanup (teardown handler)
 @app.teardown_appcontext
 def shutdown_database_sessions(exception=None):
-    """Remove all scoped sessions after each request to prevent FD leaks"""
-    # All (module, session_variable_name) pairs that use scoped_session.
-    # Each must be removed per-request to release the underlying DB connection
-    # and prevent file descriptor accumulation.
-    _sessions = [
-        # --- Previously cleaned up ---
-        ("database.auth_db", "db_session"),
-        ("database.traffic_db", "logs_session"),
-        ("database.apilog_db", "db_session"),
-        ("database.latency_db", "latency_session"),
-        ("database.health_db", "health_session"),
-        # --- Previously missing (caused FD leak) ---
-        ("database.settings_db", "db_session"),
-        ("database.strategy_db", "db_session"),
-        ("database.user_db", "db_session"),
-        ("database.action_center_db", "db_session"),
-        ("database.qty_freeze_db", "db_session"),
-        ("database.sandbox_db", "db_session"),
-        ("database.analyzer_db", "db_session"),
-        ("database.chart_prefs_db", "db_session"),
-        ("database.chartink_db", "db_session"),
-        ("database.flow_db", "db_session"),
-        ("database.scalping_db", "db_session"),
-        ("database.leverage_db", "db_session"),
-        ("database.strategy_portfolio_db", "db_session"),
-        ("database.market_calendar_db", "db_session"),
-        ("database.telegram_db", "db_session"),
-        ("database.symbol", "db_session"),
-        ("database.strategy_book_db", "db_session"),
-    ]
+    """Remove all scoped sessions after each request to prevent FD leaks.
 
-    for module_name, session_attr in _sessions:
-        try:
-            import importlib
-            mod = importlib.import_module(module_name)
-            session = getattr(mod, session_attr, None)
-            if session is not None:
-                session.remove()
-        except Exception:
-            pass
+    The registry lives in utils/db_sessions.py so that background threads,
+    which have no app context and never reach this handler, release exactly
+    the same set.
+    """
+    from utils.db_sessions import remove_all_scoped_sessions
+
+    remove_all_scoped_sessions()
 
 
 # Integrate the WebSocket proxy server with the Flask app
@@ -1008,7 +997,9 @@ if __name__ == "__main__":
     # FLASK_DEBUG_ALLOW_EXTERNAL=true to opt out of this guard.
     _LOOPBACK_HOSTS = {"127.0.0.1", "localhost", "::1", ""}
     _allow_external_debug = os.getenv("FLASK_DEBUG_ALLOW_EXTERNAL", "False").lower() in (
-        "true", "1", "t"
+        "true",
+        "1",
+        "t",
     )
     if debug and host_ip not in _LOOPBACK_HOSTS and not _allow_external_debug:
         sys.stderr.write(
@@ -1050,16 +1041,19 @@ if __name__ == "__main__":
     }
     # Suppress Flask/Werkzeug's default startup banner — our banner replaces it
     import flask.cli
+
     flask.cli.show_server_banner = lambda *_: None
 
     # Print startup banner NOW — right before the server starts accepting connections.
     # When the user sees this banner, the portal is ready to load.
     if not debug or os.environ.get("WERKZEUG_RUN_MAIN") == "true":
         from utils.version import get_version as _get_ver
+
         _ver = _get_ver()
         _dip = host_ip
         if host_ip == "0.0.0.0":
             import socket as _sk
+
             try:
                 _s = _sk.socket(_sk.AF_INET, _sk.SOCK_DGRAM)
                 _s.connect(("8.8.8.8", 80))
@@ -1070,12 +1064,32 @@ if __name__ == "__main__":
         _wu = f"http://{_dip}:{port}"
         _wsu = f"ws://{_dip}:{os.getenv('WEBSOCKET_PORT', 8765)}"
         _du = "https://docs.openalgo.in"
-        G, C, M, W, Y, R, BD, DM = "\033[92m", "\033[96m", "\033[95m", "\033[97m", "\033[93m", "\033[0m", "\033[1m", "\033[2m"
+        G, C, M, W, Y, R, BD, DM = (
+            "\033[92m",
+            "\033[96m",
+            "\033[95m",
+            "\033[97m",
+            "\033[93m",
+            "\033[0m",
+            "\033[1m",
+            "\033[2m",
+        )
         _ae = re.compile(r"\x1B\[[0-9;]*m")
-        def _vl(t): return len(_ae.sub("", t))
+
+        def _vl(t):
+            return len(_ae.sub("", t))
+
         _t = f" OpenAlgo v{_ver} "
         _sl = "Your Personal Algo Trading Platform"
-        _samps = ["", _sl, f"{W}{BD}Endpoints{R}", f"{W}Web App{R}    {C}{_wu}{R}", f"{W}WebSocket{R}  {M}{_wsu}{R}", f"{W}Docs{R}       {Y}{_du}{R}", f"{W}Status{R}     {G}{BD}Ready{R}"]
+        _samps = [
+            "",
+            _sl,
+            f"{W}{BD}Endpoints{R}",
+            f"{W}Web App{R}    {C}{_wu}{R}",
+            f"{W}WebSocket{R}  {M}{_wsu}{R}",
+            f"{W}Docs{R}       {Y}{_du}{R}",
+            f"{W}Status{R}     {G}{BD}Ready{R}",
+        ]
         _iw = max(50, max((_vl(s) for s in _samps), default=0))
         _W = max(_iw + 4, len(_t) + 5)
         _enc = getattr(sys.stdout, "encoding", None) or "utf-8"
@@ -1084,21 +1098,34 @@ if __name__ == "__main__":
             TL, TR, BL, BR, H, V = "\u256d", "\u256e", "\u2570", "\u256f", "\u2500", "\u2502"
         except Exception:
             TL, TR, BL, BR, H, V = "+", "+", "+", "+", "-", "|"
+
         def _ml(t=""):
             p = max(_W - 4 - _vl(t), 0)
-            return f"{C}{V}{R} {t}{' '*p} {C}{V}{R}"
+            return f"{C}{V}{R} {t}{' ' * p} {C}{V}{R}"
+
         _slp = max((_W - 4 - _vl(_sl)) // 2, 0)
         _srp = max(_W - 4 - _vl(_sl) - _slp, 0)
         _td = max(0, _W - 5 - len(_t))
-        print("\n".join(["",
-            f"{C}{TL}{H*3}{G}{BD}{_t}{R}{C}{H*_td}{TR}{R}",
-            _ml(), f"{C}{V}{R} {' '*_slp}{DM}{_sl}{R}{' '*_srp} {C}{V}{R}", _ml(),
-            _ml(f"{W}{BD}Endpoints{R}"),
-            _ml(f"{W}Web App{R}    {C}{_wu}{R}"),
-            _ml(f"{W}WebSocket{R}  {M}{_wsu}{R}"),
-            _ml(f"{W}Docs{R}       {Y}{_du}{R}"), _ml(),
-            _ml(f"{W}Status{R}     {G}{BD}Ready{R}"), _ml(),
-            f"{C}{BL}{H*(_W-2)}{BR}{R}", "",
-        ]), flush=True)
+        print(
+            "\n".join(
+                [
+                    "",
+                    f"{C}{TL}{H * 3}{G}{BD}{_t}{R}{C}{H * _td}{TR}{R}",
+                    _ml(),
+                    f"{C}{V}{R} {' ' * _slp}{DM}{_sl}{R}{' ' * _srp} {C}{V}{R}",
+                    _ml(),
+                    _ml(f"{W}{BD}Endpoints{R}"),
+                    _ml(f"{W}Web App{R}    {C}{_wu}{R}"),
+                    _ml(f"{W}WebSocket{R}  {M}{_wsu}{R}"),
+                    _ml(f"{W}Docs{R}       {Y}{_du}{R}"),
+                    _ml(),
+                    _ml(f"{W}Status{R}     {G}{BD}Ready{R}"),
+                    _ml(),
+                    f"{C}{BL}{H * (_W - 2)}{BR}{R}",
+                    "",
+                ]
+            ),
+            flush=True,
+        )
 
     socketio.run(app, host=host_ip, port=port, debug=debug, reloader_options=reloader_options)

--- a/app.py
+++ b/app.py
@@ -721,15 +721,35 @@ def setup_environment(app):
             # accepted: order.placed carries the only copy of the strategy tag,
             # so an order placed before this registration loses its attribution
             # permanently. Registered ahead of db_ready for that reason.
-            try:
-                from database.strategy_book_db import init_strategy_book_db
-                from subscribers.strategy_book_subscriber import register as register_strategy_book
-                from utils.event_bus import bus as _bus
+            # Retried rather than attempted once: the failure that matters here
+            # is a transient one (the DB file briefly unavailable during a
+            # parallel init), and losing it means every order placed afterwards
+            # is unattributable. Startup still proceeds if it ultimately fails -
+            # a P&L ledger must not keep the platform from trading - but the
+            # book then reports itself unavailable instead of an innocent zero,
+            # so nothing downstream can mistake it for a flat strategy.
+            for _attempt in range(1, 4):
+                try:
+                    from database.strategy_book_db import init_strategy_book_db
+                    from subscribers.strategy_book_subscriber import (
+                        register as register_strategy_book,
+                    )
+                    from utils.event_bus import bus as _bus
 
-                init_strategy_book_db()
-                register_strategy_book(_bus)
-            except Exception:
-                logger.exception("Failed to initialize strategy book")
+                    init_strategy_book_db()
+                    register_strategy_book(_bus)
+                    break
+                except Exception:
+                    logger.exception(
+                        f"Failed to initialize strategy book (attempt {_attempt} of 3)"
+                    )
+                    time.sleep(0.5 * _attempt)
+            else:
+                logger.error(
+                    "Strategy book unavailable after 3 attempts. Orders will still be "
+                    "placed, but per-strategy P&L will report an error until restart "
+                    "rather than a misleading zero."
+                )
 
             # Signal that DB tables are ready (unblocks cache restoration)
             app.db_ready.set()

--- a/app.py
+++ b/app.py
@@ -744,6 +744,16 @@ def setup_environment(app):
                 logger.error(f"Failed to restore Flow order-update watches: {e}")
 
             try:
+                from database.strategy_book_db import init_strategy_book_db
+                from subscribers.strategy_book_subscriber import register as register_strategy_book
+                from utils.event_bus import bus as _bus
+
+                init_strategy_book_db()
+                register_strategy_book(_bus)
+            except Exception as e:
+                logger.error(f"Failed to initialize strategy book: {e}")
+
+            try:
                 from services.historify_scheduler_service import init_historify_scheduler
 
                 init_historify_scheduler(socketio=socketio)

--- a/blueprints/flow.py
+++ b/blueprints/flow.py
@@ -702,14 +702,31 @@ def export_workflow(workflow_id):
 @flow_bp.route("/api/workflows/import", methods=["POST"])
 @check_session_validity
 def import_workflow():
-    """Import a workflow"""
+    """Import a workflow.
+
+    Validated before persistence: the editor checks the payload, but this
+    endpoint is reachable directly, and a malformed graph stored here fails
+    later - at activation or mid-execution - instead of at import.
+    """
     from database.flow_db import create_workflow
+    from services.flow_workflow_validator import validate_workflow
 
     data = request.get_json()
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
-    name = data.get("name", "Imported Workflow")
+    errors = validate_workflow(data)
+    if errors:
+        return jsonify(
+            {
+                "status": "error",
+                "error": "Invalid workflow format",
+                "message": errors[0]["message"],
+                "errors": errors,
+            }
+        ), 400
+
+    name = data.get("name")
     description = data.get("description")
     nodes = data.get("nodes", [])
     edges = data.get("edges", [])

--- a/blueprints/flow.py
+++ b/blueprints/flow.py
@@ -150,12 +150,21 @@ def update_workflow(workflow_id):
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
-    # Partial updates (rename, toggle) carry no graph, so validate only what is
-    # present. Same structural-not-complete rule as create.
+    # Partial updates (rename, toggle) carry no graph, and the API also accepts
+    # nodes without edges or vice versa. Validate the merged graph so a partial
+    # update is checked against what the workflow will actually become, rather
+    # than being rejected for the half it did not send.
     if "nodes" in data or "edges" in data:
+        from database.flow_db import get_workflow as _get_workflow
         from services.flow_workflow_validator import validate_workflow
 
-        errors = validate_workflow(data, require_name=False, strict=False)
+        existing = _get_workflow(workflow_id)
+        merged = {
+            "name": data.get("name") or (existing.name if existing else ""),
+            "nodes": data.get("nodes", (existing.nodes if existing else []) or []),
+            "edges": data.get("edges", (existing.edges if existing else []) or []),
+        }
+        errors = validate_workflow(merged, require_name=False, strict=False)
         if errors:
             return jsonify(
                 {
@@ -241,23 +250,9 @@ def activate_workflow(workflow_id):
     if not api_key:
         return jsonify({"error": "API key not configured"}), 400
 
-    # Activation is the point the workflow is asked to run for real, so the
-    # completeness rules apply here even though saving allowed a partial graph.
-    from services.flow_workflow_validator import validate_workflow
-
-    errors = validate_workflow(
-        {"name": workflow.name, "nodes": workflow.nodes or [], "edges": workflow.edges or []},
-        strict=True,
-    )
-    if errors:
-        return jsonify(
-            {
-                "status": "error",
-                "error": "Workflow cannot be activated",
-                "message": errors[0]["message"],
-                "errors": errors,
-            }
-        ), 400
+    blocked = _execution_blocked(workflow)
+    if blocked:
+        return jsonify({**blocked, "error": "Workflow cannot be activated"}), 400
 
     nodes = workflow.nodes or []
 
@@ -307,6 +302,10 @@ def activate_workflow(workflow_id):
                 price_upper=trigger_data.get("priceUpper"),
                 percentage=trigger_data.get("percentage"),
                 api_key=api_key,
+                # Previously dropped here, so "Every Time" behaved as one-shot
+                # and the expiry window was never applied.
+                trigger=trigger_data.get("trigger", "once"),
+                expiration=trigger_data.get("expiration", "none"),
             )
 
         elif trigger_type == "orderUpdateTrigger":
@@ -383,6 +382,31 @@ def deactivate_workflow(workflow_id):
 # === Execution Routes ===
 
 
+def _execution_blocked(workflow):
+    """Structured 400 payload when a workflow is not fit to execute, else None.
+
+    Saving deliberately accepts a half-built graph so the editor stays usable,
+    which means "stored" is not the same as "runnable". Every path that can
+    reach the broker - Run Now, activation, and webhooks - checks completeness
+    here instead. A workflow can also be edited into an invalid state after it
+    was activated, so checking once at activation is not enough.
+    """
+    from services.flow_workflow_validator import validate_workflow
+
+    errors = validate_workflow(
+        {"name": workflow.name, "nodes": workflow.nodes or [], "edges": workflow.edges or []},
+        strict=True,
+    )
+    if not errors:
+        return None
+    return {
+        "status": "error",
+        "error": "Workflow cannot be executed",
+        "message": errors[0]["message"],
+        "errors": errors,
+    }
+
+
 @flow_bp.route("/api/workflows/<int:workflow_id>/execute", methods=["POST"])
 @check_session_validity
 def execute_workflow_now(workflow_id):
@@ -397,6 +421,10 @@ def execute_workflow_now(workflow_id):
     api_key = get_current_api_key()
     if not api_key:
         return jsonify({"error": "API key not configured"}), 400
+
+    blocked = _execution_blocked(workflow)
+    if blocked:
+        return jsonify(blocked), 400
 
     try:
         result = execute_workflow(workflow_id, api_key=api_key)
@@ -664,6 +692,13 @@ def _execute_webhook(token, webhook_data=None, url_secret=None):
                 "error": "No API key configured for workflow execution. Please re-activate the workflow."
             }
         ), 500
+
+    blocked = _execution_blocked(workflow)
+    if blocked:
+        logger.error(
+            f"Webhook for workflow {workflow.id} rejected: {blocked['message']}"
+        )
+        return jsonify(blocked), 400
 
     try:
         logger.info(f"Webhook triggered for workflow {workflow.id}: {workflow.name}")

--- a/blueprints/flow.py
+++ b/blueprints/flow.py
@@ -67,6 +67,22 @@ def create_workflow():
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
+    # Structural validation only: the editor saves while a graph is still being
+    # wired, so completeness (required fields, one trigger, reachability) is
+    # enforced at import and activation instead of blocking every save.
+    from services.flow_workflow_validator import validate_workflow
+
+    errors = validate_workflow(data, require_name=False, strict=False)
+    if errors:
+        return jsonify(
+            {
+                "status": "error",
+                "error": "Invalid workflow structure",
+                "message": errors[0]["message"],
+                "errors": errors,
+            }
+        ), 400
+
     name = data.get("name", "Untitled Workflow")
     description = data.get("description")
     nodes = data.get("nodes", [])
@@ -133,6 +149,22 @@ def update_workflow(workflow_id):
     data = request.get_json()
     if not data:
         return jsonify({"error": "No data provided"}), 400
+
+    # Partial updates (rename, toggle) carry no graph, so validate only what is
+    # present. Same structural-not-complete rule as create.
+    if "nodes" in data or "edges" in data:
+        from services.flow_workflow_validator import validate_workflow
+
+        errors = validate_workflow(data, require_name=False, strict=False)
+        if errors:
+            return jsonify(
+                {
+                    "status": "error",
+                    "error": "Invalid workflow structure",
+                    "message": errors[0]["message"],
+                    "errors": errors,
+                }
+            ), 400
 
     workflow = update_workflow(workflow_id, **data)
     if not workflow:
@@ -208,6 +240,24 @@ def activate_workflow(workflow_id):
     api_key = get_current_api_key()
     if not api_key:
         return jsonify({"error": "API key not configured"}), 400
+
+    # Activation is the point the workflow is asked to run for real, so the
+    # completeness rules apply here even though saving allowed a partial graph.
+    from services.flow_workflow_validator import validate_workflow
+
+    errors = validate_workflow(
+        {"name": workflow.name, "nodes": workflow.nodes or [], "edges": workflow.edges or []},
+        strict=True,
+    )
+    if errors:
+        return jsonify(
+            {
+                "status": "error",
+                "error": "Workflow cannot be activated",
+                "message": errors[0]["message"],
+                "errors": errors,
+            }
+        ), 400
 
     nodes = workflow.nodes or []
 
@@ -709,11 +759,19 @@ def import_workflow():
     later - at activation or mid-execution - instead of at import.
     """
     from database.flow_db import create_workflow
-    from services.flow_workflow_validator import validate_workflow
+    from services.flow_workflow_validator import migrate_legacy_node_data, validate_workflow
 
     data = request.get_json()
     if not data:
         return jsonify({"error": "No data provided"}), 400
+
+    # Upgrade legacy node payloads before validating, so an older exported
+    # workflow imports as its canonical shape rather than being stored with a
+    # field no reader honors.
+    migration_notes: list[str] = []
+    if isinstance(data.get("nodes"), list):
+        data = dict(data)
+        data["nodes"], migration_notes = migrate_legacy_node_data(data["nodes"])
 
     errors = validate_workflow(data)
     if errors:
@@ -736,7 +794,10 @@ def import_workflow():
     )
 
     if workflow:
-        return jsonify({"status": "success", "workflow_id": workflow.id}), 201
+        response = {"status": "success", "workflow_id": workflow.id}
+        if migration_notes:
+            response["migrations"] = migration_notes
+        return jsonify(response), 201
     return jsonify({"error": "Failed to import workflow"}), 500
 
 

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -1,0 +1,301 @@
+# database/strategy_book_db.py
+"""
+Per-strategy position book and P&L ledger.
+
+The broker nets positions per `(symbol, exchange, product)` and knows nothing
+about which strategy opened them, so two strategies trading the same contract
+are indistinguishable downstream. This module keeps a parallel book keyed by
+strategy so a workflow can ask "how is *this* strategy doing?" and exit on
+its own P&L rather than the account's.
+
+Design notes:
+
+* **Fed entirely from the event bus.** `order.placed` supplies the
+  orderid -> strategy mapping (the only place the tag is known) and
+  `order.update` supplies fills. Nothing in the order execution path is
+  modified, so live trading is untouched by this feature.
+* **Idempotent.** Order updates can arrive more than once - a broker feed and
+  a postback may both report the same fill - so applied quantity is tracked
+  per order and only the unseen delta is booked. This also makes partial
+  fills fall out naturally.
+* **Weighted-average cost**, matching how OpenAlgo and Indian brokers report
+  `average_price`. A position flipping through zero realizes the closed leg
+  and reopens the remainder at the fill price.
+* **Realized P&L accumulates**; `today_realized` resets on the first fill of
+  a new trading date, which keeps it aligned with the ~3 AM IST session
+  rollover without needing a scheduler.
+
+Unrealized P&L is deliberately *not* stored. It is a function of the last
+traded price and would be stale the moment it was written; it is computed at
+read time in `services/strategy_pnl_service.py`.
+"""
+
+import os
+from datetime import date, datetime
+
+from sqlalchemy import (
+    Column,
+    DateTime,
+    Float,
+    Integer,
+    String,
+    UniqueConstraint,
+    create_engine,
+)
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+DATABASE_URL = os.getenv("DATABASE_URL")
+
+if DATABASE_URL and "sqlite" in DATABASE_URL:
+    engine = create_engine(
+        DATABASE_URL, poolclass=NullPool, connect_args={"check_same_thread": False}
+    )
+else:
+    engine = create_engine(DATABASE_URL, pool_size=50, max_overflow=100, pool_timeout=10)
+
+db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
+Base = declarative_base()
+Base.query = db_session.query_property()
+
+
+class StrategyOrderTag(Base):
+    """orderid -> strategy, captured when the order is placed.
+
+    Fills arrive later carrying only an orderid, so without this the strategy
+    that produced a trade cannot be recovered.
+    """
+
+    __tablename__ = "strategy_order_tags"
+
+    id = Column(Integer, primary_key=True)
+    orderid = Column(String(64), nullable=False, unique=True, index=True)
+    user_id = Column(String(64), nullable=False, index=True)
+    strategy = Column(String(120), nullable=False, index=True)
+    symbol = Column(String(64), nullable=False)
+    exchange = Column(String(20), nullable=False)
+    product = Column(String(20), nullable=False)
+    # Cumulative quantity already booked for this order, so a repeated or
+    # partial-fill update only contributes its unseen delta.
+    applied_quantity = Column(Float, nullable=False, default=0.0)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+
+
+class StrategyPosition(Base):
+    """Open position and accumulated realized P&L for one strategy leg."""
+
+    __tablename__ = "strategy_positions"
+    __table_args__ = (
+        UniqueConstraint(
+            "user_id", "strategy", "symbol", "exchange", "product", name="uq_strategy_leg"
+        ),
+    )
+
+    id = Column(Integer, primary_key=True)
+    user_id = Column(String(64), nullable=False, index=True)
+    strategy = Column(String(120), nullable=False, index=True)
+    symbol = Column(String(64), nullable=False, index=True)
+    exchange = Column(String(20), nullable=False)
+    product = Column(String(20), nullable=False)
+    # Signed: positive long, negative short.
+    quantity = Column(Float, nullable=False, default=0.0)
+    average_price = Column(Float, nullable=False, default=0.0)
+    realized_pnl = Column(Float, nullable=False, default=0.0)
+    today_realized_pnl = Column(Float, nullable=False, default=0.0)
+    trade_date = Column(String(10), nullable=True)
+    updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
+
+
+def init_strategy_book_db() -> None:
+    """Create tables if absent. Safe to call repeatedly."""
+    Base.metadata.create_all(bind=engine)
+    logger.info("Strategy book DB initialized")
+
+
+def record_order_tag(
+    orderid: str, user_id: str, strategy: str, symbol: str, exchange: str, product: str
+) -> bool:
+    """Remember which strategy placed an order. Ignores duplicates."""
+    if not orderid or not strategy:
+        return False
+    try:
+        existing = db_session.query(StrategyOrderTag).filter_by(orderid=str(orderid)).one_or_none()
+        if existing:
+            return True
+        db_session.add(
+            StrategyOrderTag(
+                orderid=str(orderid),
+                user_id=user_id or "",
+                strategy=strategy,
+                symbol=symbol or "",
+                exchange=exchange or "",
+                product=product or "",
+            )
+        )
+        db_session.commit()
+        return True
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not tag order {orderid} with strategy {strategy}")
+        return False
+
+
+def get_order_tag(orderid: str) -> StrategyOrderTag | None:
+    try:
+        return db_session.query(StrategyOrderTag).filter_by(orderid=str(orderid)).one_or_none()
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not read order tag for {orderid}")
+        return None
+
+
+def apply_fill(
+    orderid: str,
+    filled_quantity: float,
+    average_price: float,
+    action: str,
+) -> dict | None:
+    """Book the unseen portion of a fill against its strategy's position.
+
+    Returns a summary of the affected leg, or None when the order is unknown
+    (not placed with a strategy tag) or the fill adds nothing new.
+    """
+    tag = get_order_tag(orderid)
+    if tag is None:
+        return None
+
+    filled_quantity = abs(float(filled_quantity or 0))
+    delta = filled_quantity - float(tag.applied_quantity or 0)
+    if delta <= 0:
+        return None  # already booked; duplicate or out-of-order event
+
+    price = float(average_price or 0)
+    signed = delta if str(action).upper() == "BUY" else -delta
+    today = date.today().isoformat()
+
+    try:
+        leg = (
+            db_session.query(StrategyPosition)
+            .filter_by(
+                user_id=tag.user_id,
+                strategy=tag.strategy,
+                symbol=tag.symbol,
+                exchange=tag.exchange,
+                product=tag.product,
+            )
+            .one_or_none()
+        )
+        if leg is None:
+            leg = StrategyPosition(
+                user_id=tag.user_id,
+                strategy=tag.strategy,
+                symbol=tag.symbol,
+                exchange=tag.exchange,
+                product=tag.product,
+                trade_date=today,
+            )
+            db_session.add(leg)
+
+        if leg.trade_date != today:
+            leg.today_realized_pnl = 0.0
+            leg.trade_date = today
+
+        qty = float(leg.quantity or 0)
+        avg = float(leg.average_price or 0)
+
+        if qty == 0 or (qty > 0) == (signed > 0):
+            total = abs(qty) + abs(signed)
+            leg.average_price = ((avg * abs(qty)) + (price * abs(signed))) / total
+            leg.quantity = qty + signed
+        else:
+            closing = min(abs(signed), abs(qty))
+            direction = 1.0 if qty > 0 else -1.0
+            realized = closing * (price - avg) * direction
+            leg.realized_pnl = float(leg.realized_pnl or 0) + realized
+            leg.today_realized_pnl = float(leg.today_realized_pnl or 0) + realized
+            remaining = abs(signed) - closing
+            leg.quantity = qty + signed
+            if abs(leg.quantity) < 1e-9:
+                leg.quantity = 0.0
+                leg.average_price = 0.0
+            elif remaining > 0:
+                leg.average_price = price
+
+        tag.applied_quantity = filled_quantity
+        db_session.commit()
+        return {
+            "strategy": leg.strategy,
+            "symbol": leg.symbol,
+            "exchange": leg.exchange,
+            "product": leg.product,
+            "quantity": round(float(leg.quantity), 4),
+            "average_price": round(float(leg.average_price), 4),
+            "realized_pnl": round(float(leg.realized_pnl), 4),
+            "today_realized_pnl": round(float(leg.today_realized_pnl), 4),
+            "booked_quantity": round(delta, 4),
+        }
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not apply fill for order {orderid}")
+        return None
+
+
+def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -> list[dict]:
+    """Every tracked leg, optionally narrowed to one user and/or strategy."""
+    try:
+        query = db_session.query(StrategyPosition)
+        if user_id:
+            query = query.filter_by(user_id=user_id)
+        if strategy:
+            query = query.filter_by(strategy=strategy)
+        return [
+            {
+                "strategy": r.strategy,
+                "symbol": r.symbol,
+                "exchange": r.exchange,
+                "product": r.product,
+                "quantity": float(r.quantity or 0),
+                "average_price": float(r.average_price or 0),
+                "realized_pnl": float(r.realized_pnl or 0),
+                "today_realized_pnl": float(r.today_realized_pnl or 0),
+                "updated_at": r.updated_at.isoformat() if r.updated_at else None,
+            }
+            for r in query.all()
+        ]
+    except Exception:
+        db_session.rollback()
+        logger.exception("Could not read strategy legs")
+        return []
+
+
+def list_strategies(user_id: str | None = None) -> list[str]:
+    try:
+        query = db_session.query(StrategyPosition.strategy).distinct()
+        if user_id:
+            query = query.filter(StrategyPosition.user_id == user_id)
+        return sorted(r[0] for r in query.all())
+    except Exception:
+        db_session.rollback()
+        logger.exception("Could not list strategies")
+        return []
+
+
+def reset_strategy(user_id: str, strategy: str) -> int:
+    """Delete a strategy's legs. Administrative / test helper."""
+    try:
+        n = (
+            db_session.query(StrategyPosition)
+            .filter_by(user_id=user_id, strategy=strategy)
+            .delete()
+        )
+        db_session.commit()
+        return n
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not reset strategy {strategy}")
+        return 0

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -31,7 +31,7 @@ read time in `services/strategy_pnl_service.py`.
 """
 
 import os
-from datetime import date, datetime
+from datetime import date, datetime, timedelta
 
 from sqlalchemy import (
     Column,
@@ -40,24 +40,16 @@ from sqlalchemy import (
     Integer,
     String,
     UniqueConstraint,
-    create_engine,
 )
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.pool import NullPool
 
+from database.engine_factory import create_db_engine
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
-DATABASE_URL = os.getenv("DATABASE_URL")
-
-if DATABASE_URL and "sqlite" in DATABASE_URL:
-    engine = create_engine(
-        DATABASE_URL, poolclass=NullPool, connect_args={"check_same_thread": False}
-    )
-else:
-    engine = create_engine(DATABASE_URL, pool_size=50, max_overflow=100, pool_timeout=10)
+engine = create_db_engine()
 
 db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
 Base = declarative_base()
@@ -83,6 +75,31 @@ class StrategyOrderTag(Base):
     # Cumulative quantity already booked for this order, so a repeated or
     # partial-fill update only contributes its unseen delta.
     applied_quantity = Column(Float, nullable=False, default=0.0)
+    # Cumulative notional (quantity x price) already booked. Brokers report
+    # `average_price` cumulatively, so the incremental price of a partial fill
+    # must be derived from the change in notional - booking the delta at the
+    # latest cumulative average corrupts the cost basis whenever partials
+    # execute at different prices.
+    applied_notional = Column(Float, nullable=False, default=0.0)
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+
+
+class StrategyPendingFill(Base):
+    """A fill whose order tag had not been recorded yet.
+
+    EventBus callbacks run on a shared pool, and in analyze mode an
+    immediately marketable order publishes its fill from the sandbox engine
+    *before* place_order_service publishes order.placed. Without buffering,
+    such a fill finds no tag and is lost permanently.
+    """
+
+    __tablename__ = "strategy_pending_fills"
+
+    id = Column(Integer, primary_key=True)
+    orderid = Column(String(64), nullable=False, index=True)
+    filled_quantity = Column(Float, nullable=False)
+    average_price = Column(Float, nullable=False)
+    action = Column(String(10), nullable=False)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
 
 
@@ -112,9 +129,37 @@ class StrategyPosition(Base):
 
 
 def init_strategy_book_db() -> None:
-    """Create tables if absent. Safe to call repeatedly."""
+    """Create tables if absent, then apply column migrations. Idempotent."""
     Base.metadata.create_all(bind=engine)
+    _migrate_add_columns()
     logger.info("Strategy book DB initialized")
+
+
+def _migrate_add_columns():
+    """Add columns introduced after the table's first release (idempotent).
+
+    create_all() only creates missing *tables*, so an install that already has
+    strategy_order_tags would otherwise never gain applied_notional and every
+    query against the model would fail.
+    """
+    try:
+        from sqlalchemy import inspect, text
+
+        inspector = inspect(engine)
+        if "strategy_order_tags" not in inspector.get_table_names():
+            return
+        existing = {c["name"] for c in inspector.get_columns("strategy_order_tags")}
+        with engine.begin() as conn:
+            if "applied_notional" not in existing:
+                conn.execute(
+                    text(
+                        "ALTER TABLE strategy_order_tags "
+                        "ADD COLUMN applied_notional FLOAT NOT NULL DEFAULT 0.0"
+                    )
+                )
+                logger.info("Strategy book DB: added applied_notional column")
+    except Exception:
+        logger.exception("Strategy book DB: column migration failed")
 
 
 def record_order_tag(
@@ -138,11 +183,87 @@ def record_order_tag(
             )
         )
         db_session.commit()
-        return True
     except Exception:
         db_session.rollback()
         logger.exception(f"Could not tag order {orderid} with strategy {strategy}")
         return False
+
+    _drain_pending_fills(str(orderid))
+    return True
+
+
+def _drain_pending_fills(orderid: str) -> None:
+    """Apply any fills that arrived before this order's tag was recorded."""
+    try:
+        pending = (
+            db_session.query(StrategyPendingFill)
+            .filter_by(orderid=orderid)
+            .order_by(StrategyPendingFill.id)
+            .all()
+        )
+        rows = [(p.filled_quantity, p.average_price, p.action) for p in pending]
+        for p in pending:
+            db_session.delete(p)
+        db_session.commit()
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not read buffered fills for order {orderid}")
+        return
+
+    for qty, price, action in rows:
+        logger.info(f"Applying buffered fill for order {orderid} (arrived before its tag)")
+        apply_fill(orderid, qty, price, action)
+
+
+def _buffer_fill(orderid: str, filled_quantity: float, average_price: float, action: str) -> None:
+    """Hold a fill until its order tag is recorded.
+
+    Most untagged fills are not racing anything - they are ordinary orders
+    placed outside any strategy, and their tag will never arrive. Those rows
+    are pruned by age so the table cannot grow without bound.
+    """
+    if not orderid:
+        return
+    try:
+        _prune_pending_fills()
+        db_session.add(
+            StrategyPendingFill(
+                orderid=str(orderid),
+                filled_quantity=abs(float(filled_quantity or 0)),
+                average_price=float(average_price or 0),
+                action=str(action or ""),
+            )
+        )
+        db_session.commit()
+        logger.debug(f"Buffered fill for untagged order {orderid}")
+    except Exception:
+        db_session.rollback()
+        logger.exception(f"Could not buffer fill for order {orderid}")
+
+
+# A tag that is going to arrive arrives within milliseconds - the buffer only
+# has to survive the publish race, never a session.
+_PENDING_FILL_TTL = timedelta(minutes=int(os.getenv("STRATEGY_PENDING_FILL_TTL_MIN", "10")))
+
+
+def _prune_pending_fills() -> None:
+    """Drop buffered fills whose tag never arrived (ordinary untagged orders)."""
+    try:
+        cutoff = datetime.now() - _PENDING_FILL_TTL
+        removed = (
+            db_session.query(StrategyPendingFill)
+            .filter(StrategyPendingFill.created_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        if removed:
+            db_session.commit()
+            # The bulk delete bypasses the identity map; drop the stale entries
+            # so a reused primary key does not warn on the next flush.
+            db_session.expire_all()
+            logger.debug(f"Strategy book: pruned {removed} unclaimed buffered fill(s)")
+    except Exception:
+        db_session.rollback()
+        logger.exception("Could not prune pending fills")
 
 
 def get_order_tag(orderid: str) -> StrategyOrderTag | None:
@@ -167,6 +288,9 @@ def apply_fill(
     """
     tag = get_order_tag(orderid)
     if tag is None:
+        # The fill beat its own order.placed event. Buffer it; record_order_tag
+        # drains the buffer as soon as the tag lands.
+        _buffer_fill(orderid, filled_quantity, average_price, action)
         return None
 
     filled_quantity = abs(float(filled_quantity or 0))
@@ -174,7 +298,13 @@ def apply_fill(
     if delta <= 0:
         return None  # already booked; duplicate or out-of-order event
 
-    price = float(average_price or 0)
+    # `average_price` is cumulative over the whole order, so the incremental
+    # price is the change in notional over the change in quantity. Booking the
+    # delta at the cumulative average would misprice partials filled at
+    # different levels.
+    cumulative_notional = filled_quantity * float(average_price or 0)
+    incremental_notional = cumulative_notional - float(tag.applied_notional or 0)
+    price = incremental_notional / delta if delta else float(average_price or 0)
     signed = delta if str(action).upper() == "BUY" else -delta
     today = date.today().isoformat()
 
@@ -227,6 +357,7 @@ def apply_fill(
                 leg.average_price = price
 
         tag.applied_quantity = filled_quantity
+        tag.applied_notional = cumulative_notional
         db_session.commit()
         return {
             "strategy": leg.strategy,
@@ -247,6 +378,7 @@ def apply_fill(
 
 def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -> list[dict]:
     """Every tracked leg, optionally narrowed to one user and/or strategy."""
+    today = date.today().isoformat()
     try:
         query = db_session.query(StrategyPosition)
         if user_id:
@@ -262,7 +394,12 @@ def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -
                 "quantity": float(r.quantity or 0),
                 "average_price": float(r.average_price or 0),
                 "realized_pnl": float(r.realized_pnl or 0),
-                "today_realized_pnl": float(r.today_realized_pnl or 0),
+                # Stale once the trading date rolls over. The stored value is
+                # only reset by the next fill, so a strategy read early in a
+                # new session would otherwise report yesterday's figure.
+                "today_realized_pnl": (
+                    float(r.today_realized_pnl or 0) if r.trade_date == today else 0.0
+                ),
                 "updated_at": r.updated_at.isoformat() if r.updated_at else None,
             }
             for r in query.all()
@@ -286,12 +423,21 @@ def list_strategies(user_id: str | None = None) -> list[str]:
 
 
 def reset_strategy(user_id: str, strategy: str) -> int:
-    """Delete a strategy's legs. Administrative / test helper."""
+    """Delete a strategy's legs and its order tags. Administrative helper.
+
+    The tags carry the applied-quantity watermark, so leaving them behind
+    would make the reset strategy permanently unable to re-book those orders.
+    Fills from orders still in flight at reset time become untagged and are
+    ignored, which is the intended clean-slate semantic.
+    """
     try:
         n = (
             db_session.query(StrategyPosition)
             .filter_by(user_id=user_id, strategy=strategy)
             .delete()
+        )
+        db_session.query(StrategyOrderTag).filter_by(user_id=user_id, strategy=strategy).delete(
+            synchronize_session=False
         )
         db_session.commit()
         return n

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -46,6 +46,7 @@ from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
 from database.engine_factory import create_db_engine
+from utils.env_config import env_int
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -56,6 +57,15 @@ logger = get_logger(__name__)
 # because draining a buffered fill re-enters apply_fill. Production is a single
 # worker, so an in-process lock is sufficient.
 _fill_lock = threading.RLock()
+
+# Set once the tables exist. Reads must fail loudly rather than report an empty
+# book: a strategy P&L of zero is indistinguishable from "flat and fine" to an
+# exit trigger, so an uninitialized book must never be reported as one.
+_initialized = False
+
+
+class StrategyBookUnavailable(RuntimeError):
+    """The per-strategy book could not be read, so its figures are unknown."""
 
 engine = create_db_engine()
 
@@ -138,16 +148,23 @@ class StrategyPosition(Base):
 
 def init_strategy_book_db() -> None:
     """Create tables if absent, then apply column migrations. Idempotent."""
+    global _initialized
     Base.metadata.create_all(bind=engine)
     _migrate_add_columns()
     _prune_old_tags()
+    _initialized = True
     logger.info("Strategy book DB initialized")
+
+
+def is_initialized() -> bool:
+    """Whether the book is usable. False means its figures are unknown."""
+    return _initialized
 
 
 # One tag row exists per order, forever, and the key space is every order ever
 # placed - so it needs a retention bound. An order cannot report new fills days
 # after the fact, making anything past this window safe to drop.
-_TAG_RETENTION = timedelta(days=int(os.getenv("STRATEGY_TAG_RETENTION_DAYS", "30")))
+_TAG_RETENTION = timedelta(days=env_int("STRATEGY_TAG_RETENTION_DAYS", 30, minimum=1))
 
 
 def _prune_old_tags() -> None:
@@ -213,9 +230,23 @@ def _session_date() -> str:
 def record_order_tag(
     orderid: str, user_id: str, strategy: str, symbol: str, exchange: str, product: str
 ) -> bool:
-    """Remember which strategy placed an order. Ignores duplicates."""
+    """Remember which strategy placed an order. Ignores duplicates.
+
+    Takes the same lock as apply_fill. Serializing only fill application is not
+    enough: a fill could find no tag, then the tag could be written and its
+    (still empty) buffer drained, and only then would the fill be buffered -
+    leaving it orphaned until it expired. Holding one lock across both makes
+    the two orderings the only possible ones, and both are handled.
+    """
     if not orderid or not strategy:
         return False
+    with _fill_lock:
+        return _record_order_tag_locked(orderid, user_id, strategy, symbol, exchange, product)
+
+
+def _record_order_tag_locked(
+    orderid: str, user_id: str, strategy: str, symbol: str, exchange: str, product: str
+) -> bool:
     try:
         existing = db_session.query(StrategyOrderTag).filter_by(orderid=str(orderid)).one_or_none()
         if existing:
@@ -304,7 +335,7 @@ def _buffer_fill(orderid: str, filled_quantity: float, average_price: float, act
 
 # A tag that is going to arrive arrives within milliseconds - the buffer only
 # has to survive the publish race, never a session.
-_PENDING_FILL_TTL = timedelta(minutes=int(os.getenv("STRATEGY_PENDING_FILL_TTL_MIN", "10")))
+_PENDING_FILL_TTL = timedelta(minutes=env_int("STRATEGY_PENDING_FILL_TTL_MIN", 10, minimum=1))
 
 
 def _prune_pending_fills() -> None:
@@ -453,7 +484,18 @@ def _apply_fill_locked(
 
 
 def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -> list[dict]:
-    """Every tracked leg, optionally narrowed to one user and/or strategy."""
+    """Every tracked leg, optionally narrowed to one user and/or strategy.
+
+    Raises:
+        StrategyBookUnavailable: the book is not initialized or cannot be read.
+            Returning an empty list here would be reported as a P&L of zero,
+            which an exit trigger cannot distinguish from a flat, healthy
+            strategy - so an unknown book is raised, never rendered as zero.
+    """
+    if not _initialized:
+        raise StrategyBookUnavailable(
+            "Strategy book is not initialized; per-strategy P&L is unavailable"
+        )
     # Same boundary the write path stamps, so a leg booked at 02:00 IST is not
     # read back as belonging to a different day.
     today = _session_date()
@@ -482,10 +524,10 @@ def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -
             }
             for r in query.all()
         ]
-    except Exception:
+    except Exception as exc:
         db_session.rollback()
         logger.exception("Could not read strategy legs")
-        return []
+        raise StrategyBookUnavailable("Could not read the strategy book") from exc
 
 
 def list_strategies(user_id: str | None = None) -> list[str]:

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -31,7 +31,8 @@ read time in `services/strategy_pnl_service.py`.
 """
 
 import os
-from datetime import date, datetime, timedelta
+import threading
+from datetime import datetime, timedelta
 
 from sqlalchemy import (
     Column,
@@ -48,6 +49,13 @@ from database.engine_factory import create_db_engine
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Serializes the read-modify-write of an order's applied-quantity watermark and
+# its position row. The event bus dispatches on a thread pool, so concurrent
+# updates for one order would otherwise double-book or lose a fill. Reentrant
+# because draining a buffered fill re-enters apply_fill. Production is a single
+# worker, so an in-process lock is sufficient.
+_fill_lock = threading.RLock()
 
 engine = create_db_engine()
 
@@ -132,7 +140,31 @@ def init_strategy_book_db() -> None:
     """Create tables if absent, then apply column migrations. Idempotent."""
     Base.metadata.create_all(bind=engine)
     _migrate_add_columns()
+    _prune_old_tags()
     logger.info("Strategy book DB initialized")
+
+
+# One tag row exists per order, forever, and the key space is every order ever
+# placed - so it needs a retention bound. An order cannot report new fills days
+# after the fact, making anything past this window safe to drop.
+_TAG_RETENTION = timedelta(days=int(os.getenv("STRATEGY_TAG_RETENTION_DAYS", "30")))
+
+
+def _prune_old_tags() -> None:
+    """Drop order tags well past the point where new fills could arrive."""
+    try:
+        cutoff = datetime.now() - _TAG_RETENTION
+        removed = (
+            db_session.query(StrategyOrderTag)
+            .filter(StrategyOrderTag.created_at < cutoff)
+            .delete(synchronize_session=False)
+        )
+        if removed:
+            db_session.commit()
+            logger.info(f"Strategy book: pruned {removed} order tag(s) past retention")
+    except Exception:
+        db_session.rollback()
+        logger.exception("Could not prune old order tags")
 
 
 def _migrate_add_columns():
@@ -160,6 +192,22 @@ def _migrate_add_columns():
                 logger.info("Strategy book DB: added applied_notional column")
     except Exception:
         logger.exception("Strategy book DB: column migration failed")
+
+
+def _session_date() -> str:
+    """The current trading session's date (03:00 IST rollover), as ISO text.
+
+    Not ``date.today()``: that is the server's local calendar date, which
+    mislabels everything traded between midnight and the rollover and is not
+    even IST on a host outside India.
+    """
+    try:
+        from utils.session import get_trading_session_date
+
+        return get_trading_session_date()
+    except Exception:
+        logger.exception("Could not resolve trading session date; falling back to local date")
+        return datetime.now().date().isoformat()
 
 
 def record_order_tag(
@@ -193,7 +241,13 @@ def record_order_tag(
 
 
 def _drain_pending_fills(orderid: str) -> None:
-    """Apply any fills that arrived before this order's tag was recorded."""
+    """Apply any fills that arrived before this order's tag was recorded.
+
+    Each row is deleted only *after* its fill is booked. Deleting first would
+    lose the fill permanently if booking then failed. Booking first is safe in
+    the other direction too: apply_fill is idempotent on the applied-quantity
+    watermark, so a row that is booked but not yet deleted is a no-op on retry.
+    """
     try:
         pending = (
             db_session.query(StrategyPendingFill)
@@ -201,18 +255,25 @@ def _drain_pending_fills(orderid: str) -> None:
             .order_by(StrategyPendingFill.id)
             .all()
         )
-        rows = [(p.filled_quantity, p.average_price, p.action) for p in pending]
-        for p in pending:
-            db_session.delete(p)
-        db_session.commit()
+        rows = [(p.id, p.filled_quantity, p.average_price, p.action) for p in pending]
     except Exception:
         db_session.rollback()
         logger.exception(f"Could not read buffered fills for order {orderid}")
         return
 
-    for qty, price, action in rows:
-        logger.info(f"Applying buffered fill for order {orderid} (arrived before its tag)")
-        apply_fill(orderid, qty, price, action)
+    for row_id, qty, price, action in rows:
+        try:
+            logger.info(f"Applying buffered fill for order {orderid} (arrived before its tag)")
+            apply_fill(orderid, qty, price, action)
+            db_session.query(StrategyPendingFill).filter_by(id=row_id).delete(
+                synchronize_session=False
+            )
+            db_session.commit()
+        except Exception:
+            db_session.rollback()
+            # Left in place deliberately: the row is retried on the next tag or
+            # fill for this order, and pruned by age if it never applies.
+            logger.exception(f"Could not apply buffered fill {row_id} for order {orderid}")
 
 
 def _buffer_fill(orderid: str, filled_quantity: float, average_price: float, action: str) -> None:
@@ -285,7 +346,22 @@ def apply_fill(
 
     Returns a summary of the affected leg, or None when the order is unknown
     (not placed with a strategy tag) or the fill adds nothing new.
+
+    Serialized: the event bus dispatches callbacks on a thread pool, so two
+    updates for the same order can run concurrently. Reading the watermark,
+    booking the delta and writing the watermark back must be one critical
+    section or a duplicate event double-books the fill.
     """
+    with _fill_lock:
+        return _apply_fill_locked(orderid, filled_quantity, average_price, action)
+
+
+def _apply_fill_locked(
+    orderid: str,
+    filled_quantity: float,
+    average_price: float,
+    action: str,
+) -> dict | None:
     tag = get_order_tag(orderid)
     if tag is None:
         # The fill beat its own order.placed event. Buffer it; record_order_tag
@@ -306,7 +382,7 @@ def apply_fill(
     incremental_notional = cumulative_notional - float(tag.applied_notional or 0)
     price = incremental_notional / delta if delta else float(average_price or 0)
     signed = delta if str(action).upper() == "BUY" else -delta
-    today = date.today().isoformat()
+    today = _session_date()
 
     try:
         leg = (
@@ -378,7 +454,9 @@ def apply_fill(
 
 def get_strategy_legs(user_id: str | None = None, strategy: str | None = None) -> list[dict]:
     """Every tracked leg, optionally narrowed to one user and/or strategy."""
-    today = date.today().isoformat()
+    # Same boundary the write path stamps, so a leg booked at 02:00 IST is not
+    # read back as belonging to a different day.
+    today = _session_date()
     try:
         query = db_session.query(StrategyPosition)
         if user_id:

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -1391,6 +1391,13 @@ resolve. Shapes below were captured from live responses, not inferred.
 | `indicator` | `{status, indicator, nested, inputs, params, outputs, latest, previous, at_offset, series, offset_bars, bars_used}` | `{{r.latest.value}}`, `{{r.previous.value}}`, `{{r.at_offset.out0}}`, `{{r.series[0].value}}` |
 | `priorPeriodOhlc` | `{status, symbol, exchange, period, date, open, high, low, close, volume, pdh, pdl, pdc}` | `{{pd.pdh}}`, `{{pd.pdl}}`, `{{pd.close}}` |
 | `barOffset` | `{status, symbol, exchange, offsetBars, timestamp, open, high, low, close, volume}` | `{{b.close}}`, `{{b.high}}` |
+| `strategyPnl` | `{status, strategy, realized, today_realized, unrealized, total, open_quantity, unpriced_legs, legs: [{symbol, exchange, product, quantity, average_price, ltp, realized_pnl, unrealized}]}` | `{{pnl.total}}`, `{{pnl.today_realized}}`, `{{pnl.open_quantity}}` |
+
+`strategyPnl` reports **only this strategy's** legs, not the account's. It
+defaults to the workflow's own name, which is the same tag its order nodes
+apply, so the usual case needs no configuration. `unpriced_legs` counts open
+legs with no live price - those are excluded from `unrealized`, so treat a
+non-zero value as "this total is incomplete" before acting on it.
 
 Single-output indicators expose `value`; multi-output expose `out0`, `out1`,
 … (macd: line/signal/histogram, supertrend: level/direction, bbands:

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -316,6 +316,17 @@ A workflow must contain exactly one trigger node, and that node must be one
 of: `start`, `priceAlert`, `webhookTrigger`, `orderUpdateTrigger`. Every
 other path of execution flows from there.
 
+> **A second trigger is silently ignored.** The executor takes the *first*
+> trigger node it finds and walks the graph from there, so any additional
+> trigger - and every node downstream of it - never runs, with no error. If a
+> strategy needs two schedules (say entries each minute and a square-off at
+> 14:00), either express the second as a `timeWindow`-gated branch on the
+> same trigger, or split it into a second workflow.
+>
+> Note that splitting costs broker calls: branches sharing one trigger also
+> share their data nodes, whereas separate workflows each re-fetch. Quotes and
+> the order book are **not** de-duplicated by the history cache.
+
 #### start — Schedule Trigger
 
 Fires on a clock schedule.

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -42,7 +42,8 @@ Actions    placeOrder · smartOrder · optionsOrder · optionsMultiOrder ·
 Conditions positionCheck · fundCheck · priceCondition · varCondition ·
            timeWindow · timeCondition · andGate · orGate · notGate
 Data       getQuote · multiQuotes · getDepth · history · indicator ·
-           priorPeriodOhlc · barOffset · openPosition · getOrderStatus ·
+           priorPeriodOhlc · barOffset · strategyPnl · openPosition ·
+           getOrderStatus ·
            orderBook · tradeBook · positionBook · holdings · funds · margin ·
            symbol · optionSymbol · expiry · intervals · optionChain ·
            syntheticFuture · holidays · timings
@@ -286,10 +287,18 @@ gate needs a working else-branch:
 Gates wait until every wired input has been evaluated, then fire exactly
 once per run.
 
-`andGate` / `orGate` source handles are not bool branches — they emit a single
-`condition` value to whatever connects to them downstream. Their **incoming**
-edges do use `targetHandle` to pin a specific input slot:
+`andGate` / `orGate` **do** branch: both render `true` and `false` source
+handles, and the executor routes their result through the same truthy/falsy
+edge filter as a condition node. Set `sourceHandle: "true"` or `"false"` on a
+gate's outgoing edges exactly as you would for a condition. An edge with no
+`sourceHandle` is followed unconditionally, which is rarely what you want from
+a gate.
+
+Their **incoming** edges use `targetHandle` to pin a specific input slot:
 `targetHandle: "input-0"`, `"input-1"`, ... up to `inputCount - 1`.
+
+`notGate` emits `yes` / `no` handles, which the executor treats as synonyms of
+`true` / `false`.
 
 ---
 
@@ -987,6 +996,41 @@ Exposes `{{name.open/high/low/close/volume}}` plus aliases `{{name.pdh}}`,
   "type": "priorPeriodOhlc",
   "position": { "x": 100, "y": 100 },
   "data": { "symbol": "NIFTY", "exchange": "NSE_INDEX", "period": "previous_day", "source": "api", "outputVariable": "pd" }
+}
+```
+
+#### strategyPnl — Strategy P&L
+
+Realized / unrealized / total P&L for **one strategy**, not the whole account.
+The broker nets positions per `(symbol, exchange, product)` and carries no
+strategy label, so this is the only way a workflow can exit on its own
+performance while another strategy holds the same contract.
+
+| Field | Type | Default | Notes |
+|---|---|---|---|
+| `strategy` | string | the workflow's own name | Matches the tag this workflow's order nodes apply. Leave blank in almost every case. |
+| `outputVariable` | string | — | |
+
+Exposes `{{name.realized}}`, `{{name.today_realized}}`, `{{name.unrealized}}`,
+`{{name.total}}`, `{{name.today_total}}`, `{{name.open_quantity}}`,
+`{{name.unpriced_legs}}` and a per-leg `{{name.legs[0].*}}` breakdown.
+
+The book is fed from orders placed **through OpenAlgo carrying a strategy
+tag**; a position opened by hand in the broker terminal is invisible to it.
+`unpriced_legs` counts open legs with no live price, which are excluded from
+`unrealized` — a non-zero value means `total` is understated. If the position
+book or the strategy book cannot be read, the node returns `status: "error"`
+rather than a zero, because a zero is indistinguishable from a flat strategy.
+
+Guard on `open_quantity` before acting, or an exit re-fires every run once the
+position is already flat and realized P&L still exceeds the target.
+
+```json
+{
+  "id": "node_2",
+  "type": "strategyPnl",
+  "position": { "x": 100, "y": 100 },
+  "data": { "outputVariable": "pnl" }
 }
 ```
 

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -57,7 +57,8 @@ Do not emit nodes for these; restructure the strategy instead.
 
 | Not available | What to do instead |
 |---|---|
-| Variables that persist between runs (flags, counters, "already traded today") | Ask the broker: `positionCheck`, or `orderBook` statistics. Or derive it statelessly from the quote's session `high`/`low`. |
+| Variables that persist between runs (flags, counters, "already traded today") | Ask the broker, which is the real record of what you did: `positionCheck` for an open position, or `orderBook` statistics for orders already placed today (the order book resets daily). |
+| Remembering that price *reached* a level earlier today ("the gap has filled", "it already tagged VWAP") | The quote's session `high`/`low` are the running extremes of today's session, so `day_low <= PDH` proves price traded down to PDH at some point today. This records where price has been, **not** what you have traded - do not use it to infer your own activity. |
 | Loops / iteration / "monitor from 09:20 to 12:30" | Use `start` with `scheduleType: "interval"` plus a `timeWindow` condition. One run per tick. |
 | Waiting inside a run for a target or stop | A separate workflow on its own schedule. Entry, exit and square-off are different workflows. |
 | Iterating a list of symbols | One workflow per symbol, or drive it from `webhookTrigger` using `{{webhook.symbol}}`. |

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -12,6 +12,94 @@ flat declarative style suitable for that purpose.
 
 ---
 
+## 0. Output contract — read before generating anything
+
+**Emit exactly this shape. Nothing else imports.**
+
+```jsonc
+// shape only - see the runnable example below
+{ "name": "...", "nodes": [ ... ], "edges": [ ... ] }
+```
+
+* `name` (string), `nodes` (array), `edges` (array) are **required at the top
+  level**. Any other top-level shape is rejected with *"Invalid workflow
+  format. Must have name, nodes, and edges."*
+* Every node must be `{ "id", "type", "position": {"x","y"}, "data": {} }`.
+* **`type` must be copied verbatim from the list below.** Do not invent node
+  types, and do not translate a strategy description into your own schema.
+  If a requirement has no matching node, say so in prose — do not fabricate
+  one.
+* Emit the JSON object alone: no ``` fences, no commentary, no comments, no
+  trailing commas.
+
+### The only valid `type` values
+
+```
+Triggers   start · priceAlert · webhookTrigger · orderUpdateTrigger
+Actions    placeOrder · smartOrder · optionsOrder · optionsMultiOrder ·
+           basketOrder · splitOrder · modifyOrder · cancelOrder ·
+           cancelAllOrders · closePositions
+Conditions positionCheck · fundCheck · priceCondition · varCondition ·
+           timeWindow · timeCondition · andGate · orGate · notGate
+Data       getQuote · multiQuotes · getDepth · history · indicator ·
+           priorPeriodOhlc · barOffset · openPosition · getOrderStatus ·
+           orderBook · tradeBook · positionBook · holdings · funds · margin ·
+           symbol · optionSymbol · expiry · intervals · optionChain ·
+           syntheticFuture · holidays · timings
+Streaming  subscribeLtp · subscribeQuote · subscribeDepth · unsubscribe
+Utility    log · telegramAlert · whatsappAlert · variable · mathExpression ·
+           httpRequest · delay · waitUntil · group
+```
+
+### Capabilities Flow does NOT have
+
+Do not emit nodes for these; restructure the strategy instead.
+
+| Not available | What to do instead |
+|---|---|
+| Variables that persist between runs (flags, counters, "already traded today") | Ask the broker: `positionCheck`, or `orderBook` statistics. Or derive it statelessly from the quote's session `high`/`low`. |
+| Loops / iteration / "monitor from 09:20 to 12:30" | Use `start` with `scheduleType: "interval"` plus a `timeWindow` condition. One run per tick. |
+| Waiting inside a run for a target or stop | A separate workflow on its own schedule. Entry, exit and square-off are different workflows. |
+| Iterating a list of symbols | One workflow per symbol, or drive it from `webhookTrigger` using `{{webhook.symbol}}`. |
+| Structured trade logs, backtesting, string manipulation, date arithmetic | Not Flow. Order Book / Trade Book / P&L Tracker hold the trade record. |
+| `crossover` / `crossunder` / `correlation` / `beta` as an `indicator` | Two `indicator` nodes plus an `andGate` — see §8.14. |
+
+### Worked example of the required shape
+
+```json
+{
+  "name": "Buy RELIANCE if RSI below 30",
+  "nodes": [
+    { "id": "n1", "type": "start", "position": { "x": 0, "y": 0 },
+      "data": { "scheduleType": "interval", "intervalValue": 5, "intervalUnit": "minutes", "marketHoursOnly": true } },
+    { "id": "n2", "type": "indicator", "position": { "x": 0, "y": 100 },
+      "data": { "symbol": "RELIANCE", "exchange": "NSE", "interval": "D", "source": "api",
+                "indicatorName": "rsi", "params": "{\"period\": 14}", "outputVariable": "rsi" } },
+    { "id": "n3", "type": "varCondition", "position": { "x": 0, "y": 200 },
+      "data": { "leftValue": "{{rsi.latest.value}}", "operator": "<", "rightValue": "30" } },
+    { "id": "n4", "type": "placeOrder", "position": { "x": 0, "y": 300 },
+      "data": { "symbol": "RELIANCE", "exchange": "NSE", "action": "BUY", "quantity": 1,
+                "priceType": "MARKET", "product": "MIS", "outputVariable": "ord" } }
+  ],
+  "edges": [
+    { "id": "e1", "source": "n1", "target": "n2" },
+    { "id": "e2", "source": "n2", "target": "n3" },
+    { "id": "e3", "source": "n3", "sourceHandle": "true", "target": "n4" }
+  ]
+}
+```
+
+### Shapes that are rejected
+
+```jsonc
+{ "strategy": {...}, "settings": {...}, "flow": [...] }   // no name/nodes/edges
+{ "workflow": { "name": "...", "nodes": [], "edges": [] } } // nested one level too deep
+{ "name": "x", "nodes": [ { "type": "Decision" } ] }        // invented type, and no id/position/data
+{ "name": "x", "nodes": [], "edges": [], }                  // trailing comma
+```
+
+---
+
 ## 1. Workflow shape
 
 A workflow is a JSON object with the following top-level keys (the snippet

--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -1391,7 +1391,7 @@ resolve. Shapes below were captured from live responses, not inferred.
 | `indicator` | `{status, indicator, nested, inputs, params, outputs, latest, previous, at_offset, series, offset_bars, bars_used}` | `{{r.latest.value}}`, `{{r.previous.value}}`, `{{r.at_offset.out0}}`, `{{r.series[0].value}}` |
 | `priorPeriodOhlc` | `{status, symbol, exchange, period, date, open, high, low, close, volume, pdh, pdl, pdc}` | `{{pd.pdh}}`, `{{pd.pdl}}`, `{{pd.close}}` |
 | `barOffset` | `{status, symbol, exchange, offsetBars, timestamp, open, high, low, close, volume}` | `{{b.close}}`, `{{b.high}}` |
-| `strategyPnl` | `{status, strategy, realized, today_realized, unrealized, total, open_quantity, unpriced_legs, legs: [{symbol, exchange, product, quantity, average_price, ltp, realized_pnl, unrealized}]}` | `{{pnl.total}}`, `{{pnl.today_realized}}`, `{{pnl.open_quantity}}` |
+| `strategyPnl` | `{status, strategy, realized, today_realized, unrealized, total, today_total, open_quantity, unpriced_legs, legs: [{symbol, exchange, product, quantity, average_price, ltp, realized, today_realized, unrealized}]}` | `{{pnl.total}}`, `{{pnl.today_total}}`, `{{pnl.today_realized}}`, `{{pnl.open_quantity}}` |
 
 `strategyPnl` reports **only this strategy's** legs, not the account's. It
 defaults to the workflow's own name, which is the same tag its order nodes

--- a/docs/prompt/indicators/flow indicator reference.md
+++ b/docs/prompt/indicators/flow indicator reference.md
@@ -45,22 +45,22 @@ uv run python scripts/generate_indicator_reference.py
 | `cmo` | `ta.cmo(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `coppock` | `ta.coppock(close, wma_length=10, long_roc_length=14)` | `close` | `wma_length`=10, `long_roc_length`=14, `short_roc_length`=11 | `value` | `{"wma_length": 10, "long_roc_length": 14}` |
 | `crsi` | `ta.crsi(close, lenrsi=3, lenupdown=2)` | `close` | `lenrsi`=3, `lenupdown`=2, `lenroc`=100 | `value` | `{"lenrsi": 3, "lenupdown": 2}` |
-| `dema` | `ta.dema(close)` | `close` | - | `value` | `{}` |
+| `dema` | `ta.dema(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `dmi` | `ta.dmi(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `out0`, `out1` | `{"period": 14}` |
 | `donchian` | `ta.donchian(high, low, period=20)` | `high`, `low` | `period`=20 | `out0`, `out1`, `out2` | `{"period": 20}` |
 | `dpo` | `ta.dpo(close, period=21, is_centered=False)` | `close` | `period`=21, `is_centered`=False | `value` | `{"period": 21, "is_centered": False}` |
 | `dx` | `ta.dx(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
 | `elderray` | `ta.elderray(high, low, close, period=13)` | `high`, `low`, `close` | `period`=13 | `out0`, `out1` | `{"period": 13}` |
-| `ema` | `ta.ema(close)` | `close` | - | `value` | `{}` |
+| `ema` | `ta.ema(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `emv` | `ta.emv(high, low, volume, length=14, divisor=10000)` | `high`, `low`, `volume` | `length`=14, `divisor`=10000 | `value` | `{"length": 14, "divisor": 10000}` |
-| `falling` | `ta.falling(close)` | `close` | - | `value` | `{}` |
+| `falling` | `ta.falling(close, length=1)` | `close` | `length`=1 | `value` | `{"length": 1}` |
 | `fisher` | `ta.fisher(high, low, length=9)` | `high`, `low` | `length`=9 | `out0`, `out1` | `{"length": 9}` |
 | `force_index` | `ta.force_index(close, volume, length=13)` | `close`, `volume` | `length`=13 | `value` | `{"length": 13}` |
 | `fractals` | `ta.fractals(high, low, periods=2)` | `high`, `low` | `periods`=2 | `out0`, `out1` | `{"periods": 2}` |
 | `frama` | `ta.frama(high, low, period=26)` | `high`, `low` | `period`=26 | `value` | `{"period": 26}` |
 | `gator_oscillator` | `ta.gator_oscillator(high, low, jaw_period=13, teeth_period=8)` | `high`, `low` | `jaw_period`=13, `teeth_period`=8, `lips_period`=5 | `out0`, `out1` | `{"jaw_period": 13, "teeth_period": 8}` |
-| `highest` | `ta.highest(close)` | `close` | - | `value` | `{}` |
-| `hma` | `ta.hma(close)` | `close` | - | `value` | `{}` |
+| `highest` | `ta.highest(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `hma` | `ta.hma(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `hv` | `ta.hv(close, length=10, annual=365)` | `close` | `length`=10, `annual`=365, `per`=1 | `value` | `{"length": 10, "annual": 365}` |
 | `ichimoku` | `ta.ichimoku(high, low, close, conversion_periods=9, base_periods=26)` | `high`, `low`, `close` | `conversion_periods`=9, `base_periods`=26, `lagging_span2_periods`=52, `displacement`=26 | `out0`, `out1`, `out2`, `out3`, `out4` | `{"conversion_periods": 9, "base_periods": 26}` |
 | `kama` | `ta.kama(close, length=14, fast_length=2)` | `close` | `length`=14, `fast_length`=2, `slow_length`=30 | `value` | `{"length": 14, "fast_length": 2}` |
@@ -70,7 +70,7 @@ uv run python scripts/generate_indicator_reference.py
 | `linreg` | `ta.linreg(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `linregangle` | `ta.linregangle(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `linregintercept` | `ta.linregintercept(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
-| `lowest` | `ta.lowest(close)` | `close` | - | `value` | `{}` |
+| `lowest` | `ta.lowest(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `lrslope` | `ta.lrslope(close, period=100, interval=1)` | `close` | `period`=100, `interval`=1 | `value` | `{"period": 100, "interval": 1}` |
 | `ma_envelopes` | `ta.ma_envelopes(close, period=20, percentage=2.5)` | `close` | `period`=20, `percentage`=2.5, `ma_type`='SMA' | `out0`, `out1`, `out2` | `{"period": 20, "percentage": 2.5}` |
 | `macd` | `ta.macd(close, fast_period=12, slow_period=26)` | `close` | `fast_period`=12, `slow_period`=26, `signal_period`=9 | `out0`, `out1`, `out2` | `{"fast_period": 12, "slow_period": 26}` |
@@ -97,8 +97,8 @@ uv run python scripts/generate_indicator_reference.py
 | `pvi` | `ta.pvi(close, volume, initial_value=100.0)` | `close`, `volume` | `initial_value`=100.0 | `value` | `{"initial_value": 100.0}` |
 | `pvi_with_signal` | `ta.pvi_with_signal(close, volume, initial_value=100.0, signal_type='EMA')` | `close`, `volume` | `initial_value`=100.0, `signal_type`='EMA', `signal_length`=255 | `out0`, `out1` | `{"initial_value": 100.0, "signal_type": "EMA"}` |
 | `pvt` | `ta.pvt(close, volume)` | `close`, `volume` | - | `value` | `{}` |
-| `rising` | `ta.rising(close)` | `close` | - | `value` | `{}` |
-| `roc` | `ta.roc(close)` | `close` | - | `value` | `{}` |
+| `rising` | `ta.rising(close, length=1)` | `close` | `length`=1 | `value` | `{"length": 1}` |
+| `roc` | `ta.roc(close, length=14)` | `close` | `length`=14 | `value` | `{"length": 14}` |
 | `rocp` | `ta.rocp(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
 | `rocr` | `ta.rocr(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
 | `rocr100` | `ta.rocr100(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
@@ -106,16 +106,16 @@ uv run python scripts/generate_indicator_reference.py
 | `rvi` | `ta.rvi(open, high, low, close, period=10)` | `open`, `high`, `low`, `close` | `period`=10 | `out0`, `out1` | `{"period": 10}` |
 | `rvol` | `ta.rvol(volume, period=20)` | `volume` | `period`=20 | `value` | `{"period": 20}` |
 | `rwi` | `ta.rwi(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `out0`, `out1` | `{"period": 14}` |
-| `sma` | `ta.sma(close)` | `close` | - | `value` | `{}` |
+| `sma` | `ta.sma(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `starc` | `ta.starc(high, low, close, ma_period=5, atr_period=15)` | `high`, `low`, `close` | `ma_period`=5, `atr_period`=15, `multiplier`=1.33 | `out0`, `out1`, `out2` | `{"ma_period": 5, "atr_period": 15}` |
 | `stc` | `ta.stc(close, fast_length=23, slow_length=50)` | `close` | `fast_length`=23, `slow_length`=50, `cycle_length`=10, `d1_length`=3, `d2_length`=3 | `value` | `{"fast_length": 23, "slow_length": 50}` |
-| `stdev` | `ta.stdev(close)` | `close` | - | `value` | `{}` |
+| `stdev` | `ta.stdev(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `stochastic` | `ta.stochastic(high, low, close, k_period=14, smooth_k=3)` | `high`, `low`, `close` | `k_period`=14, `smooth_k`=3, `d_period`=3 | `out0`, `out1` | `{"k_period": 14, "smooth_k": 3}` |
 | `stochf` | `ta.stochf(high, low, close, fastk_period=5, fastd_period=3)` | `high`, `low`, `close` | `fastk_period`=5, `fastd_period`=3 | `out0`, `out1` | `{"fastk_period": 5, "fastd_period": 3}` |
 | `stochrsi` | `ta.stochrsi(close, rsi_period=14, stoch_period=14)` | `close` | `rsi_period`=14, `stoch_period`=14, `k_period`=3, `d_period`=3 | `out0`, `out1` | `{"rsi_period": 14, "stoch_period": 14}` |
 | `supertrend` | `ta.supertrend(high, low, close, period=10, multiplier=3.0)` | `high`, `low`, `close` | `period`=10, `multiplier`=3.0 | `out0`, `out1` | `{"period": 10, "multiplier": 3.0}` |
 | `t3` | `ta.t3(close, period=21, v_factor=0.7)` | `close` | `period`=21, `v_factor`=0.7 | `value` | `{"period": 21, "v_factor": 0.7}` |
-| `tema` | `ta.tema(close)` | `close` | - | `value` | `{}` |
+| `tema` | `ta.tema(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 | `trima` | `ta.trima(close, period=20)` | `close` | `period`=20 | `value` | `{"period": 20}` |
 | `trix` | `ta.trix(close, length=18)` | `close` | `length`=18 | `value` | `{"length": 18}` |
 | `true_range` | `ta.true_range(high, low, close)` | `high`, `low`, `close` | - | `value` | `{}` |
@@ -129,11 +129,11 @@ uv run python scripts/generate_indicator_reference.py
 | `volosc` | `ta.volosc(volume, short_length=5, long_length=10)` | `volume` | `short_length`=5, `long_length`=10, `check_volume_validity`=True | `value` | `{"short_length": 5, "long_length": 10}` |
 | `vroc` | `ta.vroc(volume, period=25)` | `volume` | `period`=25 | `value` | `{"period": 25}` |
 | `vwap` | `ta.vwap(high, low, close, volume, anchor='Session', source='hlc3')` | `high`, `low`, `close`, `volume` | `anchor`='Session', `source`='hlc3', `stdev_mult_1`=1.0, `stdev_mult_2`=2.0, `stdev_mult_3`=3.0, `percent_mult_1`=0.236, `percent_mult_2`=0.382, `percent_mult_3`=0.618 | `value` | `{"anchor": "Session", "source": "hlc3"}` |
-| `vwma` | `ta.vwma(close, volume)` | `close`, `volume` | - | `value` | `{}` |
+| `vwma` | `ta.vwma(close, volume, period=14)` | `close`, `volume` | `period`=14 | `value` | `{"period": 14}` |
 | `wclprice` | `ta.wclprice(high, low, close)` | `high`, `low`, `close` | - | `value` | `{}` |
 | `williams_r` | `ta.williams_r(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
-| `wma` | `ta.wma(close)` | `close` | - | `value` | `{}` |
-| `zlema` | `ta.zlema(close)` | `close` | - | `value` | `{}` |
+| `wma` | `ta.wma(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `zlema` | `ta.zlema(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
 
 **116 indicators**, all verified to compute.
 

--- a/docs/prompt/indicators/flow indicator reference.md
+++ b/docs/prompt/indicators/flow indicator reference.md
@@ -1,0 +1,170 @@
+# Flow Indicator Reference
+
+Generated from the installed `openalgo` build: every entry was produced by
+introspecting the callable and then executing it over 400 deterministic
+OHLCV bars. Each one returned a non-null value in that run, so each is
+usable from the Flow `indicator` node.
+
+**Do not hand-edit.** Regenerate with:
+
+```bash
+uv run python scripts/generate_indicator_reference.py
+```
+
+- **Inputs** are the OHLCV columns the node feeds in for you.
+- **Parameters** go in the node's `params` object.
+- **Outputs** are the keys under `latest` / `previous` / `at_offset`. A single
+  output is always `value`; multiple outputs are `out0`, `out1`, ...
+
+| Indicator | Python call | Inputs | Parameters | Outputs | `params` example |
+|---|---|---|---|---|---|
+| `accelerator_oscillator` | `ta.accelerator_oscillator(high, low, period=5)` | `high`, `low` | `period`=5 | `value` | `{"period": 5}` |
+| `adl` | `ta.adl(high, low, close, volume)` | `high`, `low`, `close`, `volume` | - | `value` | `{}` |
+| `adx` | `ta.adx(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `out0`, `out1`, `out2` | `{"period": 14}` |
+| `adxr` | `ta.adxr(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `alligator` | `ta.alligator(close, jaw_period=13, jaw_shift=8)` | `close` | `jaw_period`=13, `jaw_shift`=8, `teeth_period`=8, `teeth_shift`=5, `lips_period`=5, `lips_shift`=3 | `out0`, `out1`, `out2` | `{"jaw_period": 13, "jaw_shift": 8}` |
+| `alma` | `ta.alma(close, period=21, offset=0.85)` | `close` | `period`=21, `offset`=0.85, `sigma`=6.0 | `value` | `{"period": 21, "offset": 0.85}` |
+| `apo` | `ta.apo(close, fast_period=12, slow_period=26)` | `close` | `fast_period`=12, `slow_period`=26, `ma_type`='SMA' | `value` | `{"fast_period": 12, "slow_period": 26}` |
+| `aroon` | `ta.aroon(high, low, period=25)` | `high`, `low` | `period`=25 | `out0`, `out1` | `{"period": 25}` |
+| `aroon_oscillator` | `ta.aroon_oscillator(high, low, period=14)` | `high`, `low` | `period`=14 | `value` | `{"period": 14}` |
+| `atr` | `ta.atr(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `avgprice` | `ta.avgprice(open, high, low, close)` | `open`, `high`, `low`, `close` | - | `value` | `{}` |
+| `awesome_oscillator` | `ta.awesome_oscillator(high, low, fast_period=5, slow_period=34)` | `high`, `low` | `fast_period`=5, `slow_period`=34 | `value` | `{"fast_period": 5, "slow_period": 34}` |
+| `bbands` | `ta.bbands(close, period=20, std_dev=2.0)` | `close` | `period`=20, `std_dev`=2.0 | `out0`, `out1`, `out2` | `{"period": 20, "std_dev": 2.0}` |
+| `bbpercent` | `ta.bbpercent(close, period=20, std_dev=2.0)` | `close` | `period`=20, `std_dev`=2.0 | `value` | `{"period": 20, "std_dev": 2.0}` |
+| `bbwidth` | `ta.bbwidth(close, period=20, std_dev=2.0)` | `close` | `period`=20, `std_dev`=2.0 | `value` | `{"period": 20, "std_dev": 2.0}` |
+| `bop` | `ta.bop(open, high, low, close)` | `open`, `high`, `low`, `close` | - | `value` | `{}` |
+| `cci` | `ta.cci(high, low, close, period=20)` | `high`, `low`, `close` | `period`=20 | `value` | `{"period": 20}` |
+| `chaikin` | `ta.chaikin(high, low, ema_period=10, roc_period=10)` | `high`, `low` | `ema_period`=10, `roc_period`=10 | `value` | `{"ema_period": 10, "roc_period": 10}` |
+| `chandelier_exit` | `ta.chandelier_exit(high, low, close, period=22, multiplier=3.0)` | `high`, `low`, `close` | `period`=22, `multiplier`=3.0 | `out0`, `out1` | `{"period": 22, "multiplier": 3.0}` |
+| `change` | `ta.change(close, length=1)` | `close` | `length`=1 | `value` | `{"length": 1}` |
+| `cho` | `ta.cho(high, low, close, volume, fast_period=3, slow_period=10)` | `high`, `low`, `close`, `volume` | `fast_period`=3, `slow_period`=10 | `value` | `{"fast_period": 3, "slow_period": 10}` |
+| `chop` | `ta.chop(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `ckstop` | `ta.ckstop(high, low, close, p=10, x=1.0)` | `high`, `low`, `close` | `p`=10, `x`=1.0, `q`=9 | `out0`, `out1` | `{"p": 10, "x": 1.0}` |
+| `cmf` | `ta.cmf(high, low, close, volume, period=20)` | `high`, `low`, `close`, `volume` | `period`=20 | `value` | `{"period": 20}` |
+| `cmo` | `ta.cmo(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `coppock` | `ta.coppock(close, wma_length=10, long_roc_length=14)` | `close` | `wma_length`=10, `long_roc_length`=14, `short_roc_length`=11 | `value` | `{"wma_length": 10, "long_roc_length": 14}` |
+| `crsi` | `ta.crsi(close, lenrsi=3, lenupdown=2)` | `close` | `lenrsi`=3, `lenupdown`=2, `lenroc`=100 | `value` | `{"lenrsi": 3, "lenupdown": 2}` |
+| `dema` | `ta.dema(close)` | `close` | - | `value` | `{}` |
+| `dmi` | `ta.dmi(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `out0`, `out1` | `{"period": 14}` |
+| `donchian` | `ta.donchian(high, low, period=20)` | `high`, `low` | `period`=20 | `out0`, `out1`, `out2` | `{"period": 20}` |
+| `dpo` | `ta.dpo(close, period=21, is_centered=False)` | `close` | `period`=21, `is_centered`=False | `value` | `{"period": 21, "is_centered": False}` |
+| `dx` | `ta.dx(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `elderray` | `ta.elderray(high, low, close, period=13)` | `high`, `low`, `close` | `period`=13 | `out0`, `out1` | `{"period": 13}` |
+| `ema` | `ta.ema(close)` | `close` | - | `value` | `{}` |
+| `emv` | `ta.emv(high, low, volume, length=14, divisor=10000)` | `high`, `low`, `volume` | `length`=14, `divisor`=10000 | `value` | `{"length": 14, "divisor": 10000}` |
+| `falling` | `ta.falling(close)` | `close` | - | `value` | `{}` |
+| `fisher` | `ta.fisher(high, low, length=9)` | `high`, `low` | `length`=9 | `out0`, `out1` | `{"length": 9}` |
+| `force_index` | `ta.force_index(close, volume, length=13)` | `close`, `volume` | `length`=13 | `value` | `{"length": 13}` |
+| `fractals` | `ta.fractals(high, low, periods=2)` | `high`, `low` | `periods`=2 | `out0`, `out1` | `{"periods": 2}` |
+| `frama` | `ta.frama(high, low, period=26)` | `high`, `low` | `period`=26 | `value` | `{"period": 26}` |
+| `gator_oscillator` | `ta.gator_oscillator(high, low, jaw_period=13, teeth_period=8)` | `high`, `low` | `jaw_period`=13, `teeth_period`=8, `lips_period`=5 | `out0`, `out1` | `{"jaw_period": 13, "teeth_period": 8}` |
+| `highest` | `ta.highest(close)` | `close` | - | `value` | `{}` |
+| `hma` | `ta.hma(close)` | `close` | - | `value` | `{}` |
+| `hv` | `ta.hv(close, length=10, annual=365)` | `close` | `length`=10, `annual`=365, `per`=1 | `value` | `{"length": 10, "annual": 365}` |
+| `ichimoku` | `ta.ichimoku(high, low, close, conversion_periods=9, base_periods=26)` | `high`, `low`, `close` | `conversion_periods`=9, `base_periods`=26, `lagging_span2_periods`=52, `displacement`=26 | `out0`, `out1`, `out2`, `out3`, `out4` | `{"conversion_periods": 9, "base_periods": 26}` |
+| `kama` | `ta.kama(close, length=14, fast_length=2)` | `close` | `length`=14, `fast_length`=2, `slow_length`=30 | `value` | `{"length": 14, "fast_length": 2}` |
+| `keltner` | `ta.keltner(high, low, close, ema_period=20, atr_period=10)` | `high`, `low`, `close` | `ema_period`=20, `atr_period`=10, `multiplier`=2.0 | `out0`, `out1`, `out2` | `{"ema_period": 20, "atr_period": 10}` |
+| `kst` | `ta.kst(close, roclen1=10, roclen2=15)` | `close` | `roclen1`=10, `roclen2`=15, `roclen3`=20, `roclen4`=30, `smalen1`=10, `smalen2`=10, `smalen3`=10, `smalen4`=15, `siglen`=9 | `out0`, `out1` | `{"roclen1": 10, "roclen2": 15}` |
+| `kvo` | `ta.kvo(high, low, close, volume, trig_len=13, fast_x=34)` | `high`, `low`, `close`, `volume` | `trig_len`=13, `fast_x`=34, `slow_x`=55 | `out0`, `out1` | `{"trig_len": 13, "fast_x": 34}` |
+| `linreg` | `ta.linreg(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `linregangle` | `ta.linregangle(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `linregintercept` | `ta.linregintercept(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `lowest` | `ta.lowest(close)` | `close` | - | `value` | `{}` |
+| `lrslope` | `ta.lrslope(close, period=100, interval=1)` | `close` | `period`=100, `interval`=1 | `value` | `{"period": 100, "interval": 1}` |
+| `ma_envelopes` | `ta.ma_envelopes(close, period=20, percentage=2.5)` | `close` | `period`=20, `percentage`=2.5, `ma_type`='SMA' | `out0`, `out1`, `out2` | `{"period": 20, "percentage": 2.5}` |
+| `macd` | `ta.macd(close, fast_period=12, slow_period=26)` | `close` | `fast_period`=12, `slow_period`=26, `signal_period`=9 | `out0`, `out1`, `out2` | `{"fast_period": 12, "slow_period": 26}` |
+| `massindex` | `ta.massindex(high, low, length=10)` | `high`, `low` | `length`=10 | `value` | `{"length": 10}` |
+| `mcginley` | `ta.mcginley(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `median` | `ta.median(close, period=3)` | `close` | `period`=3 | `value` | `{"period": 3}` |
+| `medprice` | `ta.medprice(high, low)` | `high`, `low` | - | `value` | `{}` |
+| `mfi` | `ta.mfi(high, low, close, volume, period=14)` | `high`, `low`, `close`, `volume` | `period`=14 | `value` | `{"period": 14}` |
+| `midpoint` | `ta.midpoint(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `midprice` | `ta.midprice(high, low, period=14)` | `high`, `low` | `period`=14 | `value` | `{"period": 14}` |
+| `minus_dm` | `ta.minus_dm(high, low, period=14)` | `high`, `low` | `period`=14 | `value` | `{"period": 14}` |
+| `mode` | `ta.mode(close, period=20, bins=10)` | `close` | `period`=20, `bins`=10 | `value` | `{"period": 20, "bins": 10}` |
+| `mom` | `ta.mom(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
+| `natr` | `ta.natr(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `nvi` | `ta.nvi(close, volume)` | `close`, `volume` | - | `value` | `{}` |
+| `nvi_with_ema` | `ta.nvi_with_ema(close, volume, ema_length=255)` | `close`, `volume` | `ema_length`=255 | `out0`, `out1` | `{"ema_length": 255}` |
+| `obv` | `ta.obv(close, volume)` | `close`, `volume` | - | `value` | `{}` |
+| `obv_smoothed` | `ta.obv_smoothed(close, volume, ma_type='None', ma_length=20)` | `close`, `volume` | `ma_type`='None', `ma_length`=20, `bb_length`=20, `bb_mult`=2.0 | `value` | `{"ma_type": "None", "ma_length": 20}` |
+| `pivot_points` | `ta.pivot_points(high, low, close)` | `high`, `low`, `close` | - | `out0`, `out1`, `out2`, `out3`, `out4`, `out5`, `out6` | `{}` |
+| `plus_dm` | `ta.plus_dm(high, low, period=14)` | `high`, `low` | `period`=14 | `value` | `{"period": 14}` |
+| `po` | `ta.po(close, fast_period=10, slow_period=20)` | `close` | `fast_period`=10, `slow_period`=20, `ma_type`='SMA' | `value` | `{"fast_period": 10, "slow_period": 20}` |
+| `ppo` | `ta.ppo(close, fast_period=12, slow_period=26)` | `close` | `fast_period`=12, `slow_period`=26, `signal_period`=9 | `out0`, `out1`, `out2` | `{"fast_period": 12, "slow_period": 26}` |
+| `psar` | `ta.psar(high, low, acceleration=0.02, maximum=0.2)` | `high`, `low` | `acceleration`=0.02, `maximum`=0.2 | `value` | `{"acceleration": 0.02, "maximum": 0.2}` |
+| `pvi` | `ta.pvi(close, volume, initial_value=100.0)` | `close`, `volume` | `initial_value`=100.0 | `value` | `{"initial_value": 100.0}` |
+| `pvi_with_signal` | `ta.pvi_with_signal(close, volume, initial_value=100.0, signal_type='EMA')` | `close`, `volume` | `initial_value`=100.0, `signal_type`='EMA', `signal_length`=255 | `out0`, `out1` | `{"initial_value": 100.0, "signal_type": "EMA"}` |
+| `pvt` | `ta.pvt(close, volume)` | `close`, `volume` | - | `value` | `{}` |
+| `rising` | `ta.rising(close)` | `close` | - | `value` | `{}` |
+| `roc` | `ta.roc(close)` | `close` | - | `value` | `{}` |
+| `rocp` | `ta.rocp(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
+| `rocr` | `ta.rocr(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
+| `rocr100` | `ta.rocr100(close, period=10)` | `close` | `period`=10 | `value` | `{"period": 10}` |
+| `rsi` | `ta.rsi(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `rvi` | `ta.rvi(open, high, low, close, period=10)` | `open`, `high`, `low`, `close` | `period`=10 | `out0`, `out1` | `{"period": 10}` |
+| `rvol` | `ta.rvol(volume, period=20)` | `volume` | `period`=20 | `value` | `{"period": 20}` |
+| `rwi` | `ta.rwi(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `out0`, `out1` | `{"period": 14}` |
+| `sma` | `ta.sma(close)` | `close` | - | `value` | `{}` |
+| `starc` | `ta.starc(high, low, close, ma_period=5, atr_period=15)` | `high`, `low`, `close` | `ma_period`=5, `atr_period`=15, `multiplier`=1.33 | `out0`, `out1`, `out2` | `{"ma_period": 5, "atr_period": 15}` |
+| `stc` | `ta.stc(close, fast_length=23, slow_length=50)` | `close` | `fast_length`=23, `slow_length`=50, `cycle_length`=10, `d1_length`=3, `d2_length`=3 | `value` | `{"fast_length": 23, "slow_length": 50}` |
+| `stdev` | `ta.stdev(close)` | `close` | - | `value` | `{}` |
+| `stochastic` | `ta.stochastic(high, low, close, k_period=14, smooth_k=3)` | `high`, `low`, `close` | `k_period`=14, `smooth_k`=3, `d_period`=3 | `out0`, `out1` | `{"k_period": 14, "smooth_k": 3}` |
+| `stochf` | `ta.stochf(high, low, close, fastk_period=5, fastd_period=3)` | `high`, `low`, `close` | `fastk_period`=5, `fastd_period`=3 | `out0`, `out1` | `{"fastk_period": 5, "fastd_period": 3}` |
+| `stochrsi` | `ta.stochrsi(close, rsi_period=14, stoch_period=14)` | `close` | `rsi_period`=14, `stoch_period`=14, `k_period`=3, `d_period`=3 | `out0`, `out1` | `{"rsi_period": 14, "stoch_period": 14}` |
+| `supertrend` | `ta.supertrend(high, low, close, period=10, multiplier=3.0)` | `high`, `low`, `close` | `period`=10, `multiplier`=3.0 | `out0`, `out1` | `{"period": 10, "multiplier": 3.0}` |
+| `t3` | `ta.t3(close, period=21, v_factor=0.7)` | `close` | `period`=21, `v_factor`=0.7 | `value` | `{"period": 21, "v_factor": 0.7}` |
+| `tema` | `ta.tema(close)` | `close` | - | `value` | `{}` |
+| `trima` | `ta.trima(close, period=20)` | `close` | `period`=20 | `value` | `{"period": 20}` |
+| `trix` | `ta.trix(close, length=18)` | `close` | `length`=18 | `value` | `{"length": 18}` |
+| `true_range` | `ta.true_range(high, low, close)` | `high`, `low`, `close` | - | `value` | `{}` |
+| `tsf` | `ta.tsf(close, period=14)` | `close` | `period`=14 | `value` | `{"period": 14}` |
+| `tsi` | `ta.tsi(close, long_period=25, short_period=13)` | `close` | `long_period`=25, `short_period`=13, `signal_period`=13 | `out0`, `out1` | `{"long_period": 25, "short_period": 13}` |
+| `typprice` | `ta.typprice(high, low, close)` | `high`, `low`, `close` | - | `value` | `{}` |
+| `ultimate_oscillator` | `ta.ultimate_oscillator(high, low, close, period1=7, period2=14)` | `high`, `low`, `close` | `period1`=7, `period2`=14, `period3`=28 | `value` | `{"period1": 7, "period2": 14}` |
+| `uo_oscillator` | `ta.uo_oscillator(high, low, close, period1=7, period2=14)` | `high`, `low`, `close` | `period1`=7, `period2`=14, `period3`=28 | `value` | `{"period1": 7, "period2": 14}` |
+| `variance` | `ta.variance(close, lookback=20, mode='PR')` | `close` | `lookback`=20, `mode`='PR', `ema_period`=20, `filter_lookback`=20, `ema_length`=14, `return_components`=False | `value` | `{"lookback": 20, "mode": "PR"}` |
+| `vidya` | `ta.vidya(close, period=14, alpha=0.2)` | `close` | `period`=14, `alpha`=0.2 | `value` | `{"period": 14, "alpha": 0.2}` |
+| `volosc` | `ta.volosc(volume, short_length=5, long_length=10)` | `volume` | `short_length`=5, `long_length`=10, `check_volume_validity`=True | `value` | `{"short_length": 5, "long_length": 10}` |
+| `vroc` | `ta.vroc(volume, period=25)` | `volume` | `period`=25 | `value` | `{"period": 25}` |
+| `vwap` | `ta.vwap(high, low, close, volume, anchor='Session', source='hlc3')` | `high`, `low`, `close`, `volume` | `anchor`='Session', `source`='hlc3', `stdev_mult_1`=1.0, `stdev_mult_2`=2.0, `stdev_mult_3`=3.0, `percent_mult_1`=0.236, `percent_mult_2`=0.382, `percent_mult_3`=0.618 | `value` | `{"anchor": "Session", "source": "hlc3"}` |
+| `vwma` | `ta.vwma(close, volume)` | `close`, `volume` | - | `value` | `{}` |
+| `wclprice` | `ta.wclprice(high, low, close)` | `high`, `low`, `close` | - | `value` | `{}` |
+| `williams_r` | `ta.williams_r(high, low, close, period=14)` | `high`, `low`, `close` | `period`=14 | `value` | `{"period": 14}` |
+| `wma` | `ta.wma(close)` | `close` | - | `value` | `{}` |
+| `zlema` | `ta.zlema(close)` | `close` | - | `value` | `{}` |
+
+**116 indicators**, all verified to compute.
+
+## Not available from the `indicator` node
+
+| Function | Why |
+|---|---|
+| `crossover`, `crossunder`, `cross` | Need two independent series. Use two `indicator` nodes plus an `andGate`. |
+| `correlation`, `beta` | Compare two symbols. |
+| `exrem`, `flip`, `valuewhen` | Need a second boolean series and carry state across bars. |
+| `median_bands`, `ulcerindex`, `vi` | The installed build returns no usable value for these. |
+
+## Using an indicator in Flow
+
+```json
+{
+  "id": "node_2",
+  "type": "indicator",
+  "position": { "x": 100, "y": 100 },
+  "data": {
+    "symbol": "RELIANCE",
+    "exchange": "NSE",
+    "interval": "5m",
+    "indicatorName": "rsi",
+    "params": { "period": 14 },
+    "outputVariable": "r"
+  }
+}
+```
+
+Read the latest value as `{{r.latest.value}}`, the prior bar as
+`{{r.previous.value}}`, and a specific bar back as `{{r.at_offset.value}}`
+with `offsetBars` set. For a multi-output indicator use `{{r.latest.out0}}`,
+`{{r.latest.out1}}`, and so on.

--- a/docs/prompt/order-constants.md
+++ b/docs/prompt/order-constants.md
@@ -15,6 +15,8 @@
 * NCO: NSE Commodities (futures + options) — Zerodha only
 * NSE_INDEX: NSE Index (quote-only)
 * BSE_INDEX: BSE Index (quote-only)
+* MCX_INDEX: MCX commodity sectoral indices, e.g. MCXBULLDEX (quote-only)
+* CRYPTO: Crypto derivatives — Delta Exchange only
 * GLOBAL_INDEX: Global indices like US30, JAPAN225, HANGSENG, GIFTNIFTY (quote-only) — Zerodha only
 
 ### Product Type

--- a/frontend/src/components/flow/nodes/StrategyPnlNode.tsx
+++ b/frontend/src/components/flow/nodes/StrategyPnlNode.tsx
@@ -1,0 +1,51 @@
+/**
+ * Strategy P&L Node
+ * Realized / unrealized / total P&L for one strategy, so a workflow can exit
+ * on its own performance rather than the whole account's
+ */
+
+import { Handle, Position } from '@xyflow/react'
+import { Wallet } from 'lucide-react'
+import { memo } from 'react'
+import { cn } from '@/lib/utils'
+import type { StrategyPnlNodeData } from '@/types/flow'
+
+interface StrategyPnlNodeProps {
+  data: StrategyPnlNodeData
+  selected?: boolean
+}
+
+export const StrategyPnlNode = memo(({ data, selected }: StrategyPnlNodeProps) => {
+  return (
+    <div className={cn('workflow-node min-w-[130px] border-l-primary', selected && 'selected')}>
+      <Handle type="target" position={Position.Top} className="!top-0 !-translate-y-1/2" />
+      <div className="p-2">
+        <div className="mb-1.5 flex items-center gap-1.5">
+          <div className="flex h-5 w-5 items-center justify-center rounded bg-primary/20 text-primary">
+            <Wallet className="h-3 w-3" />
+          </div>
+          <div>
+            <div className="text-xs font-medium leading-tight">Strategy P&amp;L</div>
+            <div className="text-[9px] text-muted-foreground">realized + unrealized</div>
+          </div>
+        </div>
+        <div className="rounded bg-muted/50 px-1.5 py-1">
+          <div className="flex items-center justify-between">
+            <span className="text-[10px] text-muted-foreground">Strategy</span>
+            <span className="mono-data truncate text-[10px] font-medium" style={{ maxWidth: 76 }}>
+              {data.strategy || 'this workflow'}
+            </span>
+          </div>
+        </div>
+        {data.outputVariable && (
+          <div className="mt-1 text-center text-[9px] text-muted-foreground">
+            {data.outputVariable}
+          </div>
+        )}
+      </div>
+      <Handle type="source" position={Position.Bottom} className="!bottom-0 !translate-y-1/2" />
+    </div>
+  )
+})
+
+StrategyPnlNode.displayName = 'StrategyPnlNode'

--- a/frontend/src/components/flow/nodes/index.ts
+++ b/frontend/src/components/flow/nodes/index.ts
@@ -67,6 +67,7 @@ import { WebhookTriggerNode } from './WebhookTriggerNode'
 import { IndicatorNode } from './IndicatorNode'
 import { VarConditionNode } from './VarConditionNode'
 import { PriorPeriodOhlcNode } from './PriorPeriodOhlcNode'
+import { StrategyPnlNode } from './StrategyPnlNode'
 import { BarOffsetNode } from './BarOffsetNode'
 import { OrderUpdateTriggerNode } from './OrderUpdateTriggerNode'
 import { WhatsappAlertNode } from './WhatsappAlertNode'
@@ -111,6 +112,7 @@ export {
   HistoryNode,
   IndicatorNode,
   PriorPeriodOhlcNode,
+  StrategyPnlNode,
   BarOffsetNode,
   OpenPositionNode,
   ExpiryNode,
@@ -189,6 +191,7 @@ export const nodeTypes = {
   history: HistoryNode,
   indicator: IndicatorNode,
   priorPeriodOhlc: PriorPeriodOhlcNode,
+  strategyPnl: StrategyPnlNode,
   barOffset: BarOffsetNode,
   openPosition: OpenPositionNode,
   expiry: ExpiryNode,

--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -126,6 +126,7 @@ const NODE_TITLES: Record<string, string> = {
   history: 'History Data',
   indicator: 'Indicator',
   priorPeriodOhlc: 'Prior Period OHLC',
+  strategyPnl: 'Strategy P&L',
   barOffset: 'Bar Offset',
   expiry: 'Get Expiry',
   multiQuotes: 'Multi Quotes',
@@ -2093,6 +2094,38 @@ export function ConfigPanel() {
                     Access with {'{{name.latest.value}}'}, {'{{name.previous.value}}'}, or{' '}
                     {'{{name.series[N]}}'}. Multi-output indicators (MACD, BBands, ADX, ...)
                     expose out0, out1, ...
+                  </p>
+                </div>
+              </>
+            )}
+
+            {nodeType === 'strategyPnl' && (
+              <>
+                <div className="space-y-2">
+                  <Label className="text-xs">Strategy</Label>
+                  <Input
+                    className="h-8"
+                    placeholder="blank = this workflow's name"
+                    value={(nodeData.strategy as string) || ''}
+                    onChange={(e) => handleDataChange('strategy', e.target.value)}
+                  />
+                  <p className="text-[10px] text-muted-foreground">
+                    Order nodes tag their orders with the workflow name, so leaving this
+                    blank reports this workflow's own P&amp;L.
+                  </p>
+                </div>
+                <div className="space-y-2">
+                  <Label className="text-xs">Output Variable</Label>
+                  <Input
+                    className="h-8"
+                    placeholder="spnl"
+                    value={(nodeData.outputVariable as string) || ''}
+                    onChange={(e) => handleDataChange('outputVariable', e.target.value)}
+                  />
+                  <p className="text-[10px] text-muted-foreground">
+                    Exposes {'{{spnl.realized}}'}, {'{{spnl.unrealized}}'},{' '}
+                    {'{{spnl.total}}'}, {'{{spnl.today_realized}}'},{' '}
+                    {'{{spnl.open_quantity}}'}.
                   </p>
                 </div>
               </>

--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -1309,6 +1309,38 @@ export function ConfigPanel() {
                     </SelectContent>
                   </Select>
                 </div>
+                <div className="space-y-2">
+                  <Label className="text-xs">Price Type</Label>
+                  <Select
+                    value={(nodeData.priceType as string) || 'MARKET'}
+                    onValueChange={(v) => handleDataChange('priceType', v)}
+                  >
+                    <SelectTrigger className="h-8">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="MARKET">MARKET</SelectItem>
+                      <SelectItem value="LIMIT">LIMIT</SelectItem>
+                    </SelectContent>
+                  </Select>
+                </div>
+                {(nodeData.priceType as string) === 'LIMIT' && (
+                  <div className="space-y-2">
+                    <Label className="text-xs">Limit Price</Label>
+                    <Input
+                      type="number"
+                      min={0}
+                      step="0.05"
+                      className="h-8"
+                      value={(nodeData.price as number) ?? 0}
+                      onChange={(e) => handleDataChange('price', parseFloat(e.target.value) || 0)}
+                    />
+                    <p className="text-[10px] text-muted-foreground">
+                      Applied to every generated leg. A LIMIT order without a positive price is
+                      rejected rather than sent at market.
+                    </p>
+                  </div>
+                )}
                 {/* Strategy Legs Preview */}
                 <div className="rounded-lg border bg-muted/30 p-2">
                   <p className="text-[10px] font-medium mb-1.5">Strategy Legs:</p>

--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -129,6 +129,7 @@ const NODE_TITLES: Record<string, string> = {
   strategyPnl: 'Strategy P&L',
   barOffset: 'Bar Offset',
   expiry: 'Get Expiry',
+  intervals: 'Intervals',
   multiQuotes: 'Multi Quotes',
   symbol: 'Symbol Info',
   optionSymbol: 'Option Symbol',
@@ -664,9 +665,9 @@ export function ConfigPanel() {
                     onChange={(e) => handleDataChange('orderId', e.target.value)}
                   />
                   <p className="text-[10px] text-muted-foreground">
-                    A literal broker order id. {'{{variable}}'} references are not supported
-                    here - a trigger has no upstream node to resolve them from. To react to
-                    an order this workflow placed, filter by Symbol instead.
+                    A literal broker order id. {'{{variable}}'} references are not supported here -
+                    a trigger has no upstream node to resolve them from. To react to an order this
+                    workflow placed, filter by Symbol instead.
                   </p>
                 </div>
                 <div className="space-y-2">
@@ -679,8 +680,8 @@ export function ConfigPanel() {
                   />
                 </div>
                 <p className="text-[10px] text-muted-foreground">
-                  Set at least one of Order ID / Symbol - an unfiltered watch would fire on
-                  every order in the account.
+                  Set at least one of Order ID / Symbol - an unfiltered watch would fire on every
+                  order in the account.
                 </p>
                 <div className="space-y-2">
                   <Label className="text-xs">Exchange (optional)</Label>
@@ -1001,10 +1002,12 @@ export function ConfigPanel() {
                       if (s) {
                         handleDataChange('exchange', s.exchange)
                       }
-                      const lotSize = getLotSizeFromDb(v)
-                      if (lotSize) {
-                        handleDataChange('quantity', lotSize)
-                      }
+                      // Deliberately does NOT write the lot size into quantity.
+                      // This field is a lot COUNT and the executor multiplies it
+                      // by the lot size, so storing the lot size here squared it
+                      // (NIFTY: 65 lots x 65 = 4,225 units instead of 65).
+                      // The lot count is the user's; only the resolved preview
+                      // below reflects the instrument's lot size.
                     }}
                   >
                     <SelectTrigger className="h-8">
@@ -1110,6 +1113,17 @@ export function ConfigPanel() {
                       handleDataChange('quantity', parseInt(e.target.value, 10) || 1)
                     }
                   />
+                  {(() => {
+                    const lotSize = getLotSizeFromDb((nodeData.underlying as string) || 'NIFTY')
+                    const lots = (nodeData.quantity as number) || 1
+                    if (!lotSize) return null
+                    return (
+                      <p className="text-[10px] text-muted-foreground">
+                        {lots} lot{lots === 1 ? '' : 's'} x {lotSize} ={' '}
+                        <span className="font-medium text-foreground">{lots * lotSize} units</span>
+                      </p>
+                    )
+                  })()}
                 </div>
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
@@ -1944,11 +1958,10 @@ export function ConfigPanel() {
                     onChange={(e) => handleDataChange('sourceSeries', e.target.value)}
                   />
                   <p className="text-[10px] text-muted-foreground">
-                    Set to compute this indicator over another Indicator node's output
-                    (e.g. SMA of RSI) instead of fetching fresh history. Accepts a raw
-                    History array too - {'{{h.data}}'} uses each row's close. Only
-                    single-series indicators (SMA, EMA, RSI, WMA, stdev, highest/lowest,
-                    ...) can be nested.
+                    Set to compute this indicator over another Indicator node's output (e.g. SMA of
+                    RSI) instead of fetching fresh history. Accepts a raw History array too -{' '}
+                    {'{{h.data}}'} uses each row's close. Only single-series indicators (SMA, EMA,
+                    RSI, WMA, stdev, highest/lowest, ...) can be nested.
                   </p>
                 </div>
                 {nodeData.sourceSeries ? (
@@ -2003,8 +2016,8 @@ export function ConfigPanel() {
                         onChange={(e) => handleDataChange('interval', e.target.value)}
                       />
                       <p className="text-[10px] text-muted-foreground">
-                        Any interval your connected broker supports (check the Intervals
-                        node) - not a fixed list.
+                        Any interval your connected broker supports (check the Intervals node) - not
+                        a fixed list.
                       </p>
                     </div>
                     <div className="space-y-2">
@@ -2061,8 +2074,8 @@ export function ConfigPanel() {
                   />
                   <p className="text-[10px] text-muted-foreground">
                     0 = latest closed bar. Read it via {'{{name.at_offset.value}}'} (or{' '}
-                    {'{{name.at_offset.out0}}'} for multi-output indicators). Prefer this
-                    over indexing {'{{name.series[N]}}'}, whose offsets shift with Tail Bars.
+                    {'{{name.at_offset.out0}}'} for multi-output indicators). Prefer this over
+                    indexing {'{{name.series[N]}}'}, whose offsets shift with Tail Bars.
                   </p>
                 </div>
                 <div className="space-y-2">
@@ -2092,8 +2105,8 @@ export function ConfigPanel() {
                   />
                   <p className="text-[10px] text-muted-foreground">
                     Access with {'{{name.latest.value}}'}, {'{{name.previous.value}}'}, or{' '}
-                    {'{{name.series[N]}}'}. Multi-output indicators (MACD, BBands, ADX, ...)
-                    expose out0, out1, ...
+                    {'{{name.series[N]}}'}. Multi-output indicators (MACD, BBands, ADX, ...) expose
+                    out0, out1, ...
                   </p>
                 </div>
               </>
@@ -2110,8 +2123,8 @@ export function ConfigPanel() {
                     onChange={(e) => handleDataChange('strategy', e.target.value)}
                   />
                   <p className="text-[10px] text-muted-foreground">
-                    Order nodes tag their orders with the workflow name, so leaving this
-                    blank reports this workflow's own P&amp;L.
+                    Order nodes tag their orders with the workflow name, so leaving this blank
+                    reports this workflow's own P&amp;L.
                   </p>
                 </div>
                 <div className="space-y-2">
@@ -2123,9 +2136,8 @@ export function ConfigPanel() {
                     onChange={(e) => handleDataChange('outputVariable', e.target.value)}
                   />
                   <p className="text-[10px] text-muted-foreground">
-                    Exposes {'{{spnl.realized}}'}, {'{{spnl.unrealized}}'},{' '}
-                    {'{{spnl.total}}'}, {'{{spnl.today_realized}}'},{' '}
-                    {'{{spnl.open_quantity}}'}.
+                    Exposes {'{{spnl.realized}}'}, {'{{spnl.unrealized}}'}, {'{{spnl.total}}'},{' '}
+                    {'{{spnl.today_realized}}'}, {'{{spnl.open_quantity}}'}.
                   </p>
                 </div>
               </>
@@ -2524,6 +2536,20 @@ export function ConfigPanel() {
               </>
             )}
 
+            {nodeType === 'intervals' && (
+              <div className="space-y-2">
+                <Label className="text-xs">Output Variable</Label>
+                <Input
+                  className="h-8"
+                  placeholder="intervals"
+                  value={(nodeData.outputVariable as string) || 'intervals'}
+                  onChange={(e) => handleDataChange('outputVariable', e.target.value)}
+                />
+                <p className="text-[10px] text-muted-foreground">
+                  Timeframes this broker supports. Use {`{{intervals.data.minutes}}`}
+                </p>
+              </div>
+            )}
             {nodeType === 'orderBook' && (
               <div className="space-y-2">
                 <Label className="text-xs">Output Variable</Label>
@@ -2957,32 +2983,32 @@ export function ConfigPanel() {
             {/* ===== UTILITY NODES ===== */}
             {nodeType === 'delay' && (
               <div className="space-y-2">
-                  <Label className="text-xs">Wait Duration</Label>
-                  <div className="flex gap-2">
-                    <Input
-                      type="number"
-                      min={1}
-                      className="h-8 flex-1"
-                      value={(nodeData.delayValue as number) || 1}
-                      onChange={(e) =>
-                        handleDataChange('delayValue', parseInt(e.target.value, 10) || 1)
-                      }
-                    />
-                    <Select
-                      value={(nodeData.delayUnit as string) || 'seconds'}
-                      onValueChange={(v) => handleDataChange('delayUnit', v)}
-                    >
-                      <SelectTrigger className="h-8 w-28">
-                        <SelectValue />
-                      </SelectTrigger>
-                      <SelectContent>
-                        <SelectItem value="seconds">Seconds</SelectItem>
-                        <SelectItem value="minutes">Minutes</SelectItem>
-                        <SelectItem value="hours">Hours</SelectItem>
-                      </SelectContent>
-                    </Select>
-                  </div>
+                <Label className="text-xs">Wait Duration</Label>
+                <div className="flex gap-2">
+                  <Input
+                    type="number"
+                    min={1}
+                    className="h-8 flex-1"
+                    value={(nodeData.delayValue as number) || 1}
+                    onChange={(e) =>
+                      handleDataChange('delayValue', parseInt(e.target.value, 10) || 1)
+                    }
+                  />
+                  <Select
+                    value={(nodeData.delayUnit as string) || 'seconds'}
+                    onValueChange={(v) => handleDataChange('delayUnit', v)}
+                  >
+                    <SelectTrigger className="h-8 w-28">
+                      <SelectValue />
+                    </SelectTrigger>
+                    <SelectContent>
+                      <SelectItem value="seconds">Seconds</SelectItem>
+                      <SelectItem value="minutes">Minutes</SelectItem>
+                      <SelectItem value="hours">Hours</SelectItem>
+                    </SelectContent>
+                  </Select>
                 </div>
+              </div>
             )}
 
             {nodeType === 'waitUntil' && (
@@ -3507,8 +3533,8 @@ export function ConfigPanel() {
                   />
                 </div>
                 <p className="text-[10px] text-muted-foreground">
-                  Compares any two values after {'{{...}}'} interpolation - an indicator
-                  output, a prior-period level, a workflow variable, or a literal number.
+                  Compares any two values after {'{{...}}'} interpolation - an indicator output, a
+                  prior-period level, a workflow variable, or a literal number.
                 </p>
               </>
             )}

--- a/frontend/src/components/flow/panels/NodePalette.tsx
+++ b/frontend/src/components/flow/panels/NodePalette.tsx
@@ -294,6 +294,13 @@ export function NodePalette({ onDragStart }: NodePaletteProps) {
       color: 'bg-cyan-500/10',
     },
     {
+      type: 'strategyPnl',
+      label: 'Strategy P&L',
+      description: 'Per-strategy realized/unrealized',
+      icon: <Wallet className="h-3.5 w-3.5 text-cyan-500" />,
+      color: 'bg-cyan-500/10',
+    },
+    {
       type: 'priorPeriodOhlc',
       label: 'Prior Period OHLC',
       description: 'Prev hour/day/week/month',

--- a/frontend/src/components/flow/panels/NodePalette.tsx
+++ b/frontend/src/components/flow/panels/NodePalette.tsx
@@ -329,6 +329,13 @@ export function NodePalette({ onDragStart }: NodePaletteProps) {
       color: 'bg-pink-500/10',
     },
     {
+      type: 'intervals',
+      label: 'Intervals',
+      description: 'Broker timeframes',
+      icon: <Clock className="h-3.5 w-3.5 text-pink-500" />,
+      color: 'bg-pink-500/10',
+    },
+    {
       type: 'multiQuotes',
       label: 'Multi Quotes',
       description: 'Multiple symbols',

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -832,9 +832,14 @@ export const DEFAULT_NODE_DATA = {
     strategy: 'straddle' as const,
     underlying: 'NIFTY',
     exchange: 'NSE_INDEX' as const,
-    expiryDate: '',
+    // The executor resolves an expiry *type*; expiryDate was never read here.
+    expiryType: 'current_week' as const,
     legs: [],
+    action: 'SELL' as const,
+    quantity: 1,
+    strangleWidth: 'OTM2' as const,
     priceType: 'MARKET' as const,
+    price: 0,
     product: 'MIS' as const,
   },
   cancelOrder: {
@@ -1027,7 +1032,9 @@ export const DEFAULT_NODE_DATA = {
     outputVariable: '',
   },
   intervals: {
-    outputVariable: '',
+    // Persisted, not just shown: an empty default meant the panel displayed
+    // "intervals" while the node stored its result nowhere.
+    outputVariable: 'intervals',
   },
   multiQuotes: {
     symbols: '',

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -755,6 +755,9 @@ export const DEFAULT_NODE_DATA = {
     exchange: 'NSE',
     condition: 'above' as const,
     price: 0,
+    // Both are honored at activation; defaults match the panel's own.
+    trigger: 'once' as const,
+    expiration: 'none' as const,
   },
   orderUpdateTrigger: {
     orderId: '',

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -529,6 +529,12 @@ export const NODE_DEFINITIONS = {
       category: 'data' as const,
     },
     {
+      type: 'strategyPnl',
+      label: 'Strategy P&L',
+      description: 'Realized/unrealized P&L for a strategy',
+      category: 'data' as const,
+    },
+    {
       type: 'priorPeriodOhlc',
       label: 'Prior Period OHLC',
       description: 'Previous hour/day/week/month candle',
@@ -785,6 +791,10 @@ export const DEFAULT_NODE_DATA = {
     offsetBars: 0,
     sourceSeries: '',
     sourceField: '',
+    outputVariable: '',
+  },
+  strategyPnl: {
+    strategy: '',
     outputVariable: '',
   },
   priorPeriodOhlc: {

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -13,11 +13,13 @@ export const EXCHANGES = [
   { value: 'CDS', label: 'CDS' },
   { value: 'BCD', label: 'BCD' },
   { value: 'MCX', label: 'MCX' },
+  { value: 'NCDEX', label: 'NCDEX' },
   { value: 'NCO', label: 'NCO' },
   { value: 'NSE_INDEX', label: 'NSE_INDEX' },
   { value: 'BSE_INDEX', label: 'BSE_INDEX' },
   { value: 'MCX_INDEX', label: 'MCX_INDEX' },
   { value: 'GLOBAL_INDEX', label: 'GLOBAL_INDEX' },
+  { value: 'CRYPTO', label: 'CRYPTO' },
 ] as const
 
 export const INDEX_EXCHANGES = [
@@ -214,8 +216,15 @@ export const GREEKS = [
 // real `ta` module signatures, not hand-maintained, so re-derive it the
 // same way if the pinned `openalgo` SDK version changes.
 export const INDICATOR_CATEGORIES = [
-  'Trend', 'Momentum', 'Volatility', 'Volume', 'Oscillators',
-  'Statistical', 'Hybrid', 'Price Transform', 'Utility',
+  'Trend',
+  'Momentum',
+  'Volatility',
+  'Volume',
+  'Oscillators',
+  'Statistical',
+  'Hybrid',
+  'Price Transform',
+  'Utility',
 ] as const
 
 export const INDICATOR_CATALOG = [
@@ -271,7 +280,6 @@ export const INDICATOR_CATALOG = [
   { value: 'rvi', label: 'RVI', category: 'Volatility' },
   { value: 'starc', label: 'STARC', category: 'Volatility' },
   { value: 'true_range', label: 'True Range', category: 'Volatility' },
-  { value: 'ulcerindex', label: 'Ulcerindex', category: 'Volatility' },
   { value: 'ultimate_oscillator', label: 'Ultimate Oscillator', category: 'Volatility' },
   { value: 'uo_oscillator', label: 'Uo Oscillator', category: 'Volatility' },
   { value: 'adl', label: 'ADL', category: 'Volume' },
@@ -305,7 +313,6 @@ export const INDICATOR_CATALOG = [
   { value: 'rocr100', label: 'Rocr100', category: 'Oscillators' },
   { value: 'stc', label: 'STC', category: 'Oscillators' },
   { value: 'tsi', label: 'TSI', category: 'Oscillators' },
-  { value: 'vi', label: 'VI', category: 'Oscillators' },
   { value: 'linreg', label: 'Linreg', category: 'Statistical' },
   { value: 'linregangle', label: 'Linregangle', category: 'Statistical' },
   { value: 'linregintercept', label: 'Linregintercept', category: 'Statistical' },
@@ -553,6 +560,108 @@ export const NODE_DEFINITIONS = {
       category: 'data' as const,
     },
     {
+      type: 'getOrderStatus',
+      label: 'Order Status',
+      description: 'Check order status',
+      category: 'data' as const,
+    },
+    {
+      type: 'expiry',
+      label: 'Expiry Dates',
+      description: 'F&O expiry dates',
+      category: 'data' as const,
+    },
+    {
+      type: 'intervals',
+      label: 'Intervals',
+      description: 'Broker-supported timeframes',
+      category: 'data' as const,
+    },
+    {
+      type: 'multiQuotes',
+      label: 'Multi Quotes',
+      description: 'Quotes for several symbols',
+      category: 'data' as const,
+    },
+    {
+      type: 'symbol',
+      label: 'Symbol Info',
+      description: 'Lot size, tick size, token',
+      category: 'data' as const,
+    },
+    {
+      type: 'optionSymbol',
+      label: 'Option Symbol',
+      description: 'Resolve an ATM-relative strike',
+      category: 'data' as const,
+    },
+    {
+      type: 'syntheticFuture',
+      label: 'Synthetic Future',
+      description: 'Synthetic future price',
+      category: 'data' as const,
+    },
+    {
+      type: 'optionChain',
+      label: 'Option Chain',
+      description: 'Strikes with CE and PE',
+      category: 'data' as const,
+    },
+    {
+      type: 'margin',
+      label: 'Margin',
+      description: 'Margin required for a position or basket',
+      category: 'data' as const,
+    },
+    {
+      type: 'holidays',
+      label: 'Holidays',
+      description: 'Exchange holiday list for a year',
+      category: 'data' as const,
+    },
+    {
+      type: 'timings',
+      label: 'Market Timings',
+      description: 'Market open and close for a date',
+      category: 'data' as const,
+    },
+    {
+      type: 'subscribeLtp',
+      label: 'Subscribe LTP',
+      description: 'Stream last traded price',
+      category: 'streaming' as const,
+    },
+    {
+      type: 'subscribeQuote',
+      label: 'Subscribe Quote',
+      description: 'Stream full quote',
+      category: 'streaming' as const,
+    },
+    {
+      type: 'subscribeDepth',
+      label: 'Subscribe Depth',
+      description: 'Stream market depth',
+      category: 'streaming' as const,
+    },
+    {
+      type: 'unsubscribe',
+      label: 'Unsubscribe',
+      description: 'Stop a stream',
+      category: 'streaming' as const,
+    },
+    {
+      type: 'mathExpression',
+      label: 'Math Expression',
+      description: 'Arithmetic over variables',
+      category: 'utility' as const,
+    },
+    {
+      type: 'group',
+      label: 'Group',
+      description: 'Visual grouping only',
+      category: 'utility' as const,
+    },
+    {
       type: 'orderBook',
       label: 'Order Book',
       description: 'Get all orders',
@@ -669,6 +778,8 @@ export const DEFAULT_NODE_DATA = {
     quantity: 1,
     priceType: 'MARKET' as const,
     product: 'MIS' as const,
+    price: 0,
+    triggerPrice: 0,
   },
   smartOrder: {
     symbol: '',
@@ -679,16 +790,43 @@ export const DEFAULT_NODE_DATA = {
     priceType: 'MARKET' as const,
     product: 'MIS' as const,
   },
+  getOrderStatus: {
+    orderId: '',
+    waitForCompletion: false,
+    outputVariable: 'orderStatus',
+  },
+  subscribeLtp: {
+    symbol: '',
+    exchange: 'NSE' as const,
+    outputVariable: 'ltp',
+  },
+  subscribeQuote: {
+    symbol: '',
+    exchange: 'NSE' as const,
+    outputVariable: 'quote',
+  },
+  subscribeDepth: {
+    symbol: '',
+    exchange: 'NSE' as const,
+    outputVariable: 'depth',
+  },
+  unsubscribe: {
+    symbol: '',
+    exchange: 'NSE' as const,
+    streamType: 'all' as const,
+  },
   optionsOrder: {
     underlying: 'NIFTY',
     exchange: 'NSE_INDEX' as const,
-    expiryDate: '',
+    expiryType: 'current_week' as const,
     offset: 'ATM',
     optionType: 'CE' as const,
     action: 'BUY' as const,
     quantity: 1,
     priceType: 'MARKET' as const,
     product: 'MIS' as const,
+    price: 0,
+    triggerPrice: 0,
   },
   optionsMultiOrder: {
     strategy: 'straddle' as const,
@@ -732,18 +870,21 @@ export const DEFAULT_NODE_DATA = {
     symbol: '',
     exchange: 'NSE',
     product: 'MIS' as const,
-    operator: 'gt' as const,
+    condition: 'exists' as const,
     threshold: 0,
   },
   fundCheck: {
-    operator: 'gt' as const,
-    threshold: 10000,
+    // The executor reads minAvailable. Shipping operator/threshold left a new
+    // node with no minAvailable at all, so the guard defaulted to 0 and passed
+    // on any balance - a fund check that never checked.
+    minAvailable: 10000,
   },
   priceCondition: {
     symbol: '',
     exchange: 'NSE',
-    operator: 'gt' as const,
-    threshold: 0,
+    field: 'ltp' as const,
+    operator: '>' as const,
+    value: 0,
   },
   varCondition: {
     leftValue: '',
@@ -775,6 +916,9 @@ export const DEFAULT_NODE_DATA = {
     symbol: '',
     exchange: 'NSE',
     interval: '5m' as const,
+    // The panel exposes Days; startDate/endDate stay available for an explicit
+    // range and take precedence when both are set.
+    days: 30,
     startDate: '',
     endDate: '',
     outputVariable: '',
@@ -904,11 +1048,13 @@ export const DEFAULT_NODE_DATA = {
     outputVariable: '',
   },
   holidays: {
-    exchange: 'NSE',
+    // The calendar service takes a year, not an exchange. Blank = current year.
+    year: undefined as number | undefined,
     outputVariable: '',
   },
   timings: {
-    exchange: 'NSE',
+    // The calendar service takes a date (YYYY-MM-DD). Blank = today.
+    date: '',
     outputVariable: '',
   },
   mathExpression: {

--- a/frontend/src/types/flow.ts
+++ b/frontend/src/types/flow.ts
@@ -395,6 +395,15 @@ export interface IndicatorNodeData {
   outputVariable?: string
 }
 
+/** Strategy P&L - realized / unrealized / total for one strategy, so a
+ * workflow can exit on its own performance instead of the whole account's. */
+export interface StrategyPnlNodeData {
+  label?: string
+  /** Blank = this workflow's own name, which is also the tag its order nodes apply. */
+  strategy?: string
+  outputVariable?: string
+}
+
 /** Prior Period OHLC - last fully-closed hour/day/week/month candle
  * (e.g. previous day's high/low for a PDH/PDL breakout strategy) without
  * the workflow author computing a relative date. */
@@ -706,6 +715,7 @@ export type DataNodeData =
   | HistoryNodeData
   | IndicatorNodeData
   | PriorPeriodOhlcNodeData
+  | StrategyPnlNodeData
   | BarOffsetNodeData
   | OpenPositionNodeData
   | ExpiryNodeData

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -198,6 +198,9 @@ packages = []
 
 # Pytest configuration
 [tool.pytest.ini_options]
+# The repo root must be importable: tests import `services`, `database`, and
+# `utils` directly, which otherwise only works if PYTHONPATH is set by hand.
+pythonpath = ["."]
 testpaths = ["test"]
 python_files = ["test_*.py"]
 python_functions = ["test_*"]

--- a/scripts/generate_indicator_reference.py
+++ b/scripts/generate_indicator_reference.py
@@ -11,6 +11,7 @@ Run: uv run python scripts/generate_indicator_reference.py
 """
 
 import inspect
+import json
 import pathlib
 import sys
 
@@ -22,6 +23,7 @@ sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
 from openalgo import ta  # noqa: E402
 
 from services.indicator_service import (  # noqa: E402
+    _REQUIRED_PARAM_DEFAULTS,
     _SERIES_PARAM_TO_COLUMN,
     compute_indicator,
     list_supported_indicators,
@@ -62,8 +64,20 @@ def describe(name: str, records: list[dict]) -> dict | None:
             inputs.append(_SERIES_PARAM_TO_COLUMN[param.name])
         elif param.default is not inspect.Parameter.empty:
             params.append((param.name, param.default))
+        else:
+            # Required, no default. Omitting these produced call examples like
+            # `ta.sma(close)` that raise TypeError when run directly, and implied
+            # no configuration was needed. The service supplies a value from
+            # _REQUIRED_PARAM_DEFAULTS; show what it actually uses.
+            supplied = _REQUIRED_PARAM_DEFAULTS.get(name, {}).get(param.name)
+            params.append((param.name, supplied if supplied is not None else "required"))
 
-    result = compute_indicator(records, name, {})
+    try:
+        result = compute_indicator(records, name, {})
+    except Exception:
+        # One indicator with an unexpected required parameter must not take the
+        # whole reference down with it.
+        return None
     if result.get("status") != "success":
         return None
     return {

--- a/scripts/generate_indicator_reference.py
+++ b/scripts/generate_indicator_reference.py
@@ -1,0 +1,172 @@
+# scripts/generate_indicator_reference.py
+"""Generate the Flow indicator reference from the installed openalgo build.
+
+Hand-maintained indicator docs drift from the library: the QA audit found 43 of
+the catalog's indicators had no discoverable call example, leaving a user or a
+generating model to guess parameter names. This derives every entry by
+introspecting the callable and then executing it, so an indicator that cannot
+produce a value never reaches the reference.
+
+Run: uv run python scripts/generate_indicator_reference.py
+"""
+
+import inspect
+import pathlib
+import sys
+
+import numpy as np
+import pandas as pd
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from openalgo import ta  # noqa: E402
+
+from services.indicator_service import (  # noqa: E402
+    _SERIES_PARAM_TO_COLUMN,
+    compute_indicator,
+    list_supported_indicators,
+)
+
+OUTPUT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "docs/prompt/indicators/flow indicator reference.md"
+)
+BARS = 400
+
+
+def sample_records() -> list[dict]:
+    """Deterministic OHLCV long enough for any warm-up in the catalog."""
+    rng = np.random.default_rng(7)
+    close = 100 + np.cumsum(rng.normal(0, 1, BARS))
+    return [
+        {
+            "timestamp": 1_700_000_000 + i * 300,
+            "open": float(close[i] - 0.2),
+            "high": float(close[i] + 1),
+            "low": float(close[i] - 1),
+            "close": float(close[i]),
+            "volume": int(rng.integers(100, 1000)),
+        }
+        for i in range(BARS)
+    ]
+
+
+def describe(name: str, records: list[dict]) -> dict | None:
+    fn = getattr(ta, name, None)
+    if fn is None:
+        return None
+    sig = inspect.signature(fn)
+    inputs, params = [], []
+    for param in sig.parameters.values():
+        if param.name in _SERIES_PARAM_TO_COLUMN and not params:
+            inputs.append(_SERIES_PARAM_TO_COLUMN[param.name])
+        elif param.default is not inspect.Parameter.empty:
+            params.append((param.name, param.default))
+
+    result = compute_indicator(records, name, {})
+    if result.get("status") != "success":
+        return None
+    return {
+        "name": name,
+        "inputs": inputs,
+        "params": params,
+        "outputs": list((result.get("latest") or {}).keys()),
+    }
+
+
+def main() -> int:
+    records = sample_records()
+    entries, unusable = [], []
+    for name in sorted(list_supported_indicators()):
+        entry = describe(name, records)
+        (entries if entry else unusable).append(entry or name)
+
+    lines = [
+        "# Flow Indicator Reference",
+        "",
+        "Generated from the installed `openalgo` build: every entry was produced by",
+        f"introspecting the callable and then executing it over {BARS} deterministic",
+        "OHLCV bars. Each one returned a non-null value in that run, so each is",
+        "usable from the Flow `indicator` node.",
+        "",
+        "**Do not hand-edit.** Regenerate with:",
+        "",
+        "```bash",
+        "uv run python scripts/generate_indicator_reference.py",
+        "```",
+        "",
+        "- **Inputs** are the OHLCV columns the node feeds in for you.",
+        "- **Parameters** go in the node's `params` object.",
+        "- **Outputs** are the keys under `latest` / `previous` / `at_offset`. A single",
+        "  output is always `value`; multiple outputs are `out0`, `out1`, ...",
+        "",
+        "| Indicator | Python call | Inputs | Parameters | Outputs | `params` example |",
+        "|---|---|---|---|---|---|",
+    ]
+    for e in entries:
+        inputs = ", ".join(f"`{i}`" for i in e["inputs"]) or "-"
+        params = ", ".join(f"`{p}`={d!r}" for p, d in e["params"]) or "-"
+        outputs = ", ".join(f"`{o}`" for o in e["outputs"]) or "-"
+        if e["params"]:
+            pairs = ", ".join(f'"{p}": {d!r}' for p, d in e["params"][:2])
+            example = "{" + pairs + "}"
+        else:
+            example = "{}"
+        call_args = ", ".join(e["inputs"]) or "data"
+        if e["params"]:
+            call_args += ", " + ", ".join(f"{p}={d!r}" for p, d in e["params"][:2])
+        lines.append(
+            f"| `{e['name']}` | `ta.{e['name']}({call_args})` | {inputs} | {params} | "
+            f"{outputs} | `{example.replace(chr(39), chr(34))}` |"
+        )
+
+    lines += [
+        "",
+        f"**{len(entries)} indicators**, all verified to compute.",
+        "",
+        "## Not available from the `indicator` node",
+        "",
+        "| Function | Why |",
+        "|---|---|",
+        "| `crossover`, `crossunder`, `cross` | Need two independent series. Use two "
+        "`indicator` nodes plus an `andGate`. |",
+        "| `correlation`, `beta` | Compare two symbols. |",
+        "| `exrem`, `flip`, `valuewhen` | Need a second boolean series and carry state "
+        "across bars. |",
+        "| `median_bands`, `ulcerindex`, `vi` | The installed build returns no usable "
+        "value for these. |",
+        "",
+        "## Using an indicator in Flow",
+        "",
+        "```json",
+        "{",
+        '  "id": "node_2",',
+        '  "type": "indicator",',
+        '  "position": { "x": 100, "y": 100 },',
+        '  "data": {',
+        '    "symbol": "RELIANCE",',
+        '    "exchange": "NSE",',
+        '    "interval": "5m",',
+        '    "indicatorName": "rsi",',
+        '    "params": { "period": 14 },',
+        '    "outputVariable": "r"',
+        "  }",
+        "}",
+        "```",
+        "",
+        "Read the latest value as `{{r.latest.value}}`, the prior bar as",
+        "`{{r.previous.value}}`, and a specific bar back as `{{r.at_offset.value}}`",
+        "with `offsetBars` set. For a multi-output indicator use `{{r.latest.out0}}`,",
+        "`{{r.latest.out1}}`, and so on.",
+        "",
+    ]
+
+    OUTPUT.write_text("\n".join(lines))
+    print(f"Wrote {OUTPUT} with {len(entries)} indicators")
+    if unusable:
+        print(f"Skipped (no usable value): {unusable}")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_flow_workflow.py
+++ b/scripts/update_flow_workflow.py
@@ -1,0 +1,130 @@
+# scripts/update_flow_workflow.py
+"""Update an existing Flow workflow from a JSON file, in place.
+
+Importing a JSON always creates a *new* workflow, so iterating on a strategy
+leaves a trail of copies and, worse, a new webhook URL each time. This replaces
+the graph of a workflow you already have, keeping its id, webhook token and
+secret, API key, and active state.
+
+    # see what you have
+    uv run python scripts/update_flow_workflow.py --list
+
+    # replace workflow 3's graph with a new JSON
+    uv run python scripts/update_flow_workflow.py --id 3 --file strategy.json
+
+    # check what would change without writing
+    uv run python scripts/update_flow_workflow.py --id 3 --file strategy.json --dry-run
+
+The graph is re-read from the database on every run, so a workflow that is
+already active picks up the new nodes on its next tick. The one exception is
+the trigger itself: its schedule is registered at activation, so if you change
+the trigger type or its schedule, deactivate and reactivate the workflow.
+"""
+
+import argparse
+import json
+import pathlib
+import sys
+
+sys.path.insert(0, str(pathlib.Path(__file__).resolve().parents[1]))
+
+from dotenv import load_dotenv  # noqa: E402
+
+load_dotenv(pathlib.Path(__file__).resolve().parents[1] / ".env")
+
+from database.flow_db import get_all_workflows, get_workflow, update_workflow  # noqa: E402
+from services.flow_workflow_validator import validate_workflow  # noqa: E402
+
+
+def show_list() -> int:
+    workflows = get_all_workflows() or []
+    if not workflows:
+        print("No workflows found.")
+        return 0
+    print(f"{'ID':>4}  {'ACTIVE':7}  {'NODES':>5}  NAME")
+    for wf in workflows:
+        nodes = len(wf.nodes or [])
+        print(f"{wf.id:>4}  {'yes' if wf.is_active else 'no':7}  {nodes:>5}  {wf.name}")
+    return 0
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description=__doc__)
+    parser.add_argument("--list", action="store_true", help="list workflows and exit")
+    parser.add_argument("--id", type=int, help="workflow id to update")
+    parser.add_argument("--file", help="path to the updated workflow JSON")
+    parser.add_argument("--name", help="also rename the workflow")
+    parser.add_argument(
+        "--dry-run", action="store_true", help="validate and report, but do not write"
+    )
+    args = parser.parse_args()
+
+    if args.list:
+        return show_list()
+    if args.id is None or not args.file:
+        parser.error("--id and --file are required (or use --list)")
+
+    workflow = get_workflow(args.id)
+    if not workflow:
+        print(f"No workflow with id {args.id}. Use --list to see what exists.")
+        return 1
+
+    try:
+        payload = json.loads(pathlib.Path(args.file).read_text())
+    except (OSError, ValueError) as exc:
+        print(f"Could not read {args.file}: {exc}")
+        return 1
+
+    # Same rules the import endpoint applies, so a graph that would be rejected
+    # at import is not written here through the side door.
+    errors = validate_workflow(payload)
+    if errors:
+        print(f"{args.file} is not a valid workflow:\n")
+        for err in errors:
+            print(f"  {err['path']}: {err['message']}")
+        return 1
+
+    old_nodes = len(workflow.nodes or [])
+    old_edges = len(workflow.edges or [])
+    new_nodes = len(payload.get("nodes") or [])
+    new_edges = len(payload.get("edges") or [])
+
+    print(f"Workflow {workflow.id}: {workflow.name}")
+    print(f"  active      : {'yes' if workflow.is_active else 'no'}")
+    print(f"  nodes       : {old_nodes} -> {new_nodes}")
+    print(f"  edges       : {old_edges} -> {new_edges}")
+    if args.name:
+        print(f"  name        : {workflow.name} -> {args.name}")
+    print("  webhook url : unchanged")
+
+    if args.dry_run:
+        print("\nDry run: nothing written.")
+        return 0
+
+    fields = {"nodes": payload["nodes"], "edges": payload["edges"]}
+    if args.name:
+        fields["name"] = args.name
+
+    if not update_workflow(args.id, **fields):
+        print("\nUpdate failed.")
+        return 1
+
+    print("\nUpdated.")
+    if workflow.is_active:
+        old_triggers = {
+            n.get("type") for n in (workflow.nodes or []) if isinstance(n, dict)
+        }
+        new_triggers = {n.get("type") for n in payload["nodes"] if isinstance(n, dict)}
+        trigger_types = {"start", "webhookTrigger", "priceAlert", "orderUpdateTrigger"}
+        if (old_triggers & trigger_types) != (new_triggers & trigger_types):
+            print(
+                "The trigger changed and this workflow is active. Deactivate and "
+                "reactivate it so the scheduler picks up the new trigger."
+            )
+        else:
+            print("Active workflow: the new graph applies from the next run.")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/scripts/update_flow_workflow.py
+++ b/scripts/update_flow_workflow.py
@@ -17,8 +17,14 @@ secret, API key, and active state.
 
 The graph is re-read from the database on every run, so a workflow that is
 already active picks up the new nodes on its next tick. The one exception is
-the trigger itself: its schedule is registered at activation, so if you change
-the trigger type or its schedule, deactivate and reactivate the workflow.
+the trigger itself: its schedule and any price/order watch are registered at
+activation, so changing any part of the trigger's configuration needs a
+deactivate/reactivate cycle. This script reports when that applies.
+
+Output note: this is an operator-facing CLI, so results go to stdout via
+print() rather than the application logger - the output *is* the product here,
+and it must be readable when run outside the app. Application code continues to
+use utils.logging.get_logger.
 """
 
 import argparse
@@ -33,7 +39,33 @@ from dotenv import load_dotenv  # noqa: E402
 load_dotenv(pathlib.Path(__file__).resolve().parents[1] / ".env")
 
 from database.flow_db import get_all_workflows, get_workflow, update_workflow  # noqa: E402
-from services.flow_workflow_validator import validate_workflow  # noqa: E402
+from services.flow_workflow_validator import (  # noqa: E402
+    migrate_legacy_node_data,
+    validate_workflow,
+)
+
+# Fields registered at activation rather than read per run. A change to any of
+# them needs a deactivate/reactivate cycle, which comparing node *types* alone
+# would miss - editing an interval from 1m to 5m keeps the same trigger type.
+_TRIGGER_TYPES = ("start", "webhookTrigger", "priceAlert", "orderUpdateTrigger")
+_TRIGGER_CONFIG_FIELDS = (
+    "scheduleType", "time", "days", "executeAt", "intervalMinutes", "intervalValue",
+    "intervalUnit", "marketHoursOnly", "symbol", "exchange", "condition", "price",
+    "orderId", "status", "trigger",
+)
+
+
+def _trigger_config(nodes: list) -> dict:
+    """The activation-relevant configuration of a graph's trigger node(s)."""
+    config: dict = {}
+    for node in nodes:
+        if not isinstance(node, dict) or node.get("type") not in _TRIGGER_TYPES:
+            continue
+        data = node.get("data") or {}
+        config[str(node.get("type"))] = {
+            field: data.get(field) for field in _TRIGGER_CONFIG_FIELDS if field in data
+        }
+    return config
 
 
 def show_list() -> int:
@@ -75,6 +107,12 @@ def main() -> int:
         print(f"Could not read {args.file}: {exc}")
         return 1
 
+    # Same normalization the import endpoint applies, so a legacy export does
+    # not arrive here still carrying a field no reader honors.
+    migration_notes: list[str] = []
+    if isinstance(payload.get("nodes"), list):
+        payload["nodes"], migration_notes = migrate_legacy_node_data(payload["nodes"])
+
     # Same rules the import endpoint applies, so a graph that would be rejected
     # at import is not written here through the side door.
     errors = validate_workflow(payload)
@@ -83,6 +121,11 @@ def main() -> int:
         for err in errors:
             print(f"  {err['path']}: {err['message']}")
         return 1
+
+    # Captured before the write. Reading workflow.nodes afterwards can return
+    # the refreshed row, so the comparison would be against the new graph.
+    old_trigger = _trigger_config(workflow.nodes or [])
+    new_trigger = _trigger_config(payload["nodes"])
 
     old_nodes = len(workflow.nodes or [])
     old_edges = len(workflow.edges or [])
@@ -96,6 +139,10 @@ def main() -> int:
     if args.name:
         print(f"  name        : {workflow.name} -> {args.name}")
     print("  webhook url : unchanged")
+    if migration_notes:
+        print("  migrations  :")
+        for note in migration_notes:
+            print(f"    - {note}")
 
     if args.dry_run:
         print("\nDry run: nothing written.")
@@ -111,15 +158,13 @@ def main() -> int:
 
     print("\nUpdated.")
     if workflow.is_active:
-        old_triggers = {
-            n.get("type") for n in (workflow.nodes or []) if isinstance(n, dict)
-        }
-        new_triggers = {n.get("type") for n in payload["nodes"] if isinstance(n, dict)}
-        trigger_types = {"start", "webhookTrigger", "priceAlert", "orderUpdateTrigger"}
-        if (old_triggers & trigger_types) != (new_triggers & trigger_types):
+        if old_trigger != new_trigger:
             print(
-                "The trigger changed and this workflow is active. Deactivate and "
-                "reactivate it so the scheduler picks up the new trigger."
+                "The trigger configuration changed and this workflow is active.\n"
+                f"  was: {old_trigger}\n"
+                f"  now: {new_trigger}\n"
+                "Deactivate and reactivate it: the schedule and any price/order "
+                "watch are registered at activation, not read per run."
             )
         else:
             print("Active workflow: the new graph applies from the next run.")

--- a/services/basket_order_service.py
+++ b/services/basket_order_service.py
@@ -138,8 +138,16 @@ def place_single_order(
         res, response_data, order_id = broker_module.place_order_api(order_data, auth_token)
 
         if res.status == 200:
-            # No per-order event emission - a summary event is emitted at the end of all orders
-            return {"symbol": order_data["symbol"], "status": "success", "orderid": order_id}
+            # No per-order event emission - a summary event is emitted at the end of all orders.
+            # exchange/product identify the leg: a basket spans several contracts, so the
+            # summary event cannot supply them and subscribers have only this dict to key on.
+            return {
+                "symbol": order_data["symbol"],
+                "exchange": order_data.get("exchange", ""),
+                "product": order_data.get("product", ""),
+                "status": "success",
+                "orderid": order_id,
+            }
         else:
             message = (
                 response_data.get("message", "Failed to place order")
@@ -261,6 +269,8 @@ def process_basket_order_with_auth(
                 analyze_results.append(
                     {
                         "symbol": order.get("symbol", "Unknown"),
+                        "exchange": order.get("exchange", ""),
+                        "product": order.get("product", ""),
                         "status": "success",
                         "orderid": response.get("orderid"),
                         "batch_order": True,

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -325,11 +325,37 @@ class NodeExecutor:
         "SENSEX50": 25,
     }
 
-    def _resolve_lot_size(self, underlying: str, fo_exchange: str) -> int:
-        """Lot size for an underlying, preferring the master contract."""
-        try:
-            from database.symbol import SymToken, db_session
+    @staticmethod
+    def _invalid_price_reason(price_type: str, price: float, trigger_price: float) -> str | None:
+        """Why this price type cannot be sent, or None when it is usable.
 
+        A LIMIT or SL order whose price never reached the broker executes at an
+        unintended level, so it is refused rather than sent with a zero.
+        """
+        price_type = (price_type or "MARKET").upper()
+        if price_type in ("LIMIT", "SL") and price <= 0:
+            return f"{price_type} order needs a positive price, got {price}"
+        if price_type in ("SL", "SL-M") and trigger_price <= 0:
+            return f"{price_type} order needs a positive trigger price, got {trigger_price}"
+        return None
+
+    class LotSizeUnavailable(RuntimeError):
+        """The lot size could not be determined, so quantity cannot be computed."""
+
+    def _resolve_lot_size(self, underlying: str, fo_exchange: str) -> int:
+        """Lot size for an underlying, from the master contract.
+
+        Fails closed. A lookup error means the lot size is *unknown*, and
+        guessing it sizes a real order wrongly - the fallback table is used only
+        when the master contract is genuinely unseeded for this exchange, and
+        only for an underlying whose lot size we ship.
+
+        Raises:
+            LotSizeUnavailable: the lot size cannot be established.
+        """
+        from database.symbol import SymToken, db_session
+
+        try:
             row = (
                 db_session.query(SymToken.lotsize)
                 .filter(
@@ -342,15 +368,42 @@ class NodeExecutor:
             )
             if row and row[0]:
                 return int(row[0])
-            self.log(
-                f"No master-contract lot size for {underlying} on {fo_exchange}; "
-                "using the built-in fallback",
-                "warning",
+            # Distinguish "this exchange has no contracts loaded" from "this
+            # underlying is not one of them". Only the former is a fallback case.
+            exchange_seeded = (
+                db_session.query(SymToken.id).filter(SymToken.exchange == fo_exchange).first()
+                is not None
             )
-        except Exception:
-            logger.exception(f"Lot size lookup failed for {underlying}")
-            self.log(f"Lot size lookup failed for {underlying}; using fallback", "warning")
-        return self._FALLBACK_LOT_SIZES.get(underlying, 75)
+        except Exception as exc:
+            db_session.rollback()
+            logger.exception(f"Lot size lookup failed for {underlying} on {fo_exchange}")
+            raise self.LotSizeUnavailable(
+                f"Could not read the lot size for {underlying} on {fo_exchange}. "
+                "Refusing to size an order on a guess."
+            ) from exc
+        finally:
+            # Flow runs in background threads with no Flask app context, so the
+            # per-request teardown never fires and this session would stay bound
+            # to the thread holding its connection.
+            db_session.remove()
+
+        if exchange_seeded:
+            raise self.LotSizeUnavailable(
+                f"{underlying} has no contract on {fo_exchange} in the master contract. "
+                "Check the symbol, or re-download the master contract."
+            )
+        fallback = self._FALLBACK_LOT_SIZES.get(underlying)
+        if fallback is None:
+            raise self.LotSizeUnavailable(
+                f"The master contract has no {fo_exchange} contracts loaded and no "
+                f"built-in lot size for {underlying}. Download the master contract first."
+            )
+        self.log(
+            f"Master contract has no {fo_exchange} contracts loaded; using the built-in "
+            f"lot size {fallback} for {underlying}",
+            "warning",
+        )
+        return fallback
 
     def execute_options_order(self, node_data: dict) -> dict:
         """Execute Options Order node"""
@@ -366,24 +419,10 @@ class NodeExecutor:
         price = self.get_float(node_data, "price", 0.0)
         trigger_price = self.get_float(node_data, "triggerPrice", 0.0)
 
-        # A LIMIT/SL order whose price never reached the broker would silently
-        # execute at an unintended level, so refuse rather than send a zero.
-        if price_type in ("LIMIT", "SL") and price <= 0:
-            error_result = {
-                "status": "error",
-                "message": f"{price_type} options order needs a positive price, got {price}",
-            }
-            self.log(f"Options order failed: {error_result['message']}", "error")
-            return error_result
-        if price_type in ("SL", "SL-M") and trigger_price <= 0:
-            error_result = {
-                "status": "error",
-                "message": (
-                    f"{price_type} options order needs a positive trigger price, "
-                    f"got {trigger_price}"
-                ),
-            }
-            self.log(f"Options order failed: {error_result['message']}", "error")
+        invalid = self._invalid_price_reason(price_type, price, trigger_price)
+        if invalid:
+            error_result = {"status": "error", "message": invalid}
+            self.log(f"Options order failed: {invalid}", "error")
             return error_result
 
         self.log(f"Placing options order: {underlying} {option_type} {offset}")
@@ -396,7 +435,12 @@ class NodeExecutor:
             underlying_exchange = "NSE_INDEX"
             fo_exchange = "NFO"
 
-        lot_size = self._resolve_lot_size(underlying, fo_exchange)
+        try:
+            lot_size = self._resolve_lot_size(underlying, fo_exchange)
+        except self.LotSizeUnavailable as exc:
+            error_result = {"status": "error", "message": str(exc)}
+            self.log(f"Options order failed: {exc}", "error")
+            return error_result
         total_quantity = quantity * lot_size
         self.log(f"Lot size for {underlying}: {lot_size} -> {quantity} lot(s) = {total_quantity}")
 
@@ -469,19 +513,19 @@ class NodeExecutor:
             underlying_exchange = "NSE_INDEX"
             fo_exchange = "NFO"
 
-        # Get lot size for quantity calculation
-        lot_sizes = {
-            "NIFTY": 65,
-            "BANKNIFTY": 30,
-            "FINNIFTY": 65,
-            "MIDCPNIFTY": 120,
-            "NIFTYNXT50": 25,
-            "SENSEX": 20,
-            "BANKEX": 30,
-            "SENSEX50": 25,
-        }
-        lot_size = lot_sizes.get(underlying, 65)
+        # Same master-contract lookup the single-leg options node uses. A second
+        # hardcoded table here drifted the same way the first one had: it still
+        # claimed FINNIFTY was 65 where the contract says 60.
+        try:
+            lot_size = self._resolve_lot_size(underlying, fo_exchange)
+        except self.LotSizeUnavailable as exc:
+            error_result = {"status": "error", "message": str(exc)}
+            self.log(f"Options multi-order failed: {exc}", "error")
+            return error_result
         total_quantity = quantity_lots * lot_size
+        self.log(
+            f"Lot size for {underlying}: {lot_size} -> {quantity_lots} lot(s) = {total_quantity}"
+        )
 
         # Resolve expiry date
         expiry_date = self._resolve_expiry_date(underlying, fo_exchange, expiry_type)
@@ -501,19 +545,38 @@ class NodeExecutor:
             # Use custom legs from node data
             for leg in legs_data:
                 leg_qty = self.get_int(leg, "quantity", 1)
+                leg_price_type = self.get_str(leg, "priceType", multi_price_type).upper()
+                leg_price = self.get_float(leg, "price", multi_price)
+                leg_trigger = self.get_float(leg, "triggerPrice", 0.0)
                 leg_entry = {
                     "offset": self.get_str(leg, "offset", "ATM"),
                     "option_type": self.get_str(leg, "optionType", "CE"),
                     "action": self.get_str(leg, "action", "BUY"),
                     "quantity": leg_qty * lot_size,
-                    "pricetype": self.get_str(leg, "priceType", "MARKET"),
+                    "pricetype": leg_price_type,
                     "product": self.get_str(leg, "product", product),
-                    "price": self.get_float(leg, "price", 0),
+                    "price": leg_price,
+                    "trigger_price": leg_trigger,
                     "splitsize": self.get_int(leg, "splitSize", 0),
                 }
+                invalid = self._invalid_price_reason(leg_price_type, leg_price, leg_trigger)
+                if invalid:
+                    error_result = {
+                        "status": "error",
+                        "message": f"Leg {len(legs) + 1}: {invalid}",
+                    }
+                    self.log(f"Options multi-order failed: {error_result['message']}", "error")
+                    return error_result
                 legs.append(leg_entry)
         else:
             # Generate legs from predefined strategy type
+            # A generated strategy shares one price type across its legs, so
+            # validate it once before building them.
+            invalid = self._invalid_price_reason(multi_price_type, multi_price, 0.0)
+            if invalid:
+                error_result = {"status": "error", "message": invalid}
+                self.log(f"Options multi-order failed: {invalid}", "error")
+                return error_result
             legs = self._generate_strategy_legs(
                 strategy_type,
                 action,
@@ -1438,14 +1501,26 @@ class NodeExecutor:
             raw = [raw]
         if not isinstance(raw, list) or not raw:
             return None
-        return [p for p in raw if isinstance(p, dict)] or None
+        if any(not isinstance(entry, dict) for entry in raw):
+            # Dropping the bad entries would quietly price part of the basket
+            # and report it as the whole estimate.
+            raise ValueError(
+                "Margin positions must all be objects; the basket contains a "
+                "non-object entry."
+            )
+        return raw or None
 
     def execute_margin(self, node_data: dict) -> dict:
         """Execute Margin node - calculate margin requirements"""
         # The panel can supply a whole basket as positionsJson; a single
         # position is the fallback. Ignoring positionsJson silently priced only
         # the first leg of a multi-leg estimate.
-        positions = self._parse_margin_positions(node_data)
+        try:
+            positions = self._parse_margin_positions(node_data)
+        except ValueError as exc:
+            error_result = {"status": "error", "message": str(exc)}
+            self.log(f"Margin failed: {exc}", "error")
+            return error_result
         symbol = self.get_str(node_data, "symbol", "")
         exchange = self.get_str(node_data, "exchange", "NSE")
         quantity = self.get_int(node_data, "quantity", 1)
@@ -1815,7 +1890,21 @@ class NodeExecutor:
         `operator`/`threshold` (never written by the UI), so it always
         defaulted to `available > 0` and ignored `minAvailable`.
         """
-        min_available = self.get_float(node_data, "minAvailable", 0.0)
+        # A node saved before minAvailable existed carries the old
+        # operator/threshold pair. Reading only minAvailable would silently
+        # treat those as a minimum of zero, so the guard would pass on any
+        # balance - the exact bypass this field was added to prevent.
+        if "minAvailable" in node_data:
+            min_available = self.get_float(node_data, "minAvailable", 0.0)
+        elif "threshold" in node_data:
+            min_available = self.get_float(node_data, "threshold", 0.0)
+            self.log(
+                f"Fund Check is using its legacy threshold of {min_available}. "
+                "Re-save the node to store it as Minimum Available.",
+                "warning",
+            )
+        else:
+            min_available = 0.0
 
         self.log("Checking funds")
         result = self.client.funds()

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -9,7 +9,7 @@ import logging
 import re
 import threading
 import time as time_module
-from datetime import datetime, time
+from datetime import datetime, time, timedelta
 from typing import Any, Dict, List, Optional, Tuple
 
 from database.flow_db import (
@@ -310,6 +310,48 @@ class NodeExecutor:
         self.store_output(node_data, result)
         return result
 
+    # Exchange lot sizes are revised by the exchanges periodically, so a
+    # hardcoded table goes stale silently and mis-sizes every order placed
+    # against it. The master contract is refreshed daily and is authoritative;
+    # the table below is only a last resort for an unseeded database.
+    _FALLBACK_LOT_SIZES = {
+        "NIFTY": 65,
+        "BANKNIFTY": 30,
+        "FINNIFTY": 60,
+        "MIDCPNIFTY": 120,
+        "NIFTYNXT50": 25,
+        "SENSEX": 20,
+        "BANKEX": 30,
+        "SENSEX50": 25,
+    }
+
+    def _resolve_lot_size(self, underlying: str, fo_exchange: str) -> int:
+        """Lot size for an underlying, preferring the master contract."""
+        try:
+            from database.symbol import SymToken, db_session
+
+            row = (
+                db_session.query(SymToken.lotsize)
+                .filter(
+                    SymToken.name == underlying,
+                    SymToken.exchange == fo_exchange,
+                    SymToken.lotsize.isnot(None),
+                    SymToken.lotsize > 0,
+                )
+                .first()
+            )
+            if row and row[0]:
+                return int(row[0])
+            self.log(
+                f"No master-contract lot size for {underlying} on {fo_exchange}; "
+                "using the built-in fallback",
+                "warning",
+            )
+        except Exception:
+            logger.exception(f"Lot size lookup failed for {underlying}")
+            self.log(f"Lot size lookup failed for {underlying}; using fallback", "warning")
+        return self._FALLBACK_LOT_SIZES.get(underlying, 75)
+
     def execute_options_order(self, node_data: dict) -> dict:
         """Execute Options Order node"""
         underlying = self.get_str(node_data, "underlying", "NIFTY")
@@ -318,9 +360,31 @@ class NodeExecutor:
         offset = self.get_str(node_data, "offset", "ATM")
         option_type = self.get_str(node_data, "optionType", "CE")
         action = self.get_str(node_data, "action", "BUY")
-        price_type = self.get_str(node_data, "priceType", "MARKET")
+        price_type = self.get_str(node_data, "priceType", "MARKET").upper()
         product = self.get_str(node_data, "product", "NRML")
         split_size = self.get_int(node_data, "splitSize", 0)
+        price = self.get_float(node_data, "price", 0.0)
+        trigger_price = self.get_float(node_data, "triggerPrice", 0.0)
+
+        # A LIMIT/SL order whose price never reached the broker would silently
+        # execute at an unintended level, so refuse rather than send a zero.
+        if price_type in ("LIMIT", "SL") and price <= 0:
+            error_result = {
+                "status": "error",
+                "message": f"{price_type} options order needs a positive price, got {price}",
+            }
+            self.log(f"Options order failed: {error_result['message']}", "error")
+            return error_result
+        if price_type in ("SL", "SL-M") and trigger_price <= 0:
+            error_result = {
+                "status": "error",
+                "message": (
+                    f"{price_type} options order needs a positive trigger price, "
+                    f"got {trigger_price}"
+                ),
+            }
+            self.log(f"Options order failed: {error_result['message']}", "error")
+            return error_result
 
         self.log(f"Placing options order: {underlying} {option_type} {offset}")
 
@@ -332,19 +396,9 @@ class NodeExecutor:
             underlying_exchange = "NSE_INDEX"
             fo_exchange = "NFO"
 
-        # Get lot size (updated Jan 2026)
-        lot_sizes = {
-            "NIFTY": 65,
-            "BANKNIFTY": 30,
-            "FINNIFTY": 65,
-            "MIDCPNIFTY": 120,
-            "NIFTYNXT50": 25,
-            "SENSEX": 20,
-            "BANKEX": 30,
-            "SENSEX50": 25,
-        }
-        lot_size = lot_sizes.get(underlying, 75)
+        lot_size = self._resolve_lot_size(underlying, fo_exchange)
         total_quantity = quantity * lot_size
+        self.log(f"Lot size for {underlying}: {lot_size} -> {quantity} lot(s) = {total_quantity}")
 
         # Resolve expiry date from expiry type
         expiry_date = self._resolve_expiry_date(underlying, fo_exchange, expiry_type)
@@ -368,6 +422,8 @@ class NodeExecutor:
             option_type=option_type,
             price_type=price_type,
             product=product,
+            price=price,
+            trigger_price=trigger_price,
             splitsize=split_size,
             strategy=self.strategy_tag(node_data),
         )
@@ -393,6 +449,10 @@ class NodeExecutor:
         quantity_lots = self.get_int(node_data, "quantity", 1)  # Number of lots per leg
         product = self.get_str(node_data, "product", "MIS")
         strangle_width = self.get_str(node_data, "strangleWidth", "OTM2")  # For strangle strategy
+        # Documented as a top-level field; previously read for custom legs only,
+        # so a predefined strategy silently executed MARKET legs.
+        multi_price_type = self.get_str(node_data, "priceType", "MARKET").upper()
+        multi_price = self.get_float(node_data, "price", 0.0)
 
         # Check for custom legs data
         legs_data = node_data.get("legs", []) or node_data.get("orderLegs", [])
@@ -455,7 +515,13 @@ class NodeExecutor:
         else:
             # Generate legs from predefined strategy type
             legs = self._generate_strategy_legs(
-                strategy_type, action, total_quantity, product, strangle_width
+                strategy_type,
+                action,
+                total_quantity,
+                product,
+                strangle_width,
+                price_type=multi_price_type,
+                price=multi_price,
             )
 
         if not legs:
@@ -493,8 +559,15 @@ class NodeExecutor:
         quantity: int,
         product: str,
         strangle_width: str = "OTM2",
+        price_type: str = "MARKET",
+        price: float = 0.0,
     ) -> list[dict]:
-        """Generate legs for predefined option strategies"""
+        """Generate legs for predefined option strategies.
+
+        `price_type` is honored rather than hardcoded: silently turning a
+        documented LIMIT instruction into a MARKET order is the one outcome a
+        trader can never recover from.
+        """
         legs = []
 
         # Common leg template
@@ -504,9 +577,9 @@ class NodeExecutor:
                 "option_type": option_type,
                 "action": leg_action,
                 "quantity": quantity,
-                "pricetype": "MARKET",
+                "pricetype": price_type,
                 "product": product,
-                "price": 0,
+                "price": price,
                 "splitsize": 0,
             }
 
@@ -847,6 +920,17 @@ class NodeExecutor:
         interval = self.get_str(node_data, "interval", "5m")
         start_date = self.get_str(node_data, "startDate", "")
         end_date = self.get_str(node_data, "endDate", "")
+        # The panel offers a "Days" control, which was previously ignored -
+        # configuring 30 days sent empty dates and silently got whatever the
+        # broker defaults to. An explicit range still wins when both are set.
+        if not (start_date and end_date):
+            days = self.get_int(node_data, "days", 0)
+            if days > 0:
+                end_dt = datetime.now()
+                start_dt = end_dt - timedelta(days=days)
+                start_date = start_dt.strftime("%Y-%m-%d")
+                end_date = end_dt.strftime("%Y-%m-%d")
+                self.log(f"History range from days={days}: {start_date} to {end_date}")
         if start_date and end_date:
             start_date, end_date = clamp_history_range(start_date, end_date, interval)
         self.log(f"Getting history for: {symbol} ({interval})")
@@ -1319,25 +1403,49 @@ class NodeExecutor:
         return result
 
     def execute_holidays(self, node_data: dict) -> dict:
-        """Execute Holidays node - get market holidays"""
-        exchange = self.get_str(node_data, "exchange", "NSE")
-        self.log(f"Fetching holidays for exchange: {exchange}")
-        result = self.client.holidays(exchange=exchange)
-        self.log(f"Holidays result received")
+        """Execute Holidays node - get market holidays for a year."""
+        year = self.get_int(node_data, "year", 0)
+        self.log(f"Fetching holidays for year: {year or 'current'}")
+        result = self.client.holidays(year=year or None)
+        self.log("Holidays result received")
         self.store_output(node_data, result)
         return result
 
     def execute_timings(self, node_data: dict) -> dict:
-        """Execute Timings node - get market timings"""
-        exchange = self.get_str(node_data, "exchange", "NSE")
-        self.log(f"Fetching market timings for exchange: {exchange}")
-        result = self.client.timings(exchange=exchange)
+        """Execute Timings node - get market timings for a date."""
+        date_str = self.get_str(node_data, "date", "") or datetime.now().strftime("%Y-%m-%d")
+        self.log(f"Fetching market timings for date: {date_str}")
+        result = self.client.timings(date_str=date_str)
         self.log(f"Timings result: {result}")
         self.store_output(node_data, result)
         return result
 
+    def _parse_margin_positions(self, node_data: dict) -> list[dict] | None:
+        """Read the panel's positionsJson basket, if present and usable."""
+        raw = node_data.get("positionsJson") or node_data.get("positions")
+        if not raw:
+            return None
+        if isinstance(raw, str):
+            raw = self.context.interpolate(raw).strip()
+            if not raw:
+                return None
+            try:
+                raw = json.loads(raw)
+            except (TypeError, ValueError):
+                self.log("Margin positions JSON is not valid JSON; using the single position", "warning")
+                return None
+        if isinstance(raw, dict):
+            raw = [raw]
+        if not isinstance(raw, list) or not raw:
+            return None
+        return [p for p in raw if isinstance(p, dict)] or None
+
     def execute_margin(self, node_data: dict) -> dict:
         """Execute Margin node - calculate margin requirements"""
+        # The panel can supply a whole basket as positionsJson; a single
+        # position is the fallback. Ignoring positionsJson silently priced only
+        # the first leg of a multi-leg estimate.
+        positions = self._parse_margin_positions(node_data)
         symbol = self.get_str(node_data, "symbol", "")
         exchange = self.get_str(node_data, "exchange", "NSE")
         quantity = self.get_int(node_data, "quantity", 1)
@@ -1345,7 +1453,10 @@ class NodeExecutor:
         product_type = self.get_str(node_data, "product", "MIS")
         action = self.get_str(node_data, "action", "BUY")
         price_type = self.get_str(node_data, "priceType", "MARKET")
-        self.log(f"Calculating margin for: {symbol} ({exchange})")
+        if positions:
+            self.log(f"Calculating margin for a basket of {len(positions)} position(s)")
+        else:
+            self.log(f"Calculating margin for: {symbol} ({exchange})")
         result = self.client.margin(
             symbol=symbol,
             exchange=exchange,
@@ -1354,6 +1465,7 @@ class NodeExecutor:
             product_type=product_type,
             action=action,
             price_type=price_type,
+            positions=positions,
         )
         self.log(f"Margin result: {result}")
         self.store_output(node_data, result)

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -570,8 +570,20 @@ class NodeExecutor:
                 legs.append(leg_entry)
         else:
             # Generate legs from predefined strategy type
-            # A generated strategy shares one price type across its legs, so
-            # validate it once before building them.
+            # A generated strategy shares one price type across its legs. Its
+            # legs have no individual trigger price - the panel offers MARKET
+            # and LIMIT only - so an SL type here has no way to carry the
+            # trigger the broker requires. Say that, rather than sending a
+            # zero trigger or rejecting it as a missing price.
+            if multi_price_type in ("SL", "SL-M"):
+                message = (
+                    f"{multi_price_type} is not available for a generated "
+                    f"{strategy_type} strategy: its legs carry no trigger price. "
+                    "Use MARKET or LIMIT, or build the legs individually as custom "
+                    "legs where each can set its own trigger price."
+                )
+                self.log(f"Options multi-order failed: {message}", "error")
+                return {"status": "error", "message": message}
             invalid = self._invalid_price_reason(multi_price_type, multi_price, 0.0)
             if invalid:
                 error_result = {"status": "error", "message": invalid}
@@ -1897,6 +1909,18 @@ class NodeExecutor:
         if "minAvailable" in node_data:
             min_available = self.get_float(node_data, "minAvailable", 0.0)
         elif "threshold" in node_data:
+            # This node only expresses "at least". A legacy less-than means the
+            # opposite, so treating its threshold as a minimum would invert the
+            # guard - refuse instead of guessing.
+            legacy_operator = str(node_data.get("operator") or "gt").strip().lower()
+            if legacy_operator not in ("gt", "gte", "ge", ">", ">="):
+                message = (
+                    f"Fund Check has a legacy '{legacy_operator}' comparison, which this "
+                    "node cannot express - it only supports a minimum. Open the node and "
+                    "set Minimum Available."
+                )
+                self.log(message, "error")
+                return {"status": "error", "message": message}
             min_available = self.get_float(node_data, "threshold", 0.0)
             self.log(
                 f"Fund Check is using its legacy threshold of {min_available}. "

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -185,10 +185,29 @@ class WorkflowContext:
 class NodeExecutor:
     """Executes individual workflow nodes"""
 
-    def __init__(self, client: FlowOpenAlgoClient, context: WorkflowContext, logs: list):
+    def __init__(
+        self,
+        client: FlowOpenAlgoClient,
+        context: WorkflowContext,
+        logs: list,
+        default_strategy: str = "flow_workflow",
+    ):
         self.client = client
         self.context = context
         self.logs = logs
+        # Tag applied to every order this workflow places, so trades can be
+        # attributed back to the strategy that produced them (the tradebook
+        # carries this field). Defaults to the workflow's own name; a node may
+        # override it with `strategyTag`.
+        self.default_strategy = default_strategy or "flow_workflow"
+
+    def strategy_tag(self, node_data: dict) -> str:
+        """Strategy label for an order node.
+
+        Uses `strategyTag`, not `strategy`: optionsMultiOrder already uses
+        `strategy` for the structure type (straddle / iron_condor / custom).
+        """
+        return self.get_str(node_data, "strategyTag", "") or self.default_strategy
 
     def log(self, message: str, level: str = "info"):
         """Add log entry"""
@@ -255,6 +274,7 @@ class NodeExecutor:
             product_type=product,
             price=price,
             trigger_price=trigger_price,
+            strategy=self.strategy_tag(node_data),
         )
         self.log(
             f"Order result: {result}", "info" if result.get("status") == "success" else "error"
@@ -281,6 +301,7 @@ class NodeExecutor:
             position_size=position_size,
             price_type=price_type,
             product_type=product,
+            strategy=self.strategy_tag(node_data),
         )
         self.log(
             f"Smart order result: {result}",
@@ -348,6 +369,7 @@ class NodeExecutor:
             price_type=price_type,
             product=product,
             splitsize=split_size,
+            strategy=self.strategy_tag(node_data),
         )
         self.log(
             f"Options order result: {result}",
@@ -455,6 +477,7 @@ class NodeExecutor:
             exchange=underlying_exchange,
             expiry_date=expiry_date,
             legs=legs,
+            strategy=self.strategy_tag(node_data),
         )
         self.log(
             f"Options multi-order result: {result}",
@@ -757,6 +780,7 @@ class NodeExecutor:
             split_size=split_size,
             price_type=price_type,
             product_type=product,
+            strategy=self.strategy_tag(node_data),
         )
         self.log(
             f"Split order result: {result}",
@@ -861,6 +885,36 @@ class NodeExecutor:
                 )
             return f"History fetch failed for {symbol} ({interval}): {detail}.{hint}"
         return None
+
+    def execute_strategy_pnl(self, node_data: dict) -> dict:
+        """Execute Strategy P&L node - realized / unrealized / total for one
+        strategy, so a workflow can exit on its own performance rather than
+        the account's.
+
+        `strategy` defaults to this workflow's name, which is also the tag its
+        order nodes apply, so the common case needs no configuration.
+        """
+        from services.strategy_pnl_service import get_strategy_pnl
+
+        strategy = self.get_str(node_data, "strategy", "") or self.default_strategy
+        result = get_strategy_pnl(self.client, strategy=strategy)
+        if result.get("status") == "error":
+            self.log(f"Strategy P&L error: {result.get('message')}", "error")
+            return result
+
+        self.log(
+            f"Strategy P&L [{strategy}]: realized={result.get('realized')} "
+            f"unrealized={result.get('unrealized')} total={result.get('total')} "
+            f"openQty={result.get('open_quantity')}"
+        )
+        if result.get("unpriced_legs"):
+            self.log(
+                f"{result['unpriced_legs']} open leg(s) had no live price and were "
+                "excluded from unrealized P&L",
+                "warning",
+            )
+        self.store_output(node_data, result)
+        return result
 
     def execute_prior_period_ohlc(self, node_data: dict) -> dict:
         """Execute Prior Period OHLC node.
@@ -2488,6 +2542,8 @@ def execute_node_chain(
         result = executor.execute_open_position(node_data)
     elif node_type == "history":
         result = executor.execute_history(node_data)
+    elif node_type == "strategyPnl":
+        result = executor.execute_strategy_pnl(node_data)
     elif node_type == "priorPeriodOhlc":
         result = executor.execute_prior_period_ohlc(node_data)
     elif node_type == "barOffset":
@@ -2694,7 +2750,7 @@ def execute_workflow(
                 raise Exception("API key required for workflow execution")
 
             client = get_flow_client(api_key)
-            executor = NodeExecutor(client, context, logs)
+            executor = NodeExecutor(client, context, logs, default_strategy=workflow.name)
             logger.info(f"Starting workflow: {workflow.name}")
             executor.log(f"Starting workflow: {workflow.name}")
 

--- a/services/flow_openalgo_client.py
+++ b/services/flow_openalgo_client.py
@@ -419,9 +419,10 @@ class FlowOpenAlgoClient:
         price_type: str = "MARKET",
         product: str = "NRML",
         price: float = 0,
-        trigger_price: float = 0,
         splitsize: int = 0,
         strategy: str = "flow_workflow",
+        # Appended last so existing positional callers keep working.
+        trigger_price: float = 0,
     ) -> dict[str, Any]:
         """Place an options order with ATM/ITM/OTM offset resolution
 

--- a/services/flow_openalgo_client.py
+++ b/services/flow_openalgo_client.py
@@ -205,6 +205,8 @@ class FlowOpenAlgoClient:
         Args:
             orders: List of order dicts with symbol, exchange, action, quantity, etc.
             strategy: Strategy name for tracking
+            trigger_price: Trigger price for SL / SL-M orders (declared last so
+                existing positional callers keep working)
         """
         from services.basket_order_service import place_basket_order
 
@@ -437,7 +439,6 @@ class FlowOpenAlgoClient:
             price_type: MARKET, LIMIT, SL, SL-M
             product: NRML, MIS
             price: Price for limit orders
-            trigger_price: Trigger price for SL / SL-M orders
             splitsize: Split large orders into smaller chunks (0 = no split)
             strategy: Strategy name for tracking
         """

--- a/services/flow_openalgo_client.py
+++ b/services/flow_openalgo_client.py
@@ -419,6 +419,7 @@ class FlowOpenAlgoClient:
         price_type: str = "MARKET",
         product: str = "NRML",
         price: float = 0,
+        trigger_price: float = 0,
         splitsize: int = 0,
         strategy: str = "flow_workflow",
     ) -> dict[str, Any]:
@@ -435,6 +436,7 @@ class FlowOpenAlgoClient:
             price_type: MARKET, LIMIT, SL, SL-M
             product: NRML, MIS
             price: Price for limit orders
+            trigger_price: Trigger price for SL / SL-M orders
             splitsize: Split large orders into smaller chunks (0 = no split)
             strategy: Strategy name for tracking
         """
@@ -453,6 +455,7 @@ class FlowOpenAlgoClient:
             "pricetype": price_type,
             "product": product,
             "price": price,
+            "trigger_price": trigger_price,
             "splitsize": splitsize,
         }
 
@@ -499,46 +502,55 @@ class FlowOpenAlgoClient:
 
     # --- Market Calendar ---
 
-    def holidays(self, exchange: str = "NSE") -> dict[str, Any]:
-        """Get market holidays"""
+    def holidays(self, year: int | None = None) -> dict[str, Any]:
+        """Get market holidays for a year (defaults to the current year)."""
         from services.market_calendar_service import get_holidays
 
-        success, response, status_code = get_holidays(exchange=exchange, api_key=self.api_key)
+        success, response, status_code = get_holidays(year=year)
         return self._handle_response(success, response, status_code)
 
-    def timings(self, exchange: str = "NSE") -> dict[str, Any]:
-        """Get market timings"""
+    def timings(self, date_str: str) -> dict[str, Any]:
+        """Get market timings for a date (YYYY-MM-DD)."""
         from services.market_calendar_service import get_timings
 
-        success, response, status_code = get_timings(exchange=exchange, api_key=self.api_key)
+        success, response, status_code = get_timings(date_str)
         return self._handle_response(success, response, status_code)
 
     # --- Margin ---
 
     def margin(
         self,
-        symbol: str,
-        exchange: str,
-        quantity: int,
+        symbol: str = "",
+        exchange: str = "NSE",
+        quantity: int = 0,
         price: float = 0,
         product_type: str = "MIS",
         action: str = "BUY",
         price_type: str = "MARKET",
+        positions: list[dict[str, Any]] | None = None,
     ) -> dict[str, Any]:
-        """Get margin required for an order"""
-        from services.margin_service import get_margin
+        """Margin required for one position, or for a basket.
 
-        order_data = {
-            "symbol": symbol,
-            "exchange": exchange,
-            "quantity": str(quantity),  # Schema expects string
-            "price": str(price),  # Schema expects string
-            "product": product_type,  # Schema expects 'product' not 'product_type'
-            "pricetype": price_type,  # Schema expects 'pricetype' (no underscore)
-            "action": action.upper(),
-        }
+        The service calculates a basket, so a single position is sent as a
+        one-element array. `positions` takes precedence when supplied.
+        """
+        from services.margin_service import calculate_margin
 
-        success, response, status_code = get_margin(order_data, api_key=self.api_key)
+        if not positions:
+            positions = [
+                {
+                    "exchange": exchange,
+                    "symbol": symbol,
+                    "action": action.upper(),
+                    "quantity": str(quantity),
+                    "product": product_type,
+                    "pricetype": price_type,
+                    "price": str(price),
+                }
+            ]
+
+        margin_data = {"apikey": self.api_key, "positions": positions}
+        success, response, status_code = calculate_margin(margin_data, api_key=self.api_key)
         return self._handle_response(success, response, status_code)
 
     # --- Alerts ---

--- a/services/flow_order_update_monitor_service.py
+++ b/services/flow_order_update_monitor_service.py
@@ -13,7 +13,9 @@ see docs/prompt/websockets-format.md "Order Updates") instead of running its
 own polling thread.
 """
 
+import os
 import threading
+from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Optional
@@ -22,6 +24,15 @@ from utils.event_bus import bus
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Shared and bounded, never one thread per event: order updates arrive in
+# bursts (a basket filling leg by leg), and each run executes a whole workflow
+# holding DB sessions and broker calls. A module-level pool caps that
+# concurrency and reuses its threads for the life of the worker.
+_WORKFLOW_POOL = ThreadPoolExecutor(
+    max_workers=max(int(os.getenv("FLOW_ORDER_UPDATE_WORKERS", "4")), 1),
+    thread_name_prefix="flow-order-update",
+)
 
 # order_status values a watch can match on; "any" matches every update.
 VALID_STATUSES = {"any", "open", "trigger pending", "complete", "rejected", "cancelled"}
@@ -260,13 +271,22 @@ class FlowOrderUpdateMonitor:
                     self.remove_watch(watch.workflow_id)
                 else:
                     watch.triggered = False
+                # No app context here, so teardown_appcontext never runs and
+                # every scoped session this workflow touched would stay bound
+                # to the pool thread, holding its connection indefinitely.
+                from utils.db_sessions import remove_all_scoped_sessions
 
-        threading.Thread(target=run_workflow, daemon=True).start()
+                remove_all_scoped_sessions()
+
+        _WORKFLOW_POOL.submit(run_workflow)
 
     def shutdown(self):
         bus.unsubscribe("order.update", self._on_order_update)
         with self._watches_lock:
             self._watches.clear()
+        # Let in-flight workflows finish; the pool's threads are released with
+        # it rather than left running past shutdown.
+        _WORKFLOW_POOL.shutdown(wait=False)
         logger.info("FlowOrderUpdateMonitor shutdown")
 
 

--- a/services/flow_order_update_monitor_service.py
+++ b/services/flow_order_update_monitor_service.py
@@ -13,13 +13,13 @@ see docs/prompt/websockets-format.md "Order Updates") instead of running its
 own polling thread.
 """
 
-import os
 import threading
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass, field
 from datetime import datetime
 from typing import Any, Optional
 
+from utils.env_config import env_int
 from utils.event_bus import bus
 from utils.logging import get_logger
 
@@ -30,7 +30,7 @@ logger = get_logger(__name__)
 # holding DB sessions and broker calls. A module-level pool caps that
 # concurrency and reuses its threads for the life of the worker.
 _WORKFLOW_POOL = ThreadPoolExecutor(
-    max_workers=max(int(os.getenv("FLOW_ORDER_UPDATE_WORKERS", "4")), 1),
+    max_workers=env_int("FLOW_ORDER_UPDATE_WORKERS", 4, minimum=1),
     thread_name_prefix="flow-order-update",
 )
 

--- a/services/flow_price_monitor_service.py
+++ b/services/flow_price_monitor_service.py
@@ -9,7 +9,7 @@ import logging
 import threading
 import time
 from dataclasses import dataclass, field
-from datetime import datetime
+from datetime import datetime, timedelta
 from typing import Any, Dict, Optional, Set
 
 from services.flow_openalgo_client import FlowOpenAlgoClient, get_flow_client
@@ -33,6 +33,10 @@ class PriceAlert:
     triggered: bool = False
     created_at: datetime = field(default_factory=datetime.now)
     api_key: str | None = None
+    # The editor offers these; they were previously dropped at activation, so
+    # "Every Time" silently behaved as "Only Once" and expiry never applied.
+    trigger: str = "once"
+    expiration: str = "none"
 
 
 class FlowPriceMonitor:
@@ -63,6 +67,28 @@ class FlowPriceMonitor:
         self._stop_event = threading.Event()
         logger.info("FlowPriceMonitor initialized")
 
+    # The editor and this monitor grew separate vocabularies for the same four
+    # conditions, so every alert the UI could produce fell through to the final
+    # `return False` and the trigger never fired. Both spellings are accepted;
+    # the UI's are the ones users actually have saved.
+    _CONDITION_ALIASES = {
+        "above": "greater_than",
+        "price_above": "greater_than",
+        "below": "less_than",
+        "price_below": "less_than",
+        "crosses_above": "crossing_up",
+        "cross_above": "crossing_up",
+        "crosses_below": "crossing_down",
+        "cross_below": "crossing_down",
+        "crosses": "crossing",
+    }
+
+    @classmethod
+    def normalize_condition(cls, value: str | None) -> str:
+        """Canonical condition name, accepting either vocabulary."""
+        raw = str(value or "").strip().lower().replace("-", "_")
+        return cls._CONDITION_ALIASES.get(raw, raw)
+
     def add_alert(
         self,
         workflow_id: int,
@@ -74,8 +100,11 @@ class FlowPriceMonitor:
         price_upper: float | None = None,
         percentage: float | None = None,
         api_key: str | None = None,
+        trigger: str = "once",
+        expiration: str = "none",
     ) -> bool:
         """Add a price alert for a workflow"""
+        condition = self.normalize_condition(condition)
         alert = PriceAlert(
             workflow_id=workflow_id,
             symbol=symbol,
@@ -86,6 +115,8 @@ class FlowPriceMonitor:
             price_upper=price_upper,
             percentage=percentage,
             api_key=api_key,
+            trigger=str(trigger or "once").strip().lower(),
+            expiration=str(expiration or "none").strip().lower(),
         )
 
         self._alerts[workflow_id] = alert
@@ -165,10 +196,33 @@ class FlowPriceMonitor:
                 except Exception as e:
                     logger.exception(f"Error checking alert for workflow {workflow_id}: {e}")
 
+    # Windows the editor offers for "expiration". A watch past its window is
+    # removed rather than left running for the life of the process.
+    _EXPIRATION_WINDOWS = {
+        "1h": timedelta(hours=1),
+        "4h": timedelta(hours=4),
+        "1d": timedelta(days=1),
+        "1w": timedelta(weeks=1),
+    }
+
+    def _is_expired(self, alert: PriceAlert) -> bool:
+        window = self._EXPIRATION_WINDOWS.get(alert.expiration)
+        if window is None:
+            return False
+        return datetime.now() - alert.created_at >= window
+
     def _check_alert(self, alert: PriceAlert):
         """Check a single alert against current price"""
         if not alert.api_key:
             logger.warning(f"No API key for alert workflow {alert.workflow_id}")
+            return
+
+        if self._is_expired(alert):
+            logger.info(
+                f"Price alert for workflow {alert.workflow_id} expired after "
+                f"{alert.expiration}; no longer watching."
+            )
+            self.remove_alert(alert.workflow_id)
             return
 
         try:
@@ -196,7 +250,12 @@ class FlowPriceMonitor:
                 )
 
                 self._trigger_workflow(alert.workflow_id, current_price, alert.api_key)
-                self.remove_alert(alert.workflow_id)
+                if alert.trigger == "every_time":
+                    # Keep watching; record the price so an edge-triggered
+                    # crossing needs a fresh cross rather than re-firing.
+                    alert.last_price = current_price
+                else:
+                    self.remove_alert(alert.workflow_id)
             else:
                 alert.last_price = current_price
 
@@ -205,7 +264,7 @@ class FlowPriceMonitor:
 
     def _evaluate_condition(self, alert: PriceAlert, current_price: float) -> bool:
         """Evaluate if the price condition is met"""
-        condition = alert.condition
+        condition = self.normalize_condition(alert.condition)
         target = alert.target_price
         last_price = alert.last_price
 
@@ -262,6 +321,12 @@ class FlowPriceMonitor:
             pct_change = ((last_price - current_price) / last_price) * 100
             return pct_change >= (alert.percentage or 0)
 
+        # Never silently false: an unknown condition means the alert can never
+        # fire, which is indistinguishable from "the level was not reached".
+        logger.error(
+            f"Price alert for workflow {alert.workflow_id} has an unrecognized "
+            f"condition {alert.condition!r}; it can never trigger."
+        )
         return False
 
     def _trigger_workflow(self, workflow_id: int, trigger_price: float, api_key: str):

--- a/services/flow_workflow_validator.py
+++ b/services/flow_workflow_validator.py
@@ -109,6 +109,9 @@ BRANCHING_NODE_TYPES: frozenset[str] = frozenset(
         "andGate",
         "orGate",
         "notGate",
+        # Renders true/false handles like the condition nodes, so rejecting them
+        # made a valid price-alert workflow fail on its own edges.
+        "priceAlert",
     }
 )
 
@@ -133,6 +136,24 @@ REQUIRED_NODE_FIELDS: dict[str, tuple[str, ...]] = {
     "mathExpression": ("expression",),
     "varCondition": ("leftValue", "operator"),
     "priceCondition": ("symbol", "exchange", "operator"),
+    # Broker-mutating nodes. An empty one reaches the broker as a malformed
+    # order rather than failing at import.
+    "splitOrder": ("symbol", "exchange", "action", "quantity", "splitSize"),
+    "basketOrder": ("orders",),
+    "optionsMultiOrder": ("underlying", "quantity"),
+    "priceAlert": ("symbol", "exchange", "condition", "price"),
+    "subscribeLtp": ("symbol", "exchange"),
+    "subscribeQuote": ("symbol", "exchange"),
+    "subscribeDepth": ("symbol", "exchange"),
+    "optionSymbol": ("underlying", "optionType"),
+    "optionChain": ("underlying",),
+    "syntheticFuture": ("underlying",),
+    "expiry": ("symbol", "exchange"),
+    "symbol": ("symbol", "exchange"),
+    "multiQuotes": ("symbols",),
+    "httpRequest": ("url",),
+    "variable": ("variableName",),
+    "waitUntil": ("targetTime",),
 }
 
 
@@ -412,22 +433,36 @@ def validate_workflow(
                 )
             )
         elif source_type and source_type not in BRANCHING_NODE_TYPES:
-            if str(handle) in _BRANCHING_HANDLES:
-                errors.append(
-                    _err(
-                        f"/edges/{i}/sourceHandle",
-                        "invalid_source_handle",
-                        f"A {source_type} node does not branch, so it has no '{handle}' handle.",
-                        "no sourceHandle",
-                        handle,
-                    )
+            # Non-branching nodes render a single unnamed source handle, so any
+            # named one is a phantom: the edge points at a socket that does not
+            # exist and the branch it carries is silently dropped.
+            errors.append(
+                _err(
+                    f"/edges/{i}/sourceHandle",
+                    "invalid_source_handle",
+                    f"A {source_type} node has no '{handle}' output handle; it emits a "
+                    "single unconditional output.",
+                    "no sourceHandle",
+                    handle,
                 )
+            )
 
     # Gate input slots. `targetHandle: "input-N"` must name a slot the gate
     # actually has: a higher N is never filled, so the gate waits for an input
     # that can never arrive and its branch silently never fires.
+    def _slot_count(value) -> int:
+        """Gate input count, tolerant of a malformed value.
+
+        Casting directly raised ValueError out of the validator, so a
+        malformed payload crashed the request it was supposed to reject.
+        """
+        try:
+            return max(int(value), 1) if value not in (None, "") else 2
+        except (TypeError, ValueError):
+            return 2
+
     gate_slots = {
-        n.get("id"): max(int(n.get("data", {}).get("inputCount") or 2), 1)
+        n.get("id"): _slot_count(n.get("data", {}).get("inputCount"))
         for n in nodes
         if isinstance(n, dict)
         and n.get("type") in ("andGate", "orGate")
@@ -441,6 +476,20 @@ def validate_workflow(
             continue
         slots = gate_slots.get(edge.get("target"))
         if slots is None:
+            # Only gates render numbered input slots. Naming one on any other
+            # node points the edge at a socket that does not exist.
+            if re.fullmatch(r"input-\d+", str(handle)):
+                target_type = node_types_by_id.get(edge.get("target"))
+                errors.append(
+                    _err(
+                        f"/edges/{i}/targetHandle",
+                        "invalid_target_handle",
+                        f"Only gate nodes have numbered input slots; a "
+                        f"{target_type or 'non-gate'} node has no '{handle}'.",
+                        "no targetHandle",
+                        handle,
+                    )
+                )
             continue
         match = re.fullmatch(r"input-(\d+)", str(handle))
         if not match or int(match.group(1)) >= slots:
@@ -592,18 +641,54 @@ def migrate_legacy_node_data(nodes: list) -> tuple[list, list[str]]:
         data = dict(node["data"])
 
         if node_type == "fundCheck" and "minAvailable" not in data and "threshold" in data:
-            # The guard reads minAvailable. Left as `threshold` it silently
-            # becomes a minimum of zero, so the check passes on any balance.
-            data["minAvailable"] = data.pop("threshold")
-            data.pop("operator", None)
-            notes.append(
-                f"fundCheck '{node.get('id')}': threshold -> minAvailable "
-                f"({data['minAvailable']})"
-            )
+            # fundCheck can only express "at least this much". A legacy
+            # greater-than maps cleanly; a legacy less-than means the opposite,
+            # and silently reversing a capital guard is worse than refusing to
+            # guess, so that one is left for the user to restate.
+            operator = str(data.get("operator") or "gt").strip().lower()
+            if operator in ("gt", "gte", "ge", ">", ">="):
+                data["minAvailable"] = data.pop("threshold")
+                data.pop("operator", None)
+                notes.append(
+                    f"fundCheck '{node.get('id')}': threshold -> minAvailable "
+                    f"({data['minAvailable']})"
+                )
+            else:
+                notes.append(
+                    f"fundCheck '{node.get('id')}': operator '{operator}' has no "
+                    "equivalent - this node only supports a minimum. Left unchanged; "
+                    "set Minimum Available yourself."
+                )
         elif node_type == "positionCheck" and "condition" not in data and "operator" in data:
-            data.pop("operator", None)
-            data["condition"] = "exists"
-            notes.append(f"positionCheck '{node.get('id')}': operator -> condition")
+            # Preserve the comparison instead of flattening every legacy operator
+            # to "exists", which would turn a quantity-based exit into an
+            # unconditional one.
+            operator = str(data.get("operator") or "").strip().lower()
+            mapping = {
+                "gt": "quantity_above",
+                ">": "quantity_above",
+                "gte": "quantity_above",
+                "ge": "quantity_above",
+                ">=": "quantity_above",
+                "lt": "quantity_below",
+                "<": "quantity_below",
+                "lte": "quantity_below",
+                "le": "quantity_below",
+                "<=": "quantity_below",
+            }
+            condition = mapping.get(operator)
+            if condition:
+                data["condition"] = condition
+                data.pop("operator", None)
+                notes.append(
+                    f"positionCheck '{node.get('id')}': operator '{operator}' -> "
+                    f"condition '{condition}' (threshold kept)"
+                )
+            else:
+                notes.append(
+                    f"positionCheck '{node.get('id')}': operator '{operator}' has no "
+                    "equivalent condition. Left unchanged; set the condition yourself."
+                )
         elif node_type == "priceCondition" and "value" not in data and "threshold" in data:
             data["value"] = data.pop("threshold")
             notes.append(f"priceCondition '{node.get('id')}': threshold -> value")

--- a/services/flow_workflow_validator.py
+++ b/services/flow_workflow_validator.py
@@ -12,6 +12,7 @@ node types, edge endpoints, and the one-trigger rule. Per-node field contracts
 stay with the executor, which is where their defaults and coercions live.
 """
 
+import re
 from typing import Any
 
 from utils.logging import get_logger
@@ -93,6 +94,47 @@ TRIGGER_NODE_TYPES: frozenset[str] = frozenset(
 MAX_NODES = 500
 MAX_EDGES = 1000
 
+# Source handles each node kind may emit. Condition nodes and gates fork; the
+# executor treats yes/no as synonyms of true/false. Anything else on an edge is
+# a typo that silently drops the branch at run time.
+_BRANCHING_HANDLES = frozenset({"true", "false", "yes", "no"})
+BRANCHING_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "positionCheck",
+        "fundCheck",
+        "priceCondition",
+        "varCondition",
+        "timeWindow",
+        "timeCondition",
+        "andGate",
+        "orGate",
+        "notGate",
+    }
+)
+
+# Fields an order node cannot execute without. Checked here because a workflow
+# missing them fails at the broker, mid-session, rather than at import.
+REQUIRED_NODE_FIELDS: dict[str, tuple[str, ...]] = {
+    "placeOrder": ("symbol", "exchange", "action", "quantity"),
+    "smartOrder": ("symbol", "exchange", "action", "quantity"),
+    "optionsOrder": ("underlying", "action", "quantity"),
+    "modifyOrder": ("orderId",),
+    "cancelOrder": ("orderId",),
+    "getOrderStatus": ("orderId",),
+    "getQuote": ("symbol", "exchange"),
+    "getDepth": ("symbol", "exchange"),
+    "history": ("symbol", "exchange", "interval"),
+    "indicator": ("symbol", "exchange", "indicatorName"),
+    "priorPeriodOhlc": ("symbol", "exchange"),
+    "barOffset": ("symbol", "exchange"),
+    "openPosition": ("symbol", "exchange"),
+    "telegramAlert": ("message",),
+    "whatsappAlert": ("to", "message"),
+    "mathExpression": ("expression",),
+    "varCondition": ("leftValue", "operator"),
+    "priceCondition": ("symbol", "exchange", "operator"),
+}
+
 
 class WorkflowValidationError(Exception):
     """One or more structural problems, each with a path and a reason."""
@@ -111,8 +153,22 @@ def _err(path: str, code: str, message: str, expected=None, received=None) -> di
     return entry
 
 
-def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[str, Any]]:
-    """Return a list of structural errors; empty means the workflow is valid."""
+def validate_workflow(
+    payload: Any, *, require_name: bool = True, strict: bool = True
+) -> list[dict[str, Any]]:
+    """Return a list of errors; empty means the workflow passes.
+
+    Two levels, because the editor saves continuously while a graph is still
+    being wired:
+
+    * Always checked (structure) - shape, ids, known node types, edge endpoints,
+      branch handles. A graph failing these cannot be rendered and is corrupt
+      however incomplete the user\'s work is.
+    * ``strict`` only (completeness) - required node fields, exactly one
+      trigger, reachability, and cycles. Enforced at import and activation,
+      where the workflow is presented as finished, and skipped on save so a
+      half-built graph remains savable.
+    """
     errors: list[dict[str, Any]] = []
 
     if not isinstance(payload, dict):
@@ -226,7 +282,22 @@ def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[s
         elif node_type in TRIGGER_NODE_TYPES:
             triggers.append(str(node_id))
 
-        if not isinstance(node.get("data"), dict):
+        data = node.get("data")
+        if strict and isinstance(data, dict) and isinstance(node_type, str):
+            for field in REQUIRED_NODE_FIELDS.get(node_type, ()):
+                value = data.get(field)
+                if value is None or (isinstance(value, str) and not value.strip()):
+                    errors.append(
+                        _err(
+                            f"{base}/data/{field}",
+                            "missing_required_field",
+                            f"A {node_type} node needs {field}. Without it the node "
+                            "fails at run time, not at import.",
+                            field,
+                            value,
+                        )
+                    )
+        if not isinstance(data, dict):
             errors.append(
                 _err(
                     f"{base}/data",
@@ -317,7 +388,84 @@ def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[s
                     )
                 )
 
-    if nodes and not triggers:
+    node_types_by_id = {
+        n.get("id"): n.get("type")
+        for n in nodes
+        if isinstance(n, dict) and isinstance(n.get("id"), str)
+    }
+    for i, edge in enumerate(edges):
+        if not isinstance(edge, dict):
+            continue
+        handle = edge.get("sourceHandle")
+        if handle is None or handle == "":
+            continue  # an unconditional edge is legitimate
+        source_type = node_types_by_id.get(edge.get("source"))
+        if source_type in BRANCHING_NODE_TYPES and str(handle) not in _BRANCHING_HANDLES:
+            errors.append(
+                _err(
+                    f"/edges/{i}/sourceHandle",
+                    "invalid_source_handle",
+                    f"'{handle}' is not a branch of a {source_type} node, so this edge "
+                    "is never followed and its branch is silently dropped.",
+                    sorted(_BRANCHING_HANDLES),
+                    handle,
+                )
+            )
+        elif source_type and source_type not in BRANCHING_NODE_TYPES:
+            if str(handle) in _BRANCHING_HANDLES:
+                errors.append(
+                    _err(
+                        f"/edges/{i}/sourceHandle",
+                        "invalid_source_handle",
+                        f"A {source_type} node does not branch, so it has no '{handle}' handle.",
+                        "no sourceHandle",
+                        handle,
+                    )
+                )
+
+    # Gate input slots. `targetHandle: "input-N"` must name a slot the gate
+    # actually has: a higher N is never filled, so the gate waits for an input
+    # that can never arrive and its branch silently never fires.
+    gate_slots = {
+        n.get("id"): max(int(n.get("data", {}).get("inputCount") or 2), 1)
+        for n in nodes
+        if isinstance(n, dict)
+        and n.get("type") in ("andGate", "orGate")
+        and isinstance(n.get("data"), dict)
+    }
+    for i, edge in enumerate(edges):
+        if not isinstance(edge, dict):
+            continue
+        handle = edge.get("targetHandle")
+        if handle is None or handle == "":
+            continue
+        slots = gate_slots.get(edge.get("target"))
+        if slots is None:
+            continue
+        match = re.fullmatch(r"input-(\d+)", str(handle))
+        if not match or int(match.group(1)) >= slots:
+            errors.append(
+                _err(
+                    f"/edges/{i}/targetHandle",
+                    "invalid_target_handle",
+                    f"'{handle}' is not an input slot on this gate, which has {slots}. "
+                    "The gate would wait for an input that never arrives.",
+                    [f"input-{n}" for n in range(slots)],
+                    handle,
+                )
+            )
+
+    if strict and not nodes:
+        errors.append(
+            _err(
+                "/nodes",
+                "no_trigger",
+                "Workflow has no nodes, so it can never run.",
+                "at least a trigger node",
+                0,
+            )
+        )
+    elif strict and nodes and not triggers:
         errors.append(
             _err(
                 "/nodes",
@@ -328,7 +476,7 @@ def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[s
                 0,
             )
         )
-    elif len(triggers) > 1:
+    elif strict and len(triggers) > 1:
         # The executor walks from the first trigger it finds; the rest of the
         # graph never executes and nothing reports why.
         errors.append(
@@ -342,11 +490,123 @@ def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[s
             )
         )
 
+    # Only meaningful once ids and endpoints are sound.
+    if strict and not errors:
+        errors.extend(_graph_errors(nodes, edges, node_ids, triggers))
+
     return errors
 
 
-def assert_valid_workflow(payload: Any, *, require_name: bool = True) -> None:
-    """Raise WorkflowValidationError when the workflow is structurally invalid."""
-    errors = validate_workflow(payload, require_name=require_name)
+def _graph_errors(nodes: list, edges: list, node_ids: set[str], triggers: list[str]) -> list[dict]:
+    """Cycles and nodes the trigger can never reach."""
+    errors: list[dict] = []
+    adjacency: dict[str, list[str]] = {nid: [] for nid in node_ids}
+    for edge in edges:
+        if not isinstance(edge, dict):
+            continue
+        src, dst = edge.get("source"), edge.get("target")
+        if src in adjacency and dst in node_ids:
+            adjacency[src].append(dst)
+
+    # Cycle detection. The executor caps depth and visits rather than detecting
+    # a loop, so a cycle burns the whole budget and truncates the run instead of
+    # reporting anything.
+    WHITE, GREY, BLACK = 0, 1, 2
+    colour = dict.fromkeys(node_ids, WHITE)
+    cycle: list[str] = []
+
+    def visit(node: str, path: list[str]) -> bool:
+        colour[node] = GREY
+        for nxt in adjacency.get(node, ()):
+            if colour[nxt] == GREY:
+                cycle.extend(path[path.index(nxt) :] + [nxt] if nxt in path else [nxt])
+                return True
+            if colour[nxt] == WHITE and visit(nxt, path + [nxt]):
+                return True
+        colour[node] = BLACK
+        return False
+
+    for nid in node_ids:
+        if colour[nid] == WHITE and visit(nid, [nid]):
+            errors.append(
+                _err(
+                    "/edges",
+                    "cycle",
+                    "The graph contains a cycle, which runs until the executor's "
+                    "visit limit and then truncates rather than reporting a loop: "
+                    + " -> ".join(cycle[:6]),
+                    "an acyclic graph",
+                    cycle[:6],
+                )
+            )
+            break
+
+    # Reachability from the trigger. A node the trigger cannot reach never runs,
+    # and nothing at run time says so.
+    if triggers:
+        seen: set[str] = set()
+        stack = list(triggers)
+        while stack:
+            nid = stack.pop()
+            if nid in seen:
+                continue
+            seen.add(nid)
+            stack.extend(adjacency.get(nid, ()))
+        unreachable = sorted(node_ids - seen)
+        if unreachable:
+            errors.append(
+                _err(
+                    "/nodes",
+                    "unreachable",
+                    "These nodes cannot be reached from the trigger and will never "
+                    "run: " + ", ".join(unreachable[:8]),
+                    "every node reachable from the trigger",
+                    unreachable[:8],
+                )
+            )
+    return errors
+
+
+def assert_valid_workflow(payload: Any, *, require_name: bool = True, strict: bool = True) -> None:
+    """Raise WorkflowValidationError when the workflow does not pass."""
+    errors = validate_workflow(payload, require_name=require_name, strict=strict)
     if errors:
         raise WorkflowValidationError(errors)
+
+
+# Legacy node payloads, and the canonical shape they map to. Applied at import
+# so the stored workflow is correct, rather than relying on every reader to
+# remember the old spelling forever.
+def migrate_legacy_node_data(nodes: list) -> tuple[list, list[str]]:
+    """Upgrade legacy node payloads. Returns (nodes, human-readable notes)."""
+    notes: list[str] = []
+    if not isinstance(nodes, list):
+        return nodes, notes
+
+    migrated = []
+    for node in nodes:
+        if not isinstance(node, dict) or not isinstance(node.get("data"), dict):
+            migrated.append(node)
+            continue
+        node_type = node.get("type")
+        data = dict(node["data"])
+
+        if node_type == "fundCheck" and "minAvailable" not in data and "threshold" in data:
+            # The guard reads minAvailable. Left as `threshold` it silently
+            # becomes a minimum of zero, so the check passes on any balance.
+            data["minAvailable"] = data.pop("threshold")
+            data.pop("operator", None)
+            notes.append(
+                f"fundCheck '{node.get('id')}': threshold -> minAvailable "
+                f"({data['minAvailable']})"
+            )
+        elif node_type == "positionCheck" and "condition" not in data and "operator" in data:
+            data.pop("operator", None)
+            data["condition"] = "exists"
+            notes.append(f"positionCheck '{node.get('id')}': operator -> condition")
+        elif node_type == "priceCondition" and "value" not in data and "threshold" in data:
+            data["value"] = data.pop("threshold")
+            notes.append(f"priceCondition '{node.get('id')}': threshold -> value")
+
+        migrated.append({**node, "data": data})
+    return migrated, notes

--- a/services/flow_workflow_validator.py
+++ b/services/flow_workflow_validator.py
@@ -1,0 +1,352 @@
+# services/flow_workflow_validator.py
+"""Structural validation for Flow workflow payloads.
+
+The editor validates before it posts, but the API is reachable directly, so
+without a server-side check a malformed graph is persisted and only fails
+later - sometimes at activation, sometimes mid-execution against a live
+broker. A workflow that cannot be rendered or executed should never reach the
+database in the first place.
+
+This validates *structure*, not trading semantics: shape, identifiers, known
+node types, edge endpoints, and the one-trigger rule. Per-node field contracts
+stay with the executor, which is where their defaults and coercions live.
+"""
+
+from typing import Any
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# The node types the editor can render and the executor can dispatch. Kept in
+# lockstep with frontend/src/components/flow/nodes/index.ts; the parity test in
+# test/test_flow_workflow_validator.py fails if the two drift.
+VALID_NODE_TYPES: frozenset[str] = frozenset(
+    {
+        "andGate",
+        "barOffset",
+        "basketOrder",
+        "cancelAllOrders",
+        "cancelOrder",
+        "closePositions",
+        "delay",
+        "expiry",
+        "fundCheck",
+        "funds",
+        "getDepth",
+        "getOrderStatus",
+        "getQuote",
+        "group",
+        "history",
+        "holdings",
+        "holidays",
+        "httpRequest",
+        "indicator",
+        "intervals",
+        "log",
+        "margin",
+        "mathExpression",
+        "modifyOrder",
+        "multiQuotes",
+        "notGate",
+        "openPosition",
+        "optionChain",
+        "optionSymbol",
+        "optionsMultiOrder",
+        "optionsOrder",
+        "orGate",
+        "orderBook",
+        "orderUpdateTrigger",
+        "placeOrder",
+        "positionBook",
+        "positionCheck",
+        "priceAlert",
+        "priceCondition",
+        "priorPeriodOhlc",
+        "smartOrder",
+        "splitOrder",
+        "start",
+        "strategyPnl",
+        "subscribeDepth",
+        "subscribeLtp",
+        "subscribeQuote",
+        "symbol",
+        "syntheticFuture",
+        "telegramAlert",
+        "timeCondition",
+        "timeWindow",
+        "timings",
+        "tradeBook",
+        "unsubscribe",
+        "varCondition",
+        "variable",
+        "waitUntil",
+        "webhookTrigger",
+        "whatsappAlert",
+    }
+)
+
+TRIGGER_NODE_TYPES: frozenset[str] = frozenset(
+    {"start", "webhookTrigger", "priceAlert", "orderUpdateTrigger"}
+)
+
+MAX_NODES = 500
+MAX_EDGES = 1000
+
+
+class WorkflowValidationError(Exception):
+    """One or more structural problems, each with a path and a reason."""
+
+    def __init__(self, errors: list[dict[str, Any]]):
+        self.errors = errors
+        super().__init__(f"{len(errors)} validation error(s)")
+
+
+def _err(path: str, code: str, message: str, expected=None, received=None) -> dict[str, Any]:
+    entry = {"path": path, "code": code, "message": message}
+    if expected is not None:
+        entry["expected"] = expected
+    if received is not None:
+        entry["received"] = received
+    return entry
+
+
+def validate_workflow(payload: Any, *, require_name: bool = True) -> list[dict[str, Any]]:
+    """Return a list of structural errors; empty means the workflow is valid."""
+    errors: list[dict[str, Any]] = []
+
+    if not isinstance(payload, dict):
+        return [
+            _err(
+                "/",
+                "invalid_type",
+                "Workflow must be a JSON object",
+                "object",
+                type(payload).__name__,
+            )
+        ]
+
+    name = payload.get("name")
+    if require_name and (not isinstance(name, str) or not name.strip()):
+        errors.append(_err("/name", "required", "Workflow needs a non-empty name", "string", name))
+
+    nodes = payload.get("nodes")
+    edges = payload.get("edges")
+    if not isinstance(nodes, list):
+        errors.append(
+            _err(
+                "/nodes",
+                "required",
+                "Workflow needs a nodes array",
+                "array",
+                type(nodes).__name__ if nodes is not None else None,
+            )
+        )
+        nodes = []
+    if not isinstance(edges, list):
+        errors.append(
+            _err(
+                "/edges",
+                "required",
+                "Workflow needs an edges array",
+                "array",
+                type(edges).__name__ if edges is not None else None,
+            )
+        )
+        edges = []
+
+    if len(nodes) > MAX_NODES:
+        errors.append(
+            _err(
+                "/nodes",
+                "too_large",
+                f"Workflow has more than {MAX_NODES} nodes",
+                MAX_NODES,
+                len(nodes),
+            )
+        )
+    if len(edges) > MAX_EDGES:
+        errors.append(
+            _err(
+                "/edges",
+                "too_large",
+                f"Workflow has more than {MAX_EDGES} edges",
+                MAX_EDGES,
+                len(edges),
+            )
+        )
+
+    node_ids: set[str] = set()
+    triggers: list[str] = []
+
+    for i, node in enumerate(nodes):
+        base = f"/nodes/{i}"
+        if not isinstance(node, dict):
+            errors.append(
+                _err(base, "invalid_type", "Node must be an object", "object", type(node).__name__)
+            )
+            continue
+
+        node_id = node.get("id")
+        if not isinstance(node_id, str) or not node_id.strip():
+            errors.append(
+                _err(
+                    f"{base}/id", "required", "Node needs a non-empty string id", "string", node_id
+                )
+            )
+        elif node_id in node_ids:
+            errors.append(
+                _err(
+                    f"{base}/id",
+                    "duplicate",
+                    f"Duplicate node id '{node_id}'",
+                    "unique id",
+                    node_id,
+                )
+            )
+        else:
+            node_ids.add(node_id)
+
+        node_type = node.get("type")
+        if not isinstance(node_type, str) or not node_type:
+            errors.append(
+                _err(f"{base}/type", "required", "Node needs a type", "string", node_type)
+            )
+        elif node_type not in VALID_NODE_TYPES:
+            errors.append(
+                _err(
+                    f"{base}/type",
+                    "unknown_node_type",
+                    f"'{node_type}' is not a Flow node type. Node types are "
+                    "fixed; inventing one makes the workflow unrenderable.",
+                    "one of the documented node types",
+                    node_type,
+                )
+            )
+        elif node_type in TRIGGER_NODE_TYPES:
+            triggers.append(str(node_id))
+
+        if not isinstance(node.get("data"), dict):
+            errors.append(
+                _err(
+                    f"{base}/data",
+                    "required",
+                    "Node needs a data object",
+                    "object",
+                    type(node.get("data")).__name__ if node.get("data") is not None else None,
+                )
+            )
+
+        position = node.get("position")
+        if not isinstance(position, dict):
+            errors.append(
+                _err(
+                    f"{base}/position",
+                    "required",
+                    "Node needs a position {x, y}",
+                    "object",
+                    type(position).__name__ if position is not None else None,
+                )
+            )
+        else:
+            for axis in ("x", "y"):
+                if not isinstance(position.get(axis), (int, float)) or isinstance(
+                    position.get(axis), bool
+                ):
+                    errors.append(
+                        _err(
+                            f"{base}/position/{axis}",
+                            "invalid_type",
+                            f"position.{axis} must be a number",
+                            "number",
+                            position.get(axis),
+                        )
+                    )
+
+    edge_ids: set[str] = set()
+    for i, edge in enumerate(edges):
+        base = f"/edges/{i}"
+        if not isinstance(edge, dict):
+            errors.append(
+                _err(base, "invalid_type", "Edge must be an object", "object", type(edge).__name__)
+            )
+            continue
+
+        edge_id = edge.get("id")
+        if not isinstance(edge_id, str) or not edge_id.strip():
+            errors.append(
+                _err(
+                    f"{base}/id", "required", "Edge needs a non-empty string id", "string", edge_id
+                )
+            )
+        elif edge_id in edge_ids:
+            errors.append(
+                _err(
+                    f"{base}/id",
+                    "duplicate",
+                    f"Duplicate edge id '{edge_id}'",
+                    "unique id",
+                    edge_id,
+                )
+            )
+        else:
+            edge_ids.add(edge_id)
+
+        for endpoint in ("source", "target"):
+            value = edge.get(endpoint)
+            if not isinstance(value, str) or not value:
+                errors.append(
+                    _err(
+                        f"{base}/{endpoint}",
+                        "required",
+                        f"Edge needs a {endpoint} node id",
+                        "string",
+                        value,
+                    )
+                )
+            elif node_ids and value not in node_ids:
+                # A dangling edge renders as a broken connection and silently
+                # drops whatever branch it was meant to carry.
+                errors.append(
+                    _err(
+                        f"{base}/{endpoint}",
+                        "dangling_edge",
+                        f"Edge {endpoint} '{value}' is not a node in this workflow",
+                        "an existing node id",
+                        value,
+                    )
+                )
+
+    if nodes and not triggers:
+        errors.append(
+            _err(
+                "/nodes",
+                "no_trigger",
+                "Workflow has no trigger node, so it can never run. Add one of: "
+                + ", ".join(sorted(TRIGGER_NODE_TYPES)),
+                "exactly one trigger",
+                0,
+            )
+        )
+    elif len(triggers) > 1:
+        # The executor walks from the first trigger it finds; the rest of the
+        # graph never executes and nothing reports why.
+        errors.append(
+            _err(
+                "/nodes",
+                "multiple_triggers",
+                "Workflow has more than one trigger. Only the first would run and "
+                "everything downstream of the others would be silently skipped.",
+                "exactly one trigger",
+                triggers,
+            )
+        )
+
+    return errors
+
+
+def assert_valid_workflow(payload: Any, *, require_name: bool = True) -> None:
+    """Raise WorkflowValidationError when the workflow is structurally invalid."""
+    errors = validate_workflow(payload, require_name=require_name)
+    if errors:
+        raise WorkflowValidationError(errors)

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -283,7 +283,12 @@ TWO_SERIES_INDICATORS = {
 
 # Indicators with a non-flat call shape (submodule access) that the generic
 # getattr(ta, name)(...) dispatch below cannot call directly.
-UNSUPPORTED_INDICATORS = {"median_bands"}
+# Indicators the installed `openalgo` build cannot actually compute. Listing a
+# name the user can select but that never returns a value is worse than not
+# offering it. Verified against openalgo 2.0.3: ta.ulcerindex and ta.vi return
+# all-NaN for every input length tried (100/400/2000 bars, ndarray and Series).
+# Re-test and remove from this set when the upstream implementation is fixed.
+UNSUPPORTED_INDICATORS = {"median_bands", "ulcerindex", "vi"}
 
 # Approx bars per trading day per interval (NSE ~6h15m session), used only to
 # size the calendar window when fetching by bar-count.
@@ -668,7 +673,10 @@ def compute_indicator(
             "Condition node instead."
         )
     if name in UNSUPPORTED_INDICATORS:
-        raise ValueError(f"'{name}' has a non-standard call shape and is not supported here.")
+        raise ValueError(
+            f"'{name}' is not available: the installed openalgo build does not "
+            "return usable values for it. Pick a different indicator."
+        )
     fn = getattr(ta, name, None)
     if fn is None:
         raise ValueError(f"unknown indicator '{indicator_name}'")
@@ -736,6 +744,29 @@ def compute_indicator(
     offset = clamp_bars(offset_bars + 1, "offset bars") - 1
     at_offset = _at(-1 - offset)
 
+    latest = _at(-1)
+
+    # An indicator that returns nothing usable must not report success. A
+    # workflow comparing against `latest.value` would otherwise branch on None
+    # and look like a condition that simply never fired, with no error anywhere.
+    # This catches a broken upstream implementation as well as genuinely
+    # insufficient warm-up data.
+    if isinstance(latest, dict) and latest and all(v is None for v in latest.values()):
+        return {
+            "status": "error",
+            "indicator": name,
+            "message": (
+                f"Indicator '{name}' produced no value over {len(df_index)} bars - "
+                "every output was null. Increase the lookback if the indicator "
+                "needs a longer warm-up, or check that this indicator is usable "
+                "with the selected inputs."
+            ),
+            "inputs": cols,
+            "params": resolved_params,
+            "outputs": list(out.columns),
+            "bars_used": len(df_index),
+        }
+
     return {
         "status": "success",
         "indicator": name,
@@ -745,7 +776,7 @@ def compute_indicator(
         "inputs": cols,
         "params": resolved_params,
         "outputs": list(out.columns),
-        "latest": _at(-1),
+        "latest": latest,
         "previous": _at(-2),
         "series": tail_series,
         "bars_used": len(df_index),

--- a/services/indicator_service.py
+++ b/services/indicator_service.py
@@ -22,6 +22,7 @@ import pandas as pd
 from cachetools import TTLCache
 from openalgo import ta
 
+from utils.env_config import env_int
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
@@ -42,7 +43,7 @@ logger = get_logger(__name__)
 # Bounded via maxsize so it cannot grow without limit in a long-lived worker
 # (see the FD/memory hygiene rules in CLAUDE.md).
 _HISTORY_CACHE_TTL = float(os.getenv("FLOW_HISTORY_CACHE_TTL", "30"))
-_HISTORY_CACHE_MAXSIZE = int(os.getenv("FLOW_HISTORY_CACHE_MAXSIZE", "256"))
+_HISTORY_CACHE_MAXSIZE = env_int("FLOW_HISTORY_CACHE_MAXSIZE", 256, minimum=1)
 _history_cache: TTLCache = TTLCache(
     maxsize=max(_HISTORY_CACHE_MAXSIZE, 1), ttl=max(_HISTORY_CACHE_TTL, 0.001)
 )
@@ -187,14 +188,14 @@ def clear_history_cache() -> None:
 # not only when trimming the response, so the oversized fetch never happens
 # in the first place. Raise FLOW_MAX_HISTORY_BARS if a strategy genuinely
 # needs more depth.
-MAX_HISTORY_BARS = max(int(os.getenv("FLOW_MAX_HISTORY_BARS", "200")), 1)
+MAX_HISTORY_BARS = env_int("FLOW_MAX_HISTORY_BARS", 200, minimum=1)
 
 # Absolute ceiling on the calendar span of any single request. The bar count
 # alone is not enough: 200 quarterly bars is a 54-year range and 200 yearly
 # bars is 219 years - spans no broker will serve sensibly, and which can make
 # an adapter fall back to dumping daily rows. ~11 years keeps weekly at its
 # full 200 bars while bounding the long-period aggregates.
-MAX_HISTORY_CALENDAR_DAYS = max(int(os.getenv("FLOW_MAX_HISTORY_CALENDAR_DAYS", "4000")), 1)
+MAX_HISTORY_CALENDAR_DAYS = env_int("FLOW_MAX_HISTORY_CALENDAR_DAYS", 4000, minimum=1)
 
 # Extra rows fed to an indicator beyond its requested lookback, so recursive
 # indicators (EMA/MACD/ATR) have settled by the time the reported window

--- a/services/options_multiorder_service.py
+++ b/services/options_multiorder_service.py
@@ -331,6 +331,10 @@ def resolve_and_place_leg(
                 "leg": leg_index + 1,
                 "symbol": resolved_symbol,
                 "exchange": resolved_exchange,
+                # The split path reports one aggregated leg. Without product,
+                # subscribers keying on (symbol, exchange, product) cannot match
+                # it, unlike the non-split path below.
+                "product": leg_data.get("product", "MIS"),
                 "offset": leg_data.get("offset"),
                 "option_type": leg_data.get("option_type", "").upper(),
                 "action": leg_data.get("action", "").upper(),

--- a/services/options_multiorder_service.py
+++ b/services/options_multiorder_service.py
@@ -376,6 +376,9 @@ def resolve_and_place_leg(
                 "leg": leg_index + 1,
                 "symbol": resolved_symbol,
                 "exchange": resolved_exchange,
+                # Each leg can carry its own product, so the summary event's
+                # value is not authoritative for subscribers keying on the leg.
+                "product": order_data.get("product", ""),
                 "offset": leg_data.get("offset"),
                 "option_type": leg_data.get("option_type", "").upper(),
                 "action": leg_data.get("action", "").upper(),

--- a/services/strategy_pnl_service.py
+++ b/services/strategy_pnl_service.py
@@ -17,13 +17,9 @@ from the event bus. This module reads it:
 * **total** - realized + unrealized (plus `today_realized` / `today_total`
   for intraday exits)
 
-`pnl_from_book` is the primary path. `compute_strategy_pnl` is the
-independent trade-replay implementation: it derives the same figures from
-tagged tradebook rows without consulting the book, which makes it useful for
-reconciling the book against the broker's own record of the session. Both
-share one accounting convention - weighted-average cost, where a position
-flipping through zero realizes the closed leg and reopens the remainder at
-the fill price.
+Accounting convention: weighted-average cost, where a position flipping
+through zero realizes the closed leg and reopens the remainder at the fill
+price.
 """
 
 from typing import Any
@@ -40,146 +36,6 @@ def _f(value: Any, default: float = 0.0) -> float:
         return default
 
 
-class _Book:
-    """Weighted-average position accounting for one instrument."""
-
-    __slots__ = ("qty", "avg", "realized")
-
-    def __init__(self) -> None:
-        self.qty = 0.0  # signed: positive long, negative short
-        self.avg = 0.0  # average cost of the open quantity
-        self.realized = 0.0
-
-    def apply(self, signed_qty: float, price: float) -> None:
-        if signed_qty == 0:
-            return
-
-        # Opening, or adding to an existing position in the same direction.
-        if self.qty == 0 or (self.qty > 0) == (signed_qty > 0):
-            total = abs(self.qty) + abs(signed_qty)
-            self.avg = ((self.avg * abs(self.qty)) + (price * abs(signed_qty))) / total
-            self.qty += signed_qty
-            return
-
-        # Reducing, closing, or flipping.
-        closing = min(abs(signed_qty), abs(self.qty))
-        direction = 1.0 if self.qty > 0 else -1.0
-        self.realized += closing * (price - self.avg) * direction
-        remaining = abs(signed_qty) - closing
-        self.qty += signed_qty
-
-        if abs(self.qty) < 1e-9:
-            self.qty = 0.0
-            self.avg = 0.0
-        elif remaining > 0:
-            # Flipped through zero: the leftover opens a fresh position.
-            self.avg = price
-
-
-def compute_strategy_pnl(
-    trades: list[dict[str, Any]],
-    positions: list[dict[str, Any]] | None = None,
-    strategy: str | None = None,
-) -> dict[str, Any]:
-    """Aggregate realized / unrealized / total P&L per strategy.
-
-    Args:
-        trades: tradebook rows (need `strategy`, `symbol`, `exchange`,
-            `product`, `action`, `quantity`, and `average_price` or `price`).
-        positions: position-book rows, used only for last traded price and to
-            detect positions carried over from a previous session.
-        strategy: when given, only this strategy is returned.
-
-    Returns a dict keyed by strategy name; each value carries `realized`,
-    `unrealized`, `total`, `open_quantity`, `trade_count`, `carried_over` and
-    a per-instrument `legs` breakdown.
-    """
-    positions = positions or []
-
-    ltp_by_key: dict[tuple, float] = {}
-    pos_by_key: dict[tuple, dict[str, Any]] = {}
-    for row in positions:
-        key = (row.get("symbol"), row.get("exchange"), row.get("product"))
-        ltp_by_key[key] = _f(row.get("ltp"))
-        pos_by_key[key] = row
-
-    books: dict[str, dict[tuple, _Book]] = {}
-    counts: dict[str, int] = {}
-
-    for trade in trades:
-        name = (trade.get("strategy") or "").strip() or "untagged"
-        if strategy and name != strategy:
-            continue
-        key = (trade.get("symbol"), trade.get("exchange"), trade.get("product"))
-        qty = abs(_f(trade.get("quantity")))
-        if qty == 0:
-            continue
-        price = _f(trade.get("average_price")) or _f(trade.get("price"))
-        signed = qty if str(trade.get("action", "")).upper() == "BUY" else -qty
-        books.setdefault(name, {}).setdefault(key, _Book()).apply(signed, price)
-        counts[name] = counts.get(name, 0) + 1
-
-    out: dict[str, Any] = {}
-    for name, per_key in books.items():
-        realized = unrealized = 0.0
-        open_qty = 0.0
-        carried_over = False
-        legs = []
-
-        for key, book in per_key.items():
-            realized += book.realized
-            leg_unrealized = 0.0
-            if abs(book.qty) > 1e-9:
-                ltp = ltp_by_key.get(key)
-                if ltp is None:
-                    # Open per this strategy's trades but absent from the
-                    # position book - cannot mark to market.
-                    carried_over = True
-                else:
-                    leg_unrealized = book.qty * (ltp - book.avg)
-                unrealized += leg_unrealized
-                open_qty += book.qty
-            legs.append(
-                {
-                    "symbol": key[0],
-                    "exchange": key[1],
-                    "product": key[2],
-                    "quantity": round(book.qty, 4),
-                    "average_price": round(book.avg, 4),
-                    "ltp": ltp_by_key.get(key),
-                    "realized": round(book.realized, 4),
-                    "unrealized": round(leg_unrealized, 4),
-                }
-            )
-
-        out[name] = {
-            "strategy": name,
-            "realized": round(realized, 4),
-            "unrealized": round(unrealized, 4),
-            "total": round(realized + unrealized, 4),
-            "open_quantity": round(open_qty, 4),
-            "trade_count": counts.get(name, 0),
-            "carried_over": carried_over,
-            "legs": legs,
-        }
-
-    if strategy:
-        return out.get(
-            strategy,
-            {
-                "strategy": strategy,
-                "realized": 0.0,
-                "unrealized": 0.0,
-                "total": 0.0,
-                "open_quantity": 0.0,
-                "trade_count": 0,
-                "carried_over": False,
-                "legs": [],
-            },
-        )
-    return out
-
-
 def pnl_from_book(
     legs: list[dict[str, Any]],
     positions: list[dict[str, Any]] | None = None,
@@ -193,8 +49,15 @@ def pnl_from_book(
     function of a price that changes continuously.
     """
     positions = positions or []
+    # `ltp` is the standardized OpenAlgo position field (see
+    # docs/api/account-services/positionbook.md); every broker mapper converts
+    # its own raw field into it. `last_price` is accepted only as a fallback
+    # for a mapper that passes the broker's name through unchanged.
     ltp_by_key = {
-        (p.get("symbol"), p.get("exchange"), p.get("product")): _f(p.get("ltp")) for p in positions
+        (p.get("symbol"), p.get("exchange"), p.get("product")): _f(
+            p.get("ltp") if p.get("ltp") is not None else p.get("last_price")
+        )
+        for p in positions
     }
 
     grouped: dict[str, dict[str, Any]] = {}

--- a/services/strategy_pnl_service.py
+++ b/services/strategy_pnl_service.py
@@ -149,9 +149,16 @@ def get_strategy_pnl(
     cost basis, and durable across restarts) and marks open quantity against
     a single position-book call for last traded prices.
     """
-    from database.strategy_book_db import get_strategy_legs
+    from database.strategy_book_db import StrategyBookUnavailable, get_strategy_legs
 
-    legs = get_strategy_legs(user_id=user_id, strategy=strategy)
+    try:
+        legs = get_strategy_legs(user_id=user_id, strategy=strategy)
+    except StrategyBookUnavailable as exc:
+        # An unreadable book is unknown, not empty. Reporting zero here would
+        # look identical to a flat, healthy strategy to an exit trigger.
+        logger.error(f"Strategy P&L unavailable: {exc}")
+        return {"status": "error", "message": f"Strategy book unavailable: {exc}"}
+
     positions_resp = client.positionbook() or {}
     # Propagate rather than pricing against an empty book. A transient broker
     # failure would otherwise mark every open leg unpriced, report unrealized

--- a/services/strategy_pnl_service.py
+++ b/services/strategy_pnl_service.py
@@ -290,6 +290,16 @@ def get_strategy_pnl(
 
     legs = get_strategy_legs(user_id=user_id, strategy=strategy)
     positions_resp = client.positionbook() or {}
+    # Propagate rather than pricing against an empty book. A transient broker
+    # failure would otherwise mark every open leg unpriced, report unrealized
+    # as zero, and still return success - letting a workflow act on a total
+    # that is materially wrong.
+    if positions_resp.get("status") == "error":
+        message = positions_resp.get("error") or positions_resp.get("message") or "unavailable"
+        return {
+            "status": "error",
+            "message": f"Position book unavailable, cannot value open legs: {message}",
+        }
     positions = positions_resp.get("data") or []
     if not isinstance(positions, list):
         positions = []

--- a/services/strategy_pnl_service.py
+++ b/services/strategy_pnl_service.py
@@ -1,0 +1,300 @@
+"""
+Per-strategy realized / unrealized / total P&L.
+
+The broker - and OpenAlgo's own position book - nets positions per
+`(symbol, exchange, product)` and carries no strategy label, so a position
+alone cannot answer "how is *this* strategy doing?". Two strategies trading
+the same contract are indistinguishable downstream.
+
+`database/strategy_book_db.py` keeps a parallel book keyed by strategy, fed
+from the event bus. This module reads it:
+
+* **realized** - taken from the book, which accumulates across sessions and
+  survives restarts
+* **unrealized** - computed here by marking open quantity to the position
+  book's last traded price, because a stored value would be stale the instant
+  it was written
+* **total** - realized + unrealized (plus `today_realized` / `today_total`
+  for intraday exits)
+
+`pnl_from_book` is the primary path. `compute_strategy_pnl` is the
+independent trade-replay implementation: it derives the same figures from
+tagged tradebook rows without consulting the book, which makes it useful for
+reconciling the book against the broker's own record of the session. Both
+share one accounting convention - weighted-average cost, where a position
+flipping through zero realizes the closed leg and reopens the remainder at
+the fill price.
+"""
+
+from typing import Any
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def _f(value: Any, default: float = 0.0) -> float:
+    try:
+        return float(value)
+    except (TypeError, ValueError):
+        return default
+
+
+class _Book:
+    """Weighted-average position accounting for one instrument."""
+
+    __slots__ = ("qty", "avg", "realized")
+
+    def __init__(self) -> None:
+        self.qty = 0.0  # signed: positive long, negative short
+        self.avg = 0.0  # average cost of the open quantity
+        self.realized = 0.0
+
+    def apply(self, signed_qty: float, price: float) -> None:
+        if signed_qty == 0:
+            return
+
+        # Opening, or adding to an existing position in the same direction.
+        if self.qty == 0 or (self.qty > 0) == (signed_qty > 0):
+            total = abs(self.qty) + abs(signed_qty)
+            self.avg = ((self.avg * abs(self.qty)) + (price * abs(signed_qty))) / total
+            self.qty += signed_qty
+            return
+
+        # Reducing, closing, or flipping.
+        closing = min(abs(signed_qty), abs(self.qty))
+        direction = 1.0 if self.qty > 0 else -1.0
+        self.realized += closing * (price - self.avg) * direction
+        remaining = abs(signed_qty) - closing
+        self.qty += signed_qty
+
+        if abs(self.qty) < 1e-9:
+            self.qty = 0.0
+            self.avg = 0.0
+        elif remaining > 0:
+            # Flipped through zero: the leftover opens a fresh position.
+            self.avg = price
+
+
+def compute_strategy_pnl(
+    trades: list[dict[str, Any]],
+    positions: list[dict[str, Any]] | None = None,
+    strategy: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate realized / unrealized / total P&L per strategy.
+
+    Args:
+        trades: tradebook rows (need `strategy`, `symbol`, `exchange`,
+            `product`, `action`, `quantity`, and `average_price` or `price`).
+        positions: position-book rows, used only for last traded price and to
+            detect positions carried over from a previous session.
+        strategy: when given, only this strategy is returned.
+
+    Returns a dict keyed by strategy name; each value carries `realized`,
+    `unrealized`, `total`, `open_quantity`, `trade_count`, `carried_over` and
+    a per-instrument `legs` breakdown.
+    """
+    positions = positions or []
+
+    ltp_by_key: dict[tuple, float] = {}
+    pos_by_key: dict[tuple, dict[str, Any]] = {}
+    for row in positions:
+        key = (row.get("symbol"), row.get("exchange"), row.get("product"))
+        ltp_by_key[key] = _f(row.get("ltp"))
+        pos_by_key[key] = row
+
+    books: dict[str, dict[tuple, _Book]] = {}
+    counts: dict[str, int] = {}
+
+    for trade in trades:
+        name = (trade.get("strategy") or "").strip() or "untagged"
+        if strategy and name != strategy:
+            continue
+        key = (trade.get("symbol"), trade.get("exchange"), trade.get("product"))
+        qty = abs(_f(trade.get("quantity")))
+        if qty == 0:
+            continue
+        price = _f(trade.get("average_price")) or _f(trade.get("price"))
+        signed = qty if str(trade.get("action", "")).upper() == "BUY" else -qty
+        books.setdefault(name, {}).setdefault(key, _Book()).apply(signed, price)
+        counts[name] = counts.get(name, 0) + 1
+
+    out: dict[str, Any] = {}
+    for name, per_key in books.items():
+        realized = unrealized = 0.0
+        open_qty = 0.0
+        carried_over = False
+        legs = []
+
+        for key, book in per_key.items():
+            realized += book.realized
+            leg_unrealized = 0.0
+            if abs(book.qty) > 1e-9:
+                ltp = ltp_by_key.get(key)
+                if ltp is None:
+                    # Open per this strategy's trades but absent from the
+                    # position book - cannot mark to market.
+                    carried_over = True
+                else:
+                    leg_unrealized = book.qty * (ltp - book.avg)
+                unrealized += leg_unrealized
+                open_qty += book.qty
+            legs.append(
+                {
+                    "symbol": key[0],
+                    "exchange": key[1],
+                    "product": key[2],
+                    "quantity": round(book.qty, 4),
+                    "average_price": round(book.avg, 4),
+                    "ltp": ltp_by_key.get(key),
+                    "realized": round(book.realized, 4),
+                    "unrealized": round(leg_unrealized, 4),
+                }
+            )
+
+        out[name] = {
+            "strategy": name,
+            "realized": round(realized, 4),
+            "unrealized": round(unrealized, 4),
+            "total": round(realized + unrealized, 4),
+            "open_quantity": round(open_qty, 4),
+            "trade_count": counts.get(name, 0),
+            "carried_over": carried_over,
+            "legs": legs,
+        }
+
+    if strategy:
+        return out.get(
+            strategy,
+            {
+                "strategy": strategy,
+                "realized": 0.0,
+                "unrealized": 0.0,
+                "total": 0.0,
+                "open_quantity": 0.0,
+                "trade_count": 0,
+                "carried_over": False,
+                "legs": [],
+            },
+        )
+    return out
+
+
+def pnl_from_book(
+    legs: list[dict[str, Any]],
+    positions: list[dict[str, Any]] | None = None,
+    strategy: str | None = None,
+) -> dict[str, Any]:
+    """Aggregate the persisted per-strategy legs into realized / unrealized /
+    total, marking open quantity to the position book's last traded price.
+
+    Realized comes from the book (it accumulates across sessions and survives
+    restarts). Unrealized is computed here rather than stored, because it is a
+    function of a price that changes continuously.
+    """
+    positions = positions or []
+    ltp_by_key = {
+        (p.get("symbol"), p.get("exchange"), p.get("product")): _f(p.get("ltp")) for p in positions
+    }
+
+    grouped: dict[str, dict[str, Any]] = {}
+    for leg in legs:
+        name = leg.get("strategy") or "untagged"
+        if strategy and name != strategy:
+            continue
+        entry = grouped.setdefault(
+            name,
+            {
+                "strategy": name,
+                "realized": 0.0,
+                "today_realized": 0.0,
+                "unrealized": 0.0,
+                "total": 0.0,
+                "open_quantity": 0.0,
+                "unpriced_legs": 0,
+                "legs": [],
+            },
+        )
+
+        qty = _f(leg.get("quantity"))
+        avg = _f(leg.get("average_price"))
+        realized = _f(leg.get("realized_pnl"))
+        today_realized = _f(leg.get("today_realized_pnl"))
+
+        key = (leg.get("symbol"), leg.get("exchange"), leg.get("product"))
+        ltp = ltp_by_key.get(key)
+        unrealized = 0.0
+        if abs(qty) > 1e-9:
+            if ltp is None:
+                # Open per the book but absent from the position book, so it
+                # cannot be marked to market. Surfaced rather than silently
+                # counted as zero.
+                entry["unpriced_legs"] += 1
+            else:
+                unrealized = qty * (ltp - avg)
+            entry["open_quantity"] += qty
+
+        entry["realized"] += realized
+        entry["today_realized"] += today_realized
+        entry["unrealized"] += unrealized
+        entry["legs"].append(
+            {
+                "symbol": leg.get("symbol"),
+                "exchange": leg.get("exchange"),
+                "product": leg.get("product"),
+                "quantity": round(qty, 4),
+                "average_price": round(avg, 4),
+                "ltp": ltp,
+                "realized": round(realized, 4),
+                "today_realized": round(today_realized, 4),
+                "unrealized": round(unrealized, 4),
+            }
+        )
+
+    for entry in grouped.values():
+        entry["realized"] = round(entry["realized"], 4)
+        entry["today_realized"] = round(entry["today_realized"], 4)
+        entry["unrealized"] = round(entry["unrealized"], 4)
+        entry["total"] = round(entry["realized"] + entry["unrealized"], 4)
+        entry["today_total"] = round(entry["today_realized"] + entry["unrealized"], 4)
+        entry["open_quantity"] = round(entry["open_quantity"], 4)
+
+    if strategy:
+        return grouped.get(
+            strategy,
+            {
+                "strategy": strategy,
+                "realized": 0.0,
+                "today_realized": 0.0,
+                "unrealized": 0.0,
+                "total": 0.0,
+                "today_total": 0.0,
+                "open_quantity": 0.0,
+                "unpriced_legs": 0,
+                "legs": [],
+            },
+        )
+    return grouped
+
+
+def get_strategy_pnl(
+    client, strategy: str | None = None, user_id: str | None = None
+) -> dict[str, Any]:
+    """Realized / unrealized / total P&L for one strategy, or all of them.
+
+    Reads the persisted strategy book (authoritative for realized P&L and
+    cost basis, and durable across restarts) and marks open quantity against
+    a single position-book call for last traded prices.
+    """
+    from database.strategy_book_db import get_strategy_legs
+
+    legs = get_strategy_legs(user_id=user_id, strategy=strategy)
+    positions_resp = client.positionbook() or {}
+    positions = positions_resp.get("data") or []
+    if not isinstance(positions, list):
+        positions = []
+
+    result = pnl_from_book(legs, positions, strategy=strategy)
+    if strategy:
+        return {"status": "success", **result}
+    return {"status": "success", "strategies": result, "count": len(result)}

--- a/subscribers/strategy_book_subscriber.py
+++ b/subscribers/strategy_book_subscriber.py
@@ -26,8 +26,12 @@ _FILLABLE = {"complete", "filled", "partially filled", "partial"}
 
 
 def _user_id(event) -> str:
+    return _request_field(event, "user_id")
+
+
+def _request_field(event, key: str) -> str:
     data = getattr(event, "request_data", None) or {}
-    return str(data.get("user_id") or "")
+    return str(data.get(key) or "") if isinstance(data, dict) else ""
 
 
 def on_order_placed(event) -> None:
@@ -60,21 +64,37 @@ def on_batch_completed(event) -> None:
         return
 
     user_id = _user_id(event)
-    default_exchange = getattr(event, "exchange", "") or ""
+    # A split or options batch is one contract, so the event carries the leg
+    # identity. A basket spans several, so each result supplies its own and the
+    # event has none - hence per-leg values win and the event is the fallback.
     default_symbol = getattr(event, "symbol", "") or ""
+    default_exchange = getattr(event, "exchange", "") or ""
+    default_product = getattr(event, "product", "") or _request_field(event, "product")
     for leg in results:
         if not isinstance(leg, dict):
             continue
         orderid = leg.get("orderid") or leg.get("order_id") or ""
         if not orderid:
             continue  # a rejected leg has no id
+        symbol = leg.get("symbol") or default_symbol
+        exchange = leg.get("exchange") or default_exchange
+        product = leg.get("product") or default_product
+        if not (symbol and exchange and product):
+            # Without all three the leg cannot be matched against the broker
+            # position book, so its unrealized P&L would silently read zero.
+            logger.warning(
+                f"Strategy book: skipping batch leg {orderid} for {strategy} - "
+                f"incomplete identity (symbol={symbol!r} exchange={exchange!r} "
+                f"product={product!r})"
+            )
+            continue
         record_order_tag(
             orderid=str(orderid),
             user_id=user_id,
             strategy=strategy,
-            symbol=leg.get("symbol") or default_symbol,
-            exchange=leg.get("exchange") or default_exchange,
-            product=leg.get("product") or "",
+            symbol=symbol,
+            exchange=exchange,
+            product=product,
         )
 
 

--- a/subscribers/strategy_book_subscriber.py
+++ b/subscribers/strategy_book_subscriber.py
@@ -46,6 +46,38 @@ def on_order_placed(event) -> None:
     )
 
 
+def on_batch_completed(event) -> None:
+    """Tag the child orders of a batch node.
+
+    optionsMultiOrder, basketOrder, splitOrder and optionsOrder place their
+    legs with emit_event=False, so no per-leg order.placed is published and
+    the legs would otherwise never be tagged. Each batch instead publishes one
+    completion event carrying the strategy and a results list of child orders.
+    """
+    strategy = (getattr(event, "strategy", "") or "").strip()
+    results = getattr(event, "results", None) or []
+    if not strategy or not isinstance(results, list):
+        return
+
+    user_id = _user_id(event)
+    default_exchange = getattr(event, "exchange", "") or ""
+    default_symbol = getattr(event, "symbol", "") or ""
+    for leg in results:
+        if not isinstance(leg, dict):
+            continue
+        orderid = leg.get("orderid") or leg.get("order_id") or ""
+        if not orderid:
+            continue  # a rejected leg has no id
+        record_order_tag(
+            orderid=str(orderid),
+            user_id=user_id,
+            strategy=strategy,
+            symbol=leg.get("symbol") or default_symbol,
+            exchange=leg.get("exchange") or default_exchange,
+            product=leg.get("product") or "",
+        )
+
+
 def on_order_update(event) -> None:
     """Book a fill against its strategy's position."""
     status = str(getattr(event, "order_status", "") or "").strip().lower().replace("_", " ")
@@ -78,4 +110,13 @@ def register(bus) -> None:
     """Attach both handlers. Called once during app startup."""
     bus.subscribe("order.placed", on_order_placed, name="StrategyBookTagger")
     bus.subscribe("order.update", on_order_update, name="StrategyBookFills")
+    # Batch nodes suppress per-leg order.placed, so their legs are tagged from
+    # the single completion event each publishes.
+    for topic in (
+        "multiorder.completed",
+        "basket.completed",
+        "split.completed",
+        "options.completed",
+    ):
+        bus.subscribe(topic, on_batch_completed, name="StrategyBookBatchTagger")
     logger.info("Strategy book subscriber registered")

--- a/subscribers/strategy_book_subscriber.py
+++ b/subscribers/strategy_book_subscriber.py
@@ -1,0 +1,81 @@
+"""
+Event-bus subscriber that maintains the per-strategy position book.
+
+Two topics carry everything needed, so the order execution path itself is
+never modified:
+
+* ``order.placed`` is the only moment the strategy tag is known - it is
+  supplied by the caller and never round-trips through the broker. The
+  orderid -> strategy mapping is recorded here.
+* ``order.update`` reports fills. The mapping is looked up and the unseen
+  portion of the fill is booked against that strategy's position.
+
+Both live and analyze (sandbox) orders publish these events, so the book
+covers either mode, and orders placed through ``/api/v1`` are tracked exactly
+like Flow-placed ones as long as they carry a ``strategy``.
+"""
+
+from database.strategy_book_db import apply_fill, record_order_tag
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Statuses that can carry filled quantity worth booking. "open" and
+# "trigger pending" are skipped - nothing has traded yet.
+_FILLABLE = {"complete", "filled", "partially filled", "partial"}
+
+
+def _user_id(event) -> str:
+    data = getattr(event, "request_data", None) or {}
+    return str(data.get("user_id") or "")
+
+
+def on_order_placed(event) -> None:
+    """Record which strategy an order belongs to."""
+    strategy = (getattr(event, "strategy", "") or "").strip()
+    orderid = getattr(event, "orderid", "") or ""
+    if not orderid or not strategy:
+        return
+    record_order_tag(
+        orderid=orderid,
+        user_id=_user_id(event),
+        strategy=strategy,
+        symbol=getattr(event, "symbol", "") or "",
+        exchange=getattr(event, "exchange", "") or "",
+        product=getattr(event, "product", "") or "",
+    )
+
+
+def on_order_update(event) -> None:
+    """Book a fill against its strategy's position."""
+    status = str(getattr(event, "order_status", "") or "").strip().lower().replace("_", " ")
+    if status not in _FILLABLE:
+        return
+
+    filled = getattr(event, "filled_quantity", 0) or 0
+    if not filled:
+        # Some adapters report a completed order without restating quantity.
+        filled = getattr(event, "quantity", 0) or 0
+    if not filled:
+        return
+
+    price = getattr(event, "average_price", 0) or getattr(event, "price", 0) or 0
+    result = apply_fill(
+        orderid=getattr(event, "orderid", "") or "",
+        filled_quantity=filled,
+        average_price=price,
+        action=getattr(event, "action", "") or "",
+    )
+    if result:
+        logger.info(
+            f"Strategy book: {result['strategy']} {result['symbol']} "
+            f"qty={result['quantity']} avg={result['average_price']} "
+            f"realizedToday={result['today_realized_pnl']}"
+        )
+
+
+def register(bus) -> None:
+    """Attach both handlers. Called once during app startup."""
+    bus.subscribe("order.placed", on_order_placed, name="StrategyBookTagger")
+    bus.subscribe("order.update", on_order_update, name="StrategyBookFills")
+    logger.info("Strategy book subscriber registered")

--- a/test/test_flow_workflow_validator.py
+++ b/test/test_flow_workflow_validator.py
@@ -1,0 +1,132 @@
+"""Structural validation and catalog-parity tests for Flow workflows.
+
+The parity tests are the important ones: the Flow node catalog is maintained in
+several places (ReactFlow registry, palette, config titles, default data, and
+the backend validator), and every drift found in the QA audit - a node with no
+palette entry, a node with no defaults, a node missing from the documented type
+list - was a case of those falling out of step with no test to catch it.
+
+Run: uv run pytest test/test_flow_workflow_validator.py -v
+"""
+
+import re
+from pathlib import Path
+
+import pytest
+
+from services.flow_workflow_validator import (
+    TRIGGER_NODE_TYPES,
+    VALID_NODE_TYPES,
+    validate_workflow,
+)
+
+FRONTEND = Path(__file__).resolve().parents[1] / "frontend" / "src"
+REGISTRY = FRONTEND / "components" / "flow" / "nodes" / "index.ts"
+PALETTE = FRONTEND / "components" / "flow" / "panels" / "NodePalette.tsx"
+CONFIG_PANEL = FRONTEND / "components" / "flow" / "panels" / "ConfigPanel.tsx"
+CONSTANTS = FRONTEND / "lib" / "flow" / "constants.ts"
+
+
+def _registry_types() -> set[str]:
+    src = REGISTRY.read_text()
+    block = src.split("export const nodeTypes = {")[1].split("} as const")[0]
+    return set(re.findall(r"^\s*(\w+):\s*\w+Node,", block, re.M))
+
+
+def _default_node_data_keys() -> set[str]:
+    src = CONSTANTS.read_text()
+    block = src.split("DEFAULT_NODE_DATA")[1]
+    block = block[: block.index("\n}")]
+    return set(re.findall(r"^\s{2}(\w+):\s*\{", block, re.M))
+
+
+def _palette_types() -> set[str]:
+    return set(re.findall(r"type: '(\w+)',", PALETTE.read_text()))
+
+
+def _node_titles() -> set[str]:
+    src = CONFIG_PANEL.read_text()
+    block = src[src.index("const NODE_TITLES") :]
+    block = block[: block.index("\n}")]
+    return set(re.findall(r"^\s*(\w+):\s*'", block, re.M))
+
+
+@pytest.mark.skipif(not REGISTRY.exists(), reason="frontend sources not present")
+def test_validator_matches_reactflow_registry():
+    """A node the editor can create but the validator rejects is unimportable."""
+    assert _registry_types() == set(VALID_NODE_TYPES)
+
+
+@pytest.mark.skipif(not CONSTANTS.exists(), reason="frontend sources not present")
+def test_every_registered_node_has_default_data():
+    """Without defaults a dragged node starts as {} and its contract is implicit."""
+    assert _registry_types() - _default_node_data_keys() == set()
+
+
+@pytest.mark.skipif(not PALETTE.exists(), reason="frontend sources not present")
+def test_every_registered_node_is_in_the_palette():
+    """A registered node missing from the palette cannot be added by a no-code user."""
+    assert _registry_types() - _palette_types() == set()
+
+
+@pytest.mark.skipif(not CONFIG_PANEL.exists(), reason="frontend sources not present")
+def test_every_registered_node_has_a_config_title():
+    assert _registry_types() - _node_titles() == set()
+
+
+def _wf(nodes, edges=None, name="W"):
+    return {"name": name, "nodes": nodes, "edges": edges or []}
+
+
+def _node(node_id, node_type="log", **data):
+    return {"id": node_id, "type": node_type, "position": {"x": 0, "y": 0}, "data": data}
+
+
+def test_valid_workflow_passes():
+    wf = _wf(
+        [_node("n1", "start"), _node("n2", "log", message="hi")],
+        [{"id": "e1", "source": "n1", "target": "n2"}],
+    )
+    assert validate_workflow(wf) == []
+
+
+@pytest.mark.parametrize(
+    "payload,code",
+    [
+        ({"nodes": [], "edges": []}, "required"),
+        ({"name": "W", "edges": []}, "required"),
+        ({"name": "W", "nodes": []}, "required"),
+        (_wf([{"id": "a", "type": "NotARealNode", "position": {"x": 0, "y": 0}, "data": {}}]),
+         "unknown_node_type"),
+        (_wf([{"type": "start", "position": {"x": 0, "y": 0}, "data": {}}]), "required"),
+        (_wf([{"id": "a", "type": "start", "position": {"x": 0, "y": 0}}]), "required"),
+        (_wf([{"id": "a", "type": "start", "data": {}}]), "required"),
+        (_wf([_node("a", "start"), _node("a", "log")]), "duplicate"),
+        (_wf([_node("n1", "start")], [{"id": "e1", "source": "n1", "target": "ghost"}]),
+         "dangling_edge"),
+        (_wf([_node("a", "start"), _node("b", "start")]), "multiple_triggers"),
+        (_wf([_node("a", "log")]), "no_trigger"),
+        (["not", "an", "object"], "invalid_type"),
+    ],
+)
+def test_rejects_malformed_workflows(payload, code):
+    assert any(e["code"] == code for e in validate_workflow(payload))
+
+
+def test_rejects_the_invented_schema_shape():
+    """The shape LLMs commonly invent: strategy/settings/variables/flow."""
+    payload = {"strategy": "Gap fill", "settings": {}, "variables": {}, "flow": []}
+    errors = validate_workflow(payload)
+    assert {e["path"] for e in errors} >= {"/name", "/nodes", "/edges"}
+
+
+def test_errors_carry_a_path_and_a_code():
+    errors = validate_workflow({"name": "W", "nodes": [{"type": "start"}], "edges": []})
+    assert errors
+    for err in errors:
+        assert err["path"].startswith("/")
+        assert err["code"] and err["message"]
+
+
+def test_trigger_types_are_registered_node_types():
+    assert TRIGGER_NODE_TYPES <= VALID_NODE_TYPES

--- a/test/test_flow_workflow_validator.py
+++ b/test/test_flow_workflow_validator.py
@@ -130,3 +130,78 @@ def test_errors_carry_a_path_and_a_code():
 
 def test_trigger_types_are_registered_node_types():
     assert TRIGGER_NODE_TYPES <= VALID_NODE_TYPES
+
+
+def test_detects_a_cycle():
+    """A cycle burns the executor's visit budget instead of reporting a loop."""
+    wf = _wf(
+        [_node("t", "start"), _node("a"), _node("b")],
+        [
+            {"id": "e1", "source": "t", "target": "a"},
+            {"id": "e2", "source": "a", "target": "b"},
+            {"id": "e3", "source": "b", "target": "a"},
+        ],
+    )
+    assert any(e["code"] == "cycle" for e in validate_workflow(wf))
+
+
+def test_detects_unreachable_nodes():
+    wf = _wf(
+        [_node("t", "start"), _node("a"), _node("orphan")],
+        [{"id": "e1", "source": "t", "target": "a"}],
+    )
+    assert any(e["code"] == "unreachable" for e in validate_workflow(wf))
+
+
+@pytest.mark.parametrize(
+    "source_type,handle,expected_error",
+    [
+        ("varCondition", "maybe", True),
+        ("varCondition", "true", False),
+        ("varCondition", "no", False),
+        ("getQuote", "true", True),
+    ],
+)
+def test_validates_source_handles(source_type, handle, expected_error):
+    """A handle the source node cannot emit silently drops that branch."""
+    wf = _wf(
+        [
+            _node("t", "start"),
+            _node("c", source_type, symbol="X", exchange="NSE", leftValue="{{x}}", operator=">"),
+            _node("a"),
+        ],
+        [
+            {"id": "e1", "source": "t", "target": "c"},
+            {"id": "e2", "source": "c", "target": "a", "sourceHandle": handle},
+        ],
+    )
+    found = any(e["code"] == "invalid_source_handle" for e in validate_workflow(wf))
+    assert found is expected_error
+
+
+def test_requires_order_fields():
+    wf = _wf(
+        [_node("t", "start"), _node("o", "placeOrder", exchange="NSE", action="BUY")],
+        [{"id": "e1", "source": "t", "target": "o"}],
+    )
+    assert any(e["code"] == "missing_required_field" for e in validate_workflow(wf))
+
+
+def test_rejects_a_workflow_with_no_nodes():
+    assert any(e["code"] == "no_trigger" for e in validate_workflow(_wf([])))
+
+
+def test_partial_graphs_stay_savable():
+    """The editor saves while a graph is still being wired.
+
+    Structure is always enforced; completeness only at import and activation.
+    """
+    half = _wf([_node("t", "start"), _node("o", "placeOrder")], [])
+    assert validate_workflow(half, require_name=False, strict=False) == []
+    assert validate_workflow(half) != []
+
+
+def test_corrupt_graphs_are_rejected_even_when_saving():
+    corrupt = _wf([{"id": "a", "type": "NotReal", "position": {"x": 0, "y": 0}, "data": {}}])
+    errors = validate_workflow(corrupt, require_name=False, strict=False)
+    assert any(e["code"] == "unknown_node_type" for e in errors)

--- a/test/test_flow_workflow_validator.py
+++ b/test/test_flow_workflow_validator.py
@@ -15,8 +15,10 @@ from pathlib import Path
 import pytest
 
 from services.flow_workflow_validator import (
+    BRANCHING_NODE_TYPES,
     TRIGGER_NODE_TYPES,
     VALID_NODE_TYPES,
+    migrate_legacy_node_data,
     validate_workflow,
 )
 
@@ -205,3 +207,87 @@ def test_corrupt_graphs_are_rejected_even_when_saving():
     corrupt = _wf([{"id": "a", "type": "NotReal", "position": {"x": 0, "y": 0}, "data": {}}])
     errors = validate_workflow(corrupt, require_name=False, strict=False)
     assert any(e["code"] == "unknown_node_type" for e in errors)
+
+
+NODE_COMPONENT_DIR = FRONTEND / "components" / "flow" / "nodes"
+
+
+@pytest.mark.skipif(not NODE_COMPONENT_DIR.exists(), reason="frontend sources not present")
+def test_branching_set_matches_components_that_render_branch_handles():
+    """A node whose own handles the validator rejects cannot be imported.
+
+    priceAlert renders true/false handles like the condition nodes, and leaving
+    it out made a valid workflow fail validation on its own edges.
+    """
+    rendering = set()
+    for path in NODE_COMPONENT_DIR.glob("*Node.tsx"):
+        text = path.read_text()
+        if re.search(r'id="(true|false|yes|no)"', text):
+            name = path.stem[: -len("Node")]
+            rendering.add(name[0].lower() + name[1:])
+    rendering -= {"base"}  # shared base component, not a node type
+    rendering &= VALID_NODE_TYPES
+    assert rendering <= BRANCHING_NODE_TYPES, sorted(rendering - BRANCHING_NODE_TYPES)
+
+
+def test_malformed_gate_input_count_does_not_crash():
+    """A malformed payload must be rejected, not raise out of the validator."""
+    wf = _wf([_node("g", "andGate")])
+    wf["nodes"][0]["data"]["inputCount"] = "abc"
+    validate_workflow(wf)  # must not raise
+
+
+def test_empty_split_order_is_rejected():
+    wf = _wf(
+        [_node("t", "start"), _node("s", "splitOrder")],
+        [{"id": "e1", "source": "t", "target": "s"}],
+    )
+    assert any(e["code"] == "missing_required_field" for e in validate_workflow(wf))
+
+
+def test_phantom_handle_on_a_non_branching_node_is_rejected():
+    wf = _wf(
+        [_node("t", "start"), _node("q", "getQuote", symbol="X", exchange="NSE"), _node("a")],
+        [
+            {"id": "e1", "source": "t", "target": "q"},
+            {"id": "e2", "source": "q", "target": "a", "sourceHandle": "output-9"},
+        ],
+    )
+    assert any(e["code"] == "invalid_source_handle" for e in validate_workflow(wf))
+
+
+def test_price_alert_may_use_its_own_branch_handles():
+    wf = _wf(
+        [
+            _node("t", "priceAlert", symbol="X", exchange="NSE", condition="above", price=100),
+            _node("a"),
+        ],
+        [{"id": "e1", "source": "t", "target": "a", "sourceHandle": "true"}],
+    )
+    assert not any(e["code"] == "invalid_source_handle" for e in validate_workflow(wf))
+
+
+@pytest.mark.parametrize(
+    "operator,expected_condition",
+    [("gt", "quantity_above"), ("lt", "quantity_below"), ("weird", None)],
+)
+def test_position_check_migration_preserves_the_comparison(operator, expected_condition):
+    """Flattening every legacy operator to "exists" turns a guard into a no-op."""
+    nodes = [_node("p", "positionCheck", operator=operator, threshold=5)]
+    migrated, _ = migrate_legacy_node_data(nodes)
+    assert migrated[0]["data"].get("condition") == expected_condition
+    assert migrated[0]["data"].get("threshold") == 5
+
+
+def test_fund_check_migration_never_reverses_the_guard():
+    """fundCheck only expresses a minimum, so a legacy less-than is left alone."""
+    migrated, notes = migrate_legacy_node_data(
+        [_node("f", "fundCheck", operator="gt", threshold=10000)]
+    )
+    assert migrated[0]["data"] == {"minAvailable": 10000}
+
+    migrated, notes = migrate_legacy_node_data(
+        [_node("f", "fundCheck", operator="lt", threshold=10000)]
+    )
+    assert "minAvailable" not in migrated[0]["data"]
+    assert any("no equivalent" in note for note in notes)

--- a/utils/db_sessions.py
+++ b/utils/db_sessions.py
@@ -1,0 +1,64 @@
+# utils/db_sessions.py
+"""Central registry of scoped sessions and a single place to release them.
+
+Every ``scoped_session`` holds a DB connection per thread (per green thread
+under eventlet) until ``.remove()`` is called. Production is one Gunicorn
+worker that never restarts, so a session left behind on any code path
+accumulates until the process hits its descriptor limit.
+
+Flask requests are covered by ``teardown_appcontext`` in ``app.py``. Work that
+runs *outside* a request - background threads, schedulers, event-bus callbacks -
+has no app context and no teardown, so it must call
+``remove_all_scoped_sessions()`` itself when it finishes.
+"""
+
+import importlib
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# (module path, attribute name) for every scoped_session in the project.
+SCOPED_SESSION_MODULES = [
+    ("database.auth_db", "db_session"),
+    ("database.traffic_db", "logs_session"),
+    ("database.apilog_db", "db_session"),
+    ("database.latency_db", "latency_session"),
+    ("database.health_db", "health_session"),
+    ("database.settings_db", "db_session"),
+    ("database.strategy_db", "db_session"),
+    ("database.user_db", "db_session"),
+    ("database.action_center_db", "db_session"),
+    ("database.qty_freeze_db", "db_session"),
+    ("database.sandbox_db", "db_session"),
+    ("database.analyzer_db", "db_session"),
+    ("database.chart_prefs_db", "db_session"),
+    ("database.chartink_db", "db_session"),
+    ("database.flow_db", "db_session"),
+    ("database.scalping_db", "db_session"),
+    ("database.leverage_db", "db_session"),
+    ("database.strategy_portfolio_db", "db_session"),
+    ("database.market_calendar_db", "db_session"),
+    ("database.telegram_db", "db_session"),
+    ("database.symbol", "db_session"),
+    ("database.strategy_book_db", "db_session"),
+    ("database.oauth_db", "db_session"),
+    ("database.whatsapp_db", "db_session"),
+]
+
+
+def remove_all_scoped_sessions() -> None:
+    """Release every scoped session bound to the calling thread.
+
+    Never raises: this runs in ``finally`` blocks and on teardown paths where an
+    error must not mask the original outcome.
+    """
+    for module_name, session_attr in SCOPED_SESSION_MODULES:
+        try:
+            mod = importlib.import_module(module_name)
+            session = getattr(mod, session_attr, None)
+            if session is not None:
+                session.remove()
+        except Exception:
+            # A module that failed to import has no session to release.
+            pass

--- a/utils/db_sessions.py
+++ b/utils/db_sessions.py
@@ -12,7 +12,7 @@ has no app context and no teardown, so it must call
 ``remove_all_scoped_sessions()`` itself when it finishes.
 """
 
-import importlib
+import sys
 
 from utils.logging import get_logger
 
@@ -54,11 +54,18 @@ def remove_all_scoped_sessions() -> None:
     error must not mask the original outcome.
     """
     for module_name, session_attr in SCOPED_SESSION_MODULES:
+        # sys.modules, not import_module: a module that was never imported has
+        # no session bound to this thread, and importing it here just to clean
+        # it would create the engine it was avoiding.
+        mod = sys.modules.get(module_name)
+        if mod is None:
+            continue
+        session = getattr(mod, session_attr, None)
+        if session is None:
+            continue
         try:
-            mod = importlib.import_module(module_name)
-            session = getattr(mod, session_attr, None)
-            if session is not None:
-                session.remove()
+            session.remove()
         except Exception:
-            # A module that failed to import has no session to release.
-            pass
+            # Swallowed so one bad session cannot strand the rest, but logged:
+            # a silent failure here is exactly how a descriptor leak hides.
+            logger.exception(f"Could not release scoped session {module_name}.{session_attr}")

--- a/utils/env_config.py
+++ b/utils/env_config.py
@@ -1,0 +1,48 @@
+# utils/env_config.py
+"""Tolerant readers for numeric environment settings.
+
+Tuning values are read at module import time, so a plain ``int(os.getenv(...))``
+turns a typo in ``.env`` into a worker that cannot start at all - the whole
+platform down because a cache size was misspelled. These helpers fall back to
+the default and log instead.
+"""
+
+import os
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+
+def env_int(name: str, default: int, minimum: int | None = None) -> int:
+    """Read an integer setting, falling back to ``default`` if unusable."""
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        value = default
+    else:
+        try:
+            value = int(str(raw).strip())
+        except (TypeError, ValueError):
+            logger.warning(f"{name}={raw!r} is not an integer; using {default}")
+            value = default
+    if minimum is not None and value < minimum:
+        logger.warning(f"{name}={value} is below the minimum {minimum}; using {minimum}")
+        value = minimum
+    return value
+
+
+def env_float(name: str, default: float, minimum: float | None = None) -> float:
+    """Read a float setting, falling back to ``default`` if unusable."""
+    raw = os.getenv(name)
+    if raw is None or str(raw).strip() == "":
+        value = default
+    else:
+        try:
+            value = float(str(raw).strip())
+        except (TypeError, ValueError):
+            logger.warning(f"{name}={raw!r} is not a number; using {default}")
+            value = default
+    if minimum is not None and value < minimum:
+        logger.warning(f"{name}={value} is below the minimum {minimum}; using {minimum}")
+        value = minimum
+    return value

--- a/utils/session.py
+++ b/utils/session.py
@@ -104,6 +104,23 @@ def _todays_rollover_boundary():
     return now_ist.replace(hour=hour, minute=minute, second=0, microsecond=0)
 
 
+def get_trading_session_date():
+    """Return the current trading session's date as an ISO string (IST).
+
+    A trading session runs from SESSION_EXPIRY_TIME (default 03:00 IST) to the
+    same time next day, matching the broker token rollover. Between midnight
+    and that boundary the session still belongs to the *previous* calendar
+    date, so anything bucketed "per trading day" must use this rather than
+    ``date.today()`` - which is also the server's local date and may not be IST
+    at all on a host outside India.
+    """
+    now_ist = datetime.now(pytz.timezone("UTC")).astimezone(pytz.timezone("Asia/Kolkata"))
+    boundary = _todays_rollover_boundary()
+    if now_ist < boundary:
+        return (now_ist - timedelta(days=1)).date().isoformat()
+    return now_ist.date().isoformat()
+
+
 def _has_fresher_session(username, current_session_id=None):
     """Return True if an active session for ``username`` (other than
     ``current_session_id``) authenticated at or after today's rollover boundary.

--- a/utils/session.py
+++ b/utils/session.py
@@ -94,11 +94,16 @@ def is_session_valid():
     return True
 
 
-def _todays_rollover_boundary():
+def _todays_rollover_boundary(now_ist=None):
     """Return today's session-expiry boundary (default 03:00 IST) as a
     timezone-aware IST datetime. Mirrors the boundary used by is_session_valid().
+
+    Accepts an existing IST snapshot so a caller that already read the clock
+    compares against the same instant its date was derived from, rather than
+    two reads that could straddle the boundary.
     """
-    now_ist = datetime.now(pytz.timezone("UTC")).astimezone(pytz.timezone("Asia/Kolkata"))
+    if now_ist is None:
+        now_ist = datetime.now(pytz.timezone("UTC")).astimezone(pytz.timezone("Asia/Kolkata"))
     expiry_time = os.getenv("SESSION_EXPIRY_TIME", "03:00")
     hour, minute = map(int, expiry_time.split(":"))
     return now_ist.replace(hour=hour, minute=minute, second=0, microsecond=0)
@@ -115,7 +120,7 @@ def get_trading_session_date():
     at all on a host outside India.
     """
     now_ist = datetime.now(pytz.timezone("UTC")).astimezone(pytz.timezone("Asia/Kolkata"))
-    boundary = _todays_rollover_boundary()
+    boundary = _todays_rollover_boundary(now_ist)
     if now_ist < boundary:
         return (now_ist - timedelta(days=1)).date().isoformat()
     return now_ist.date().isoformat()


### PR DESCRIPTION
Opens against `main` because the previous PR (#1694) was merged into `feat/flow-indicator-timeframe-nodes` **after** that branch had already gone to main in #1693. Its work never reached `main` as a result. This branch carries it plus the new fixes.

## The critical one: Price Alert never fired

The editor stores `above` / `below` / `crosses_above` / `crosses_below`. The monitor only ever compared `greater_than` / `less_than` / `crossing_up` / `crossing_down`, so **all four conditions the UI can produce** fell through to a final `return False`. Every price alert evaluated false and the trigger was effectively dead.

Both vocabularies are now accepted. Verified across all four:

```
above         -> greater_than   105 > 100        fired=True
below         -> less_than       95 < 100        fired=True
crosses_above -> crossing_up    last=99  -> 105  fired=True
crosses_below -> crossing_down  last=101 -> 95   fired=True
```

An unrecognized condition is now logged as an error rather than silently returning false — the failure mode that hid this.

Two related gaps on the same node: its `true`/`false` handles were rejected by validation even though the component renders them like any condition node, and the panel's **Trigger** and **Expiration** controls were dropped at activation, so "Every Time" behaved as one-shot and the expiry window never applied. Both are forwarded and honored now.

## Execution boundaries

Saving deliberately accepts a half-built graph so the editor stays usable — which means *stored* is not the same as *runnable*. Validating only at activation was not enough either, because a workflow can be edited afterwards. **Run Now, activation, and webhooks now share one guard** that validates the stored graph before anything can reach the broker.

## Validation gaps closed

| Gap | Effect |
| --- | --- |
| `input-N` on a non-gate node | edge pointed at a socket that does not exist; branch silently dropped |
| Any named output handle on a non-branching node | same |
| Empty `splitOrder` / `basketOrder` / `optionsMultiOrder` | reached the broker malformed |
| Malformed gate `inputCount` | crashed the validator that was meant to reject it |
| Partial updates | sending only `nodes` was rejected for the half it did not send; now validated against the merged graph |

## Legacy migration no longer changes what a guard means

This was the sharpest review catch. My earlier migration mapped any legacy `fundCheck` to `minAvailable`, so `operator: lt, threshold: 10000` — "stop when funds fall below 10,000" — became "proceed when funds are at least 10,000", **the exact reverse**.

`fundCheck` can only express "at least", so only a greater-than is migrated; a less-than is left alone with an explanation, and the executor errors on that shape rather than applying minimum semantics to it. `positionCheck` now maps its operator to `quantity_above` / `quantity_below` and keeps the threshold, instead of flattening every comparison to `exists` and turning a quantity-based exit into an unconditional one.

## Also

- A generated multi-leg strategy rejects SL / SL-M with an explanation: its legs carry no trigger price, so my previous check failed them as a *missing price* and made the type unusable without saying why.
- The in-place updater compares the whole trigger configuration, captured **before** the write, so changing an interval from 1m to 5m is reported. It also applies the same legacy migration as import.

## Verification

| Suite | Result |
| --- | --- |
| Validator tests | 39/39 |
| Execution boundaries | 12/12 |
| Static contracts / field contracts / reference contracts | clean / 16/16 / 17/17 |
| Import validation, fixtures, executor contracts | 12/12, OK, OK |
| Live MCX read-only | 26 PASS |
| Frontend tests / typecheck / build | 170/170, clean, succeeds |

## Notes on the audit pack

Three boundary checks asserted behaviour via source-text scans that my refactors made invisible — for example looking for `validate_workflow` inside `execute_workflow_now` when the call now goes through the shared guard. The behaviour was correct in each case; I changed those checks to assert behaviour rather than text, and verified each independently. Flagging it so the change is visible rather than looking like tests edited to go green.

Still open and not addressed here: no Flow-specific component or Playwright tests, and the single typed node manifest. Both are work rather than fixes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)