### PR TITLE
fix(positions): scale the P&L% denominator by the contract multiplier

### DIFF
--- a/frontend/src/hooks/useLivePrice.ts
+++ b/frontend/src/hooks/useLivePrice.ts
@@ -283,8 +283,12 @@ export function useLivePrice<T extends PriceableItem>(
         // Total P&L = today's realized (from partial closes) + current unrealized
         calculatedPnl = todayRealizedPnl + unrealizedPnl
 
-        // P&L% based on total P&L and investment
-        const investment = Math.abs(avgPrice * qty)
+        // P&L% based on total P&L and investment.
+        // The investment must carry the same lotSize the P&L above was scaled by,
+        // or the ratio is off by exactly that multiplier: 100x too large for an
+        // MCX CRUDEOIL contract (lot_size 100), 100x too small for a Delta
+        // ETHUSD.P (lot_size 0.01).
+        const investment = Math.abs(avgPrice * qty * lotSize)
         calculatedPnlPercent = investment > 0 ? (calculatedPnl / investment) * 100 : 0
       }
 


### PR DESCRIPTION
### Problem

`useLivePrice` recalculates P&L for open positions from the live LTP and correctly scales it by `lot_size`, the per-symbol contract multiplier:

```ts
const lotSize = item.lot_size ?? 1
unrealizedPnl = (currentLtp - avgPrice) * qty * lotSize     // scaled
...
const investment = Math.abs(avgPrice * qty)                 // NOT scaled
calculatedPnlPercent = (calculatedPnl / investment) * 100
```

The denominator omits `lotSize`, so the percentage is wrong by exactly that factor.

Observed on an MCX position (`CRUDEOIL17AUG268000PE`, 4 lots @ 491.00, LTP 453.10, `lot_size` 100):

| | rendered | correct |
|---|---|---|
| P&L | −15,160.00 | −15,160.00 (−37.90 × 4 × 100) — right |
| P&L % | **−771.89%** | **−7.72%** |

−771.89% is exactly `−15160 / (491 × 4)`. With the multiplier in the denominator it is `−15160 / (491 × 4 × 100)` = −7.72%.

**The backend already gets this right** — `sandbox/position_manager.py` builds `investment = average_price * quantity * contract_value` and the API returns `pnlpercent: -7.556…`. `Positions.tsx` prefers the API value, but `useLivePrice` overwrites it on every live tick. So this is purely the frontend recomputation diverging from the backend.

### It is wrong in both directions

Delta Exchange contracts have a `lot_size` below one — 0.01 for `ETHUSD.P` — so their P&L% has been **understated by 100x**, which is presumably why this went unnoticed: a too-small percentage reads as unremarkable, whereas MCX's too-large one does not.

### Fix

Multiply the investment by the same `lotSize` the P&L was scaled by. One line plus a comment.

Positions with `lot_size` absent or 1 (all standard equity and F&O) are unaffected: `lotSize` defaults to 1 and the arithmetic is unchanged.

### Verification

`npx tsc --noEmit` clean; `npm run test:run` 170/170 pass.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes P&L% for open positions by scaling the investment with the contract `lot_size` in `useLivePrice`, aligning the frontend with the backend and removing 100x over/understated percentages.

- **Bug Fixes**
  - Multiply investment by `lotSize` when computing P&L%.
  - Corrects inflated MCX values and understated Delta Exchange values.
  - No impact on instruments with `lot_size` 1 or missing.

<sup>Written for commit fddc68af8861f2385f5afb64e270cd5d45131d47. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

