### PR TITLE
fix(sandbox): preserve all columns and indexes when rebuilding sandbox_orders

### DIFF
--- a/upgrade/migrate_sandbox_trigger_pending.py
+++ b/upgrade/migrate_sandbox_trigger_pending.py
@@ -31,6 +31,7 @@ Created: 2026-07-24
 
 import argparse
 import os
+import re
 import sys
 
 # Add parent directory to path for imports
@@ -119,52 +120,57 @@ def widen_order_status_constraint(conn):
 
     logger.info("Rebuilding sandbox_orders to widen the order_status CHECK constraint...")
 
+    # Derive the replacement schema from the LIVE table rather than hardcoding it.
+    #
+    # A hardcoded column list silently drops any column the installation has that
+    # this script does not know about, and the subsequent DROP TABLE makes that
+    # loss unrecoverable. That covers deployment-specific columns added by forks or
+    # operators, and -- more importantly for us -- any column a future release adds
+    # to sandbox_orders via ALTER TABLE, since this migration would then be
+    # rebuilding the table from a stale definition.
+    #
+    # Read both before the RENAME: SQLite rewrites the stored CREATE statements to
+    # reference sandbox_orders_old once the table is renamed.
+    old_ddl = conn.execute(
+        text("SELECT sql FROM sqlite_master WHERE type='table' AND name='sandbox_orders'")
+    ).scalar()
+    old_indexes = [
+        row[0]
+        for row in conn.execute(
+            text(
+                "SELECT sql FROM sqlite_master WHERE type='index' "
+                "AND tbl_name='sandbox_orders' AND sql IS NOT NULL"
+            )
+        )
+    ]
+    columns = [row[1] for row in conn.execute(text("PRAGMA table_info(sandbox_orders)"))]
+
+    new_ddl, replaced = re.subn(
+        r"order_status\s+IN\s*\([^)]*\)",
+        f"order_status IN ({NEW_ORDER_STATUS_VALUES})",
+        old_ddl,
+        flags=re.IGNORECASE,
+    )
+    if replaced != 1:
+        logger.info(
+            "Could not locate exactly one order_status CHECK constraint "
+            f"(found {replaced}); leaving sandbox_orders untouched"
+        )
+        return
+
+    column_list = ", ".join(f'"{column}"' for column in columns)
+
     conn.execute(text("PRAGMA foreign_keys=OFF"))
 
     conn.execute(text("ALTER TABLE sandbox_orders RENAME TO sandbox_orders_old"))
 
-    conn.execute(
-        text(f"""
-        CREATE TABLE sandbox_orders (
-            id INTEGER PRIMARY KEY AUTOINCREMENT,
-            orderid VARCHAR(50) UNIQUE NOT NULL,
-            user_id VARCHAR(50) NOT NULL,
-            strategy VARCHAR(100),
-            symbol VARCHAR(50) NOT NULL,
-            exchange VARCHAR(20) NOT NULL,
-            action VARCHAR(10) NOT NULL CHECK(action IN ('BUY', 'SELL')),
-            quantity INTEGER NOT NULL,
-            price DECIMAL(10, 2),
-            trigger_price DECIMAL(10, 2),
-            price_type VARCHAR(20) NOT NULL CHECK(price_type IN ('MARKET', 'LIMIT', 'SL', 'SL-M')),
-            product VARCHAR(20) NOT NULL CHECK(product IN ('CNC', 'NRML', 'MIS')),
-            order_status VARCHAR(20) NOT NULL DEFAULT 'open' CHECK(order_status IN ({NEW_ORDER_STATUS_VALUES})),
-            average_price DECIMAL(10, 2),
-            filled_quantity INTEGER DEFAULT 0,
-            pending_quantity INTEGER NOT NULL,
-            rejection_reason TEXT,
-            margin_blocked DECIMAL(10, 2) DEFAULT 0.00,
-            order_timestamp DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP),
-            update_timestamp DATETIME NOT NULL DEFAULT (CURRENT_TIMESTAMP)
-        )
-    """)
-    )
+    conn.execute(text(new_ddl))
 
     conn.execute(
-        text("""
-        INSERT INTO sandbox_orders (
-            id, orderid, user_id, strategy, symbol, exchange, action, quantity,
-            price, trigger_price, price_type, product, order_status,
-            average_price, filled_quantity, pending_quantity, rejection_reason,
-            margin_blocked, order_timestamp, update_timestamp
+        text(
+            f"INSERT INTO sandbox_orders ({column_list}) "
+            f"SELECT {column_list} FROM sandbox_orders_old"
         )
-        SELECT
-            id, orderid, user_id, strategy, symbol, exchange, action, quantity,
-            price, trigger_price, price_type, product, order_status,
-            average_price, filled_quantity, pending_quantity, rejection_reason,
-            margin_blocked, order_timestamp, update_timestamp
-        FROM sandbox_orders_old
-    """)
     )
 
     result = conn.execute(text("SELECT COUNT(*) FROM sandbox_orders_old"))
@@ -180,7 +186,10 @@ def widen_order_status_constraint(conn):
 
     conn.execute(text("DROP TABLE sandbox_orders_old"))
 
-    for stmt in SANDBOX_ORDERS_INDEXES:
+    # Dropping the old table drops its indexes with it, so replay the ones the
+    # table actually had, then the canonical set as an IF NOT EXISTS backstop for
+    # installations predating any of them.
+    for stmt in old_indexes + SANDBOX_ORDERS_INDEXES:
         conn.execute(text(stmt))
 
     conn.execute(text("PRAGMA foreign_keys=ON"))


### PR DESCRIPTION
### Problem

`widen_order_status_constraint()` rebuilds `sandbox_orders` via the SQLite create-new / copy / drop-old procedure, but both the replacement `CREATE TABLE` and the `INSERT ... SELECT` hardcode the 20 columns the model had when the script was written.

Any other column on the live table is silently dropped, and `DROP TABLE sandbox_orders_old` then makes the loss unrecoverable. The same applies to indexes: dropping the old table drops its indexes, and only the 9 hardcoded `SANDBOX_ORDERS_INDEXES` are replayed.

The module docstring already states the intended contract:

> ...rebuilds sandbox_orders with the widened constraint via the standard create-new / copy-data / drop-old / rename procedure, **preserving every existing row and every existing index**.

So this is the implementation not matching its own stated contract, rather than a deliberate narrowing.

### Why it matters even though main is currently fine

Upstream is asymptomatic today only because the hardcoded list happens to match the current model. It becomes live data loss in two cases:

1. Any installation carrying a deployment-specific column on `sandbox_orders`.
2. **Upstream itself**, the first time a release adds a column to `sandbox_orders` via `ALTER TABLE`. This migration would then rebuild the table from a stale definition and drop the new column. Note `ALTER TABLE ADD COLUMN` splices the column into the stored DDL without touching the CHECK clause, so the `_constraint_allows_trigger_pending()` guard does not protect against this.

### Fix

Derive the replacement schema from the live table instead of hardcoding it:

- Rewrite only the `order_status` CHECK clause in the existing DDL via `re.subn`.
- Copy whatever columns `PRAGMA table_info` reports.
- Replay the table's *actual* indexes, then the canonical set as an `IF NOT EXISTS` backstop.
- Read the DDL and index list **before** the `RENAME` — SQLite rewrites the stored `CREATE` statements to reference `sandbox_orders_old` once renamed.
- If exactly one `order_status` CHECK is not found, leave the table untouched rather than rebuild from a guess.

No fork-specific or deployment-specific names appear anywhere in the change.

### Verification

Ran the migration verbatim against a simulated pre-2.0.1.7 `sandbox.db` carrying two extra columns and two extra indexes, one of them a partial unique index:

```
columns preserved:  22 -> True
values preserved :  ('COID-123', 'cmd-abc')
indexes preserved:  ['ix_sandbox_orders_client_order_id', 'ux_sandbox_orders_cmd']
constraint widened: True
accepts trigger pending: True
still rejects bogus  : True
```

Against the current upstream schema the behaviour is unchanged — same 20 columns, same indexes, same widened constraint.

Found while auditing a 2.0.1.7 upgrade on a deployment that carries two extra columns on `sandbox_orders`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves all columns and indexes when rebuilding `sandbox_orders` in the trigger-pending migration. Derives the new schema from the live table to prevent silent data loss on customized installs and future releases.

- **Bug Fixes**
  - Rewrite only the `order_status` CHECK in the existing DDL; copy columns from `PRAGMA table_info`.
  - Read DDL and index SQL before RENAME; insert using a dynamic column list.
  - Replay the table’s actual indexes, then the canonical ones with IF NOT EXISTS; skip rebuild if the CHECK isn’t found exactly once.

<sup>Written for commit 8b404c99d0dc6fed8079c0d2983c36b7b1b9ac40. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

