### PR TITLE
fix(upstox): return empty funds on service-hours error instead of fabricated zeros

### DIFF
--- a/broker/upstox/api/funds.py
+++ b/broker/upstox/api/funds.py
@@ -88,7 +88,15 @@ def get_margin_data(auth_token):
     except httpx.HTTPStatusError as e:
         response_text = e.response.text
 
-        # Check if it's a service hours error (423 Locked)
+        # Check if it's a service hours error (423 Locked). Previously this
+        # fabricated a fake all-zero "success" dict, which made the funds
+        # service hours window (5:30 AM - 12:00 AM IST) indistinguishable from
+        # a genuinely live, zero-balance account — the exact same masking bug
+        # patched for Fyers (services/funds_service.py's "empty == error"
+        # contract expects {} on any error/no-data path, never fabricated
+        # values). Log it distinctly for diagnostics but still return {} so an
+        # expired session during this window is correctly reported as invalid,
+        # not silently treated as live.
         if e.response.status_code == 423:
             try:
                 error_data = json.loads(response_text)
@@ -96,17 +104,10 @@ def get_margin_data(auth_token):
                     errors = error_data.get("errors", [])
                     for error in errors:
                         if error.get("errorCode") == "UDAPI100072":
-                            # Return default values for service hours error
                             logger.info(
-                                "Upstox funds service is outside operating hours (5:30 AM to 12:00 AM IST). Returning default values."
+                                "Upstox funds service is outside operating hours (5:30 AM to 12:00 AM IST)."
                             )
-                            return {
-                                "availablecash": "0.00",
-                                "collateral": "0.00",
-                                "m2munrealized": "0.00",
-                                "m2mrealized": "0.00",
-                                "utiliseddebits": "0.00",
-                            }
+                            return {}
             except json.JSONDecodeError:
                 pass
 


### PR DESCRIPTION
### Problem

`broker/upstox/api/funds.py::get_margin_data()`'s 423 Locked / `UDAPI100072` handler (the funds service is outside its 5:30 AM - 12:00 AM IST operating hours) returns a **fabricated zero-balance dict** (`availablecash "0.00"`, `collateral "0.00"`, …) instead of propagating an error.

That makes the service-hours window **indistinguishable from a genuinely live, zero-balance account** — the exact same masking bug already fixed for Fyers in #1624: any caller that treats a funds "success" as "the broker session is live" is misled, and an expired/invalid session that happens to hit this window would be reported as healthy.

### Fix

Return `{}` (empty) instead of the fabricated dict, matching the empty-is-error contract already used elsewhere (`services/funds_service.py`, #1597). Still logs the service-hours condition for diagnostics — only the fabricated account data is removed.

### Notes

Pairs with #1597 (treat an empty broker funds response as an error, not success) and #1624 (identical fix already merged for Fyers).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stop fabricating zero balances for Upstox funds when the funds service is outside hours; return {} to signal error. This aligns with the empty-is-error contract and avoids misreporting an expired or invalid session as healthy during 5:30 AM–12:00 AM IST.

<sup>Written for commit d7d64ee6a451a25e477b93b03484d4dcdbb7ee78. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

