### PR TITLE
fix(zerodha): fail fast when the broker rejects the WS connection

### DIFF
--- a/broker/zerodha/streaming/zerodha_websocket.py
+++ b/broker/zerodha/streaming/zerodha_websocket.py
@@ -484,8 +484,30 @@ class ZerodhaWebSocket:
             return False
 
     def wait_for_connection(self, timeout: float = 15.0) -> bool:
-        """Wait for WebSocket connection to be established"""
-        return self._connection_ready.wait(timeout=timeout)
+        """Wait for WebSocket connection to be established.
+
+        Polls in short slices instead of a single blocking wait on
+        `_connection_ready`, so we can bail out EARLY the moment `self.running`
+        flips to False. On an immediate broker-side rejection (e.g. a 403 for
+        an account without WS/streaming entitlement), `_run_websocket`'s
+        fatal-error handling detects it within ~100-200ms and, if the DB token
+        is unchanged (nothing to gain by retrying), sets `self.running = False`
+        right away -- but a single `_connection_ready.wait(timeout)` would
+        still block for the FULL timeout with nothing left to wait for. The
+        caller (zerodha_adapter.connect()) already branches on `self.running`
+        to build its final status/message, so this changes nothing about the
+        eventual result -- only how quickly it arrives.
+        """
+        deadline = time.time() + timeout
+        poll_interval = 0.1
+        while True:
+            remaining = deadline - time.time()
+            if remaining <= 0:
+                return False
+            if self._connection_ready.wait(timeout=min(poll_interval, remaining)):
+                return True
+            if not self.running:
+                return False
 
     def is_connected(self) -> bool:
         """Check if WebSocket is connected"""


### PR DESCRIPTION
### Problem

`ZerodhaWebSocket.wait_for_connection()` blocks for the **full** timeout (default 15s, 10s at a second call site) on a `threading.Event` that is only ever `.set()` on a successful connection (`_on_ws_open`).

When Zerodha's ticker server rejects the connection outright — e.g. an instant HTTP 403 `"Authentication failed"` for an account without WS/streaming market-data entitlement — the fatal-error handling in `_run_websocket`'s reconnect loop detects it within ~100-200ms and sets `self.running = False` right away (a fresh DB token read comes back unchanged, so retrying would just fail again). But nothing wakes the waiting caller, so `wait_for_connection` still blocks out the full timeout with nothing left to wait for.

This isn't just wasted time: `authenticate_client` (`websocket_proxy/server.py`) calls into this **synchronously** before replying to the WS client, so every failed connection attempt (an entitlement-gated account, a health/liveness check, etc.) pays the full 15-18s delay before the client ever sees an error.

### Fix

Poll `_connection_ready` in short slices and also check `self.running` each iteration, returning as soon as either resolves. The caller (`zerodha_adapter.connect()`) already branches on `self.running` to build its final status/message, so this changes nothing about the eventual result — only how quickly it arrives.

### Verification

Reproduced live against a Zerodha account without WS/streaming entitlement: before the fix, `authenticate_client`'s reply took ~15-18s to arrive after the 403; after the fix, the same underlying failure surfaces and is reported in ~30-100ms, confirmed via server-side logs (`Adapter connection failed: Connection timeout` now logs immediately after the 403 instead of ~15s later).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail fast when Zerodha rejects the WebSocket connection so callers don’t wait the full timeout. Errors now return in ~30–100 ms instead of 15–18 s in the websocket proxy auth path.

- **Bug Fixes**
  - Updated wait_for_connection to poll in short slices and exit early if the connection opens or self.running turns False.
  - Handles immediate broker rejections (e.g., HTTP 403 “Authentication failed”) and reports failure quickly without changing success behavior.

<sup>Written for commit 8124a063775b3fe459c6f169372d34bde7731e4b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1724?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

