### PR TITLE
fix(streaming): correct reconnect counter lifecycle in two adapters

### DIFF
--- a/broker/flattrade/streaming/flattrade_websocket.py
+++ b/broker/flattrade/streaming/flattrade_websocket.py
@@ -78,6 +78,7 @@ class FlattradeWebSocket:
         # The adapter checks this after _on_close/_on_error to route into a
         # tighter-bounded auth-retry path instead of the generic reconnect loop.
         self.auth_failed = False
+        self.auth_ok = False
         self.auth_failure_message = ""
 
         # Set by stop() to interrupt any in-progress sleep/wait loop immediately
@@ -125,6 +126,7 @@ class FlattradeWebSocket:
         # Reset auth failure state so a stale flag from a previous failed
         # attempt doesn't block this fresh connection attempt.
         self.auth_failed = False
+        self.auth_ok = False
         self.auth_failure_message = ""
 
         self.ws = websocket.WebSocketApp(
@@ -148,9 +150,19 @@ class FlattradeWebSocket:
         start_time = time.time()
 
         while time.time() - start_time < self.CONNECTION_TIMEOUT:
-            if self.connected:
-                self.logger.info("WebSocket connected successfully")
+            # Wait for the broker's 'ak' acknowledgement, not merely the socket
+            # opening. _on_open sets self.connected before authentication is even
+            # sent, so returning on that would report success for a rejected
+            # token -- and the caller resets its bounded auth-retry counter on
+            # success, so the bound would never be reached.
+            if self.auth_ok:
+                self.logger.info("WebSocket connected and authenticated successfully")
                 return True
+            if self.auth_failed:
+                self.logger.error(
+                    f"Broker rejected authentication: {self.auth_failure_message}"
+                )
+                return False
             if self._stop_event.wait(0.1):
                 self.logger.info("Wait for connection interrupted by stop()")
                 return False
@@ -291,6 +303,7 @@ class FlattradeWebSocket:
             bool: True (message handled)
         """
         if data.get("s") == self.AUTH_SUCCESS:
+            self.auth_ok = True
             self.logger.info("Authentication successful")
         else:
             self.logger.error(f"Authentication failed: {data}")

--- a/websocket_proxy/order_adapter.py
+++ b/websocket_proxy/order_adapter.py
@@ -30,6 +30,12 @@ from utils.logging import get_logger
 # feed.py::_reconnect_loop pattern for consistency across the codebase.
 _RECONNECT_BACKOFFS = [1, 2, 5, 10, 30, 60]
 
+# A session that stayed connected at least this long counts as healthy, and its
+# disconnect starts a fresh backoff ladder rather than continuing the old one.
+# Comfortably longer than the whole ladder's early rungs, so a genuine
+# connect-fail-retry streak cannot accidentally qualify.
+_HEALTHY_SESSION_SECONDS = 60
+
 
 def to_openalgo_symbol(broker_symbol: str, exchange: str, token=None) -> str:
     """Best-effort mapping of a broker symbol to OpenAlgo symbol format.
@@ -167,12 +173,26 @@ class BaseOrderUpdateAdapter(ABC):
     def _run_forever(self) -> None:
         attempt = 0
         while not self._shutting_down:
+            started = time.monotonic()
             try:
                 self._connect_once()
             except Exception as e:
                 self.logger.warning(
                     f"Order-update connection error ({self.broker_name}/{self.user_id}): {e}"
                 )
+            # A session that stayed up this long was not part of a failure streak,
+            # so it must not inherit the previous backoff. Without this, `attempt`
+            # only ever grows: six unrelated disconnects over the adapter's
+            # lifetime pin every later recovery at the 60s ceiling, even though
+            # the connection has been healthy in between.
+            #
+            # Deliberately gated on session DURATION rather than on the socket
+            # opening. A broker that accepts the TCP/WebSocket handshake and only
+            # then rejects at the application layer (bad or expired token) would
+            # reset the counter on every attempt, turning the backoff into a hot
+            # reconnect loop against a dead credential.
+            if time.monotonic() - started >= _HEALTHY_SESSION_SECONDS:
+                attempt = 0
             if self._shutting_down:
                 break
             delay = _RECONNECT_BACKOFFS[min(attempt, len(_RECONNECT_BACKOFFS) - 1)]


### PR DESCRIPTION
Two mirror-image bugs in the same class, submitted together because **the obvious fix for the first introduces the second**.

### 1. `websocket_proxy/order_adapter.py` — the backoff counter never resets

`attempt` is initialised once *outside* the `while` loop and incremented on every return from `_connect_once()` — including a clean disconnect after a session that streamed healthily for hours. Nothing ever resets it; `on_open` only logs and starts the heartbeat.

With `_RECONNECT_BACKOFFS = [1, 2, 5, 10, 30, 60]`:

| disconnect | delay |
|---|---|
| 1-5 | 1s, 2s, 5s, 10s, 30s |
| 6+ | **60s, permanently** |

So six unrelated disconnects over the adapter's lifetime pin every subsequent order-feed recovery at 60 seconds, and users miss timely fill and rejection updates because of failures that already resolved.

**Fix:** reset the ladder when a session lasted at least `_HEALTHY_SESSION_SECONDS`.

Gating on session **duration** rather than on the socket opening is the whole point. A broker that accepts the TCP/WebSocket handshake and only then rejects at the application layer would reset the counter on *every* attempt under an `on_open`-based fix, turning the backoff into a hot reconnect loop against a dead credential.

That failure mode is not hypothetical — it is bug 2.

Verified the ladder still behaves for genuine streaks:

```
6 rapid failures:                  [1, 2, 5, 10, 30, 60]   (unchanged)
mixed 3 fails, 1 healthy, 2 fails: [1, 2, 5, 1, 2, 5]
5 healthy hours then a blip:       1s   (was 60s)
```

### 2. `broker/flattrade/streaming/flattrade_websocket.py` — `connect()` returns before the broker accepts

`_on_open` sets `self.connected = True` and *then* sends authentication. `_wait_for_connection` polls only that flag, never inspecting the `ak` response, so `connect()` means "socket opened", not "broker accepted us".

`flattrade_adapter` resets both `auth_refresh_retries` and `reconnect_attempts` on a truthy `connect()`. On an expired token the sequence is:

1. socket opens -> `connect()` returns True -> `auth_refresh_retries = 0`
2. broker sends the auth nack -> `_handle_auth_failure` -> `auth_refresh_retries = 1`
3. reconnect in ~5s -> back to step 1

The counter oscillates 0 -> 1 -> 0 and never reaches `max_auth_refresh_retries = 3`. `reconnect_attempts` never reaches `MAX_RECONNECT_ATTEMPTS = 10` either. Both termination conditions are defeated, so the adapter hammers a dead token every ~5 seconds indefinitely — contradicting the module's own stated rationale:

> stops well short of the full 10-attempt generic backoff so a genuinely dead token is not hammered ... against a possibly rate-limited IP (SEBI static-IP mandate)

**Fix:** track broker acceptance separately from socket open, wait for that, and return early on an explicit rejection.

`self.connected` is deliberately left alone — `_send_message` and `_send_authentication` depend on it being true at socket open. Only the meaning of `connect()`'s return value changes, which makes the adapter's existing reset correct as written and lets the bound actually terminate. Note the fix belongs here rather than at the adapter's reset line, which is where the symptom appears.

There is a narrow race where the nack and close land inside a single 100ms poll window, so `connected` is already false and no reset happens. That does not rescue the bound — terminating would require winning that race three times consecutively.

### Scope

I run neither Flattrade nor a deployment that consumes the order-update feed heavily; this is code-level analysis from auditing a 2.0.1.7 upgrade. Happy to split into two PRs if you would rather review them separately — I kept them together only because of the coupling described above.

Note: `ruff` reports a pre-existing `UP035` (`typing.Dict` deprecated) at `flattrade_websocket.py:11`, unrelated to this change.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix reconnect/backoff behavior in the order feed and Flattrade WebSocket. Healthy sessions now reset backoff, and connect() only succeeds after broker auth, preventing permanent 60s delays and infinite token retries.

- **Bug Fixes**
  - Order adapter: reset the backoff ladder after any session lasting ≥60s; based on session duration to avoid hot reconnect loops when the broker rejects at the app layer.
  - Flattrade WebSocket: add `auth_ok` and wait for broker acceptance in `connect()`; return early on explicit auth rejection so auth/reconnect counters reach their limits.

<sup>Written for commit 77c5575943303edc447980ff9552167f16318bb7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1707?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

