### PR TITLE
Fix "database is locked" during startup (SQLite parallel initialization)

### DIFF
--- a/app.py
+++ b/app.py
@@ -713,7 +713,7 @@ def setup_environment(app):
             ]
 
             db_init_start = time.time()
-            with ThreadPoolExecutor(max_workers=15) as executor:
+            with ThreadPoolExecutor(max_workers=1) as executor:  # FIX: Prevent SQLite parallel write-lock crash
                 futures = {executor.submit(func): name for name, func in db_init_functions}
                 for future in as_completed(futures):
                     db_name = futures[future]
@@ -768,6 +768,13 @@ def setup_environment(app):
                 logger.debug("Python strategy scheduler initialized")
             except Exception as e:
                 logger.error(f"Failed to initialize Python strategy scheduler: {e}")
+
+            # FIX: Clean up any SQLAlchemy sessions (SQLite transactions) left open by startup checks
+            try:
+                from utils.db_sessions import remove_all_scoped_sessions
+                remove_all_scoped_sessions()
+            except Exception:
+                pass
 
             try:
                 from services.flow_scheduler_service import init_flow_scheduler
@@ -1156,4 +1163,4 @@ if __name__ == "__main__":
             flush=True,
         )
 
-    socketio.run(app, host=host_ip, port=port, debug=debug, reloader_options=reloader_options)
+    socketio.run(app, host=host_ip, port=port, debug=debug, allow_unsafe_werkzeug=True, use_reloader=False, reloader_options=reloader_options)

--- a/app.py
+++ b/app.py
@@ -773,8 +773,8 @@ def setup_environment(app):
             try:
                 from utils.db_sessions import remove_all_scoped_sessions
                 remove_all_scoped_sessions()
-            except Exception:
-                pass
+            except Exception as e:
+                logger.error(f"Failed to clean up scoped sessions: {e}")
 
             try:
                 from services.flow_scheduler_service import init_flow_scheduler

--- a/app.py
+++ b/app.py
@@ -1163,4 +1163,4 @@ if __name__ == "__main__":
             flush=True,
         )
 
-    socketio.run(app, host=host_ip, port=port, debug=debug, allow_unsafe_werkzeug=True, use_reloader=False, reloader_options=reloader_options)
+    socketio.run(app, host=host_ip, port=port, debug=debug, **reloader_options)


### PR DESCRIPTION
Bug: "database is locked" during startup (Flow Scheduler, Telegram DB, etc.) in v2.0.1.8

Description
Hey guys, I was digging into Issue #1713 and the random SQLite `database is locked` crashes that happen during startup (sometimes it hits Flow Scheduler, sometimes Telegram DB, etc.), and I figured out exactly what's causing it. 

There's actually a "perfect storm" of two architectural issues in app.py that guarantee a crash on a fresh installation, and a change made in v2.0.1.8 that makes the crash even more confusing.

Root Cause 1: Parallel SQLite CREATE TABLE Stampede
In app.py, the initialization block attempts to initialize 20 different databases using a 15-worker thread pool:
```python
with ThreadPoolExecutor(max_workers=15) as executor:
    futures = {executor.submit(func): name for name, func in db_init_functions}
```
Because SQLite strictly prohibits parallel writers, having 15 threads simultaneously slam openalgo.db to execute CREATE TABLE IF NOT EXISTS immediately causes massive write-lock contention. 

In v2.0.1.8, the new PRAGMA busy_timeout=15000 was added. Rather than fixing the underlying transaction leak, this just masks the problem by forcing the threads to grind for 15 seconds before they eventually timeout and crash, leading to a long hang during startup before the inevitable lock error.

Root Cause 2: Leaked Read-Locks Before APScheduler Starts
Right after the parallel database initialization, app.py calls init_python_strategy(). This function executes various startup checks (like checking market holidays in market_calendar_db.py and brokers in auth_db.py). 

Because this happens during startup (outside of a Flask request lifecycle), teardown_appcontext never fires. As a result, the SQLAlchemy scoped_session objects leave their SQLite transactions open, holding lingering read-locks on the database. 
A few lines later, when init_flow_scheduler() triggers APScheduler to spin up and run CREATE TABLE flow_apscheduler_jobs, it gets permanently blocked by those leaked read-locks.

---

The Fix
The fix is actually super straightforward and completely eliminates the 15-second startup hang and the crashes. 

1. Serialize the DB Initialization
In app.py, simply change max_workers=15 to max_workers=1. Creating tables sequentially takes less than 100ms anyway and completely prevents the SQLite write-lock collision.

2. Clean up Sessions Before Schedulers Start
Inject a call to remove_all_scoped_sessions() right before the schedulers initialize in app.py to ensure the main thread drops all lingering read-locks:

```python
            # Initialize schedulers AFTER database initialization
            try:
                init_python_strategy()
                logger.debug("Python strategy scheduler initialized")
            except Exception as e:
                logger.error(f"Failed to initialize Python strategy scheduler: {e}")

            # FIX: Clean up any SQLAlchemy sessions (SQLite transactions) left open by startup checks
            try:
                from utils.db_sessions import remove_all_scoped_sessions
                remove_all_scoped_sessions()
            except Exception:
                pass

            try:
                from services.flow_scheduler_service import init_flow_scheduler
                init_flow_scheduler()
```

I've tested this on a completely fresh v2.0.1.8 deployment, and it works flawlessly every time with zero locking errors or startup delays. Hope this helps anyone else running into the same wall!

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes random SQLite “database is locked” errors during startup by serializing DB setup, cleaning stale sessions, and removing unsafe reloader flags. Startup is fast and consistent on fresh installs.

- **Bug Fixes**
  - Serialize DB initialization in `app.py` with `ThreadPoolExecutor(max_workers=1)` to avoid parallel CREATE TABLE write locks.
  - Clear `SQLAlchemy` scoped sessions before starting schedulers (with error logging) to drop lingering read locks and unblock `APScheduler` table creation.
  - Remove unintended Werkzeug reloader hacks; pass `**reloader_options` to `socketio.run` to prevent duplicate inits.

<sup>Written for commit 2964bf02ac044231a1062f7c103577310148ab10. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

