### PR TITLE
fix(sandbox): keep triggered stop-loss orders fillable

### DIFF
--- a/sandbox/execution_engine.py
+++ b/sandbox/execution_engine.py
@@ -390,11 +390,19 @@ class ExecutionEngine:
                 else:  # SELL
                     execution_price = bid if bid > 0 else ltp
 
-            elif order.price_type == "LIMIT":
+            elif order.price_type in ("LIMIT", "SL"):
                 # Limit BUY: Execute if LTP <= Limit Price, fill at limit price
                 # Limit SELL: Execute if LTP >= Limit Price, fill at limit price
                 # In real exchanges, limit orders sit on the book at the limit price
                 # and fill at that price when the market crosses through
+                #
+                # An SL order only ever reaches "open" AFTER its trigger has fired:
+                # place_order starts an untriggered SL as "trigger pending", and
+                # _process_trigger_pending_order is the only other writer of "open".
+                # Once released from the Stop-Loss book it IS a plain limit order, so
+                # it must not be re-tested against its trigger -- doing so strands it
+                # whenever the price retreats back past the trigger without ever
+                # printing inside the trigger..limit band.
                 if order.action == "BUY" and ltp <= order.price:
                     should_execute = True
                     execution_price = order.price  # Fill at limit price
@@ -402,29 +410,13 @@ class ExecutionEngine:
                     should_execute = True
                     execution_price = order.price  # Fill at limit price
 
-            elif order.price_type == "SL":
-                # Stop Loss Limit order
-                # SL BUY: When LTP >= trigger price, order activates. Execute at LTP if LTP <= limit price
-                # SL SELL: When LTP <= trigger price, order activates. Execute at LTP if LTP >= limit price
-                if order.action == "BUY" and ltp >= order.trigger_price:
-                    if ltp <= order.price:
-                        should_execute = True
-                        execution_price = ltp  # Execute at current market price (LTP)
-                elif order.action == "SELL" and ltp <= order.trigger_price:
-                    if ltp >= order.price:
-                        should_execute = True
-                        execution_price = ltp  # Execute at current market price (LTP)
-
             elif order.price_type == "SL-M":
-                # Stop Loss Market order
-                # BUY: Execute at market when LTP >= trigger price
-                # SELL: Execute at market when LTP <= trigger price
-                if order.action == "BUY" and ltp >= order.trigger_price:
-                    should_execute = True
-                    execution_price = ltp
-                elif order.action == "SELL" and ltp <= order.trigger_price:
-                    should_execute = True
-                    execution_price = ltp
+                # Stop Loss Market order. Same invariant as SL above: reaching "open"
+                # means the trigger already fired (normally SL-M goes straight to
+                # "complete", but the stale-quote guard can defer that fill), so it is
+                # now an unconditional market order.
+                should_execute = True
+                execution_price = ltp
 
             # Execute the order if conditions are met
             if should_execute:
@@ -446,11 +438,9 @@ class ExecutionEngine:
         path in order_manager.py's place_order - both places treat a
         simultaneous trigger+limit match as an instant fill rather than an
         observable middle state). Otherwise it transitions to "open" - now
-        resting live in the regular order book, unfilled - and the unmodified
-        SL branch in _process_order picks it up on subsequent ticks exactly
-        like any other open SL order (re-checking the trigger condition there
-        is safe: once crossed, BUY prices staying at/above trigger, or SELL
-        prices staying at/below it, keep satisfying the same comparison).
+        resting live in the regular order book, unfilled - and _process_order
+        handles it as a plain limit order from then on, because reaching "open"
+        is itself the record that the trigger has fired.
         """
         try:
             trigger_met = False


### PR DESCRIPTION
### Problem

A triggered SL order that is not immediately marketable transitions to `open`, and is then re-tested against its trigger price by the SL branch in `_process_order`. If the price retreats back past the trigger before ever printing inside the trigger..limit band, the order can never fill.

BUY, trigger 100, limit 101:

| tick | what happens |
|---|---|
| 102 | trigger met; limit not satisfiable (102 > 101); status -> `open` |
| 99 | limit now satisfiable (99 <= 101), but the SL branch re-tests `99 >= 100` -> false |

The order rests `open` indefinitely, cleared only by the EOD sweep.

The docstring on `_process_trigger_pending_order` states the assumption behind the re-check, and it is the defect:

> re-checking the trigger condition there is safe: once crossed, BUY prices staying at/above trigger, or SELL prices staying at/below it, keep satisfying the same comparison

Prices do not have to stay above the trigger.

### A second entry path

This is not only reachable via the trigger-pending transition. `order_manager.place_order` sets the initial status to `open` whenever `trigger_price_met` is true, so an SL whose **trigger is met at placement but whose limit is not** is born `open` and is stranded by the same re-check, never having passed through `_process_trigger_pending_order`.

### Fix

No new column or status value, and **no migration**.

An SL in status `open` is by construction already triggered: `place_order` is the only writer of the initial status and only emits `open` when the trigger is met, and `_process_trigger_pending_order` is the only other writer, post-trigger. The activated flag can therefore be read off the status rather than persisted.

So SL is handled by the LIMIT branch. That also changes the fill from LTP to the limit price, which is how a resting limit order actually fills and matches the intent of `e23b216f0` ("realistic LIMIT order fill pricing").

`SL-M` carries the same latent hole — its immediate fill can be deferred by the stale-quote guard, leaving it `open` and re-tested against its trigger. Reaching `open` means triggered, so it is now an unconditional market order.

The `order_status` CHECK constraint is untouched.

### Scope

Sandbox/analyzer only; live trading is unaffected. Requires an SL or SL-M order plus a tick gap across the trigger..limit band — easy to hit on the 5s polling fallback on a fast-moving option, less so when the WS engine is printing every tick.

Note: `ruff` reports a pre-existing `F821 Undefined name get_config` at `sandbox/execution_engine.py:953`, present on `main` and unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a sandbox bug where triggered stop-loss orders could get stuck “open” and never fill if price moved back past the trigger. Once triggered, `SL` acts like a regular limit and `SL-M` fills at market, preventing stranded orders.

- **Bug Fixes**
  - `SL` in status `open` is treated as a limit order; no trigger re-check; fills at the limit price.
  - `SL-M` in status `open` executes unconditionally at market (LTP).
  - No schema or status changes; sandbox/analyzer only. Live trading unaffected.

<sup>Written for commit 4e35c4f90f6cc0edb5a3a714e489b2b2089ddd64. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1704?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

