### PR TITLE
Fix "database is locked" during startup (SQLite parallel initialization)

### DIFF
--- a/app.py
+++ b/app.py
@@ -713,7 +713,7 @@ def setup_environment(app):
             ]
 
             db_init_start = time.time()
-            with ThreadPoolExecutor(max_workers=15) as executor:
+            with ThreadPoolExecutor(max_workers=1) as executor:
                 futures = {executor.submit(func): name for name, func in db_init_functions}
                 for future in as_completed(futures):
                     db_name = futures[future]


### PR DESCRIPTION
Fixes random SQLite “database is locked” errors during startup by serializing DB setup and cleaning stale sessions. The previous PR accidentally included `use_reloader=False` which disabled hot-reloading; this new PR strictly isolates the DB startup fix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serialize database initialization during startup to prevent random SQLite “database is locked” errors. DB init now runs sequentially; hot-reload behavior is unchanged.

- **Bug Fixes**
  - Run all DB setup via a single-thread `ThreadPoolExecutor` (max_workers=1) to avoid concurrent SQLite access during initialization.

<sup>Written for commit f708aaa1f340ebf7a4b8185a4b13e3f3b99611cb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1734?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

