### PR TITLE
feat(trading): sort derivative symbols by nearest expiry

### DIFF
--- a/frontend/src/components/trading/SymbolSearchDialog.tsx
+++ b/frontend/src/components/trading/SymbolSearchDialog.tsx
@@ -2,8 +2,10 @@ import { Search } from 'lucide-react'
 import { useEffect, useMemo, useRef, useState } from 'react'
 import { Dialog, DialogContent, DialogTitle } from '@/components/ui/dialog'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
+import { parseExpiryDate } from '@/lib/strategyMath'
 import type { SearchRow } from '@/lib/trading/terminal'
 import { cn } from '@/lib/utils'
+import { DERIVATIVE_EXCHANGES } from '@/types/strategy'
 
 /**
  * Symbol search modal for the /trading page.
@@ -80,37 +82,15 @@ const EXCHANGE_RANK: Record<string, number> = {
   CRYPTO: 0,
 }
 
-const DERIVATIVE_EXCHANGES = new Set([
-  'NFO',
-  'BFO',
-  'CDS',
-  'BCD',
-  'MCX',
-  'NCDEX',
-  'NCO',
-])
-
-const MONTH_NUM: Record<string, number> = {
-  JAN: 0,
-  FEB: 1,
-  MAR: 2,
-  APR: 3,
-  MAY: 4,
-  JUN: 5,
-  JUL: 6,
-  AUG: 7,
-  SEP: 8,
-  OCT: 9,
-  NOV: 10,
-  DEC: 11,
+function expiryMs(symbol: string): number {
+  const match = /(\d{1,2})([A-Z]{3})(\d{2})/.exec(symbol)
+  if (!match) return Infinity
+  const expiry = parseExpiryDate(match[0])
+  return expiry ? expiry.getTime() : Infinity
 }
 
-function expiryMs(symbol: string): number {
-  const match = /(\d{2})(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(\d{2})/.exec(
-    symbol,
-  )
-  if (!match) return Infinity
-  return Date.UTC(2000 + Number(match[3]), MONTH_NUM[match[2]], Number(match[1]))
+function isDerivativeExchange(exchange: string): boolean {
+  return (DERIVATIVE_EXCHANGES as readonly string[]).includes(exchange)
 }
 
 /** 0 = exact symbol match, 1 = prefix, 2 = substring, 3 = matched on name only. */
@@ -133,12 +113,12 @@ function compareRows(a: SearchRow, b: SearchRow, q: string): number {
   if (scoreDiff) return scoreDiff
   const exDiff = (EXCHANGE_RANK[exA] ?? 9) - (EXCHANGE_RANK[exB] ?? 9)
   if (exDiff) return exDiff
-  const lenDiff = String(a.symbol).length - String(b.symbol).length
-  if (lenDiff) return lenDiff
-  if (DERIVATIVE_EXCHANGES.has(exA) && DERIVATIVE_EXCHANGES.has(exB)) {
+  if (isDerivativeExchange(exA) && isDerivativeExchange(exB)) {
     const expDiff = expiryMs(String(a.symbol)) - expiryMs(String(b.symbol))
     if (expDiff) return expDiff
   }
+  const lenDiff = String(a.symbol).length - String(b.symbol).length
+  if (lenDiff) return lenDiff
   return String(a.symbol).localeCompare(String(b.symbol))
 }
 

--- a/frontend/src/components/trading/SymbolSearchDialog.tsx
+++ b/frontend/src/components/trading/SymbolSearchDialog.tsx
@@ -80,6 +80,39 @@ const EXCHANGE_RANK: Record<string, number> = {
   CRYPTO: 0,
 }
 
+const DERIVATIVE_EXCHANGES = new Set([
+  'NFO',
+  'BFO',
+  'CDS',
+  'BCD',
+  'MCX',
+  'NCDEX',
+  'NCO',
+])
+
+const MONTH_NUM: Record<string, number> = {
+  JAN: 0,
+  FEB: 1,
+  MAR: 2,
+  APR: 3,
+  MAY: 4,
+  JUN: 5,
+  JUL: 6,
+  AUG: 7,
+  SEP: 8,
+  OCT: 9,
+  NOV: 10,
+  DEC: 11,
+}
+
+function expiryMs(symbol: string): number {
+  const match = /(\d{2})(JAN|FEB|MAR|APR|MAY|JUN|JUL|AUG|SEP|OCT|NOV|DEC)(\d{2})/.exec(
+    symbol,
+  )
+  if (!match) return Infinity
+  return Date.UTC(2000 + Number(match[3]), MONTH_NUM[match[2]], Number(match[1]))
+}
+
 /** 0 = exact symbol match, 1 = prefix, 2 = substring, 3 = matched on name only. */
 function matchScore(symbol: string, q: string): number {
   if (!q) return 3
@@ -102,6 +135,10 @@ function compareRows(a: SearchRow, b: SearchRow, q: string): number {
   if (exDiff) return exDiff
   const lenDiff = String(a.symbol).length - String(b.symbol).length
   if (lenDiff) return lenDiff
+  if (DERIVATIVE_EXCHANGES.has(exA) && DERIVATIVE_EXCHANGES.has(exB)) {
+    const expDiff = expiryMs(String(a.symbol)) - expiryMs(String(b.symbol))
+    if (expDiff) return expDiff
+  }
   return String(a.symbol).localeCompare(String(b.symbol))
 }
 


### PR DESCRIPTION
Closes #1754.

Adds a final expiry tiebreaker to `compareRows` in the symbol search dialog: when both rows come from a derivative exchange (NFO, BFO, CDS, BCD, MCX, NCDEX, NCO), it parses the `DDMMMYY` fragment and sorts by UTC expiry timestamp, so the nearest expiry appears first. Equity and index rows are unaffected.

Verified with `npm run lint` and `npm run build` in `frontend/`.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sorts derivative symbols by nearest expiry in the symbol search dialog so closer contracts appear first. Previously ties after exchange rank were broken by symbol length/name; now we break those ties by parsed expiry timestamp. Equity and index results are unchanged.

- Applies only when both rows are from exchanges in `DERIVATIVE_EXCHANGES`.
- Extracts `DDMMMYY` from the symbol and parses with `parseExpiryDate`; unparsable dates rank last.

<sup>Written for commit 636ac6e6f61237421efd38c8c23399c0d7aa7656. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1763?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

