### PR TITLE
fix(iiflcapital): pace order book and trade book at their 3 req/sec cap

### DIFF
--- a/broker/iiflcapital/api/order_api.py
+++ b/broker/iiflcapital/api/order_api.py
@@ -5,6 +5,7 @@ from typing import Any
 
 from broker.iiflcapital.api.rate_limiter import (
     MAX_RETRIES,
+    apply_account_rate_limit,
     apply_rate_limit,
     is_rate_limited,
     retry_delay_from_headers,
@@ -79,6 +80,7 @@ def _request(
     payload=None,
     params=None,
     _retry_count: int = 0,
+    account_class: bool = False,
 ):
     """
     Issue an HTTP request to an IIFL Capital order/account endpoint through
@@ -96,6 +98,9 @@ def _request(
     url = f"{BASE_URL}{endpoint}"
 
     apply_rate_limit()
+    if account_class:
+        # Order Book / Trade Book / Cancel-All sit in IIFL's 3 req/sec class.
+        apply_account_rate_limit()
 
     if method == "GET":
         response = client.get(url, headers=_headers(auth), params=params)
@@ -121,7 +126,9 @@ def _request(
             f"{delay:.2f}s (attempt {_retry_count + 1}/{MAX_RETRIES})"
         )
         time.sleep(delay)
-        return _request(endpoint, auth, method, payload, params, _retry_count + 1)
+        return _request(
+            endpoint, auth, method, payload, params, _retry_count + 1, account_class
+        )
 
     return response, data
 
@@ -220,7 +227,7 @@ def _is_success_result(result: dict) -> bool:
 
 
 def get_order_book(auth):
-    response, data = _request("/orders", auth)
+    response, data = _request("/orders", auth, account_class=True)
 
     if response.status_code == 200:
         rows = data if isinstance(data, list) else _extract_rows(data)
@@ -238,7 +245,7 @@ def get_order_book(auth):
 
 
 def get_trade_book(auth):
-    response, data = _request("/trades", auth)
+    response, data = _request("/trades", auth, account_class=True)
 
     if response.status_code == 200:
         if isinstance(data, list):

--- a/broker/iiflcapital/api/rate_limiter.py
+++ b/broker/iiflcapital/api/rate_limiter.py
@@ -9,12 +9,16 @@ Order placement/modification/cancellation is 10 req/sec (20 registered);
 Order Book/Trade Book/Cancel-All are 3 req/sec; Limits (funds) and
 Pre-order Margin/SPAN Exposure are 10 req/sec (20 registered). OpenAlgo does
 not currently track a user's registration tier, so this module paces every
-IIFL call against a single shared, conservative floor -- the tightest
-documented cap (10 req/sec) with headroom, rather than maximizing per-category
-throughput. A future refinement could split data/order/funds into separate
-limiter instances if that throughput ceiling becomes a real constraint; for
-the bug this fixes (silent OI data loss from an unthrottled concurrent burst)
-one shared limiter is the correct, low-risk fix.
+IIFL call against a single shared, conservative floor sized for the common
+10 req/sec cap, rather than maximizing per-category throughput.
+
+The one class that floor does not cover is Order Book/Trade Book/Cancel-All at
+3 req/sec, which apply_account_rate_limit() paces separately on top of the
+shared floor. A future refinement could split data/order/funds into separate
+limiter instances if the shared ceiling becomes a real constraint; for the bug
+this module was written to fix (silent OI data loss from an unthrottled
+concurrent burst) one shared limiter plus the account-class pacer is the
+correct, low-risk arrangement.
 
 `broker/iiflcapital/api/data.py`, `order_api.py`, and `funds.py` each build
 their own httpx request internally rather than sharing one call site, and
@@ -37,10 +41,19 @@ import time
 _lock = threading.Lock()
 _last_call_time = 0.0
 
-# Tightest documented cap across categories is 10 req/sec; pace at ~8 req/sec
-# (0.125s) to leave headroom for clock jitter and for data/order/funds calls
-# sharing the same process-wide pacer concurrently.
+# Most categories cap at 10 req/sec; pace at ~8 req/sec (0.125s) to leave
+# headroom for clock jitter and for data/order/funds calls sharing the same
+# process-wide pacer concurrently.
 MIN_INTERVAL = 0.125
+
+_account_lock = threading.Lock()
+_account_last_call_time = 0.0
+
+# Order Book, Trade Book and Cancel-All are capped at 3 req/sec, well below the
+# 10 req/sec that MIN_INTERVAL is sized for. Pacing them at ~2.85 req/sec
+# (0.35s) keeps them inside their own class instead of relying on the 429 retry
+# path to absorb the overshoot.
+ACCOUNT_MIN_INTERVAL = 0.35
 
 MAX_RETRIES = 3
 BASE_BACKOFF = 1.0  # seconds; exponential fallback when no Retry-After header: 1, 2, 4
@@ -60,6 +73,24 @@ def apply_rate_limit():
         elapsed = now - _last_call_time
         sleep_time = MIN_INTERVAL - elapsed if elapsed < MIN_INTERVAL else 0
         _last_call_time = now + sleep_time
+
+    if sleep_time > 0:
+        time.sleep(sleep_time)
+
+
+def apply_account_rate_limit():
+    """Extra pacing for IIFL's 3 req/sec class (Order Book, Trade Book, Cancel-All).
+
+    Call AFTER apply_rate_limit(), not instead of it: the two locks are taken
+    sequentially and never held at once, so this stacks the tighter account
+    budget on top of the shared floor without any nesting or deadlock risk.
+    """
+    global _account_last_call_time
+    with _account_lock:
+        now = time.time()
+        elapsed = now - _account_last_call_time
+        sleep_time = ACCOUNT_MIN_INTERVAL - elapsed if elapsed < ACCOUNT_MIN_INTERVAL else 0
+        _account_last_call_time = now + sleep_time
 
     if sleep_time > 0:
         time.sleep(sleep_time)


### PR DESCRIPTION
### Problem

The module docstring enumerates IIFL's per-endpoint-class limits, including:

> Order Book/Trade Book/Cancel-All are 3 req/sec

and then two sentences later describes the shared pacer as:

> the tightest documented cap (10 req/sec) with headroom

Those contradict each other — 3 is the tightest documented cap, not 10.

`MIN_INTERVAL = 0.125` permits roughly 8 req/sec. `order_api._request()` is the single choke point for both `/orders` (order book) and `/trades` (trade book), so that class is paced at up to **2.6x its documented limit**.

The existing 429 detection with `Retry-After` backoff absorbs the overshoot, so the practical symptom is added latency under concurrent account-endpoint polling rather than silent data loss — unlike the OI fanout this module was originally written to fix, `get_order_book` returns an explicit error rather than swallowing it. But the pacer is not doing what the module says it does.

### Fix

A second module-level pacer for the 3 req/sec class, applied after the shared one for `/orders` and `/trades`:

- The two locks are taken **sequentially and never held simultaneously**, so there is no nesting or deadlock risk.
- The `account_class` flag is threaded through the 429 retry recursion so retries stay paced.
- Cancel-All fans out per-order cancels through the same `_request`, so it is covered wherever those hit an account endpoint.

`MIN_INTERVAL` is deliberately left alone: the 10 req/sec classes are correctly paced by it today, and lowering the shared floor to 3 would throttle market data and order placement for no reason.

Docstring corrected to match.

### Scope

I do not run IIFL Capital — this is code-level analysis from auditing a 2.0.1.7 upgrade, not a field report. Behaviour for every other IIFL endpoint is unchanged.

Note: `ruff` reports two pre-existing `I001` import-order errors in `broker/iiflcapital/mapping/order_data.py`, unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a dedicated 3 req/sec rate limiter for IIFL Capital account endpoints (Order Book, Trade Book, Cancel-All) and apply it on top of the shared 10 req/sec limiter to reduce 429s and latency under concurrent polling. Updated docs to reflect the correct per-class limits.

- **Bug Fixes**
  - Introduced `apply_account_rate_limit()` (0.35s) and call it after `apply_rate_limit()` in `order_api._request()` when `account_class=True` for `/orders` and `/trades` (Cancel-All fanouts are covered via the same path).
  - Threaded the `account_class` flag through `_request` retries so backoffs stay paced; locks are taken sequentially to avoid nesting/deadlocks.
  - Kept `MIN_INTERVAL` (0.125s) unchanged to preserve throughput for 10 req/sec classes; non-account endpoints are unaffected.

<sup>Written for commit 8f49d614d034d579a0d5f4524d0a4aaf3e53590c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1705?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

