### PR TITLE
fix(hdfcsky): send the complete modify payload

### DIFF
--- a/broker/hdfcsky/mapping/transform_data.py
+++ b/broker/hdfcsky/mapping/transform_data.py
@@ -310,23 +310,20 @@ def transform_modify_order_data(data, auth_token):
     """OpenAlgo modify-order dict -> HDFC Sky modify payload.
 
     HDFC Sky modifies via PUT /oapi/v1/orders with the SAME body shape as
-    placement plus `oms_order_id`. The product cannot be changed, but the
-    field is still required by the validator.
-    """
-    exchange = data["exchange"]
-    order_type = map_order_type(data.get("pricetype", "MARKET"))
+    placement plus `oms_order_id`. Product and side cannot be changed, but both
+    fields are still required by the validator, so the placement builder is
+    reused verbatim rather than re-listing the fields.
 
-    return {
-        "exchange": to_rest_exchange(exchange),
-        "instrument_token": _resolve_token(data["symbol"], exchange),
-        "client_id": get_client_id(auth_token),
-        "oms_order_id": str(data["orderid"]),
-        "order_type": order_type,
-        "product": map_product_type(data.get("product", "MIS")),
-        "quantity": int(data.get("quantity", 0)),
-        "price": float(data.get("price", 0) or 0),
-        "trigger_price": float(data.get("trigger_price", 0) or 0),
-        "disclosed_quantity": int(data.get("disclosed_quantity", 0) or 0),
-        "validity": "DAY",
-        "execution_type": "REGULAR",
-    }
+    Building on top of transform_data also means a modify to MARKET or SL-M
+    inherits the same MPP protected-limit conversion that placement applies;
+    calling map_order_type() directly here would send a bare MARKET order that
+    the exchange rejects on MPP-regulated scrips.
+
+    `action` is required on ModifyOrderSchema, so order_side is always present.
+    """
+    payload = transform_data(data, auth_token)
+    payload["oms_order_id"] = str(data["orderid"])
+    # Tags are applied once at placement; re-sending them on modify is not part
+    # of the modify contract.
+    payload.pop("tags", None)
+    return payload


### PR DESCRIPTION
### Problem

`transform_modify_order_data` builds its own body and omits `order_side`, `device`, `amo` and `user_order_id`.

The function's own docstring states the contract:

> HDFC Sky modifies via PUT `/oapi/v1/orders` with the **SAME body shape as placement** plus `oms_order_id`. The product cannot be changed, but the field is still required by the validator.

`product` is kept precisely because the validator requires it despite being immutable. `order_side` is equally immutable and equally part of the placement shape, but is dropped. If the validator requires it — which the docstring asserts — every modify order on HDFC Sky is rejected before it can change price or quantity.

I do not have HDFC Sky credentials to confirm the validator's required-field set against a live endpoint, so the rejection is inferred from the module's own stated contract rather than observed. The omission itself is not in question.

### Second defect, same function

Placement routes MARKET and SL-M through `_protect_market_order()` for MPP slab protection:

```python
if pricetype in _MARKET_PRICETYPES:
    order_type, price = _protect_market_order(data, auth_token, pricetype, action, price)
```

Modify called `map_order_type()` directly, so a modify **to** MARKET or SL-M skipped the protected-limit conversion and would hit exactly the exchange rejection that code exists to avoid.

### Fix

Build the modify body from `transform_data` and add `oms_order_id`. This restores all four missing fields and inherits the MPP protection for free, rather than duplicating a field list that has already drifted once.

`action` is `required=True` on `ModifyOrderSchema` (`restx_api/schemas.py:93`), so `order_side` is always resolvable. `tags` are dropped, being a placement-time concern.

### Notes for review

- `user_order_id` is regenerated from the clock by `_user_order_id()` because OpenAlgo does not persist the original. If HDFC Sky treats it as an immutable client tag, the alternative is to omit it on modify specifically — but it should not be silently dropped alongside `order_side` without a stated reason.
- `transform_data` may perform a live `get_quotes()` call for MARKET modifies via the MPP path. That is the same cost placement already pays and is the correct behaviour, but it is a behaviour change worth noting.

Found while auditing a 2.0.1.7 upgrade. No HDFC Sky deployment of my own, so this is code-level analysis, not a field report.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix HDFC Sky modify-order payload to send the full placement shape plus `oms_order_id`. Prevents validator rejections and applies MPP protection to MARKET/SL-M modifies.

- **Bug Fixes**
  - Build modify payload from `transform_data` and add `oms_order_id`; restores `order_side`, `device`, `amo`, `user_order_id`, and drops `tags`.
  - MARKET/SL-M modifies now route through `_protect_market_order()` via `transform_data` to avoid exchange rejections on MPP scrips.

<sup>Written for commit c217af9b00cc235c36a907fd579f432b81b52fd4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1702?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

