### PR TITLE
fix(angel): decode pong payload before comparing so liveness actually feeds the stall watchdog

### DIFF
--- a/broker/angel/streaming/smartWebSocketV2.py
+++ b/broker/angel/streaming/smartWebSocketV2.py
@@ -183,17 +183,49 @@ class SmartWebSocketV2:
             self.on_open(wsapp)
 
     def _on_pong(self, wsapp, data):
-        if data == self.HEART_BEAT_MESSAGE:
-            timestamp = time.time()
-            formatted_timestamp = time.strftime("%d-%m-%y %H:%M:%S", time.localtime(timestamp))
-            logger.info(f"In on pong function ==> {data}, Timestamp: {formatted_timestamp}")
-            self.last_pong_timestamp = timestamp
+        # `data` arrives as raw bytes off the wire (websocket-client does
+        # NOT utf-8-decode PING/PONG frame payloads -- only TEXT/BINARY data
+        # frames get that treatment). HEART_BEAT_MESSAGE is a plain str
+        # ("ping"), so comparing them directly (`data == self.HEART_BEAT_MESSAGE`)
+        # was ALWAYS False in Python 3 (b"ping" != "ping"), meaning this
+        # entire method body was silently dead code: every single pong Angel
+        # ever sent back (confirmed via the underlying WebSocketApp's own
+        # last_pong_tm bookkeeping ticking every HEART_BEAT_INTERVAL) was
+        # discarded without ever updating _last_message_time or logging.
+        # Decode before comparing, and treat receipt of ANY pong frame as
+        # proof of liveness regardless of payload -- the exact bytes echoed
+        # back are not something we control or need to gate correctness on.
+        payload = data.decode("utf-8", errors="replace") if isinstance(data, bytes) else data
+        timestamp = time.time()
+        formatted_timestamp = time.strftime("%d-%m-%y %H:%M:%S", time.localtime(timestamp))
+        logger.info(f"In on pong function ==> {payload}, Timestamp: {formatted_timestamp}")
+        self.last_pong_timestamp = timestamp
+        # Treat a WebSocket pong as proof the connection is alive.
+        #
+        # Angel only pushes a tick on price change, so during a quiet or
+        # closed market _last_message_time would otherwise freeze and the
+        # data-stall watchdog (_health_check_loop) would force a needless
+        # reconnect every DATA_TIMEOUT seconds. The protocol ping/pong
+        # (HEART_BEAT_INTERVAL=10s, wired via ping_interval on
+        # run_forever) keeps the socket alive regardless of market
+        # activity, so we feed the liveness clock from it too — exactly
+        # as Zerodha's 1-byte heartbeat feeds its identical watchdog, and
+        # as Fyers/Upstox already do — making the watchdog fire only when
+        # the socket is genuinely dead (no data AND no pong).
+        self._last_message_time = timestamp
+        if payload != self.HEART_BEAT_MESSAGE:
+            logger.debug(
+                f"Pong payload {payload!r} != expected {self.HEART_BEAT_MESSAGE!r} "
+                "(still treated as valid liveness proof)"
+            )
 
     def _on_ping(self, wsapp, data):
         timestamp = time.time()
         formatted_timestamp = time.strftime("%d-%m-%y %H:%M:%S", time.localtime(timestamp))
         logger.info(f"In on ping function ==> {data}, Timestamp: {formatted_timestamp}")
         self.last_ping_timestamp = timestamp
+        # A server-initiated ping also proves the socket is alive (see _on_pong).
+        self._last_message_time = timestamp
 
     def subscribe(self, correlation_id, mode, token_list):
         """


### PR DESCRIPTION
## Problem

`SmartWebSocketV2._health_check_loop` force-reconnects the socket if `_last_message_time` is older than `DATA_TIMEOUT` (90s). `_last_message_time` was only ever updated in `_on_data` (an actual price tick), never in `_on_pong`/`_on_ping`, even though the client sends a protocol-level ping every `HEART_BEAT_INTERVAL` (10s) and the server replies with a pong.

Angel only pushes a tick on price change, so a quiet/illiquid symbol can legitimately go >90s with no tick while the underlying socket is perfectly healthy. Running this live against a real account, the log showed `Angel data stall detected - no data for 90.0s` + `Forcing Angel WebSocket reconnection...` firing on a strict ~90-130s cadence continuously for over an hour — both during active trading hours and after market close — and each reconnect cycle repeated the exact same pattern, which is what you'd expect from a code-level liveness-detection gap, not genuine price silence.

## Root cause (revised — see history below)

My first attempt (previous revision of this PR) fed the liveness clock from `_on_pong`/`_on_ping`, matching the pattern already used by Zerodha/Fyers/Upstox. **That alone did not fix the problem.** After deploying it live, reconnects kept happening on the same cadence, and `_on_pong`'s own log line (`In on pong function ==> ...`) never appeared even once across an hour of logs, before or after that change.

The actual bug: `_on_pong` is gated behind `if data == self.HEART_BEAT_MESSAGE:`. `websocket-client` (`_app.py`) dispatches PING/PONG frame payloads as **raw bytes** without any UTF-8 decoding (unlike TEXT/BINARY data frames) — so `data` arrives as `bytes` (whatever Angel echoes back), while `HEART_BEAT_MESSAGE` is the `str` literal `"ping"`. In Python 3, `bytes` never equals `str`, so this comparison is **always `False`**, and the entire `_on_pong` body — including any liveness-feed logic added inside it — was silently dead code the whole time.

Confirmed via live instrumentation: `websocket-client`'s own internal `last_pong_tm` bookkeeping (set unconditionally by `_app.py` before invoking the `on_pong` callback) updated every ~10s in lockstep with `last_ping_tm`, proving Angel's server correctly replies to every protocol ping — the pong frames were arriving the entire time, just silently discarded by this type mismatch.

## Fix

- Decode `bytes` payloads before comparing.
- Since the exact echoed payload isn't something we control or need to gate correctness on, treat receipt of **any** pong frame as valid proof of liveness rather than requiring an exact payload match (a mismatch is now just a debug-level log note, not a discard).
- Keeps the `_on_ping` liveness feed from the previous revision (still correct, just never exercised during testing since Angel's server doesn't appear to initiate its own pings — only replies to ours).

## Testing

Verified live over 20+ minutes post-fix against a real Angel account/session:
- `_on_pong` now fires every ~10s as expected (previously: zero occurrences, ever)
- Zero `data stall detected` / `Forcing reconnect` events (previously: firing every ~90-130s continuously, all day)
- Zero downstream REST timeouts on concurrent API calls (e.g. `/api/v1/holdings`) that had been intermittently coinciding with the reconnect churn