### PR TITLE
fix(trading): load a chart symbol transactionally

### DIFF
--- a/frontend/src/lib/trading/terminal.ts
+++ b/frontend/src/lib/trading/terminal.ts
@@ -1538,24 +1538,18 @@ export class TradingTerminal {
   /* ── symbol selection ─────────────────────────────────────────────────── */
   async loadSymbol(pick: SearchRow, opts: { silent?: boolean } = {}): Promise<boolean> {
     if (!this.rest) return false
-    // swap the live stream: drop the previous symbol's subscription
-    if (
-      this.ws &&
-      this.sym &&
-      (this.sym.symbol !== pick.symbol || this.sym.exchange !== pick.exchange)
-    ) {
-      // Mirror connectLive's single-subscription model: the outgoing symbol
-      // holds exactly one mode -- LTP when quote-only, Depth otherwise.
-      try {
-        if (this.sym.quoteOnly) {
-          this.ws.unsubscribe('LTP', this.sym.symbol, this.sym.exchange)
-        } else {
-          this.ws.unsubscribe('Depth', this.sym.symbol, this.sym.exchange)
-        }
-      } catch {
-        /* not subscribed */
-      }
-    }
+    // Load transactionally: nothing below mutates terminal state until the new
+    // symbol's history is in hand. A failed or empty history used to leave
+    // this.sym pointing at the NEW symbol while the canvas, the toolbar and the
+    // live feed still belonged to the OLD one -- and since order actions read
+    // this.sym directly (placeFromMenu, exitPosition), a context-menu order
+    // would be placed on an instrument the user was not looking at.
+    //
+    // It also blanked rawBars, which made marketPrice() null and so silently
+    // disabled BOTH price guards: contextMenuAt stopped greying out order types
+    // and placeFromMenu stopped rejecting stops on the wrong side of the LTP,
+    // with the price taken from the old symbol's scale.
+    const prev = this.sym
     // authoritative metadata (lotsize / tick_size / freeze_qty)
     let info: Record<string, unknown> = { ...pick }
     try {
@@ -1572,10 +1566,10 @@ export class TradingTerminal {
     const lots = DERIVATIVE_EXCHANGES.has(exchange) && lotsize > 1
     const savedProduct = this.lsGet('product')
     const productOptions = lots ? ['MIS', 'NRML'] : ['MIS', 'CNC']
-    this.product = productOptions.includes(savedProduct || '')
+    const product = productOptions.includes(savedProduct || '')
       ? (savedProduct as string)
       : productOptions[0]
-    this.sym = {
+    const next = {
       symbol: String(info.symbol),
       exchange,
       name: String(info.name || ''),
@@ -1585,35 +1579,52 @@ export class TradingTerminal {
       freezeQty: Number(info.freeze_qty) || 1,
       quoteOnly: QUOTE_ONLY.has(exchange),
       productOptions,
-      product: this.product,
+      product,
     }
-    this.qty = 1
-    this.lsSet('symbol', JSON.stringify({ symbol: this.sym.symbol, exchange: this.sym.exchange }))
 
     // history
     const to = nowSec()
-    this.lastLtp = null
-    this.prevClose = null
-    this.liveBucket = null
-    this.noMoreHistory = false
+    let bars: typeof this.rawBars
     try {
-      this.rawBars = await this.rest.getBars({
-        symbol: this.sym.symbol,
-        exchange: this.sym.exchange,
+      bars = await this.rest.getBars({
+        symbol: next.symbol,
+        exchange: next.exchange,
         interval: this.interval,
         from: to - lookbackDays(this.interval) * 86400,
         to,
       })
     } catch (e) {
-      this.rawBars = []
       if (!opts.silent) this.toast(`history error: ${this.cleanError(e)}`, 'err')
       return false // caller may fall back (e.g. to the default symbol)
     }
-    if (!this.rawBars.length) {
+    if (!bars.length) {
       if (!opts.silent)
-        this.toast(`no history for ${this.sym.symbol} ${this.sym.exchange} ${this.interval}`, 'err')
+        this.toast(`no history for ${next.symbol} ${next.exchange} ${this.interval}`, 'err')
       return false
     }
+
+    // ---- commit: past this point the load cannot fail ----
+    // Swap the live stream only now, mirroring connectLive's single-subscription
+    // model: the outgoing symbol holds exactly one mode -- LTP when quote-only,
+    // Depth otherwise.
+    if (this.ws && prev && (prev.symbol !== next.symbol || prev.exchange !== next.exchange)) {
+      try {
+        if (prev.quoteOnly) {
+          this.ws.unsubscribe('LTP', prev.symbol, prev.exchange)
+        } else {
+          this.ws.unsubscribe('Depth', prev.symbol, prev.exchange)
+        }
+      } catch {
+        /* not subscribed */
+      }
+    }
+    this.sym = next
+    this.product = product
+    this.qty = 1
+    this.lsSet('symbol', JSON.stringify({ symbol: this.sym.symbol, exchange: this.sym.exchange }))
+    this.rawBars = bars
+    this.liveBucket = null
+    this.noMoreHistory = false
     this.prevClose =
       this.rawBars.length > 1
         ? this.rawBars[this.rawBars.length - 2].close


### PR DESCRIPTION
### Problem

`loadSymbol()` unsubscribes the previous feed and replaces `this.sym` **before** fetching history. When the history request fails or returns nothing, it returns early — leaving `this.sym` pointing at the NEW symbol while the canvas, the toolbar and the live subscription still belong to the OLD one.

Ordering in the current code:

| step | when |
|---|---|
| unsubscribe previous feed | first, unconditionally |
| assign `this.sym`, `this.product`, `this.qty`, localStorage | before the fetch |
| reset `lastLtp` / `prevClose` | before the fetch |
| fetch history | |
| **early return on error / empty** | `buildChart`, `onSymbolLoaded`, `connectLive` are all downstream, so none run |

The old chart object survives (`buildChart` is the only thing that recreates it) and nothing is subscribed at all.

### Why it is not merely cosmetic

**The order path reads `this.sym` directly.** `placeFromMenu` and `exitPosition` both send `this.sym.symbol` / `this.sym.exchange`. The React toolbar renders a *separate* copy fed only by `onSymbolLoaded`, which never fired. So a context-menu order placed after a failed load goes to an instrument the user is not looking at.

**It also disables both price guards at once.** The failure path sets `rawBars = []`, so `marketPrice()` returns `null`, and:

- `contextMenuAt` skips its `if (m != null)` gate, rendering **all six order types as enabled** including limits and stops it cannot price
- `placeFromMenu` skips the "stop must be on the correct side of LTP" rejection

...while the order price still comes from `chart.coordinateToPrice()` on the **old symbol's** price scale.

**The trigger is not exotic.** Deep-OTM strikes with no trades, newly listed or expiring contracts, and unusual intervals all return empty bar sets routinely.

In fairness: the on-canvas legend *does* switch to the new symbol via `setLegend`, and a red error toast fires on the non-silent path, so the display is internally contradictory rather than cleanly deceptive. That does not fix the order path.

### Fix

Load transactionally. Build the new symbol into a local, fetch, and only then unsubscribe the old feed and commit `this.sym` / `this.product` / `this.qty` / `rawBars`. A failed load becomes a true no-op plus a toast, with the previous symbol still live and still correctly subscribed.

I chose this over restoring state after the fact because a partial restore is fragile: `this.product` and the `lastLtp`/`prevClose` resets are clobbered before the fetch too, so a naive "put `this.sym` back" would still leave e.g. `CNC` selected for a still-displayed F&O symbol and the old symbol's LTP blanked from the legend.

`connectLive()` does not unsubscribe the outgoing symbol itself, which is why the unsubscribe moves as a block using a captured `prev` rather than simply being deleted.

### Verification

`npx tsc --noEmit` passes clean. Diff is 44 insertions / 33 deletions in one function.

`biome check` reports a formatting failure on this file, but it does so **identically on the unmodified upstream file** in my checkout — it is CRLF line endings from a Windows working tree, not this change. The committed diff contains no CR characters.

`ChartPane.tsx:738` discards `loadSymbol`'s boolean return. With this change that is harmless (failure is a no-op plus a toast), so I left it alone.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Load chart symbols transactionally to keep terminal state consistent when history fetches fail. The previous symbol stays active, so orders and price guards remain correct.

- **Bug Fixes**
  - Build `next` symbol and `product` locally; fetch bars using `next` before mutating state.
  - On fetch error or empty bars, exit early with a toast and no state change.
  - After success, unsubscribe the captured `prev` symbol (LTP/Depth as appropriate), then commit `this.sym`, `this.product`, `this.qty`, and `rawBars`; reset `liveBucket`/`noMoreHistory`/`prevClose`.
  - Persist the selected symbol to localStorage only after commit.

<sup>Written for commit c2202a7ef7e22b0e1cc9acfd3bf5e7830854fd55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1708?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

