### PR TITLE
fix(auth): clear session on logout in half-logged-in state

### DIFF
--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -1310,8 +1310,14 @@ def logout():
         })
 
         # Clear entire session to ensure complete logout
-        session.clear()
         logger.info(f"Session cleared for user: {username}")
+
+    # Always wipe the session cookie. A half-done login (password step complete,
+    # broker OAuth not done) leaves session["user"] set without
+    # session["logged_in"]. Without this, /auth/logout is a no-op in that state
+    # and the user is stuck in an infinite /broker redirect loop with no escape
+    # short of clearing cookies.
+    session.clear()
 
     # For POST requests (AJAX from React), return JSON
     if request.method == "POST":

--- a/blueprints/auth.py
+++ b/blueprints/auth.py
@@ -1264,8 +1264,14 @@ def get_dashboard_data():
 
 @auth_bp.route("/logout", methods=["GET", "POST"])
 def logout():
-    if session.get("logged_in"):
-        username = session["user"]
+    was_logged_in = bool(session.get("logged_in"))
+    username = session.get("user")
+
+    # Wipe the browser session before teardown so a revocation or notification
+    # failure cannot leave the user stuck in a half-logged-in state.
+    session.clear()
+
+    if was_logged_in:
 
         # Clear cache entries before database update to prevent stale data access
         cache_key_auth = f"auth-{username}"
@@ -1311,13 +1317,6 @@ def logout():
 
         # Clear entire session to ensure complete logout
         logger.info(f"Session cleared for user: {username}")
-
-    # Always wipe the session cookie. A half-done login (password step complete,
-    # broker OAuth not done) leaves session["user"] set without
-    # session["logged_in"]. Without this, /auth/logout is a no-op in that state
-    # and the user is stuck in an infinite /broker redirect loop with no escape
-    # short of clearing cookies.
-    session.clear()
 
     # For POST requests (AJAX from React), return JSON
     if request.method == "POST":

--- a/test/test_auth_logout.py
+++ b/test/test_auth_logout.py
@@ -1,0 +1,54 @@
+"""Regression tests for /auth/logout session cleanup."""
+
+import os
+import sys
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import blueprints.auth as auth_bp_module  # noqa: E402
+import database.auth_db as auth_db  # noqa: E402
+
+
+def _app():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(auth_bp_module.auth_bp)
+    return app
+
+
+def test_logout_clears_half_logged_in_session():
+    """A password-only session (broker OAuth unfinished) must still be cleared."""
+    app = _app()
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["user"] = "rajandran"
+
+        response = client.get("/auth/logout")
+
+        assert response.status_code == 302
+        with client.session_transaction() as session:
+            assert "user" not in session
+
+
+def test_logout_clears_full_session(monkeypatch):
+    """A fully logged-in session is also cleared."""
+    monkeypatch.setattr(auth_bp_module, "upsert_auth", lambda *args, **kwargs: None)
+    monkeypatch.setattr(auth_db, "clear_user_sessions", lambda *args, **kwargs: None)
+    monkeypatch.setattr(auth_bp_module.socketio, "emit", lambda *args, **kwargs: None)
+
+    app = _app()
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["user"] = "rajandran"
+            session["logged_in"] = True
+            session["broker"] = "dhan"
+
+        response = client.post("/auth/logout")
+
+        assert response.status_code == 200
+        with client.session_transaction() as session:
+            assert "user" not in session
+            assert "logged_in" not in session


### PR DESCRIPTION
Closes #1756.

`/auth/logout` now always clears the Flask session, not only when `logged_in` is true. The heavy side effects (cache cleanup, token revocation, clearing user sessions, SocketIO notifications) remain gated on a fully active session.

This fixes the half-logged-in state where the password step succeeded but broker OAuth was abandoned: previously the stale `session["user"]` survived logout and redirected the user straight back to `/broker`.

Adds regression coverage for both the half-logged-in and fully logged-in paths. Verified with the auth test files.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Always clear the `Flask` session on `/auth/logout`, now clearing it first to prevent the half-logged-in redirect back to `/broker`. Heavy cleanup still only runs when the session was fully active.

- **Bug Fixes**
  - Clear the session before logout teardown so failures can't leave users half logged in; applies to both GET and POST.
  - Added regression tests for half-logged-in and fully logged-in paths.

<sup>Written for commit d35a1be7372841719c8a629db417ca8dc393bfdf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1762?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

