### PR TITLE
fix(kotak): use ranged GET instead of HEAD for scripmaster fallback accessibility check

### DIFF
--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -406,20 +406,25 @@ def get_kotak_master_filepaths():
     # accessible_urls stayed empty and the caller (download_csv_kotak_data)
     # raised "Scripmaster API failed" even though the files were fully
     # downloadable the whole time. Use a ranged GET (bytes=0-0) instead of
-    # HEAD -- avoids the redirect loop and, unlike a plain GET, does not pull
-    # the full multi-MB CSV twice (once here, once in the real download).
+    # HEAD -- avoids the redirect loop. Kotak's CDN ignores the Range header
+    # and answers with the full multi-MB body regardless, so stream the
+    # request and close it after reading only the status line/headers --
+    # otherwise a plain client.get() call buffers the entire CSV into memory
+    # just for this check, then the real download in download_csv_kotak_data
+    # pulls the same bytes again.
     accessible_urls = {}
     for key, url in fallback_urls.items():
         try:
             logger.info(f"Testing direct URL: {url}")
-            response = client.get(
-                url, timeout=10, follow_redirects=True, headers={"Range": "bytes=0-0"}
-            )
-            if response.status_code in (200, 206):
+            with client.stream(
+                "GET", url, timeout=10, follow_redirects=True, headers={"Range": "bytes=0-0"}
+            ) as response:
+                status_code = response.status_code
+            if status_code in (200, 206):
                 accessible_urls[key] = url
                 logger.info(f"Direct URL accessible: {key}")
             else:
-                logger.warning(f"Direct URL returned {response.status_code}: {key}")
+                logger.warning(f"Direct URL returned {status_code}: {key}")
         except httpx.HTTPError as e:
             logger.warning(f"Direct URL HTTP error: {key} - {e}")
         except Exception as e:

--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -396,13 +396,26 @@ def get_kotak_master_filepaths():
         "NSE_CM": f"https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/{today}/transformed-v1/nse_cm-v1.csv",
     }
 
-    # Test accessibility of fallback URLs using httpx
+    # Test accessibility of fallback URLs using httpx.
+    #
+    # A plain HEAD request here reliably hits an infinite redirect loop on
+    # Kotak's CDN (lapi.kotaksecurities.com) -- verified directly: httpx.head()
+    # on these URLs raises "Exceeded maximum allowed redirects" every time,
+    # while httpx.get() on the identical URL returns 200 immediately with the
+    # full CSV, no redirects at all. Because every accessibility check failed,
+    # accessible_urls stayed empty and the caller (download_csv_kotak_data)
+    # raised "Scripmaster API failed" even though the files were fully
+    # downloadable the whole time. Use a ranged GET (bytes=0-0) instead of
+    # HEAD -- avoids the redirect loop and, unlike a plain GET, does not pull
+    # the full multi-MB CSV twice (once here, once in the real download).
     accessible_urls = {}
     for key, url in fallback_urls.items():
         try:
             logger.info(f"Testing direct URL: {url}")
-            response = client.head(url, timeout=10, follow_redirects=True)
-            if response.status_code == 200:
+            response = client.get(
+                url, timeout=10, follow_redirects=True, headers={"Range": "bytes=0-0"}
+            )
+            if response.status_code in (200, 206):
                 accessible_urls[key] = url
                 logger.info(f"Direct URL accessible: {key}")
             else:


### PR DESCRIPTION
## Summary

Fixes #1729 — the fallback scripmaster accessibility check uses `client.head()`, which reliably hits an infinite redirect loop on Kotak's CDN (`lapi.kotaksecurities.com`) and raises `httpx.TooManyRedirects` for every fallback URL, every time. Since every check "fails," `get_kotak_master_filepaths()` returns an empty dict and master contract download fails completely with "Scripmaster API failed" — even though the exact same URLs are fully downloadable via GET, with zero redirects.

## Root cause (verified, not a guess)

```python
import httpx
url = "https://lapi.kotaksecurities.com/wso2-scripmaster/v1/prod/<today>/transformed/nse_fo.csv"

httpx.head(url, timeout=10, follow_redirects=True)
# -> httpx.TooManyRedirects: Exceeded maximum allowed redirects.

httpx.get(url, timeout=15, follow_redirects=True)
# -> 200, history=[], 24,531,196 bytes of real CSV
```

Reproduced identically from two unrelated networks (a home connection and a separate cloud VM), both with a genuinely valid, currently-active Kotak session. Not account-specific, not a credentials problem, not a Kotak API-key/consumer-key issue — purely a HEAD-vs-GET CDN quirk.

## Fix

Swap the accessibility check to a ranged `client.get()` (`Range: bytes=0-0`) instead of `client.head()`. This avoids the redirect loop and was intended to also avoid a full duplicate download of each multi-MB CSV (once for the check, once for the real download in `download_csv_kotak_data`) — but Kotak's CDN currently ignores the `Range` header and returns the full body regardless, so in practice this is a correctness fix only, not a bandwidth improvement today. Accepts both `200` and `206` as "accessible" in case that changes.

## Test plan

- [x] Reproduced the HEAD redirect loop directly against Kotak's live CDN
- [x] Confirmed GET (with and without the Range header) succeeds immediately, no redirects
- [x] Ran the full `master_contract_download()` flow end-to-end after the fix — succeeded, 153,899 records loaded across NSE Cash/F&O, BSE Cash/F&O, CDS, and MCX
- [x] Confirmed via the OpenAlgo UI (master contract status page) that the download now reports real data instead of "Ready (0 symbols)"

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches the Scripmaster fallback accessibility check from `HEAD` to a ranged, streamed `GET` to bypass Kotak’s CDN redirect loop and avoid buffering multi‑MB CSVs. Restores master contract downloads and accepts `200` and `206` for future range support.

- **Bug Fixes**
  - Use `client.stream("GET", ..., headers={"Range": "bytes=0-0"})` instead of `client.head()`, reading only the status code and closing the stream.
  - Prevents `httpx.TooManyRedirects` from `lapi.kotaksecurities.com` and avoids buffering when the CDN ignores Range.
  - End-to-end master contract download now completes; bandwidth unchanged today.

<sup>Written for commit 5b8efe3696a32c7404e3fbfe85b761aef5175978. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1730?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

