### PR TITLE
fix: Upstox multiquotes never populated prev_close, breaking %-change

### DIFF
--- a/broker/upstox/api/data.py
+++ b/broker/upstox/api/data.py
@@ -459,7 +459,7 @@ class BrokerData:
             logger.error(f"API Error: {error_msg}")
             raise Exception(f"API Error: {error_msg}")
 
-        # Also fetch v2 quotes for bid/ask/OI data
+        # Also fetch v2 quotes for bid/ask/OI data (and prev_close — see below)
         v2_quotes = {}
         try:
             client = get_httpx_client()
@@ -512,6 +512,15 @@ class BrokerData:
             best_bid = depth.get("buy", [{}])[0] if depth.get("buy") else {}
             best_ask = depth.get("sell", [{}])[0] if depth.get("sell") else {}
 
+            # prev_close: v3's batch OHLC endpoint often returns an EMPTY prev_ohlc
+            # (unlike the single-symbol get_quotes() path above, which is why single
+            # quotes work but multiquotes came back with prev_close=0 for every
+            # symbol — breaking any %-change screener/ticker). Mirror get_quotes()'s
+            # fallback: prefer v2's ohlc.close, fall back to v3's prev_ohlc.close.
+            v2_ohlc = v2_quote.get("ohlc", {}) or {}
+            prev_close_v2 = v2_ohlc.get("close", 0)
+            prev_close_final = prev_close_v2 or prev_ohlc.get("close", 0)
+
             result_item = {
                 "symbol": original["symbol"],
                 "exchange": original["exchange"],
@@ -522,7 +531,7 @@ class BrokerData:
                     "low": float(live_ohlc.get("low", 0)) if live_ohlc.get("low") else 0,
                     "ltp": float(quote.get("last_price", 0)) if quote.get("last_price") else 0,
                     "open": float(live_ohlc.get("open", 0)) if live_ohlc.get("open") else 0,
-                    "prev_close": float(prev_ohlc.get("close", 0)) if prev_ohlc.get("close") else 0,
+                    "prev_close": float(prev_close_final) if prev_close_final else 0,
                     "volume": int(live_ohlc.get("volume", 0)) if live_ohlc.get("volume") else 0,
                     "oi": int(v2_quote.get("oi", 0)) if v2_quote.get("oi") else 0,
                 },


### PR DESCRIPTION
### Problem
`BrokerData.get_quotes()` (single-symbol) already has a fallback chain for `prev_close`: it prefers the v2 `/market-quote/quotes` endpoint's `ohlc.close`, falling back to v3 OHLC's `prev_ohlc.close` only if that's empty. The batch path used by `/api/v1/multiquotes` — `_process_quotes_batch()` — never got this fallback: it fetches `v2_quotes` for bid/ask/OI, but reads `prev_close` ONLY from v3's `prev_ohlc.close`.

On accounts where Upstox's v3 batch OHLC response has an empty `prev_ohlc` (confirmed live), every symbol in a multiquotes response comes back with `prev_close: 0`, even though the single-symbol quotes endpoint returns the correct value for the very same instrument. Any consumer that derives a day change % from multiquotes (screeners, movers, a market ticker, etc.) sees every row/tick as "no change" or filters the row out entirely when it guards against a zero prev_close — even though live prices are flowing fine.

### Fix
Mirror `get_quotes()`'s fallback in `_process_quotes_batch()`: read `prev_close` from the already-fetched v2 quote's `ohlc.close` first, falling back to v3's `prev_ohlc.close` if the v2 value is unavailable.

### Notes
Verified live against a real Upstox session: the same symbol via `/api/v1/quotes` returned a correct non-zero `prev_close`, while `/api/v1/multiquotes` returned `prev_close: 0` for it (and every other requested symbol) before this fix; after the fix both paths agree.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a `prev_close` fallback in `_process_quotes_batch()` for Upstox multiquotes: prefer v2 `ohlc.close`, then fall back to v3 `prev_ohlc.close`. This fixes `prev_close: 0` in batch responses and restores correct %-change in `/api/v1/multiquotes`.

<sup>Written for commit b4ce98dcfbfdb0b0f5f18b0c6829265fb3869b21. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1725?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

