### PR TITLE
fix(zerodha): pace every Kite call against its documented rate limit

### DIFF
--- a/broker/zerodha/api/data.py
+++ b/broker/zerodha/api/data.py
@@ -1,11 +1,11 @@
 import json
 import os
-import time
 import urllib.parse
 from datetime import datetime, timedelta
 
 import pandas as pd
 
+from broker.zerodha.api.rate_limiter import request as paced_request
 from broker.zerodha.database.master_contract_db import SymToken, db_session
 from database.token_db import get_br_symbol, get_oa_symbol
 from utils.httpx_client import get_httpx_client
@@ -84,20 +84,19 @@ def get_api_response(endpoint, auth, method="GET", payload=None):
     url = f"{base_url}{endpoint}"
 
     try:
-        # Log the complete request details for debugging
-        # logger.info("=== API Request Details ===")
-        # logger.info(f"URL: {url}")
-        # logger.info(f"Method: {method}")
-        # logger.info(f"Headers: {json.dumps(headers, indent=2)}")
         if payload:
             logger.debug(f"Payload: {json.dumps(payload, indent=2)}")
 
-        # Make the request using the shared client
+        # Paced against the documented per-endpoint cap, and retried if the
+        # gateway still says no. Quote is 1/sec, which several pages polling at
+        # once will exceed without this.
         if method.upper() == "GET":
-            response = client.get(url, headers=headers)
+            response, response_data = paced_request(client, "GET", url, headers=headers)
         elif method.upper() == "POST":
             headers["Content-Type"] = "application/json"
-            response = client.post(url, headers=headers, json=payload)
+            response, response_data = paced_request(
+                client, "POST", url, headers=headers, json=payload
+            )
         else:
             raise ZerodhaAPIError(f"Unsupported HTTP method: {method}")
 
@@ -107,8 +106,8 @@ def get_api_response(endpoint, auth, method="GET", payload=None):
         logger.debug(f"Response Headers: {dict(response.headers)}")
         logger.debug(f"Response Body: {response.text}")
 
-        # Parse JSON response
-        response_data = response.json()
+        if response_data is None:
+            response_data = response.json()
 
         # Check for permission errors
         if response_data.get("status") == "error":
@@ -252,36 +251,24 @@ class BrokerData:
                   [{'symbol': 'SBIN', 'exchange': 'NSE', 'data': {...}}, ...]
         """
         try:
-            BATCH_SIZE = 500  # Zerodha API limit per request
-            RATE_LIMIT_DELAY = 1.0  # 1 request per second = 500 symbols/second
+            # /quote accepts 500 instruments per call and each call, whatever its
+            # size, costs one unit against the 1/sec quote budget. So batching is
+            # purely about staying under the per-call cap; the spacing between
+            # calls is owned by apply_rate_limit() in get_api_response, which is
+            # module-level and therefore also paces concurrent requests. The old
+            # sleep here only ran above 500 symbols and only within one call, so
+            # two callers in the same second both fired immediately.
+            BATCH_SIZE = 500
 
-            # If symbols exceed batch size, process in batches
-            if len(symbols) > BATCH_SIZE:
-                logger.info(f"Processing {len(symbols)} symbols in batches of {BATCH_SIZE}")
-                all_results = []
+            batch_count = (len(symbols) + BATCH_SIZE - 1) // BATCH_SIZE
+            if batch_count > 1:
+                logger.info(f"Processing {len(symbols)} symbols in {batch_count} batches")
 
-                # Split symbols into batches
-                for i in range(0, len(symbols), BATCH_SIZE):
-                    batch = symbols[i : i + BATCH_SIZE]
-                    logger.debug(
-                        f"Processing batch {i // BATCH_SIZE + 1}: symbols {i + 1} to {min(i + BATCH_SIZE, len(symbols))}"
-                    )
+            all_results = []
+            for i in range(0, len(symbols), BATCH_SIZE):
+                all_results.extend(self._process_quotes_batch(symbols[i : i + BATCH_SIZE]))
 
-                    # Process this batch
-                    batch_results = self._process_quotes_batch(batch)
-                    all_results.extend(batch_results)
-
-                    # Rate limit delay between batches
-                    if i + BATCH_SIZE < len(symbols):
-                        time.sleep(RATE_LIMIT_DELAY)
-
-                logger.info(
-                    f"Successfully processed {len(all_results)} quotes in {(len(symbols) + BATCH_SIZE - 1) // BATCH_SIZE} batches"
-                )
-                return all_results
-            else:
-                # Single batch processing
-                return self._process_quotes_batch(symbols)
+            return all_results
 
         except ZerodhaPermissionError as e:
             logger.debug(f"Permission error fetching multiquotes: {e}")

--- a/broker/zerodha/api/funds.py
+++ b/broker/zerodha/api/funds.py
@@ -2,6 +2,7 @@
 
 import os
 
+from broker.zerodha.api.rate_limiter import request as paced_request
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
@@ -19,11 +20,13 @@ def get_margin_data(auth_token):
 
     try:
         # Make the GET request using the shared client
-        response = client.get("https://api.kite.trade/user/margins", headers=headers)
+        response, margin_data = paced_request(
+            client, "GET", "https://api.kite.trade/user/margins", headers=headers
+        )
         response.raise_for_status()  # Raises an exception for 4XX/5XX responses
 
-        # Parse the response
-        margin_data = response.json()
+        if margin_data is None:
+            margin_data = response.json()
     except Exception as e:
         error_message = str(e)
         try:
@@ -74,11 +77,12 @@ def get_margin_data(auth_token):
         total_realised = 0
         total_unrealised = 0
         try:
-            pos_response = client.get(
-                "https://api.kite.trade/portfolio/positions", headers=headers
+            pos_response, position_book = paced_request(
+                client, "GET", "https://api.kite.trade/portfolio/positions", headers=headers
             )
             pos_response.raise_for_status()
-            position_book = pos_response.json()
+            if position_book is None:
+                position_book = pos_response.json()
 
             if position_book.get("status") == "success" and position_book.get("data"):
                 net_positions = position_book["data"].get("net", [])
@@ -99,11 +103,16 @@ def get_margin_data(auth_token):
                         f"{p['exchange']}:{p['tradingsymbol']}" for p in open_positions
                     ]
                     query = "&".join(f"i={inst}" for inst in instruments)
-                    quote_response = client.get(
-                        f"https://api.kite.trade/quote/ltp?{query}", headers=headers
+                    # This shares the 1/sec quote budget with every other quote
+                    # caller, so it has to go through the limiter as well: the
+                    # funds panel refreshing was competing with the option
+                    # chain for the same one request per second.
+                    quote_response, quote_data = paced_request(
+                        client, "GET", f"https://api.kite.trade/quote/ltp?{query}", headers=headers
                     )
                     quote_response.raise_for_status()
-                    quote_data = quote_response.json()
+                    if quote_data is None:
+                        quote_data = quote_response.json()
                     ltp_map = {}
                     if quote_data.get("status") == "success" and quote_data.get("data"):
                         for key, val in quote_data["data"].items():

--- a/broker/zerodha/api/gtt_api.py
+++ b/broker/zerodha/api/gtt_api.py
@@ -4,6 +4,7 @@
 import json
 import urllib.parse
 
+from broker.zerodha.api.rate_limiter import request as paced_request
 from broker.zerodha.mapping.gtt_data import (
     map_gtt_book,
     transform_modify_gtt,
@@ -150,10 +151,13 @@ def place_gtt_order(data, auth):
     logger.info(f"Zerodha place_gtt payload: type={transformed['type']}, body={body}")
 
     client = get_httpx_client()
-    response = client.post(f"{_BASE}/gtt/triggers", headers=_headers(auth, form=True), content=body)
+    response, response_data = paced_request(
+        client, "POST", f"{_BASE}/gtt/triggers", headers=_headers(auth, form=True), content=body
+    )
     logger.info(f"Zerodha place_gtt raw: status={response.status_code}, body={response.text}")
 
-    response_data = response.json()
+    if response_data is None:
+        response_data = response.json()
     response.status = response.status_code  # parity with other order APIs
 
     trigger_id = None
@@ -239,11 +243,12 @@ def get_gtt_book(auth):
     OpenAlgo-normalised GTT objects (see ``map_gtt_book``).
     """
     client = get_httpx_client()
-    response = client.get(f"{_BASE}/gtt/triggers", headers=_headers(auth))
+    response, raw = paced_request(client, "GET", f"{_BASE}/gtt/triggers", headers=_headers(auth))
     logger.info(f"Zerodha gtt_book raw: status={response.status_code}")
 
     try:
-        raw = response.json()
+        if raw is None:
+            raw = response.json()
     except Exception:
         return {"status": "error", "message": response.text or "Invalid response"}, response.status_code
 

--- a/broker/zerodha/api/margin_api.py
+++ b/broker/zerodha/api/margin_api.py
@@ -1,5 +1,6 @@
 import json
 
+from broker.zerodha.api.rate_limiter import request as paced_request
 from broker.zerodha.mapping.margin_data import parse_margin_response, transform_margin_positions
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
@@ -74,14 +75,14 @@ def calculate_margin_api(positions, auth):
 
     try:
         # Make the request using the shared client
-        response = client.post(endpoint, headers=headers, json=payload)
+        response, parsed = paced_request(client, "POST", endpoint, headers=headers, json=payload)
 
         # Add status attribute for compatibility with the existing codebase
         response.status = response.status_code
 
         # Parse the JSON response
         try:
-            response_data = response.json()
+            response_data = parsed if parsed is not None else response.json()
         except json.JSONDecodeError:
             logger.error(f"Failed to parse JSON response from Zerodha: {response.text}")
             error_response = {"status": "error", "message": "Invalid response from broker API"}

--- a/broker/zerodha/api/order_api.py
+++ b/broker/zerodha/api/order_api.py
@@ -5,6 +5,7 @@ import threading
 import time
 import urllib.parse
 
+from broker.zerodha.api.rate_limiter import request as paced_request
 from broker.zerodha.mapping.transform_data import (
     map_product_type,
     reverse_map_product_type,
@@ -43,24 +44,30 @@ def get_api_response(endpoint, auth, method="GET", payload=None):
     url = f"{base_url}{endpoint}"
 
     try:
-        # Handle different HTTP methods
+        # Paced and retried by the shared limiter so order, position and
+        # holdings traffic queues against its own 10/sec budget rather than
+        # competing with quote polling.
         if method.upper() == "GET":
-            response = client.get(url, headers=headers)
+            response, response_data = paced_request(client, "GET", url, headers=headers)
         elif method.upper() == "POST":
             if isinstance(payload, str):
                 # For form-urlencoded data
                 headers["Content-Type"] = "application/x-www-form-urlencoded"
-                response = client.post(url, headers=headers, content=payload)
+                response, response_data = paced_request(
+                    client, "POST", url, headers=headers, content=payload
+                )
             else:
                 # For JSON data
                 headers["Content-Type"] = "application/json"
-                response = client.post(url, headers=headers, json=payload)
+                response, response_data = paced_request(
+                    client, "POST", url, headers=headers, json=payload
+                )
         else:
             raise ValueError(f"Unsupported HTTP method: {method}")
 
         # Parse and return JSON response
         response.raise_for_status()
-        return response.json()
+        return response_data if response_data is not None else response.json()
 
     except Exception as e:
         error_msg = str(e)
@@ -199,15 +206,20 @@ def place_order_api(data, auth):
     }
 
     # Make the request using the shared client
-    response = client.post(
-        "https://api.kite.trade/orders/regular", headers=headers, content=payload_encoded
+    response, response_data = paced_request(
+        client,
+        "POST",
+        "https://api.kite.trade/orders/regular",
+        headers=headers,
+        content=payload_encoded,
     )
 
     # Log raw response
     logger.debug(f"Zerodha raw response: status={response.status_code}, body={response.text}")
 
     # Parse the response
-    response_data = response.json()
+    if response_data is None:
+        response_data = response.json()
     logger.debug(f"Response from place_order_api: {response_data}")
 
     # Handle the response

--- a/broker/zerodha/api/rate_limiter.py
+++ b/broker/zerodha/api/rate_limiter.py
@@ -1,0 +1,183 @@
+"""
+Shared rate limiting and 429-retry helpers for all Zerodha (Kite) API calls.
+
+Zerodha publishes a **per-endpoint-class** cap rather than one global budget
+(zerodha-api-docs/19-api-reference.md -> "Rate Limits"):
+
+    Quote        1 / second
+    Historical   3 / second
+    Orders      10 / second
+    Others      10 / second
+
+Quote at 1/sec is the tightest limit of any broker OpenAlgo supports, and it is
+what /gammadensity, the option chain and the OI tracker all lean on hardest.
+Note that the cap counts *requests*, not instruments: /quote carries up to 500
+instruments per call and /quote/ltp up to 1000, and a full batch costs the same
+one unit as a single symbol. Batching is therefore about the per-call cap, and
+pacing is about the per-second cap; they are independent.
+
+The pacing state is module-level for the same reason it is in the Fyers
+limiter: services construct a fresh ``BrokerData(auth_token)`` for every
+request (services/quotes_service.py, option_chain_service.py, and others), so
+anything kept on ``self`` is discarded before the next call and paces nothing.
+The previous implementation slept between batches *inside* one
+``get_multiquotes`` call, which meant a single call of 500 symbols or fewer was
+never throttled at all, and two calls arriving in the same second both fired
+immediately.
+
+Unlike Fyers, the classes here do not share a budget, so each keeps its own
+clock: a burst of quote calls must not delay order placement.
+"""
+
+import threading
+import time
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+BASE_URL = "https://api.kite.trade"
+
+# Documented limits, paced slightly under to leave room for clock jitter and
+# for the network putting two requests on the wire closer than they were sent.
+LIMITS = {
+    "quote": 1.05,       # 1/sec documented; 1.05s between calls
+    "historical": 0.35,  # 3/sec documented
+    "order": 0.11,       # 10/sec documented
+    "other": 0.11,       # 10/sec documented
+}
+
+MAX_RETRIES = 3
+BASE_BACKOFF = 1.0  # seconds; 1, 2, 4 when the response carries no hint
+
+_lock = threading.Lock()
+_last_call: dict[str, float] = dict.fromkeys(LIMITS, 0.0)
+
+
+def category_for(endpoint: str) -> str:
+    """
+    Which documented limit an endpoint falls under.
+
+    Derived from the path rather than passed by each caller, so a new call site
+    is paced correctly without anyone remembering to classify it.
+    """
+    path = (endpoint or "").split("?", 1)[0]
+
+    # Historical is checked first: its path also contains "/instruments".
+    if "/instruments/historical" in path:
+        return "historical"
+    if path.startswith("/quote") or "/quote" in path:
+        return "quote"
+    if path.startswith("/orders") or path.startswith("/trades") or "/gtt" in path:
+        return "order"
+    return "other"
+
+
+def apply_rate_limit(endpoint: str) -> None:
+    """
+    Block until it is safe to make this call.
+
+    The timestamp is advanced to the *scheduled* time rather than to now, so
+    concurrent threads queue behind one another instead of all measuring the
+    same idle gap and firing together.
+    """
+    key = category_for(endpoint)
+    interval = LIMITS[key]
+
+    with _lock:
+        now = time.time()
+        elapsed = now - _last_call[key]
+        sleep_for = interval - elapsed if elapsed < interval else 0.0
+        _last_call[key] = now + sleep_for
+
+    if sleep_for > 0:
+        time.sleep(sleep_for)
+
+
+def is_rate_limited(response_data: dict | None, status_code: int | None = None) -> bool:
+    """
+    Whether a response is a rate-limit rejection.
+
+    Kite answers with HTTP 429, but it also returns 200 carrying
+    ``{"status": "error", "message": "Too many requests"}`` and
+    ``error_type: "NetworkException"``, which is what the reported failure
+    showed. Both forms have to count, or the retry never triggers on the one
+    users actually hit.
+    """
+    if status_code == 429:
+        return True
+    if not isinstance(response_data, dict):
+        return False
+    if response_data.get("status") != "error":
+        return False
+    message = str(response_data.get("message", "")).lower()
+    return "too many request" in message or "rate limit" in message
+
+
+def retry_delay(headers, attempt: int, endpoint: str) -> float:
+    """
+    How long to wait before retrying a rate-limited call.
+
+    Prefers a ``Retry-After`` header when the gateway sends one, otherwise
+    backs off exponentially from a floor of one full interval for that class,
+    so a quote retry never comes back inside the 1-second window.
+    """
+    if headers:
+        retry_after = headers.get("Retry-After") or headers.get("retry-after")
+        if retry_after:
+            try:
+                return max(float(retry_after), 0.05)
+            except (TypeError, ValueError):
+                pass
+
+    floor = LIMITS[category_for(endpoint)]
+    return max(floor, BASE_BACKOFF * (2**attempt))
+
+
+def request(client, method: str, url: str, **kwargs):
+    """
+    Issue a Kite request through the limiter, retrying rate-limit rejections.
+
+    Returns ``(response, data)``, where ``data`` is the parsed JSON body or
+    ``None`` when the body was not JSON. It is handed back rather than left to
+    the caller because the retry loop has already parsed it once, and a
+    500-instrument quote body is not worth decoding twice.
+
+    Callers keep their own error handling: this only adds pacing and retries,
+    and returns the final response either way so nothing changes shape.
+    """
+    endpoint = url[len(BASE_URL) :] if url.startswith(BASE_URL) else url
+    path = endpoint.split("?", 1)[0]
+    send = getattr(client, method.lower())
+
+    response = None
+    data = None
+    for attempt in range(MAX_RETRIES + 1):
+        apply_rate_limit(endpoint)
+        response = send(url, **kwargs)
+
+        try:
+            data = response.json()
+        except Exception:  # noqa: BLE001 - a rejection page need not be JSON
+            data = None
+
+        if not is_rate_limited(data, response.status_code):
+            return response, data
+
+        if attempt >= MAX_RETRIES:
+            logger.warning(
+                "Zerodha rate limit on %s persisted after %d retries", path, MAX_RETRIES
+            )
+            return response, data
+
+        wait = retry_delay(response.headers, attempt, endpoint)
+        logger.info(
+            "Zerodha rate limited on %s, retrying in %.2fs (attempt %d/%d)",
+            path,
+            wait,
+            attempt + 1,
+            MAX_RETRIES,
+        )
+        time.sleep(wait)
+
+    return response, data

--- a/test/test_zerodha_rate_limiter.py
+++ b/test/test_zerodha_rate_limiter.py
@@ -1,0 +1,236 @@
+"""
+Tests for the Zerodha rate limiter (GitHub issue #1710).
+
+The reported failure was "Error fetching multiquotes: API Error: Too many
+requests" from /gammadensity on a live deployment. Three things had to be true
+for that to happen, and each has a test here:
+
+  1. Quote is capped at 1 request/second, the tightest limit Kite publishes.
+  2. Pacing has to be process-wide, because a fresh BrokerData is built for
+     every request, so nothing kept on the instance survives to the next call.
+  3. A rejection arrives as HTTP 200 with an error body, not only as a 429, so
+     status-code-only detection would never retry.
+"""
+
+import threading
+import time
+
+import pytest
+
+from broker.zerodha.api import rate_limiter as rl
+
+
+@pytest.fixture(autouse=True)
+def _reset_clocks():
+    """Each test starts from an idle limiter."""
+    with rl._lock:
+        for key in rl._last_call:
+            rl._last_call[key] = 0.0
+    yield
+
+
+# --- classification -------------------------------------------------------
+
+
+@pytest.mark.parametrize(
+    ("endpoint", "expected"),
+    [
+        ("/quote?i=NSE:SBIN", "quote"),
+        ("/quote/ltp?i=NSE:SBIN&i=NSE:TCS", "quote"),
+        ("/quote/ohlc?i=NSE:INFY", "quote"),
+        ("/instruments/historical/408065/day?from=2024-01-01&to=2024-02-01", "historical"),
+        ("/orders", "order"),
+        ("/orders/regular", "order"),
+        ("/trades", "order"),
+        ("/gtt/triggers", "order"),
+        ("/portfolio/holdings", "other"),
+        ("/portfolio/positions", "other"),
+        ("/user/margins", "other"),
+        ("/margins/basket?consider_positions=true", "other"),
+        ("/instruments", "other"),
+    ],
+)
+def test_category_for(endpoint, expected):
+    assert rl.category_for(endpoint) == expected
+
+
+def test_historical_is_not_mistaken_for_the_instruments_dump():
+    """/instruments/historical contains "/instruments" and must not fall to "other"."""
+    assert rl.category_for("/instruments/historical/408065/minute") == "historical"
+    assert rl.LIMITS["historical"] > rl.LIMITS["other"]
+
+
+# --- pacing ---------------------------------------------------------------
+
+
+def test_quote_calls_are_spaced_by_at_least_one_second():
+    start = time.monotonic()
+    rl.apply_rate_limit("/quote?i=NSE:SBIN")
+    rl.apply_rate_limit("/quote?i=NSE:TCS")
+    elapsed = time.monotonic() - start
+
+    # Documented cap is 1/sec. The first call is free, the second waits.
+    assert elapsed >= 1.0
+
+
+def test_a_single_call_of_500_symbols_is_not_delayed():
+    """
+    Batching and pacing are separate concerns.
+
+    /quote takes 500 instruments per request and the whole request costs one
+    unit, so one batch must not be slowed down. The old code conflated the two
+    and only threw in a sleep above 500 symbols.
+    """
+    start = time.monotonic()
+    rl.apply_rate_limit("/quote?" + "&".join(f"i=NSE:SYM{n}" for n in range(500)))
+    assert time.monotonic() - start < 0.1
+
+
+def test_the_classes_do_not_share_a_budget():
+    """A burst of quote traffic must not hold up order placement."""
+    rl.apply_rate_limit("/quote?i=NSE:SBIN")
+
+    start = time.monotonic()
+    rl.apply_rate_limit("/orders/regular")
+    assert time.monotonic() - start < 0.1
+
+
+def test_concurrent_callers_queue_instead_of_firing_together():
+    """
+    The real-world shape of the bug: several requests in flight at once.
+
+    Each thread builds its own BrokerData, so only module-level state can
+    serialise them. Three quote calls must span at least two intervals.
+    """
+    fired = []
+    lock = threading.Lock()
+
+    def call():
+        rl.apply_rate_limit("/quote?i=NSE:SBIN")
+        with lock:
+            fired.append(time.monotonic())
+
+    start = time.monotonic()
+    threads = [threading.Thread(target=call) for _ in range(3)]
+    for t in threads:
+        t.start()
+    for t in threads:
+        t.join()
+
+    assert len(fired) == 3
+    assert max(fired) - start >= 2.0
+
+    gaps = [b - a for a, b in zip(sorted(fired), sorted(fired)[1:], strict=False)]
+    assert all(gap >= 0.9 for gap in gaps), gaps
+
+
+# --- rejection detection --------------------------------------------------
+
+
+def test_http_429_counts_as_rate_limited():
+    assert rl.is_rate_limited(None, 429)
+    assert rl.is_rate_limited({"status": "success"}, 429)
+
+
+def test_a_200_carrying_the_error_body_counts_as_rate_limited():
+    """This is the form the reported traceback actually showed."""
+    body = {
+        "status": "error",
+        "message": "Too many requests",
+        "error_type": "NetworkException",
+    }
+    assert rl.is_rate_limited(body, 200)
+
+
+def test_ordinary_errors_are_not_treated_as_rate_limits():
+    assert not rl.is_rate_limited({"status": "success", "data": {}}, 200)
+    assert not rl.is_rate_limited(
+        {"status": "error", "message": "Invalid session", "error_type": "TokenException"}, 403
+    )
+    assert not rl.is_rate_limited("<html>gateway timeout</html>", 504)
+    assert not rl.is_rate_limited(None, None)
+
+
+# --- backoff --------------------------------------------------------------
+
+
+def test_retry_after_header_is_honoured():
+    assert rl.retry_delay({"Retry-After": "5"}, 0, "/quote") == 5.0
+    assert rl.retry_delay({"retry-after": "2.5"}, 0, "/quote") == 2.5
+
+
+def test_a_junk_retry_after_falls_back_to_backoff():
+    assert rl.retry_delay({"Retry-After": "soon"}, 0, "/quote") == rl.retry_delay(
+        {}, 0, "/quote"
+    )
+
+
+def test_backoff_grows_and_never_dips_under_the_class_interval():
+    delays = [rl.retry_delay({}, n, "/quote") for n in range(3)]
+    assert delays == sorted(delays)
+    assert all(d >= rl.LIMITS["quote"] for d in delays)
+
+
+# --- the request wrapper --------------------------------------------------
+
+
+class _FakeResponse:
+    def __init__(self, payload, status_code=200):
+        self._payload = payload
+        self.status_code = status_code
+        self.headers = {}
+
+    def json(self):
+        if self._payload is None:
+            raise ValueError("not json")
+        return self._payload
+
+
+class _FakeClient:
+    """Rejects the first ``fail_times`` calls the way Kite does."""
+
+    def __init__(self, fail_times=0):
+        self.fail_times = fail_times
+        self.calls = 0
+
+    def get(self, url, **kwargs):
+        self.calls += 1
+        if self.calls <= self.fail_times:
+            return _FakeResponse(
+                {"status": "error", "message": "Too many requests"}, status_code=200
+            )
+        return _FakeResponse({"status": "success", "data": {"NSE:SBIN": {"last_price": 800}}})
+
+
+def test_request_retries_a_rejection_and_returns_the_good_body():
+    client = _FakeClient(fail_times=1)
+    response, data = rl.request(client, "GET", f"{rl.BASE_URL}/portfolio/holdings")
+
+    assert client.calls == 2
+    assert response.status_code == 200
+    assert data["status"] == "success"
+
+
+def test_request_gives_up_after_max_retries_and_returns_the_rejection():
+    """
+    The caller's own error handling still runs.
+
+    Returning the last response rather than raising keeps every existing call
+    site behaving exactly as it did before.
+    """
+    client = _FakeClient(fail_times=99)
+    response, data = rl.request(client, "GET", f"{rl.BASE_URL}/portfolio/holdings")
+
+    assert client.calls == rl.MAX_RETRIES + 1
+    assert data["message"] == "Too many requests"
+    assert response.status_code == 200
+
+
+def test_request_passes_a_non_json_body_back_as_none():
+    class _HtmlClient:
+        def get(self, url, **kwargs):
+            return _FakeResponse(None, status_code=502)
+
+    response, data = rl.request(_HtmlClient(), "GET", f"{rl.BASE_URL}/portfolio/holdings")
+    assert data is None
+    assert response.status_code == 502


### PR DESCRIPTION
Fixes #1710.

## The report

A live deployment hit `Error fetching multiquotes: API Error: Too many requests` on `/gammadensity`. The issue is real and reproducible from the code alone.

## Root causes

Kite caps **Quote at 1 request/second** ([API reference](https://kite.trade/docs/connect/v3/exceptions/#rate-limiting)), the tightest limit of any broker OpenAlgo supports. Three separate things went wrong:

1. **Pacing barely existed.** The only throttle was a `time.sleep` inside `get_multiquotes` that ran solely when a call carried more than 500 symbols. An ordinary call was never paced at all.
2. **Instance state cannot pace anything.** Services build a fresh `BrokerData(auth_token)` per request (`services/quotes_service.py`, `option_chain_service.py`, and others), so anything held on `self` is discarded before the next call. Two requests arriving in the same second both fired immediately. This is the same root cause already documented in the Fyers limiter.
3. **No retry.** Kite signals the rejection as HTTP 200 with `{"status": "error", "message": "Too many requests"}` at least as often as it does with a 429, so status-code-only handling would never have retried.

## The fix

Adds `broker/zerodha/api/rate_limiter.py` with module-level pacing per endpoint class:

| Class | Documented | Enforced interval |
|---|---|---|
| Quote | 1/sec | 1.05s |
| Historical | 3/sec | 0.35s |
| Orders | 10/sec | 0.11s |
| Others | 10/sec | 0.11s |

Unlike Fyers' single global budget, the classes keep independent clocks, so a burst of quote polling cannot delay order placement. Endpoints are classified from the path rather than by each caller, so a new call site is paced correctly without anyone remembering to classify it.

`request()` wraps a call with pacing plus bounded retries, honouring `Retry-After` when the gateway sends one and otherwise backing off exponentially from a floor of one full class interval.

Wired into both `get_api_response` definitions and into the five call sites that bypassed them entirely: **funds** (which quietly issues a `/quote/ltp` of its own, so the funds panel was competing with the option chain for the same one request per second), GTT, margins and order placement.

## Batching vs pacing

`get_multiquotes` still batches at 500 but no longer sleeps. The cap counts **requests, not instruments**: `/quote` carries up to 500 instruments per call and a full batch costs the same single unit as one symbol. Batching respects the per-call cap, the limiter respects the per-second cap. The old code conflated the two, which is why sub-500 calls went entirely unthrottled.

## Testing

`test/test_zerodha_rate_limiter.py`, 27 tests covering endpoint classification, spacing, the fact that a 500-symbol batch is *not* delayed, class independence, concurrent callers queueing rather than firing together, 200-with-error-body detection, `Retry-After` handling and the retry path.

```
27 passed
```

Ruff on `broker/zerodha/api/` reports the same 8 pre-existing findings as `main` — no new ones.

Not covered: no live Kite session was available, so this is verified against the documented limits and the reported failure shape rather than against the real gateway.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
