### PR TITLE
fix(postback): authenticate every broker postback, not just Zerodha

### DIFF
--- a/.sample.env
+++ b/.sample.env
@@ -10,6 +10,13 @@ ENV_CONFIG_VERSION = '1.0.7'
 BROKER_API_KEY = 'YOUR_BROKER_API_KEY'
 BROKER_API_SECRET = 'YOUR_BROKER_API_SECRET'
 
+# Broker postback (order-update webhook) secret. Only needed if you register a
+# postback URL with your broker; leave unset and the /postback route accepts
+# nothing. Generate with:
+#   python -c "import secrets; print(secrets.token_urlsafe(32))"
+# Then register the URL as https://<your-host>/postback/<broker>/<secret>
+POSTBACK_SECRET = ''
+
 # Market Data Configuration (Optional and Required only for XTS API Supported Brokers)
 
 BROKER_API_KEY_MARKET = 'YOUR_BROKER_MARKET_API_KEY'

--- a/blueprints/postback.py
+++ b/blueprints/postback.py
@@ -1,13 +1,27 @@
 """
 Broker postback (webhook) receivers for real-time order updates.
 
-Public POST routes at /postback/<broker> — brokers cannot authenticate with
-OpenAlgo sessions, so these are CSRF-exempt (see app.py) and validated per
-broker instead:
-- the <broker> in the URL must match the instance's active broker session
+Public POST routes at /postback/<broker>/<secret> — brokers cannot authenticate
+with OpenAlgo sessions, so these are CSRF-exempt (see app.py) and validated
+instead by:
+- an installation secret carried in the URL path and compared against
+  POSTBACK_SECRET. Every supported broker lets the user register an arbitrary
+  postback URL, so this authenticates all of them without broker-side support.
+  Fails closed: with POSTBACK_SECRET unset the route accepts nothing.
+- the <broker> in the URL matching the instance's active broker session
   (single-user-per-deployment, per CLAUDE.md), and
-- Zerodha payloads carry a SHA-256 checksum (order_id + order_timestamp +
-  api_secret) that is verified against BROKER_API_SECRET.
+- for Zerodha, the SHA-256 checksum (order_id + order_timestamp + api_secret)
+  verified against BROKER_API_SECRET, as a second factor.
+
+Matching a database session is NOT proof that a request came from the broker,
+which is why the URL secret is required: only Zerodha signs its payloads, so
+without it any internet client that guesses the broker name could publish
+arbitrary order updates into the user's real-time feed.
+
+Every non-crash outcome returns the same 200 body. A caller must not be able to
+distinguish accepted from rejected, or it can probe which broker is active and
+whether it has guessed the secret; real reasons are logged server-side. It also
+keeps brokers from retrying on a 4xx.
 
 Each route parses the broker payload, normalizes it into OpenAlgo's common
 order-update format (reusing the status/pricetype/product tables from the
@@ -24,6 +38,7 @@ clients may see duplicate updates for the same transition — deduplicate on
 """
 
 import hashlib
+import hmac
 import os
 
 from flask import Blueprint, jsonify, request
@@ -301,37 +316,75 @@ def _validate_zerodha_checksum(data: dict) -> bool:
     expected = hashlib.sha256(
         f"{order_id}{order_timestamp}{api_secret}".encode()
     ).hexdigest()
-    return checksum == expected
+    return hmac.compare_digest(str(checksum), expected)
+
+
+def _validate_postback_secret(token: str) -> bool:
+    """Check the installation secret carried in the postback URL path.
+
+    Only Zerodha signs its postbacks. For every other broker, matching an
+    active database session proves nothing about the caller, so without a
+    shared secret any internet client that can guess the broker name can
+    publish arbitrary order updates into the user's real-time feed.
+
+    Every supported broker lets the user register an arbitrary postback URL,
+    so a path segment works for all of them without broker-side support.
+
+    Fails closed: with POSTBACK_SECRET unset the route accepts nothing, so an
+    installation that has not configured it is not silently left open.
+    """
+    secret = os.getenv("POSTBACK_SECRET", "").strip()
+    if not secret:
+        logger.error(
+            "Postback rejected — POSTBACK_SECRET is not set. Generate one with "
+            'python -c "import secrets; print(secrets.token_urlsafe(32))" and '
+            "register the postback URL as https://<host>/postback/<broker>/<secret>"
+        )
+        return False
+    return hmac.compare_digest(token or "", secret)
 
 
 @postback_bp.route("/<broker>", methods=["POST"])
-def broker_postback(broker: str):
+@postback_bp.route("/<broker>/<token>", methods=["POST"])
+def broker_postback(broker: str, token: str = ""):
+    # Uniform response for every non-crash outcome. A caller must not be able to
+    # tell an accepted postback from a rejected one: differing status codes let
+    # an unauthenticated client probe which broker is active and whether it has
+    # guessed the secret. Real reasons are logged server-side.
+    ack = (jsonify({"status": "success"}), 200)
+
     broker = broker.lower()
     if broker not in SUPPORTED_BROKERS:
-        return jsonify({"status": "error", "message": f"Unsupported broker: {broker}"}), 404
+        logger.warning(f"Postback rejected — unsupported broker: {broker}")
+        return ack
+
+    if not _validate_postback_secret(token):
+        logger.warning(f"Postback for '{broker}' rejected — bad or missing URL secret")
+        return ack
 
     session_obj = _get_active_session()
     if session_obj is None or (session_obj.broker or "").lower() != broker:
-        # Don't leak which broker IS active to unauthenticated callers.
         logger.warning(f"Postback for '{broker}' rejected — no matching active broker session")
-        return jsonify({"status": "error", "message": "No matching broker session"}), 403
+        return ack
 
     data = request.get_json(silent=True)
     if not isinstance(data, dict):
         # Some brokers POST form-encoded payloads with a JSON body field.
         data = request.form.to_dict() or None
     if not isinstance(data, dict) or not data:
-        return jsonify({"status": "error", "message": "Invalid payload"}), 400
+        logger.warning(f"Postback for '{broker}' rejected — invalid payload")
+        return ack
 
+    # Kept as a second factor on top of the URL secret, not a replacement.
     if broker == "zerodha" and not _validate_zerodha_checksum(data):
         logger.warning("Zerodha postback rejected — checksum validation failed")
-        return jsonify({"status": "error", "message": "Checksum validation failed"}), 403
+        return ack
 
     try:
         fields = _NORMALIZERS[broker](data)
     except Exception:
         logger.exception(f"Postback normalization failed for {broker}")
-        return jsonify({"status": "error", "message": "Payload normalization failed"}), 400
+        return ack
 
     if fields:
         _publish(session_obj.name, broker, fields)
@@ -340,4 +393,4 @@ def broker_postback(broker: str):
             f"status={fields.get('order_status')}"
         )
 
-    return jsonify({"status": "success"}), 200
+    return ack


### PR DESCRIPTION
### Problem

Only Zerodha's postback is verified. For `dhan`, `fyers`, `upstox`, `angel` and `aliceblue` the entire gate is:

1. broker name is in `SUPPORTED_BROKERS`
2. it matches the active `Auth` session row
3. the payload is a non-empty dict

Step 2 is a fact about the server, not evidence about the caller. The routes are CSRF-exempt, un-rate-limited, and intended for public HTTPS exposure.

So an unauthenticated caller who guesses the active broker can inject arbitrary `OrderUpdateEvent`s:

```bash
curl -s https://target/auth/broker-config          # -> {"broker_name":"dhan",...}  (already unauthenticated by design)

curl -s -X POST https://target/postback/dhan \
  -H 'Content-Type: application/json' \
  -d '{"orderId":"52250715000001","orderStatus":"TRADED","tradingSymbol":"NIFTY",
       "exchangeSegment":"NSE_FNO","transactionType":"SELL","quantity":"5000",
       "filled_qty":"5000","price":"1","productType":"INTRADAY","orderType":"MARKET"}'
# -> 200 {"status":"success"}
```

The victim's dashboard socket and every `subscribe_orders` WebSocket client receive a fabricated 5000-qty SELL fill.

**Scoping this honestly:** I traced the subscriber graph — there are exactly two subscribers (`socketio_subscriber`, `wsproxy_subscriber`), and neither writes to the database, places an order, or mutates sandbox state. `user_id` comes from the session row, never the payload. So this is **feed/display spoofing, not state corruption**. The material risk is an SDK strategy that subscribes to order updates and keys decisions off fills.

### Fix

An installation secret in the URL path, compared with `hmac.compare_digest` against a new `POSTBACK_SECRET`.

Every supported broker lets the user register an arbitrary postback URL, so a path segment authenticates all six without needing broker-side signature support — which only Zerodha offers.

- **Fails closed.** With `POSTBACK_SECRET` unset the route accepts nothing, so an installation that has not configured it is not silently left open.
- **Zerodha's checksum is kept as a second factor**, and its comparison moves from `==` on a hex digest to `hmac.compare_digest`.
- **Uniform 200 response** for every non-crash outcome. The differing 200/403 let a caller probe which broker is active and whether it had guessed the secret. (This limb is partly redundant — `/auth/broker-config` already returns the broker name unauthenticated by design — but it is free, and it also stops brokers retrying a rejected delivery.)

### Deployment impact

Breaking: the postback URL becomes `https://<host>/postback/<broker>/<secret>`. Existing users must set `POSTBACK_SECRET` and re-register the URL with their broker. The feature is recent (`2960edace`), so the blast radius should be small. `.sample.env` documents the variable and the generation command.

The bare `/postback/<broker>` route is retained so an un-migrated broker still reaches the handler and gets a logged rejection rather than a 404 that looks like an outage.

### Notes

Also worth flagging separately: the docstrings reference `broker-api-docs/zerodha-api-docs/12-postbacks.md` and `12-postback.md`, neither of which exists in the tree.

Found while auditing a 2.0.1.7 upgrade. My own deployment sits behind Cloudflare Access so it is not reachable there, but the fix belongs upstream.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Secure all broker postbacks by requiring a per-installation URL secret, not just Zerodha. Zerodha’s checksum remains as a second factor, and all non-crash outcomes return a uniform 200 to prevent probing and retries.

- **Bug Fixes**
  - Require `POSTBACK_SECRET` in `/postback/<broker>/<secret>`; if unset, all postbacks are rejected (fails closed).
  - Use `hmac.compare_digest` for both the URL secret and Zerodha checksum validation.
  - Always return 200 `{"status":"success"}` and log reasons server-side to avoid information leaks and broker retries.
  - Keep the bare `/postback/<broker>` route only to log-and-reject; `.sample.env` documents `POSTBACK_SECRET` and how to generate it.

- **Migration**
  - Generate a secret: `python -c "import secrets; print(secrets.token_urlsafe(32))"`.
  - Set `POSTBACK_SECRET` and redeploy.
  - Update your broker webhook to `https://<host>/postback/<broker>/<secret>`.

<sup>Written for commit cca544804c4c51aeddbdbd2d1cc496cd97277831. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1706?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

