### PR TITLE
fix(groww): holdings statistics silently return zero

### DIFF
--- a/broker/groww/mapping/order_data.py
+++ b/broker/groww/mapping/order_data.py
@@ -963,6 +963,21 @@ def calculate_portfolio_statistics(holdings_data):
             "totalprofitandloss": 0,
         }
 
+    # Handle tuple input (holdings list, metadata) -- get_holdings() returns
+    # (holdings, status) for this broker, and holdings_service passes that
+    # through unchanged. transform_holdings_data() already unwraps it; without
+    # the same handling here every statistic silently came back as zero.
+    if isinstance(holdings_data, tuple):
+        holdings_data = holdings_data[0]  # Take the first element (holdings list)
+
+    if not holdings_data:
+        return {
+            "totalholdingvalue": 0,
+            "totalinvvalue": 0,
+            "totalpnlpercentage": 0,
+            "totalprofitandloss": 0,
+        }
+
     # Extract holdings from the API response structure
     if isinstance(holdings_data, dict):
         # Check if statistics are already provided

--- a/test/test_groww_holdings_mapping.py
+++ b/test/test_groww_holdings_mapping.py
@@ -1,0 +1,96 @@
+"""Regression coverage for Groww holdings statistics.
+
+broker.groww.api.order_api.get_holdings() returns a tuple of
+(holdings, status) and services/holdings_service.py passes that value
+straight through, so calculate_portfolio_statistics() must accept it.
+When it did not, every total silently came back as zero while the
+holdings rows still rendered correctly.
+"""
+
+from broker.groww.mapping.order_data import calculate_portfolio_statistics
+
+ZERO_STATS = {
+    "totalholdingvalue": 0,
+    "totalinvvalue": 0,
+    "totalpnlpercentage": 0,
+    "totalprofitandloss": 0,
+}
+
+# Shape returned by Groww's GET /v1/holdings/user, as normalised by
+# get_holdings(). Note there is no price or pnl field.
+HOLDINGS = [
+    {
+        "symbol": "ASTRAL",
+        "isin": "INE006I01046",
+        "quantity": 250.0,
+        "average_price": 1325.70,
+        "free_quantity": 250.0,
+        "locked_quantity": 0.0,
+        "pledged_quantity": 0.0,
+        "t1_quantity": 0.0,
+    },
+    {
+        "symbol": "IFCI",
+        "isin": "INE039A01010",
+        "quantity": 4000.0,
+        "average_price": 69.18,
+        "free_quantity": 4000.0,
+        "locked_quantity": 0.0,
+        "pledged_quantity": 0.0,
+        "t1_quantity": 0.0,
+    },
+]
+
+# 250 * 1325.70 + 4000 * 69.18
+EXPECTED_VALUE = 608145.0
+
+
+def test_statistics_from_get_holdings_tuple():
+    """The actual (holdings, status) return value must be unwrapped."""
+    stats = calculate_portfolio_statistics((HOLDINGS, {"status": "success"}))
+
+    assert stats["totalinvvalue"] == EXPECTED_VALUE
+    assert stats["totalholdingvalue"] == EXPECTED_VALUE
+
+
+def test_statistics_from_plain_list():
+    """A bare list keeps working."""
+    assert calculate_portfolio_statistics(HOLDINGS)["totalinvvalue"] == EXPECTED_VALUE
+
+
+def test_statistics_from_payload_and_data_wrappers():
+    """Both documented dict wrappers keep working."""
+    assert (
+        calculate_portfolio_statistics({"payload": {"holdings": HOLDINGS}})["totalinvvalue"]
+        == EXPECTED_VALUE
+    )
+    assert (
+        calculate_portfolio_statistics({"data": {"holdings": HOLDINGS}})["totalinvvalue"]
+        == EXPECTED_VALUE
+    )
+
+
+def test_precomputed_statistics_are_passed_through():
+    precomputed = {"totalholdingvalue": 7, "totalinvvalue": 7}
+    assert calculate_portfolio_statistics({"data": {"statistics": precomputed}}) == precomputed
+
+
+def test_error_tuple_yields_zero_stats():
+    """get_holdings() returns (None, {"status": "error"}) on failure."""
+    assert calculate_portfolio_statistics((None, {"status": "error"})) == ZERO_STATS
+
+
+def test_empty_inputs_yield_zero_stats():
+    assert calculate_portfolio_statistics(([], {"status": "success"})) == ZERO_STATS
+    assert calculate_portfolio_statistics([]) == ZERO_STATS
+    assert calculate_portfolio_statistics(None) == ZERO_STATS
+
+
+def test_pnl_is_summed_when_present():
+    """Groww omits pnl today, but the field is honoured when supplied."""
+    with_pnl = [dict(HOLDINGS[0], pnl=1000.0), dict(HOLDINGS[1], pnl=-250.0)]
+
+    stats = calculate_portfolio_statistics((with_pnl, {"status": "success"}))
+
+    assert stats["totalprofitandloss"] == 750.0
+    assert stats["totalpnlpercentage"] == round(750.0 / EXPECTED_VALUE * 100, 2)


### PR DESCRIPTION
## Problem

On a Groww instance, the Investor Summary page lists every holding correctly — symbol, quantity, average price — but all four summary tiles read `0.00`:

- Total Holding Value `₹0.00`
- Total Investment Value `₹0.00`
- Total Profit and Loss `₹0.00`
- Total PnL Percentage `+0.00%`

The log fills with:

```
broker.groww.mapping.order_data | Invalid holdings data format: <class 'tuple'>
```

## Cause

`broker/groww/api/order_api.py::get_holdings()` returns a **tuple** — `(holdings_list, {"status": "success"})` — and `services/holdings_service.py` passes that value through unchanged:

```python
holdings = broker_funcs["get_holdings"](auth_token)
holdings = broker_funcs["map_portfolio_data"](holdings)          # passes tuple through
portfolio_stats = broker_funcs["calculate_portfolio_statistics"](holdings)
holdings = broker_funcs["transform_holdings_data"](holdings)
```

`transform_holdings_data()` already handles this:

```python
# Handle tuple input (holdings list, metadata)
if isinstance(holdings_data, tuple):
    holdings_data = holdings_data[0]
```

`calculate_portfolio_statistics()` does not. It only unwraps `dict` inputs, so the tuple reaches the `isinstance(holdings_data, list)` guard, logs the error above, and returns zeros.

That asymmetry is why this presents as a display bug: the rows come from `transform_holdings_data()` and render fine, so only the totals are wrong.

## Fix

Apply the same tuple handling `transform_holdings_data()` already uses, then re-check emptiness so an error tuple of `(None, {"status": "error"})` yields zeros rather than raising.

## Verification

Against a live Groww account with 3 holdings whose investment value is `1,127,529.00`:

| Input shape | Before | After |
|---|---|---|
| `(holdings, status)` — actual `get_holdings()` return | `0.00` | `1,127,529.00` |

Existing input shapes are unchanged:

| Input | Result |
|---|---|
| plain `list` | `1,127,529.00` |
| `{"payload": {"holdings": [...]}}` | `1,127,529.00` |
| `{"data": {"holdings": [...]}}` | `1,127,529.00` |
| `{"data": {"statistics": {...}}}` | returned as-is |
| `(None, {"status": "error"})` | zeros |
| `[]` / `None` | zeros |

`transform_holdings_data()` still returns all 3 rows.

## Scope note

`totalprofitandloss` remains `0` for Groww. `GET /v1/holdings/user` returns only `symbol, isin, quantity, average_price, demat_free_quantity, demat_locked_quantity, groww_locked_quantity, pledge_quantity, t1_quantity` — no price and no P&L, unlike Kite's `/portfolio/holdings`, which returns `last_price`, `pnl` and `close_price` server-side. Populating P&L for Groww needs a separate live-data call (which is subscription-gated and returns HTTP 403 without one). That is a different change and is deliberately out of scope here; this PR makes investment and holding value correct.

## Possible follow-up (not addressed here)

`broker/groww/api/order_api.py` defines `get_holdings(auth)` **twice** — once around line 1279 and again around line 2096. The second silently overrides the first, so the earlier implementation (which targets `{GROWW_BASE_URL}/v1/portfolio/holdings` and builds a `{"status", "message", "data", "raw_response"}` dict) is dead code. Happy to remove it in a separate PR if maintainers agree, but it seemed wrong to bundle a deletion with a behavioural fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Groww Investor Summary totals showing 0.00 by unwrapping the `(holdings, status)` tuple from `get_holdings()` in `calculate_portfolio_statistics()`. Adds regression tests; totals compute correctly, and zeros only for empty or error inputs.

<sup>Written for commit 6e7fdd6ae38b6f2ad09e925eb4ac202073cfec1f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1721?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

