### PR TITLE
fix(order-dialog): offer only exchanges that list the scrip

### DIFF
--- a/frontend/src/components/trading/PlaceOrderDialog.tsx
+++ b/frontend/src/components/trading/PlaceOrderDialog.tsx
@@ -122,6 +122,37 @@ export function PlaceOrderDialog({
   const exchange_ = formExchange || exchange
   const isEquityExchange = exchange_ === 'NSE' || exchange_ === 'BSE'
 
+  // Which cash exchanges actually list THIS scrip. Not every equity is on both:
+  // SME and other exchange-exclusive listings trade on one side only, and
+  // offering the other produces a (symbol, exchange) pair with no token, dead
+  // quotes, and an order the broker rejects. Always includes the originating
+  // exchange so a failed or empty lookup degrades to today's fixed behaviour.
+  const [cashListings, setCashListings] = useState<string[]>([])
+
+  useEffect(() => {
+    if (!open || !symbol || (exchange !== 'NSE' && exchange !== 'BSE')) {
+      setCashListings([])
+      return
+    }
+    let cancelled = false
+    const params = new URLSearchParams({ q: symbol, exchange: 'NSE,BSE' })
+    fetch(`/search/api/search?${params.toString()}`, { credentials: 'include' })
+      .then((r) => (r.ok ? r.json() : Promise.reject(new Error(String(r.status)))))
+      .then((data: { results?: Array<{ symbol?: string; exchange?: string }> }) => {
+        if (cancelled) return
+        const listed = (data.results || [])
+          .filter((r) => r.symbol === symbol && r.exchange)
+          .map((r) => r.exchange as string)
+        setCashListings([...new Set<string>([exchange, ...listed])])
+      })
+      .catch(() => {
+        if (!cancelled) setCashListings([exchange])
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [open, symbol, exchange])
+
   // Get available product types based on exchange
   const productTypes = isFnOExchange(exchange_) ? FNO_PRODUCT_TYPES : EQUITY_PRODUCT_TYPES
 
@@ -409,10 +440,12 @@ export function PlaceOrderDialog({
             )}
           </div>
 
-          {/* Exchange, for cash equity only. The same scrip is listed on both
-              NSE and BSE, so the user picks where to route. Derivatives are
-              contract-specific and stay on the exchange they came from. */}
-          {isEquityExchange && (
+          {/* Exchange, for cash equity listed on more than one cash exchange.
+              Most scrips are on both NSE and BSE, so the user picks where to
+              route; exchange-exclusive listings keep the exchange they came
+              from and the selector is hidden. Derivatives are contract-specific
+              and never reach here. */}
+          {isEquityExchange && cashListings.length > 1 && (
             <div className="space-y-2">
               <Label className="text-xs">Exchange</Label>
               <Select value={exchange_} onValueChange={setFormExchange}>
@@ -420,8 +453,11 @@ export function PlaceOrderDialog({
                   <SelectValue />
                 </SelectTrigger>
                 <SelectContent>
-                  <SelectItem value="NSE">NSE</SelectItem>
-                  <SelectItem value="BSE">BSE</SelectItem>
+                  {cashListings.map((ex) => (
+                    <SelectItem key={ex} value={ex}>
+                      {ex}
+                    </SelectItem>
+                  ))}
                 </SelectContent>
               </Select>
             </div>


### PR DESCRIPTION
### Problem

The cash-equity exchange selector hardcodes both options for every equity symbol:

```tsx
{isEquityExchange && (
  ...
  <SelectItem value="NSE">NSE</SelectItem>
  <SelectItem value="BSE">BSE</SelectItem>
```

`isEquityExchange` is a pure string test (`exchange_ === 'NSE' || exchange_ === 'BSE'`) — there is no check that the scrip is actually listed on the alternate exchange. Exchange-exclusive listings, including many SME securities, can be switched to a `(symbol, exchange)` pair that does not exist. The chosen exchange flows straight into the order payload.

**Nothing downstream stops it.** `isValid()` checks only that symbol, exchange and quantity are non-empty and that LIMIT/SL orders carry a price — so for a MARKET order the submit button stays enabled. `useLiveQuote` does re-subscribe on the switch and the quote panel goes blank (LTP and bid/ask render as `-`), but that is presentational, not a gate.

### Scoping this honestly

The finding is real but its consequence is narrower than "silently wrong order":

- **Analyzer mode:** `sandbox/order_manager.py` calls `get_symbol_info` and returns a clean `Symbol X not found on Y` 400. Order never created.
- **Live mode:** `services/place_order_service.py::validate_order_data` validates exchange *membership* but never `(symbol, exchange)` existence, so it reaches the broker adapter, `get_token` returns `None`, and the broker rejects it.

So the failure mode is a **rejected order with a mediocre error message**, not a bad fill. Still an order the UI should never have let the user submit.

The genuinely worse variant, which I mention for completeness: a symbol that *is* listed on both but is near-illiquid on the alternate (common for BSE listings of NSE-primary scrips). There a MARKET order succeeds and can fill far from the primary-exchange price. This change does not address that, though the dialog does re-quote on switch so the thin LTP is visible before submitting.

### Fix

Derive the choices from the master contract. The search endpoint already accepts a multi-exchange filter and is used the same way elsewhere in the app (`Search.tsx`, `Historify.tsx`), so no new API plumbing is needed. When only one listing comes back, the selector is hidden and the originating exchange is kept.

Fails safe in every direction — a search error, an empty result, or a non-equity caller all collapse to a single-element list, which reproduces exactly today's pre-selector behaviour.

### Worth considering separately

`services/place_order_service.py::validate_order_data` does not reject unresolvable `(symbol, exchange)` pairs in **live** mode, though `sandbox/order_manager.py` already does for analyzer mode. Closing that would fix this whole class for every client — REST, strategies and UI alike — rather than just this dialog, and would turn a broker-worded rejection into a clean OpenAlgo 400. Happy to open that as its own PR if you would like it.

### Verification

`npx tsc --noEmit` passes clean.

`biome check` flags formatting on this file, but does so identically on the unmodified upstream file in my Windows checkout — CRLF line endings, not this change. The committed diff contains no CR characters.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show only NSE/BSE options that actually list the selected equity, preventing invalid (symbol, exchange) pairs and broker-rejected orders. Hide the exchange selector when there’s only one listing, and fall back to the originating exchange if lookup fails.

- **Bug Fixes**
  - Build the cash exchange list from the existing search API (`/search/api/search?q=<symbol>&exchange=NSE,BSE`) and dedupe results.
  - Always include the originating exchange; collapse to a single option on errors or non-equity.
  - Render the exchange selector only when more than one cash listing exists; derivatives are unaffected.

<sup>Written for commit b1f4607ab31659740e668932ffd729b2b1762fe4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

