### PR TITLE
fix(upstox): holdings dropped average_price and could divide by zero

### DIFF
--- a/broker/upstox/mapping/order_data.py
+++ b/broker/upstox/mapping/order_data.py
@@ -208,15 +208,36 @@ def transform_positions_data(positions_data):
 def transform_holdings_data(holdings_data):
     transformed_data = []
     for holdings in holdings_data:
+        # Upstox documents `average_price` on holdings as the acquisition
+        # price, but it can come back null or 0 -- for shares received rather
+        # than bought (IPO allotments, bonuses, transfers) the broker has no
+        # acquisition price to report.
+        average_price = float(holdings.get("average_price") or 0.0)
+        last_price = float(holdings.get("last_price") or 0.0)
+
+        if average_price == 0:
+            logger.debug(
+                f"Zero average price for holding: {holdings.get('tradingsymbol', 'Unknown')}"
+            )
+            pnlpercent = 0.0
+        else:
+            # Guarded: dividing by the average unconditionally raised
+            # ZeroDivisionError on exactly those holdings and took the whole
+            # holdings response down with it.
+            pnlpercent = round((last_price - average_price) / average_price * 100, 2)
+
         transformed_position = {
             "symbol": holdings.get("tradingsymbol", ""),
             "exchange": holdings.get("exchange", ""),
             "quantity": holdings.get("quantity", 0),
             "product": holdings.get("product", ""),
-            "pnl": holdings.get("pnl", 0.0),
-            "pnlpercent": (holdings.get("last_price", 0) - holdings.get("average_price", 0.0))
-            / holdings.get("average_price", 0.0)
-            * 100,
+            # Both were being dropped, which is why the holdings page showed a
+            # dash for every average and an investment value of zero: the data
+            # was in the Upstox response and never reached the payload.
+            "average_price": average_price,
+            "ltp": last_price,
+            "pnl": round(float(holdings.get("pnl") or 0.0), 2),
+            "pnlpercent": pnlpercent,
         }
         transformed_data.append(transformed_position)
     return transformed_data

--- a/test/test_upstox_holdings_mapping.py
+++ b/test/test_upstox_holdings_mapping.py
@@ -1,0 +1,50 @@
+from broker.upstox.mapping.order_data import transform_holdings_data
+
+
+def test_transform_holdings_uses_standard_ltp_contract():
+    out = transform_holdings_data(
+        [
+            {
+                "tradingsymbol": "INFY",
+                "exchange": "NSE",
+                "quantity": 2,
+                "product": "D",
+                "average_price": 100,
+                "last_price": 120,
+                "pnl": 40,
+            }
+        ]
+    )
+
+    assert out == [
+        {
+            "symbol": "INFY",
+            "exchange": "NSE",
+            "quantity": 2,
+            "product": "D",
+            "average_price": 100.0,
+            "ltp": 120.0,
+            "pnl": 40.0,
+            "pnlpercent": 20.0,
+        }
+    ]
+
+
+def test_transform_holdings_handles_zero_average_price():
+    out = transform_holdings_data(
+        [
+            {
+                "tradingsymbol": "BONUS",
+                "exchange": "NSE",
+                "quantity": 1,
+                "product": "D",
+                "average_price": None,
+                "last_price": 50,
+                "pnl": 5,
+            }
+        ]
+    )
+
+    assert out[0]["average_price"] == 0.0
+    assert out[0]["ltp"] == 50.0
+    assert out[0]["pnlpercent"] == 0.0


### PR DESCRIPTION
Two independent bugs in `transform_holdings_data`, both visible on the holdings page for every Upstox user. Found while building the portfolio analyzer, which needs holdings weights and could not get a usable price out of an Upstox account.

## 1. `average_price` and `ltp` were never emitted

Both fields are present in the Upstox response and were simply not copied into the payload. The holdings page rendered a dash for every average and reported **Total Investment as 0.00** regardless of what the account actually held.

## 2. `pnlpercent` divided by zero

```python
"pnlpercent": (holdings.get("last_price", 0) - holdings.get("average_price", 0.0))
/ holdings.get("average_price", 0.0)
* 100,
```

Upstox returns `null` or `0` for `average_price` on shares received rather than bought — normal for IPO allotments, bonus issues and off-market transfers. Those holdings raised `ZeroDivisionError`, and because the mapping runs in a loop building one response, **a single such share failed the entire holdings request**, not just its own row.

Zerodha's equivalent mapping already guarded this; Upstox's had not.

## Fix

Coerces both fields with `or 0.0` (handles `null` and missing alike), emits `average_price` and `ltp`, and reports `0.0` for the percentage when there is no acquisition price to compare against, logging the holding at debug level.

## Testing

`test/test_upstox_holdings_mapping.py`, 2 tests: the normal path emits both prices with a correct percentage, and a zero-average holding returns `0.0` instead of raising.

```
2 passed
```

Verified against the Upstox API docs and reproduced against a real account, where the holdings page had been showing 0.00 investment.

Extracted from the portfolio-backtester branch so it can ship independently — it is a live bug for Upstox users and shouldn't wait on a feature review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
