### PR TITLE
fix(flow): let the editor create a strategy, and stop logging a normal activation as an error

### DIFF
--- a/blueprints/flow.py
+++ b/blueprints/flow.py
@@ -67,13 +67,33 @@ def create_workflow():
     if not data:
         return jsonify({"error": "No data provided"}), 400
 
-    # Structural validation only: the editor saves while a graph is still being
-    # wired, so completeness (required fields, one trigger, reachability) is
-    # enforced at import and activation instead of blocking every save.
+    # Structural validation only, and only over what was actually sent. A new
+    # workflow is created from the editor with just a name - no graph yet - so
+    # requiring nodes/edges here rejected every "New Strategy" click.
+    # Completeness (required fields, one trigger, reachability) is enforced at
+    # import, activation, and execution instead of blocking a save.
     from services.flow_workflow_validator import validate_workflow
 
-    errors = validate_workflow(data, require_name=False, strict=False)
+    errors = (
+        validate_workflow(
+            {
+                "name": data.get("name") or "",
+                "nodes": data.get("nodes") or [],
+                "edges": data.get("edges") or [],
+            },
+            require_name=False,
+            strict=False,
+        )
+        if ("nodes" in data or "edges" in data)
+        else []
+    )
     if errors:
+        # Logged, not just returned: a bare 400 in the browser gives no reason,
+        # which made this class of rejection hard to diagnose.
+        logger.warning(
+            f"Rejected workflow save: {errors[0]['path']} {errors[0]['code']} - "
+            f"{errors[0]['message']}"
+        )
         return jsonify(
             {
                 "status": "error",
@@ -402,6 +422,10 @@ def _execution_blocked(workflow):
     )
     if not errors:
         return None
+    logger.warning(
+        f"Workflow {getattr(workflow, 'id', '?')} ({getattr(workflow, 'name', '?')}) "
+        f"blocked: {errors[0]['path']} {errors[0]['code']} - {errors[0]['message']}"
+    )
     return {
         "status": "error",
         "error": "Workflow cannot be executed",

--- a/blueprints/flow.py
+++ b/blueprints/flow.py
@@ -381,6 +381,8 @@ def deactivate_workflow(workflow_id):
         # Remove scheduler job if any
         if workflow.schedule_job_id:
             scheduler = get_flow_scheduler()
+            # An already-gone job is expected after a restart or a double click;
+            # remove_job treats that as a no-op.
             scheduler.remove_job(workflow.schedule_job_id)
             set_schedule_job_id(workflow_id, None)
 

--- a/services/flow_scheduler_service.py
+++ b/services/flow_scheduler_service.py
@@ -107,7 +107,8 @@ class FlowScheduler:
         """
         job_id = f"flow_workflow_{workflow_id}"
 
-        # Remove existing job if any
+        # Clear any previous job for this workflow. A brand-new workflow has
+        # none, which remove_job treats as a normal no-op.
         self.remove_job(job_id)
 
         # Use default function if not provided
@@ -181,17 +182,29 @@ class FlowScheduler:
         return job_id
 
     def remove_job(self, job_id: str) -> bool:
-        """Remove a job from the scheduler"""
+        """Remove a job from the scheduler. Returns False if there was none.
+
+        A job that does not exist is not an error for any caller: activating a
+        workflow clears any prior job first (a new workflow has none), and
+        deactivating may find it already gone after a restart. Logging that as
+        an ERROR with a traceback made a perfectly normal activation look
+        broken. A real jobstore failure is still logged with its traceback.
+        """
+        from apscheduler.jobstores.base import JobLookupError
+
         try:
             self.scheduler.remove_job(job_id)
             logger.info(f"Removed job {job_id}")
             return True
-        except Exception as e:
-            logger.exception(f"Failed to remove job {job_id}: {e}")
+        except JobLookupError:
+            logger.debug(f"No scheduler job {job_id} to remove")
+            return False
+        except Exception:
+            logger.exception(f"Failed to remove job {job_id}")
             return False
 
     def remove_workflow_job(self, workflow_id: int) -> bool:
-        """Remove a workflow job"""
+        """Remove a workflow job. A job that is already gone is not a failure."""
         job_id = f"flow_workflow_{workflow_id}"
         return self.remove_job(job_id)
 

--- a/test/test_flow_workflow_validator.py
+++ b/test/test_flow_workflow_validator.py
@@ -346,3 +346,58 @@ def test_unknown_alert_condition_is_rejected():
         [{"id": "e1", "source": "t", "target": "a"}],
     )
     assert any(e["code"] == "unknown_condition" for e in validate_workflow(wf))
+
+
+def test_creating_a_new_workflow_needs_no_graph():
+    """The editor creates a strategy with only a name, before any nodes exist.
+
+    Requiring nodes/edges here rejected every "New Strategy" click with a 400.
+    Mirrors blueprints.flow.create_workflow: validate only what was sent.
+    """
+
+    def create_route(data):
+        if "nodes" in data or "edges" in data:
+            return validate_workflow(
+                {
+                    "name": data.get("name") or "",
+                    "nodes": data.get("nodes") or [],
+                    "edges": data.get("edges") or [],
+                },
+                require_name=False,
+                strict=False,
+            )
+        return []
+
+    assert create_route({"name": "My Strategy"}) == []
+    assert create_route({"name": "My Strategy", "description": "x"}) == []
+    assert create_route({"name": "My Strategy", "nodes": [], "edges": []}) == []
+    # A graph that is sent is still checked.
+    corrupt = {
+        "name": "S",
+        "nodes": [{"id": "a", "type": "Nope", "position": {"x": 0, "y": 0}, "data": {}}],
+        "edges": [],
+    }
+    assert any(e["code"] == "unknown_node_type" for e in create_route(corrupt))
+
+
+def test_a_complete_editor_built_strategy_activates():
+    """End-to-end shape the editor produces, including a true-branch edge."""
+    nodes = [
+        _node("n1", "start", scheduleType="interval", intervalValue=1, intervalUnit="minutes"),
+        _node("n2", "getQuote", symbol="RELIANCE", exchange="NSE", outputVariable="q"),
+        _node("n3", "varCondition", leftValue="{{q.data.ltp}}", operator=">", rightValue="1000"),
+        _node(
+            "n4",
+            "placeOrder",
+            symbol="RELIANCE",
+            exchange="NSE",
+            action="BUY",
+            quantity=1,
+        ),
+    ]
+    edges = [
+        {"id": "e1", "source": "n1", "target": "n2"},
+        {"id": "e2", "source": "n2", "target": "n3"},
+        {"id": "e3", "source": "n3", "target": "n4", "sourceHandle": "true"},
+    ]
+    assert validate_workflow(_wf(nodes, edges)) == []


### PR DESCRIPTION
Two fixes that landed after #1697 was merged, so `main` does not have them yet.

## Creating a strategy returned 400 — my regression

The validation added in #1696 required `nodes` and `edges` on **every** create, but the editor posts only a name when you click *New Strategy* — there is no graph yet. So every new strategy was rejected.

Confirmed from the traffic log rather than guessed:

```
2026-07-30 01:58:54  POST 400  /flow/api/workflows
```

It now validates only the graph that was actually sent, which is the rule the update route already used. A graph that *is* sent is still checked, so a corrupt one is still refused.

Also worth recording: the `activate` 400s in that same log are from **12:40 on 07-29**, before this validation merged at **18:53**, so they have a separate cause and are not from this work.

**Validation rejections are now logged** with their path, code and reason. A bare 400 in the browser gave nothing to work from — that is why finding this needed a traffic-log query.

Tested across the whole editor lifecycle: create with a name only, autosave a half-configured graph, rename without a graph, activate a finished one — and an incomplete graph is still refused at activation.

## A normal activation logged an ERROR with a traceback

```
ERROR in flow_scheduler_service: Failed to remove job flow_workflow_104:
'No job by the id of flow_workflow_104 was found'
```

`add_workflow_job` clears any previous job before adding the new one, and a brand-new workflow has none, so APScheduler raised `JobLookupError` on the completely normal path. Deactivating after a restart hits the same case.

A job that does not exist is not an error for any caller — the intent is "ensure no job for this workflow", which is already satisfied. That now logs at debug; a genuine jobstore failure is still logged with its traceback, so the distinction that matters is preserved.

Verified both directions:

```
missing job   -> debug only, no ERROR/WARNING
real failure  -> ERROR with traceback
```

This one is **pre-existing on main**, not introduced by the Flow validation work.

I first added a `missing_ok` keyword for this, which broke a scheduler stub in the audit pack that passes a one-argument callback. That was a signal the keyword was unnecessary — absence is benign for every caller — so the signature is unchanged.

## Verification

| Suite | Result |
| --- | --- |
| Validator tests | 54/54 |
| Execution boundaries | 25/25 |
| Field / reference / import contracts | 16/16, 17/17, 12/12 |
| Static contracts, indicator catalog, fixtures, executor contracts | all clean |

No new lint errors in either touched file (counts identical to HEAD).

**Not re-run:** the live broker read-only suite. Everything above is static, mocked, or measured locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
