### PR TITLE
fix(positions): stop overwriting broker-supplied P&L on live positions

### DIFF
--- a/frontend/src/hooks/useLivePrice.ts
+++ b/frontend/src/hooks/useLivePrice.ts
@@ -34,6 +34,9 @@ export interface UseLivePriceOptions {
   multiQuotesRefreshInterval?: number
   /** Pause WebSocket and polling when tab is hidden (default: true) */
   pauseWhenHidden?: boolean
+  /** Recompute P&L from the live tick. Only correct when the caller's P&L
+   *  model matches this hook's (the sandbox). Live broker P&L is left alone. */
+  recalculatePnl?: boolean
   /** Time in ms to wait before pausing when hidden (default: 5000) */
   pauseDelay?: number
 }
@@ -86,6 +89,7 @@ export function useLivePrice<T extends PriceableItem>(
     useMultiQuotesFallback = true,
     multiQuotesRefreshInterval = 30000,
     pauseWhenHidden = true,
+    recalculatePnl = false,
   } = options
 
   const { apiKey } = useAuthStore()
@@ -265,7 +269,20 @@ export function useLivePrice<T extends PriceableItem>(
       // This ensures cumulative P&L (realized + unrealized) is shown correctly
       const todayRealizedPnl = item.today_realized_pnl || 0
 
-      if (currentLtp && avgPrice > 0) {
+      // Only recompute P&L when the caller owns the same P&L model we do.
+      //
+      // The sandbox does: it reports today_realized + unrealized computed as
+      // (ltp - avg) * qty * contract_value, which is exactly what this hook
+      // recomputes, so recomputing on every tick is a faithful live refresh.
+      //
+      // A live broker does not. Its P&L comes from the exchange and can follow
+      // completely different accounting -- Delta Exchange reports option
+      // unrealized P&L as the current buyback cost, tracking -(mark * contract_value)
+      // and ignoring entry_price entirely, so no (ltp - avg) formula reproduces it in
+      // sign or magnitude. Recomputing there overwrites a correct exchange figure with
+      // a wrong one; live positions instead keep the broker's number and only refresh
+      // the displayed LTP.
+      if (recalculatePnl && currentLtp && avgPrice > 0) {
         // Contract multiplier: e.g. 0.01 for Delta Exchange ETHUSD.P (1 lot = 0.01 ETH)
         // Defaults to 1 for all standard brokers where qty is already in underlying units
         const lotSize = item.lot_size ?? 1

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -30,7 +30,7 @@ import { useOrderEventRefresh } from '@/hooks/useOrderEventRefresh'
 import { usePageVisibility } from '@/hooks/usePageVisibility'
 import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
+import { onModeChange, useThemeStore } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
 import { EmptyState } from '@/components/ui/empty-state'
@@ -50,6 +50,8 @@ interface HoldingOrderIntent {
 
 export default function Holdings() {
   const { apiKey, user } = useAuthStore()
+  // Same rule as Positions: recompute only where we own the P&L model.
+  const { appMode } = useThemeStore()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
   const [holdings, setHoldings] = useState<Holding[]>([])
   const [stats, setStats] = useState<HoldingsStats | null>(null)
@@ -71,6 +73,7 @@ export default function Holdings() {
     isPaused,
   } = useLivePrice(holdings, {
     enabled: holdings.length > 0,
+    recalculatePnl: appMode === 'analyzer',
     useMultiQuotesFallback: true,
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -56,7 +56,7 @@ import { usePageVisibility } from '@/hooks/usePageVisibility'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
+import { onModeChange, useThemeStore } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
 import { showToast } from '@/utils/toast'
 import { EmptyState } from '@/components/ui/empty-state'
@@ -146,6 +146,10 @@ const PRODUCT_COLORS: Record<string, string> = {
 
 export default function Positions() {
   const { apiKey, user } = useAuthStore()
+  // Sandbox P&L uses the same (ltp - avg) * qty * contract_value model this hook
+  // recomputes, so a live refresh is faithful. Live broker P&L comes from the
+  // exchange and must not be overwritten -- see the note in useLivePrice.
+  const { appMode } = useThemeStore()
   const { isCrypto } = useSupportedExchanges()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
   const [positions, setPositions] = useState<Position[]>([])
@@ -178,6 +182,7 @@ export default function Positions() {
     isPaused,
   } = useLivePrice(positions, {
     enabled: positions.length > 0,
+    recalculatePnl: appMode === 'analyzer',
     useMultiQuotesFallback: true,
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,


### PR DESCRIPTION
### Problem

`useLivePrice` recomputes P&L for every open position on each tick:

```ts
unrealizedPnl = (currentLtp - avgPrice) * qty * lotSize
calculatedPnl = todayRealizedPnl + unrealizedPnl
```

That is the **sandbox's** P&L model, and only the sandbox reports P&L that way. A live broker's P&L comes from the exchange and can follow entirely different accounting, so recomputing overwrites a correct figure with a wrong one.

There is no guard: `currentLtp` falls back to `item.ltp`, so this runs for any open position even with no live data flowing. Closed positions (`qty === 0`) return early, which is why it is easy to miss when spot-checking.

### Delta Exchange options are a clear counter-example

Raw `/v2/positions/margined` from a live account:

| symbol | size | entry | mark | Delta `unrealized_pnl` | `(mark−entry)×cv` | `−(mark×cv)` |
|---|---|---|---|---|---|---|
| P-BTC-63800-310726 | 1 | 773 | 28.41 | **−0.028** | −0.745 | −0.0284 |
| C-BTC-63600-310726 | 1 | 903 | 1367.52 | **−1.364** | +0.465 | −1.3675 |
| P-BTC-64400-010826 | 1 | 1045 | 289.15 | **−0.288** | −0.756 | −0.2891 |

Delta tracks **`−(mark × contract_value)`** and ignores `entry_price` entirely. No `(ltp − avg)` formula reproduces it — solving for a multiplier per row gives `0.0000376` for the first and `−0.002936` for the second, so it disagrees in **sign as well as magnitude**.

Across 8 open positions the page rendered **−0.72** against the exchange's **−6.86**, with calls displayed as gains while they were losses.

### Fix

Make the recomputation opt-in (`recalculatePnl`, default off) and enable it only in analyzer mode, where the sandbox owns the same model and a per-tick refresh is faithful.

Live positions keep the broker's P&L and refresh only the displayed LTP. They therefore update on the REST poll rather than every tick — slightly staler, but correct. That trade is clearly worth making against a number that is wrong in sign.

Applied to both `Positions.tsx` and `Holdings.tsx`, which share the hook.

### What this replaces

An earlier revision of this PR tried to preserve a realized component — first by deriving it, then by plumbing `today_realized_pnl` through the Delta and Dhan mappings. Both were wrong diagnoses. Delta reports `realized_pnl = 0` on all of these positions, so realized was never the gap; the formula itself is.

The derivation approach was also unsound for a reason raised in review: a broker whose P&L and whose `ltp` come from separate requests — true of both the Delta and Dhan mappings — would have the intervening price move misattributed to realized.

### Verification

`tsc --noEmit -p tsconfig.app.json` clean; `npm run test:run` 170/170.

`biome check` reports a formatting failure on the touched files, but does so **identically on the unmodified upstream files** in my checkout — CRLF line endings from a Windows working tree, same exit code for both. The committed diff is 28 insertions / 3 deletions.

### Note

Related to #1711 (P&L% denominator), which is independent and still applies — it fixes the sandbox path this PR keeps enabled.
