### PR TITLE
fix(deltaexchange): move market data to the public WS endpoint and batch subscriptions, (optionchain): build the quote lookup and add weighted rate limiting and fix(definedge): stop losing a full trading day at each history chunk boundary

### DIFF
--- a/broker/definedge/api/data.py
+++ b/broker/definedge/api/data.py
@@ -102,6 +102,11 @@ _oi_cache = {}  # {(segment, token): (oi, monotonic_ts)}
 _oi_cache_lock = threading.Lock()
 _OI_CACHE_TTL = 60.0  # seconds
 
+# History chunks are retried on transient failures - dropping one silently
+# removes up to a full chunk (30 days of 1m candles) from the series.
+CHUNK_FETCH_ATTEMPTS = 3
+CHUNK_RETRY_BACKOFF = 0.5  # seconds; grows 0.5, 1.0 between attempts
+
 
 def fetch_latest_oi(segment, token, api_session_key):
     """Fetch latest open interest for a derivative from its last minute candle.
@@ -608,7 +613,13 @@ class BrokerData:
             br_symbol = get_br_symbol(symbol, exchange)
             token = get_token(symbol, exchange)
 
-            logger.debug(f"Debug - Broker Symbol: {br_symbol}, Token: {token}")
+            # Field is named `instrument` rather than `token` on purpose: the log
+            # sanitizer redacts any `*token=` value as a credential, which would
+            # hide the very identifier needed to replay a request upstream.
+            logger.debug(
+                f"Definedge history request: {symbol}@{exchange} -> brsymbol={br_symbol} "
+                f"instrument={token} interval={interval} range={start_date}..{end_date}"
+            )
 
             # Check for unsupported timeframes
             if interval not in self.timeframe_map:
@@ -625,12 +636,15 @@ class BrokerData:
             from_date = pd.to_datetime(start_date)
             to_date = pd.to_datetime(end_date)
 
-            # For intraday data, set specific times
+            # For intraday data, span the whole calendar day of each boundary.
+            # Anchoring to NSE session hours (09:15-15:30) silently drops candles:
+            # MCX runs 09:00-23:30 and CDS/BCD 09:00-17:00, so a 15:30 end cut off
+            # the entire evening session on the last requested day, and a 09:15
+            # start cut off the 09:00-09:14 candles on the first one.
             if interval != "D":
-                # Set start time to 09:15 (market open) for the start date
-                from_date = from_date.replace(hour=9, minute=15)
+                from_date = from_date.replace(hour=0, minute=0)
 
-                # If end_date is today, set the end time to current time.
+                # If end_date is today, stop at the current time.
                 # Anchor "now" to IST wall-clock (not the server's local time) so
                 # the client-side clip below stays correct on UTC/non-IST hosts.
                 # Definedge candle timestamps are naive IST; comparing them against
@@ -640,8 +654,8 @@ class BrokerData:
                 if to_date.date() == current_time.date():
                     to_date = current_time.replace(second=0, microsecond=0)
                 else:
-                    # For past dates, set end time to 15:30 (market close)
-                    to_date = to_date.replace(hour=15, minute=30)
+                    # For any other date, run to the end of that day
+                    to_date = to_date.replace(hour=23, minute=59)
             else:
                 # For daily data, use 00:00
                 from_date = from_date.replace(hour=0, minute=0)
@@ -678,6 +692,19 @@ class BrokerData:
                 # Calculate chunk end date
                 current_end = min(current_start + timedelta(days=chunk_days - 1), to_date)
 
+                if interval == "D":
+                    next_start = current_end + timedelta(days=1)
+                else:
+                    # A chunk end must sit at the END of its calendar day.
+                    # timedelta arithmetic carries the start time-of-day forward, so
+                    # the boundary landed mid-session and every candle after it on the
+                    # chunk's last day was never requested - one whole trading day lost
+                    # per chunk (30 days for 1m). That hole only became visible once
+                    # Definedge started honoring the `to` boundary, which it previously
+                    # ignored (see the clip below and issue #1753).
+                    current_end = min(current_end.replace(hour=23, minute=59), to_date)
+                    next_start = current_end.normalize() + timedelta(days=1)
+
                 # Format dates for Definedge API (ddMMyyyyHHmm)
                 from_date_str = current_start.strftime("%d%m%Y%H%M")
                 to_date_str = current_end.strftime("%d%m%Y%H%M")
@@ -696,30 +723,50 @@ class BrokerData:
 
                 url = f"{DATA_URL}/history/{segment}/{token}/{timeframe}/{from_date_str}/{to_date_str}"
 
-                logger.debug(f"Debug - Fetching chunk from {current_start} to {current_end}")
-                logger.debug(f"Debug - API URL: {url}")
-                logger.debug(f"Debug - Headers: Authorization key present: {bool(api_session_key)}")
+                # Log the exact upstream call so a gap can be replayed verbatim in
+                # curl/Bruno. The api_session_key is deliberately never logged -
+                # only whether one is present.
+                logger.debug(
+                    f"Definedge history chunk {current_start} -> {current_end} | "
+                    f"segment={segment} instrument={token} timeframe={timeframe} "
+                    f"from={from_date_str} to={to_date_str} | "
+                    f"GET {url} | auth_key_present={bool(api_session_key)}"
+                )
 
                 try:
                     # Use httpx client for consistency
                     from utils.httpx_client import get_httpx_client
 
-                    client = get_httpx_client()
-
                     headers = {"Authorization": api_session_key}
 
-                    response = rate_limited_request(client, "GET", url, headers=headers)
+                    # Retry transient failures. A dropped chunk is a silent hole of
+                    # up to `chunk_days` in the returned series, so a timeout or a
+                    # 5xx must not be accepted on the first try. 4xx is terminal
+                    # (expired session, unknown token) and is not retried.
+                    response = None
+                    fetch_error = None
+                    for attempt in range(CHUNK_FETCH_ATTEMPTS):
+                        try:
+                            client = get_httpx_client()
+                            response = rate_limited_request(client, "GET", url, headers=headers)
+                            if response.status_code == 200:
+                                break
+                            fetch_error = f"HTTP {response.status_code}: {response.text[:200]}"
+                            if 400 <= response.status_code < 500:
+                                break
+                        except Exception as request_error:
+                            response = None
+                            fetch_error = str(request_error)
+                        if attempt < CHUNK_FETCH_ATTEMPTS - 1:
+                            time.sleep(CHUNK_RETRY_BACKOFF * (attempt + 1))
 
-                    logger.debug(f"Debug - Response status: {response.status_code}")
-                    logger.debug(f"Debug - Response headers: {dict(response.headers)}")
-                    logger.debug(f"Debug - Response text length: {len(response.text)}")
-
-                    if response.status_code != 200:
+                    if response is None or response.status_code != 200:
                         logger.warning(
-                            f"Debug - Definedge API returned status {response.status_code}"
+                            f"Definedge history chunk {current_start} to {current_end} for "
+                            f"{symbol}@{exchange} failed ({fetch_error}); "
+                            "these candles will be missing from the result"
                         )
-                        logger.warning(f"Debug - Response body: {response.text}")
-                        current_start = current_end + timedelta(days=1)
+                        current_start = next_start
                         continue
 
                     # Parse CSV response
@@ -727,11 +774,19 @@ class BrokerData:
                     # Format for tick: UTC(seconds), LTP, LTQ, OI
                     csv_data = response.text.strip()
 
+                    # Row count straight off the wire, before any parsing - this is
+                    # what distinguishes an upstream gap from one we introduce.
+                    raw_rows = csv_data.count("\n") + 1 if csv_data else 0
+                    logger.debug(
+                        f"Definedge history response: instrument={token} status={response.status_code} "
+                        f"bytes={len(response.text)} raw_rows={raw_rows}"
+                    )
+
                     if not csv_data:
                         logger.debug(
                             f"Debug - Empty response for chunk {current_start} to {current_end}"
                         )
-                        current_start = current_end + timedelta(days=1)
+                        current_start = next_start
                         continue
 
                     # Log first few lines of CSV for debugging
@@ -821,7 +876,15 @@ class BrokerData:
                         # Drop the datetime column
                         chunk_df = chunk_df.drop("datetime", axis=1)
 
-                        # Remove rows with invalid timestamps
+                        # Remove rows with invalid timestamps. Surface the count -
+                        # an unparseable date format is otherwise a silent data loss
+                        # (this is how the int64 leading-zero bug hid for months).
+                        unparsed = int(chunk_df["timestamp"].isna().sum())
+                        if unparsed:
+                            logger.warning(
+                                f"Definedge history: dropped {unparsed} of {len(chunk_df)} rows "
+                                f"for {symbol}@{exchange} with unparseable timestamps"
+                            )
                         chunk_df = chunk_df.dropna(subset=["timestamp"])
 
                     # Log DataFrame info after parsing
@@ -838,7 +901,7 @@ class BrokerData:
                             f"No valid data after parsing CSV for {timeframe} timeframe"
                         )
                         logger.debug("This might be due to incorrect date parsing")
-                        current_start = current_end + timedelta(days=1)
+                        current_start = next_start
                         continue
 
                     # For minute intervals other than 1m, we need to resample
@@ -917,11 +980,11 @@ class BrokerData:
                     logger.error(
                         f"Debug - Error fetching chunk {current_start} to {current_end}: {str(chunk_error)}"
                     )
-                    current_start = current_end + timedelta(days=1)
+                    current_start = next_start
                     continue
 
                 # Move to next chunk
-                current_start = current_end + timedelta(days=1)
+                current_start = next_start
 
             # If no data was found, return empty DataFrame
             if not dfs:

--- a/broker/definedge/api/data.py
+++ b/broker/definedge/api/data.py
@@ -106,10 +106,14 @@ _OI_CACHE_TTL = 60.0  # seconds
 # removes up to a full chunk (30 days of 1m candles) from the series.
 CHUNK_FETCH_ATTEMPTS = 3
 CHUNK_RETRY_BACKOFF = 0.5  # seconds; grows 0.5, 1.0 between attempts
-# 4xx is normally terminal (expired session, unknown token) but these three are
-# timing, not client error: 408 Request Timeout, 425 Too Early, 429 Too Many
-# Requests. Treating them as terminal drops a whole chunk over a hiccup.
-_TRANSIENT_4XX = {408, 425, 429}
+# 4xx is normally terminal (expired session, unknown token), but 408 Request
+# Timeout and 425 Too Early are timing rather than client error, and this loop is
+# their only handler - rate_limited_request passes both straight through.
+# 429 is deliberately absent: rate_limited_request already owns it with four
+# requests and 1/2/4s backoff that honors Retry-After. Retrying it again here
+# would issue twelve requests against an endpoint asking us to slow down, on a
+# weaker 0.5s backoff than the one that just failed.
+_TRANSIENT_4XX = {408, 425}
 
 # Session open per segment, used as the resampling origin. Definedge serves
 # NSE/BSE/NFO/BFO (09:15) plus CDS/MCX (09:00); commodity and currency segments

--- a/broker/definedge/api/data.py
+++ b/broker/definedge/api/data.py
@@ -106,6 +106,17 @@ _OI_CACHE_TTL = 60.0  # seconds
 # removes up to a full chunk (30 days of 1m candles) from the series.
 CHUNK_FETCH_ATTEMPTS = 3
 CHUNK_RETRY_BACKOFF = 0.5  # seconds; grows 0.5, 1.0 between attempts
+# 4xx is normally terminal (expired session, unknown token) but these three are
+# timing, not client error: 408 Request Timeout, 425 Too Early, 429 Too Many
+# Requests. Treating them as terminal drops a whole chunk over a hiccup.
+_TRANSIENT_4XX = {408, 425, 429}
+
+# Session open per segment, used as the resampling origin. Definedge serves
+# NSE/BSE/NFO/BFO (09:15) plus CDS/MCX (09:00); commodity and currency segments
+# open on the hour, so resampling them from a 09:15 origin buckets the
+# 09:00-09:14 candles into a bar stamped before the market opened.
+_SESSION_OPEN_MINUTE = {"MCX": 0, "MCX_INDEX": 0, "CDS": 0, "BCD": 0, "NCDEX": 0}
+_DEFAULT_SESSION_OPEN_MINUTE = 15  # NSE/BSE/NFO/BFO open at 09:15
 
 
 def fetch_latest_oi(segment, token, api_session_key):
@@ -752,7 +763,10 @@ class BrokerData:
                             if response.status_code == 200:
                                 break
                             fetch_error = f"HTTP {response.status_code}: {response.text[:200]}"
-                            if 400 <= response.status_code < 500:
+                            if (
+                                400 <= response.status_code < 500
+                                and response.status_code not in _TRANSIENT_4XX
+                            ):
                                 break
                         except Exception as request_error:
                             response = None
@@ -921,16 +935,18 @@ class BrokerData:
                                 if not chunk_df.empty:
                                     chunk_df = chunk_df.set_index("timestamp")
 
-                                    # Create a custom offset to align with market open at 09:15
-                                    # This ensures 30m candles start at 09:15, not 09:00
-                                    offset_minutes = (
-                                        15  # Market opens at 09:15, so offset by 15 minutes
+                                    # Align bins to the segment's own session open, not
+                                    # a hardcoded 09:15. MCX/CDS/BCD open at 09:00, so a
+                                    # 15-minute origin buckets their 09:00-09:14 candles
+                                    # into bars stamped 08:45 (30m) and 08:15 (1h) -
+                                    # before the market opened. 5m and 15m are unaffected
+                                    # either way since 15 divides evenly into both.
+                                    offset_minutes = _SESSION_OPEN_MINUTE.get(
+                                        exchange.upper(), _DEFAULT_SESSION_OPEN_MINUTE
                                     )
 
                                     # Resample with the offset to align with market hours
                                     resample_rule = f"{interval_minutes[interval]}min"
-                                    # Use offset parameter to shift the bins to start at :15 and :45 for 30m
-                                    # For other intervals, the offset ensures proper market alignment
                                     resampled = chunk_df.resample(
                                         resample_rule, offset=f"{offset_minutes}min"
                                     )

--- a/broker/deltaexchange/api/auth_api.py
+++ b/broker/deltaexchange/api/auth_api.py
@@ -35,6 +35,9 @@ def authenticate_broker(code):
 
         # Verify credentials with a live signed request to GET /v2/profile
         path = "/v2/profile"
+        # consume() before signing: it can block on the quota window and Delta
+        # rejects signatures older than 5 seconds ("SignatureExpired").
+        consume(path, method="GET", bucket=PRIVATE)
         headers = get_auth_headers(
             method="GET",
             path=path,
@@ -48,7 +51,6 @@ def authenticate_broker(code):
         client = get_httpx_client()
 
         logger.info("Verifying Delta Exchange credentials via GET /v2/profile")
-        consume(path, method="GET", bucket=PRIVATE)
         response = client.get(url, headers=headers)
 
         logger.debug(f"Profile response status: {response.status_code}")

--- a/broker/deltaexchange/api/auth_api.py
+++ b/broker/deltaexchange/api/auth_api.py
@@ -1,6 +1,7 @@
 import os
 
 from broker.deltaexchange.api.baseurl import BASE_URL, get_auth_headers, get_url
+from broker.deltaexchange.api.rate_limiter import PRIVATE, consume
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
@@ -47,6 +48,7 @@ def authenticate_broker(code):
         client = get_httpx_client()
 
         logger.info("Verifying Delta Exchange credentials via GET /v2/profile")
+        consume(path, method="GET", bucket=PRIVATE)
         response = client.get(url, headers=headers)
 
         logger.debug(f"Profile response status: {response.status_code}")

--- a/broker/deltaexchange/api/data.py
+++ b/broker/deltaexchange/api/data.py
@@ -16,6 +16,12 @@ import httpx
 import pandas as pd
 
 from broker.deltaexchange.api.baseurl import BASE_URL
+from broker.deltaexchange.api.rate_limiter import (
+    PUBLIC,
+    consume,
+    note_429,
+    retry_delay_from_headers,
+)
 from database.token_db import get_token
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
@@ -54,6 +60,53 @@ _MAX_RETRIES = 2        # up to 2 retries (3 total attempts)
 _RETRY_DELAY = 0.3      # seconds between retries
 
 
+def _public_get(path: str, timeout: float = 15.0, params: dict | None = None):
+    """GET a public Delta endpoint under the shared weighted quota, retrying 429s.
+
+    Market data is sent unauthenticated, so it is throttled by IP and draws on
+    a bucket separate from the one order placement uses.  A 429 here used to
+    surface as a bare "HTTP 429" exception per symbol, which the option chain
+    swallows into a blank row -- retrying on the reset the exchange reports is
+    what turns that back into data.
+    """
+    url = f"{BASE_URL}{path}"
+    last_exc: Exception | None = None
+
+    for attempt in range(_MAX_RETRIES + 1):
+        consume(path, method="GET", bucket=PUBLIC)
+        try:
+            client = get_httpx_client()
+            resp = client.get(
+                url, headers={"Accept": "application/json"}, timeout=timeout, params=params
+            )
+        except _TRANSIENT_ERRORS as exc:
+            last_exc = exc
+            if attempt >= _MAX_RETRIES:
+                raise
+            logger.warning(
+                "Transient error on %s (attempt %s/%s): %s - retrying",
+                path, attempt + 1, _MAX_RETRIES + 1, exc,
+            )
+            time.sleep(_RETRY_DELAY)
+            continue
+
+        if resp.status_code == 429:
+            note_429(resp.headers, bucket=PUBLIC)
+            if attempt >= _MAX_RETRIES:
+                return resp
+            wait = retry_delay_from_headers(resp.headers, attempt)
+            logger.warning(
+                "Delta rate-limited (429) on %s (attempt %s/%s); retrying in %.1fs",
+                path, attempt + 1, _MAX_RETRIES + 1, wait,
+            )
+            time.sleep(wait)
+            continue
+
+        return resp
+
+    raise last_exc if last_exc else Exception(f"No response for {path}")
+
+
 def _get_ticker(symbol: str) -> dict:
     """
     Fetch ticker for a single symbol via GET /v2/tickers/{symbol}.
@@ -63,24 +116,7 @@ def _get_ticker(symbol: str) -> dict:
     Retries up to _MAX_RETRIES times on transient HTTP/2 socket errors
     (e.g. WinError 10035 / WSAEWOULDBLOCK under concurrent load).
     """
-    url = f"{BASE_URL}/v2/tickers/{symbol}"
-    last_err: Exception | None = None
-
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            client = get_httpx_client()
-            resp = client.get(url, headers={"Accept": "application/json"}, timeout=15.0)
-            break  # success
-        except _TRANSIENT_ERRORS as exc:
-            last_err = exc
-            if attempt < _MAX_RETRIES:
-                logger.warning(
-                    "Transient error fetching ticker %s (attempt %d/%d): %s – retrying",
-                    symbol, attempt + 1, _MAX_RETRIES + 1, exc,
-                )
-                time.sleep(_RETRY_DELAY)
-            else:
-                raise
+    resp = _public_get(f"/v2/tickers/{symbol}")
 
     if resp.status_code != 200:
         raise Exception(f"Ticker HTTP {resp.status_code} for {symbol}: {resp.text[:200]}")
@@ -119,24 +155,7 @@ def _get_l2orderbook(product_id: int) -> dict:
 
     Retries up to _MAX_RETRIES times on transient HTTP/2 socket errors.
     """
-    url = f"{BASE_URL}/v2/l2orderbook/{product_id}"
-    last_err: Exception | None = None
-
-    for attempt in range(_MAX_RETRIES + 1):
-        try:
-            client = get_httpx_client()
-            resp = client.get(url, headers={"Accept": "application/json"}, timeout=15.0)
-            break  # success
-        except _TRANSIENT_ERRORS as exc:
-            last_err = exc
-            if attempt < _MAX_RETRIES:
-                logger.warning(
-                    "Transient error fetching l2orderbook %s (attempt %d/%d): %s – retrying",
-                    product_id, attempt + 1, _MAX_RETRIES + 1, exc,
-                )
-                time.sleep(_RETRY_DELAY)
-            else:
-                raise
+    resp = _public_get(f"/v2/l2orderbook/{product_id}")
 
     if resp.status_code != 200:
         raise Exception(
@@ -469,8 +488,6 @@ class BrokerData:
             )
 
             all_candles = []
-            url    = f"{BASE_URL}/v2/history/candles"
-            client = get_httpx_client()
 
             for chunk_start, chunk_end in chunks:
                 start_ts = self._to_epoch(chunk_start, end_of_day=False)
@@ -488,12 +505,7 @@ class BrokerData:
                     f"({start_ts} → {end_ts})"
                 )
 
-                resp = client.get(
-                    url,
-                    params=params,
-                    headers={"Accept": "application/json"},
-                    timeout=30.0,
-                )
+                resp = _public_get("/v2/history/candles", timeout=30.0, params=params)
 
                 if resp.status_code != 200:
                     raise Exception(

--- a/broker/deltaexchange/api/data.py
+++ b/broker/deltaexchange/api/data.py
@@ -17,9 +17,11 @@ import pandas as pd
 
 from broker.deltaexchange.api.baseurl import BASE_URL
 from broker.deltaexchange.api.rate_limiter import (
+    MAX_WAIT_SECONDS,
     PUBLIC,
     consume,
     note_429,
+    quota_reset_seconds,
     retry_delay_from_headers,
 )
 from database.token_db import get_token
@@ -92,12 +94,23 @@ def _public_get(path: str, timeout: float = 15.0, params: dict | None = None):
 
         if resp.status_code == 429:
             note_429(resp.headers, bucket=PUBLIC)
-            if attempt >= _MAX_RETRIES:
-                return resp
             wait = retry_delay_from_headers(resp.headers, attempt)
+            reset = quota_reset_seconds(resp.headers)
+
+            # Only retry when the window actually reopens within the limiter's
+            # wait ceiling. Past that, sleeping is pure delay: the next
+            # consume() would refuse the call anyway, so return the 429 and let
+            # the caller report it.
+            if attempt >= _MAX_RETRIES or (reset is not None and reset > MAX_WAIT_SECONDS):
+                logger.warning(
+                    "Delta rate-limited (429) on %s; quota resets in %ss, not retrying",
+                    path, round(reset) if reset is not None else "unknown",
+                )
+                return resp
+
             logger.warning(
-                "Delta rate-limited (429) on %s (attempt %s/%s); retrying in %.1fs",
-                path, attempt + 1, _MAX_RETRIES + 1, wait,
+                "Delta rate-limited (429) on %s (attempt %s/%s); retrying in %ss",
+                path, attempt + 1, _MAX_RETRIES + 1, round(wait, 1),
             )
             time.sleep(wait)
             continue

--- a/broker/deltaexchange/api/data.py
+++ b/broker/deltaexchange/api/data.py
@@ -21,8 +21,8 @@ from broker.deltaexchange.api.rate_limiter import (
     PUBLIC,
     consume,
     note_429,
-    quota_reset_seconds,
     retry_delay_from_headers,
+    server_requested_delay,
 )
 from database.token_db import get_token
 from utils.httpx_client import get_httpx_client
@@ -95,16 +95,19 @@ def _public_get(path: str, timeout: float = 15.0, params: dict | None = None):
         if resp.status_code == 429:
             note_429(resp.headers, bucket=PUBLIC)
             wait = retry_delay_from_headers(resp.headers, attempt)
-            reset = quota_reset_seconds(resp.headers)
+            requested = server_requested_delay(resp.headers)
 
-            # Only retry when the window actually reopens within the limiter's
-            # wait ceiling. Past that, sleeping is pure delay: the next
-            # consume() would refuse the call anyway, so return the 429 and let
-            # the caller report it.
-            if attempt >= _MAX_RETRIES or (reset is not None and reset > MAX_WAIT_SECONDS):
+            # Only retry when the wait the server asked for is short enough to
+            # be worth sitting through. Past the ceiling, sleeping is pure
+            # delay: the next consume() would refuse the call anyway, so return
+            # the 429 and let the caller report it. This covers Retry-After as
+            # well as X-RATE-LIMIT-RESET -- either can name a wait far longer
+            # than a request should ever block for.
+            if attempt >= _MAX_RETRIES or (requested is not None
+                                           and requested > MAX_WAIT_SECONDS):
                 logger.warning(
-                    "Delta rate-limited (429) on %s; quota resets in %ss, not retrying",
-                    path, round(reset) if reset is not None else "unknown",
+                    "Delta rate-limited (429) on %s; server asked for %ss, not retrying",
+                    path, round(requested) if requested is not None else "unknown",
                 )
                 return resp
 

--- a/broker/deltaexchange/api/funds.py
+++ b/broker/deltaexchange/api/funds.py
@@ -42,6 +42,9 @@ def _get_positions_pnl(api_key, api_secret):
     path = "/v2/positions/margined"
     url = BASE_URL + path
     try:
+        # consume() before signing: it can block on the quota window and Delta
+        # rejects signatures older than 5 seconds ("SignatureExpired").
+        consume(path, method="GET", bucket=PRIVATE)
         headers = get_auth_headers(
             method="GET",
             path=path,
@@ -50,7 +53,6 @@ def _get_positions_pnl(api_key, api_secret):
             api_key=api_key,
             api_secret=api_secret,
         )
-        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         response = client.get(url, headers=headers, timeout=30.0)
         if response.status_code != 200:
@@ -115,6 +117,9 @@ def get_margin_data(auth_token):
     url = BASE_URL + path
 
     try:
+        # consume() before signing: it can block on the quota window and Delta
+        # rejects signatures older than 5 seconds ("SignatureExpired").
+        consume(path, method="GET", bucket=PRIVATE)
         headers = get_auth_headers(
             method="GET",
             path=path,
@@ -124,7 +129,6 @@ def get_margin_data(auth_token):
             api_secret=api_secret,
         )
 
-        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         response = client.get(url, headers=headers, timeout=30.0)
 

--- a/broker/deltaexchange/api/funds.py
+++ b/broker/deltaexchange/api/funds.py
@@ -10,6 +10,7 @@
 import os
 
 from broker.deltaexchange.api.baseurl import BASE_URL, get_auth_headers
+from broker.deltaexchange.api.rate_limiter import PRIVATE, consume
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
@@ -49,6 +50,7 @@ def _get_positions_pnl(api_key, api_secret):
             api_key=api_key,
             api_secret=api_secret,
         )
+        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         response = client.get(url, headers=headers, timeout=30.0)
         if response.status_code != 200:
@@ -122,6 +124,7 @@ def get_margin_data(auth_token):
             api_secret=api_secret,
         )
 
+        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         response = client.get(url, headers=headers, timeout=30.0)
 

--- a/broker/deltaexchange/api/margin_api.py
+++ b/broker/deltaexchange/api/margin_api.py
@@ -5,6 +5,7 @@
 import os
 
 from broker.deltaexchange.api.baseurl import BASE_URL, get_auth_headers
+from broker.deltaexchange.api.rate_limiter import PRIVATE, consume
 from broker.deltaexchange.mapping.margin_data import parse_margin_response, transform_margin_positions
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
@@ -43,6 +44,7 @@ def get_margin_mode(auth: str) -> str:
             api_key=api_key,
             api_secret=api_secret,
         )
+        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         resp = client.get(BASE_URL + path, headers=headers, timeout=15.0)
         data = resp.json()
@@ -139,6 +141,7 @@ def calculate_margin_api(positions, auth):
                 api_secret=api_secret,
             )
 
+            consume(path, method="GET", bucket=PRIVATE)
             response = client.get(url, headers=headers, timeout=30.0)
             response_data = response.json()
 

--- a/broker/deltaexchange/api/margin_api.py
+++ b/broker/deltaexchange/api/margin_api.py
@@ -5,7 +5,7 @@
 import os
 
 from broker.deltaexchange.api.baseurl import BASE_URL, get_auth_headers
-from broker.deltaexchange.api.rate_limiter import PRIVATE, consume
+from broker.deltaexchange.api.rate_limiter import PRIVATE, DeltaRateLimitError, consume
 from broker.deltaexchange.mapping.margin_data import parse_margin_response, transform_margin_positions
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
@@ -36,6 +36,9 @@ def get_margin_mode(auth: str) -> str:
 
     path = "/v2/users/trading_preferences"
     try:
+        # consume() before signing: it can block on the quota window and Delta
+        # rejects signatures older than 5 seconds ("SignatureExpired").
+        consume(path, method="GET", bucket=PRIVATE)
         headers = get_auth_headers(
             method="GET",
             path=path,
@@ -44,7 +47,6 @@ def get_margin_mode(auth: str) -> str:
             api_key=api_key,
             api_secret=api_secret,
         )
-        consume(path, method="GET", bucket=PRIVATE)
         client = get_httpx_client()
         resp = client.get(BASE_URL + path, headers=headers, timeout=15.0)
         data = resp.json()
@@ -131,6 +133,19 @@ def calculate_margin_api(positions, auth):
         query_string = "?" + "&".join(f"{k}={v}" for k, v in sorted(params.items()))
         url = BASE_URL + path + query_string
 
+        # Quota first, then sign: consume() can block and a signature older
+        # than 5 seconds is rejected outright.  A rate-limit failure here is
+        # request-wide, not per-product -- swallowing it would report a
+        # successful basket whose margin silently excludes this leg.
+        try:
+            consume(path, method="GET", bucket=PRIVATE)
+        except DeltaRateLimitError as exc:
+            logger.error(f"[DeltaExchange] margin calculation aborted: {exc}")
+            return MockResponse(429), {
+                "status": "error",
+                "message": f"Delta Exchange rate limit reached during margin calculation: {exc}",
+            }
+
         try:
             headers = get_auth_headers(
                 method="GET",
@@ -141,7 +156,6 @@ def calculate_margin_api(positions, auth):
                 api_secret=api_secret,
             )
 
-            consume(path, method="GET", bucket=PRIVATE)
             response = client.get(url, headers=headers, timeout=30.0)
             response_data = response.json()
 

--- a/broker/deltaexchange/api/order_api.py
+++ b/broker/deltaexchange/api/order_api.py
@@ -5,6 +5,14 @@ import threading
 import time
 
 from broker.deltaexchange.api.baseurl import get_auth_headers, get_url
+from broker.deltaexchange.api.rate_limiter import (
+    MAX_RETRIES,
+    PRIVATE,
+    DeltaRateLimitError,
+    consume,
+    note_429,
+    retry_delay_from_headers,
+)
 from broker.deltaexchange.mapping.transform_data import (
     map_exchange_type,
     map_product_type,
@@ -61,14 +69,21 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
     client = get_httpx_client()
     logger.debug(f"[DeltaExchange] {method.upper()} {full_url}")
 
-    # Retry up to 3 times on HTTP 429 (rate limit) with exponential backoff + jitter.
-    # The Retry-After header is honoured when present.  On each retry the HMAC
-    # signature is rebuilt with a fresh timestamp.
-    _MAX_RETRIES = 3
-    _RETRY_BASE  = 1.0  # seconds; doubles each attempt
+    # Retry up to MAX_RETRIES times on HTTP 429.  Delta reports the wait in
+    # X-RATE-LIMIT-RESET (milliseconds until the 5-minute quota window resets),
+    # not Retry-After, so the delay comes from the shared rate limiter.  On each
+    # retry the HMAC signature is rebuilt with a fresh timestamp.
     response = None
 
-    for _attempt in range(_MAX_RETRIES + 1):
+    for _attempt in range(MAX_RETRIES + 1):
+        # Weighted quota accounting; authenticated calls draw on the per-user
+        # bucket, which public market data cannot exhaust.
+        try:
+            consume(endpoint, method=method, bucket=PRIVATE)
+        except DeltaRateLimitError as exc:
+            logger.error(f"[DeltaExchange] {exc}")
+            return {"success": False, "error": {"code": "rate_limited", "message": str(exc)}}
+
         try:
             m = method.upper()
             if m == "GET":
@@ -85,15 +100,14 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
             logger.error(f"[DeltaExchange] Request error: {e}")
             return {"success": False, "error": {"code": "request_error", "message": str(e)}}
 
-        if response.status_code == 429 and _attempt < _MAX_RETRIES:
-            retry_after = response.headers.get("Retry-After")
-            wait = (
-                float(retry_after) if retry_after
-                else (_RETRY_BASE * (2 ** _attempt)) + random.uniform(0.0, 0.5)
-            )
+        if response.status_code == 429:
+            note_429(response.headers, bucket=PRIVATE)
+            if _attempt >= MAX_RETRIES:
+                break
+            wait = retry_delay_from_headers(response.headers, _attempt) + random.uniform(0.0, 0.5)
             logger.warning(
                 f"[DeltaExchange] HTTP 429 rate-limit on {endpoint} "
-                f"(attempt {_attempt + 1}/{_MAX_RETRIES}). Retrying in {wait:.1f}s ..."
+                f"(attempt {_attempt + 1}/{MAX_RETRIES}). Retrying in {wait:.1f}s ..."
             )
             time.sleep(wait)
             # Re-sign with a fresh timestamp before the next attempt

--- a/broker/deltaexchange/api/order_api.py
+++ b/broker/deltaexchange/api/order_api.py
@@ -53,15 +53,6 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
 
     body = payload if payload else ""
 
-    headers = get_auth_headers(
-        method=method.upper(),
-        path=endpoint,
-        query_string=query_string,
-        payload=body,
-        api_key=auth,
-        api_secret=api_secret,
-    )
-
     # Build full URL (include query string inline so the signed string matches exactly)
     url = get_url(endpoint)
     full_url = url + query_string if query_string else url
@@ -77,12 +68,25 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
 
     for _attempt in range(MAX_RETRIES + 1):
         # Weighted quota accounting; authenticated calls draw on the per-user
-        # bucket, which public market data cannot exhaust.
+        # bucket, which public market data cannot exhaust.  This runs BEFORE the
+        # request is signed: consume() can block waiting for the quota window,
+        # and Delta rejects any signature more than 5 seconds old
+        # ("SignatureExpired"), so a signature made first would be dead on
+        # arrival.
         try:
             consume(endpoint, method=method, bucket=PRIVATE)
         except DeltaRateLimitError as exc:
             logger.error(f"[DeltaExchange] {exc}")
             return {"success": False, "error": {"code": "rate_limited", "message": str(exc)}}
+
+        headers = get_auth_headers(
+            method=method.upper(),
+            path=endpoint,
+            query_string=query_string,
+            payload=body,
+            api_key=auth,
+            api_secret=api_secret,
+        )
 
         try:
             m = method.upper()
@@ -110,15 +114,7 @@ def get_api_response(endpoint, auth, method="GET", payload="", params=None):
                 f"(attempt {_attempt + 1}/{MAX_RETRIES}). Retrying in {wait:.1f}s ..."
             )
             time.sleep(wait)
-            # Re-sign with a fresh timestamp before the next attempt
-            headers = get_auth_headers(
-                method=method.upper(),
-                path=endpoint,
-                query_string=query_string,
-                payload=body,
-                api_key=auth,
-                api_secret=api_secret,
-            )
+            # The next pass re-signs with a fresh timestamp after consume().
             continue
         break  # success, non-429, or retries exhausted
 

--- a/broker/deltaexchange/api/rate_limiter.py
+++ b/broker/deltaexchange/api/rate_limiter.py
@@ -1,0 +1,272 @@
+"""
+Shared rate limiting and 429-retry helpers for all Delta Exchange API calls.
+
+Delta does not throttle by requests-per-second like Fyers or Dhan. Every REST
+endpoint carries a **weight**, and the weights consumed are deducted from a
+quota of 10000 units per fixed 5-minute window (see
+delta-api-docs/04-rate-limits.md). Exceeding it returns HTTP 429 with
+``X-RATE-LIMIT-RESET`` holding the milliseconds left until the window resets —
+Delta does **not** send ``Retry-After``.
+
+Two independent buckets, because Delta throttles "unauthenticated api requests
+by IP address and authenticated requests by user ID". Public market data
+(tickers, order book, candles, products) is sent unauthenticated by this
+integration and therefore cannot exhaust the quota that order placement needs.
+
+Verified live 2026-08-12 against ``GET /v2/rate_limits/quota``, which reports
+``current_quota`` (units *consumed* this window, counting up) and
+``remaining_time_in_milliseconds``: 20 distinct ticker calls moved the counter
+by exactly 60, matching the documented weight of 3, and the quota endpoint
+itself costs 3.
+
+State is module-level rather than per-instance because services construct a
+fresh ``BrokerData(auth_token)`` per request (see
+services/option_chain_service.py, services/oi_tracker_service.py), so anything
+kept on ``self`` is discarded before it can pace the next caller.
+"""
+
+import threading
+import time
+
+from utils.httpx_client import get_httpx_client
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Buckets. Delta throttles unauthenticated traffic by IP and authenticated
+# traffic by user id, so they never draw down each other's quota.
+PUBLIC  = "public"
+PRIVATE = "private"
+
+WINDOW_SECONDS = 300.0    # Delta resets the quota every fixed 5 minutes
+FULL_QUOTA     = 10000
+
+# Spend at most 90% of the documented quota. The headroom absorbs the drift
+# between Delta's fixed window and the floating one tracked here, and leaves
+# room for order placement when a data poller is running hot.
+BUDGET = int(FULL_QUOTA * 0.9)
+
+# Longest a caller will be parked waiting for the window to reset. A reset can
+# be almost 5 minutes out; blocking a web request that long is worse than
+# failing it, so past this the call raises and the caller surfaces the error.
+MAX_WAIT_SECONDS = 30.0
+
+MAX_RETRIES  = 3
+BASE_BACKOFF = 1.0   # seconds; fallback ladder when no reset header: 1, 2, 4
+
+# Endpoint weights, longest prefix wins. Anything unlisted costs 1 unit.
+# Method-specific entries are keyed (method, prefix) and take precedence.
+_WEIGHTS_BY_METHOD = {
+    ("POST",   "/v2/orders/batch"):  25,   # Batch Order Apis
+    ("PUT",    "/v2/orders/batch"):  25,
+    ("DELETE", "/v2/orders/batch"):  25,
+    ("POST",   "/v2/orders"):         5,   # Place Order
+    ("PUT",    "/v2/orders"):         5,   # Edit Order
+    ("DELETE", "/v2/orders"):         5,   # Delete Order
+}
+
+_WEIGHTS = {
+    "/v2/orders/history":            10,   # Get Order History
+    "/v2/fills":                     10,   # Get Fills
+    "/v2/wallet/transactions":       10,   # Get Txn Logs
+    "/v2/positions/change_margin":    5,   # Add Position Margin
+    "/v2/products":                   3,   # Get Products
+    "/v2/tickers":                    3,   # Get Tickers
+    "/v2/l2orderbook":                3,   # Get Orderbook
+    "/v2/history/candles":            3,   # OHLC Candles
+    "/v2/history/sparklines":         3,
+    "/v2/orders":                     3,   # Get Open Orders (GET)
+    "/v2/positions":                  3,   # Get Open Positions
+    "/v2/wallet/balances":            3,   # Get Balances
+    "/v2/rate_limits/quota":          3,   # measured; the meter costs too
+}
+
+DEFAULT_WEIGHT = 1
+
+_lock = threading.Lock()
+_state = {
+    PUBLIC:  {"used": 0, "window_start": 0.0},
+    PRIVATE: {"used": 0, "window_start": 0.0},
+}
+
+
+class DeltaRateLimitError(Exception):
+    """Raised when the quota is spent and the reset is further out than MAX_WAIT_SECONDS."""
+
+
+def endpoint_weight(endpoint: str, method: str = "GET") -> int:
+    """Return the quota cost of one call to `endpoint`.
+
+    `endpoint` is the path with no host and no query string, e.g. "/v2/tickers/BTCUSD".
+    """
+    path = (endpoint or "").split("?", 1)[0].rstrip("/")
+    method = (method or "GET").upper()
+
+    for (m, prefix), weight in _WEIGHTS_BY_METHOD.items():
+        if m == method and (path == prefix or path.startswith(prefix + "/")):
+            return weight
+
+    best_weight = DEFAULT_WEIGHT
+    best_len = -1
+    for prefix, weight in _WEIGHTS.items():
+        if (path == prefix or path.startswith(prefix + "/")) and len(prefix) > best_len:
+            best_weight, best_len = weight, len(prefix)
+    return best_weight
+
+
+def _reset_if_window_elapsed(bucket: str, now: float) -> None:
+    """Start a fresh window once 5 minutes have passed. Caller must hold _lock."""
+    state = _state[bucket]
+    if now - state["window_start"] >= WINDOW_SECONDS:
+        state["used"] = 0
+        state["window_start"] = now
+
+
+def consume(endpoint: str, method: str = "GET", bucket: str = PUBLIC) -> None:
+    """Account for one API call, blocking if this window's budget is spent.
+
+    Raises DeltaRateLimitError when the window reset is further away than
+    MAX_WAIT_SECONDS, so a caller fails cleanly instead of hanging for minutes.
+    """
+    weight = endpoint_weight(endpoint, method)
+
+    with _lock:
+        now = time.time()
+        _reset_if_window_elapsed(bucket, now)
+        state = _state[bucket]
+
+        if state["used"] + weight <= BUDGET:
+            state["used"] += weight
+            return
+
+        wait = max(0.0, state["window_start"] + WINDOW_SECONDS - now)
+
+    # Budget looks spent. Delta's window is fixed and ours floats, so before
+    # parking anyone, spend 3 units asking the exchange where the real window
+    # stands — it is often further along than the local view.
+    #
+    # Only for the public bucket: the quota endpoint is unauthenticated, so it
+    # reports the IP allowance. Applying that answer to the per-user bucket
+    # would hand back a quota the user may not have, and would undo a 429 the
+    # exchange has already returned on an authenticated call.
+    if bucket == PUBLIC:
+        server = _fetch_server_quota(bucket)
+        if server is not None:
+            used, wait = server
+            with _lock:
+                state = _state[bucket]
+                state["used"] = used + weight
+                state["window_start"] = time.time() - (WINDOW_SECONDS - wait)
+            if used + weight <= BUDGET:
+                return
+
+    if wait > MAX_WAIT_SECONDS:
+        raise DeltaRateLimitError(
+            f"Delta {bucket} rate-limit quota exhausted ({BUDGET} units in a "
+            f"{int(WINDOW_SECONDS)}s window); resets in {wait:.0f}s"
+        )
+
+    logger.warning(
+        "Delta %s quota exhausted; waiting %.1fs for the window to reset before %s",
+        bucket, wait, endpoint,
+    )
+    time.sleep(wait)
+
+    with _lock:
+        now = time.time()
+        _reset_if_window_elapsed(bucket, now)
+        _state[bucket]["used"] += weight
+
+
+def _fetch_server_quota(bucket: str) -> tuple[int, float] | None:
+    """Read the authoritative quota. Returns (used_units, seconds_to_reset).
+
+    Unauthenticated, so it reports the IP bucket; for the private bucket it is
+    only a hint that the window has rolled over, which is still worth having.
+    """
+    try:
+        resp = get_httpx_client().get(
+            "https://api.india.delta.exchange/v2/rate_limits/quota",
+            headers={"Accept": "application/json"},
+            timeout=5.0,
+        )
+        if resp.status_code != 200:
+            return None
+        data = resp.json()
+        used = int(data.get("current_quota", 0))
+        left = float(data.get("remaining_time_in_milliseconds", 0)) / 1000.0
+        # %s only — SensitiveDataFilter stringifies every log arg, so %d/%f
+        # would raise and the line would print its raw format string.
+        logger.info("Delta quota check (%s bucket): %s units used, resets in %ss",
+                    bucket, used, round(left))
+        return used, left
+    except Exception as exc:
+        logger.warning("Delta quota check failed: %s", exc)
+        return None
+
+
+def note_429(headers, bucket: str = PUBLIC) -> None:
+    """Record that Delta rejected a call, so the next caller waits instead of piling on."""
+    with _lock:
+        state = _state[bucket]
+        state["used"] = BUDGET
+        reset = _reset_seconds(headers)
+        if reset is not None:
+            # Pin the local window to the exchange's, so the wait computed by
+            # consume() matches when the quota actually comes back.
+            state["window_start"] = time.time() - (WINDOW_SECONDS - reset)
+
+
+def _reset_seconds(headers) -> float | None:
+    """Seconds until the quota resets, from X-RATE-LIMIT-RESET (milliseconds)."""
+    raw = None
+    if headers:
+        raw = headers.get("X-RATE-LIMIT-RESET") or headers.get("x-rate-limit-reset")
+    if raw is None:
+        return None
+    try:
+        return max(float(raw) / 1000.0, 0.0)
+    except (TypeError, ValueError):
+        return None
+
+
+def retry_delay_from_headers(headers, attempt: int) -> float:
+    """How long to wait before retrying a 429.
+
+    Delta documents X-RATE-LIMIT-RESET (milliseconds until the window resets)
+    and does not send Retry-After; Retry-After is still read in case that
+    changes. Falls back to an exponential ladder when neither is present.
+    """
+    reset = _reset_seconds(headers)
+    if reset is not None:
+        return max(min(reset, MAX_WAIT_SECONDS), 0.05)
+
+    retry_after = headers.get("Retry-After") or headers.get("retry-after") if headers else None
+    if retry_after:
+        try:
+            return max(float(retry_after), 0.05)
+        except (TypeError, ValueError):
+            pass
+
+    return BASE_BACKOFF * (2**attempt)
+
+
+def snapshot() -> dict:
+    """Current accounting, for logging and tests."""
+    with _lock:
+        now = time.time()
+        return {
+            bucket: {
+                "used": state["used"],
+                "budget": BUDGET,
+                "resets_in": max(0.0, state["window_start"] + WINDOW_SECONDS - now),
+            }
+            for bucket, state in _state.items()
+        }
+
+
+def _reset_for_tests() -> None:
+    with _lock:
+        for state in _state.values():
+            state["used"] = 0
+            state["window_start"] = 0.0

--- a/broker/deltaexchange/api/rate_limiter.py
+++ b/broker/deltaexchange/api/rate_limiter.py
@@ -246,25 +246,45 @@ def quota_reset_seconds(headers) -> float | None:
         return None
 
 
-def retry_delay_from_headers(headers, attempt: int) -> float:
-    """How long to wait before retrying a 429.
+def server_requested_delay(headers) -> float | None:
+    """The wait the server asked for, in seconds and UNCAPPED.
 
     Delta documents X-RATE-LIMIT-RESET (milliseconds until the window resets)
     and does not send Retry-After; Retry-After is still read in case that
-    changes. Falls back to an exponential ladder when neither is present.
+    changes, and because a CDN or proxy in front of the API may send it.
+    None when neither header is present or parseable.
+
+    Callers use this to decide *whether* a retry is worth attempting, which is
+    a different question from how long to sleep — see retry_delay_from_headers.
     """
     reset = quota_reset_seconds(headers)
     if reset is not None:
-        return max(min(reset, MAX_WAIT_SECONDS), 0.05)
+        return reset
 
     retry_after = headers.get("Retry-After") or headers.get("retry-after") if headers else None
     if retry_after:
         try:
-            return max(float(retry_after), 0.05)
+            return max(float(retry_after), 0.0)
         except (TypeError, ValueError):
             pass
 
-    return BASE_BACKOFF * (2**attempt)
+    return None
+
+
+def retry_delay_from_headers(headers, attempt: int) -> float:
+    """How long to sleep before retrying a 429, never more than MAX_WAIT_SECONDS.
+
+    Every branch is capped, including Retry-After: a server or proxy asking for
+    a ten-minute wait must not park a web request for ten minutes. When the
+    requested wait exceeds the ceiling the caller should stop retrying rather
+    than sleep the capped amount and try anyway — server_requested_delay()
+    reports the uncapped figure for exactly that decision.
+    """
+    requested = server_requested_delay(headers)
+    if requested is not None:
+        return max(min(requested, MAX_WAIT_SECONDS), 0.05)
+
+    return min(BASE_BACKOFF * (2**attempt), MAX_WAIT_SECONDS)
 
 
 def snapshot() -> dict:

--- a/broker/deltaexchange/api/rate_limiter.py
+++ b/broker/deltaexchange/api/rate_limiter.py
@@ -28,6 +28,7 @@ kept on ``self`` is discarded before it can pace the next caller.
 import threading
 import time
 
+from broker.deltaexchange.api.baseurl import BASE_URL
 from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
@@ -53,6 +54,11 @@ MAX_WAIT_SECONDS = 30.0
 
 MAX_RETRIES  = 3
 BASE_BACKOFF = 1.0   # seconds; fallback ladder when no reset header: 1, 2, 4
+
+# Sleeps allowed inside one consume() call before giving up. A window reset
+# frees the whole budget, so one wait is normally enough; the cap stops a
+# clock jump or a contended bucket from parking a caller indefinitely.
+_MAX_SLEEPS = 2
 
 # Endpoint weights, longest prefix wins. Anything unlisted costs 1 unit.
 # Method-specific entries are keyed (method, prefix) and take precedence.
@@ -127,55 +133,62 @@ def consume(endpoint: str, method: str = "GET", bucket: str = PUBLIC) -> None:
 
     Raises DeltaRateLimitError when the window reset is further away than
     MAX_WAIT_SECONDS, so a caller fails cleanly instead of hanging for minutes.
+
+    IMPORTANT: this can sleep, and Delta rejects any signature older than 5
+    seconds ("SignatureExpired"). Authenticated callers must call this BEFORE
+    building their HMAC headers, never between signing and sending.
     """
     weight = endpoint_weight(endpoint, method)
+    probed = False
+    slept = 0
 
-    with _lock:
-        now = time.time()
-        _reset_if_window_elapsed(bucket, now)
-        state = _state[bucket]
+    # Re-evaluated every pass: the reservation and the budget check have to
+    # happen in the same locked section, or concurrent callers each decide
+    # there is room, sleep, and then all add their weight on top of a budget
+    # that only had space for one of them.
+    while True:
+        with _lock:
+            now = time.time()
+            _reset_if_window_elapsed(bucket, now)
+            state = _state[bucket]
 
-        if state["used"] + weight <= BUDGET:
-            state["used"] += weight
-            return
-
-        wait = max(0.0, state["window_start"] + WINDOW_SECONDS - now)
-
-    # Budget looks spent. Delta's window is fixed and ours floats, so before
-    # parking anyone, spend 3 units asking the exchange where the real window
-    # stands — it is often further along than the local view.
-    #
-    # Only for the public bucket: the quota endpoint is unauthenticated, so it
-    # reports the IP allowance. Applying that answer to the per-user bucket
-    # would hand back a quota the user may not have, and would undo a 429 the
-    # exchange has already returned on an authenticated call.
-    if bucket == PUBLIC:
-        server = _fetch_server_quota(bucket)
-        if server is not None:
-            used, wait = server
-            with _lock:
-                state = _state[bucket]
-                state["used"] = used + weight
-                state["window_start"] = time.time() - (WINDOW_SECONDS - wait)
-            if used + weight <= BUDGET:
+            if state["used"] + weight <= BUDGET:
+                state["used"] += weight
                 return
 
-    if wait > MAX_WAIT_SECONDS:
-        raise DeltaRateLimitError(
-            f"Delta {bucket} rate-limit quota exhausted ({BUDGET} units in a "
-            f"{int(WINDOW_SECONDS)}s window); resets in {wait:.0f}s"
+            wait = max(0.0, state["window_start"] + WINDOW_SECONDS - now)
+
+        # Budget looks spent. Delta's window is fixed and ours floats, so
+        # before parking anyone, spend 3 units asking the exchange where the
+        # real window stands — it is often further along than the local view.
+        #
+        # Only for the public bucket: the quota endpoint is unauthenticated, so
+        # it reports the IP allowance. Applying that answer to the per-user
+        # bucket would hand back a quota the user may not have, and would undo
+        # a 429 the exchange has already returned on an authenticated call.
+        if bucket == PUBLIC and not probed:
+            probed = True
+            server = _fetch_server_quota(bucket)
+            if server is not None:
+                used, left = server
+                with _lock:
+                    state = _state[bucket]
+                    state["used"] = used
+                    state["window_start"] = time.time() - (WINDOW_SECONDS - left)
+                continue   # re-check under the lock with the exchange's numbers
+
+        if wait > MAX_WAIT_SECONDS or slept >= _MAX_SLEEPS:
+            raise DeltaRateLimitError(
+                f"Delta {bucket} rate-limit quota exhausted ({BUDGET} units in a "
+                f"{int(WINDOW_SECONDS)}s window); resets in {wait:.0f}s"
+            )
+
+        logger.warning(
+            "Delta %s quota exhausted; waiting %ss for the window to reset before %s",
+            bucket, round(wait, 1), endpoint,
         )
-
-    logger.warning(
-        "Delta %s quota exhausted; waiting %.1fs for the window to reset before %s",
-        bucket, wait, endpoint,
-    )
-    time.sleep(wait)
-
-    with _lock:
-        now = time.time()
-        _reset_if_window_elapsed(bucket, now)
-        _state[bucket]["used"] += weight
+        time.sleep(wait)
+        slept += 1
 
 
 def _fetch_server_quota(bucket: str) -> tuple[int, float] | None:
@@ -186,7 +199,7 @@ def _fetch_server_quota(bucket: str) -> tuple[int, float] | None:
     """
     try:
         resp = get_httpx_client().get(
-            "https://api.india.delta.exchange/v2/rate_limits/quota",
+            f"{BASE_URL}/v2/rate_limits/quota",
             headers={"Accept": "application/json"},
             timeout=5.0,
         )
@@ -210,15 +223,18 @@ def note_429(headers, bucket: str = PUBLIC) -> None:
     with _lock:
         state = _state[bucket]
         state["used"] = BUDGET
-        reset = _reset_seconds(headers)
+        reset = quota_reset_seconds(headers)
         if reset is not None:
             # Pin the local window to the exchange's, so the wait computed by
             # consume() matches when the quota actually comes back.
             state["window_start"] = time.time() - (WINDOW_SECONDS - reset)
 
 
-def _reset_seconds(headers) -> float | None:
-    """Seconds until the quota resets, from X-RATE-LIMIT-RESET (milliseconds)."""
+def quota_reset_seconds(headers) -> float | None:
+    """Seconds until the quota resets, from X-RATE-LIMIT-RESET (milliseconds).
+
+    None when the header is absent or unparseable.
+    """
     raw = None
     if headers:
         raw = headers.get("X-RATE-LIMIT-RESET") or headers.get("x-rate-limit-reset")
@@ -237,7 +253,7 @@ def retry_delay_from_headers(headers, attempt: int) -> float:
     and does not send Retry-After; Retry-After is still read in case that
     changes. Falls back to an exponential ladder when neither is present.
     """
-    reset = _reset_seconds(headers)
+    reset = quota_reset_seconds(headers)
     if reset is not None:
         return max(min(reset, MAX_WAIT_SECONDS), 0.05)
 

--- a/broker/deltaexchange/database/master_contract_db.py
+++ b/broker/deltaexchange/database/master_contract_db.py
@@ -381,7 +381,7 @@ def process_delta_products(products):
         token          ← id                    (int → str)
         brsymbol       ← symbol                (Delta-native, e.g. "C-BTC-80000-280225")
         symbol         ← canonical             (OpenAlgo format, e.g. "BTC28FEB2580000CE")
-        name           ← description
+        name           ← underlying_asset.symbol  (underlying root, e.g. "BTC")
         exchange       ← "CRYPTO"              (OpenAlgo exchange abstraction)
         brexchange     ← "DELTAIN"             (broker identifier — Delta Exchange India)
         expiry         ← settlement_time       (None → "" for perpetuals;
@@ -466,12 +466,22 @@ def process_delta_products(products):
         # Build OpenAlgo canonical symbol (exchange = CRYPTO, broker-agnostic format)
         canonical_symbol = _to_canonical_symbol(symbol_str, instrument_type, expiry)
 
+        # `name` must be the underlying root (BTC, ETH, SOL) — not a human
+        # description. database/symbol.py resolves option-chain expiries with
+        # `SymToken.name.ilike(underlying)`, an exact match, so storing
+        # "BTC call option expiring on 12-8-2026" here leaves the expiry
+        # dropdown empty with no error anywhere. Delta returns the root in
+        # underlying_asset.symbol for every contract type.
+        underlying_name = (p.get("underlying_asset") or {}).get("symbol") or ""
+        if not underlying_name:
+            underlying_name = p.get("description", symbol_str)
+
         rows.append(
             {
                 "token": str(p["id"]),
                 "symbol": canonical_symbol,   # OpenAlgo canonical (e.g. BTC28FEB2580000CE)
                 "brsymbol": symbol_str,        # Delta-native (e.g. C-BTC-80000-280225)
-                "name": p.get("description", symbol_str),
+                "name": underlying_name,       # Underlying root (e.g. BTC)
                 "exchange": "CRYPTO",          # OpenAlgo exchange abstraction
                 "brexchange": "DELTAIN",       # Broker identifier (Delta Exchange India)
                 "expiry": expiry,

--- a/broker/deltaexchange/database/master_contract_db.py
+++ b/broker/deltaexchange/database/master_contract_db.py
@@ -8,6 +8,7 @@ from sqlalchemy import Column, Float, Index, Integer, Sequence, String, text
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
 
+from broker.deltaexchange.api.rate_limiter import PUBLIC, consume
 from database.engine_factory import create_db_engine
 from extensions import socketio  # Import SocketIO
 from utils.httpx_client import get_httpx_client
@@ -318,6 +319,9 @@ def fetch_delta_products():
             params["after"] = after_cursor
 
         try:
+            # Weight 3 per page against the public (IP) quota; a full master
+            # contract download is several pages.
+            consume("/v2/products", method="GET", bucket=PUBLIC)
             response = get_httpx_client().get(
                 url,
                 params=params,

--- a/broker/deltaexchange/streaming/delta_adapter.py
+++ b/broker/deltaexchange/streaming/delta_adapter.py
@@ -157,7 +157,7 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.running = False
 
         # Cancel the batch timer and drop queued work — the socket is going
-        # away, and DeltaWebSocket replays its own registry on reconnect.
+        # away, so nothing queued can still reach the wire.
         with self._lock:
             if self.batch_timer:
                 self.batch_timer.cancel()
@@ -167,6 +167,12 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
         for client in (self.public_ws, self.ws_client):
             if client:
+                # Drop the replay registry too. It exists to restore streams
+                # after a dropped connection, but this is an explicit teardown:
+                # a queued unsubscribe was just discarded above, so replaying
+                # the registry on a later connect() would resubscribe symbols
+                # that no longer have a subscriber.
+                client.forget_subscriptions()
                 client.close_connection()
         self.cleanup_zmq()
 
@@ -535,40 +541,62 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
         The channel publishes no traded volume — REST /v2/tickers still does,
         so anything polling quotes keeps showing it.
+
+        A field Delta omits is left out of the update entirely rather than sent
+        as 0.  The two are not the same thing: a genuine zero bid size has to
+        reach subscribers (the book really is empty), while a missing mark
+        price must not overwrite the last good LTP with 0.
         """
         entries = msg.get("d")
         if not isinstance(entries, list):
             entries = []
         # Spot price is per-frame, not per-contract; it is the LTP fallback for
         # instruments that publish no mark price.
-        spot = _f(msg.get("sp"))
+        spot = msg.get("sp")
+
+        def _at(seq, idx):
+            return seq[idx] if isinstance(seq, (list, tuple)) and len(seq) > idx else None
+
+        def _put(fields, key, raw, cast=_f):
+            """Record a scalar field only when Delta actually sent a value."""
+            if raw is not None:
+                fields[key] = cast(raw)
+
+        def _put_from(fields, container, key, raw, cast=_f):
+            """Record a field carried inside an array.
+
+            A present array is authoritative: a null element inside it means
+            "no value right now" (an emptied side of the book quotes null for
+            best_ask), so it publishes as 0 instead of leaving the last traded
+            size on screen forever.  A missing array says nothing at all, so
+            its fields are omitted and the previous values stand.
+            """
+            if container is not None:
+                fields[key] = cast(raw)
 
         updates: list[tuple[str, dict]] = []
         for entry in entries:
             if not isinstance(entry, dict):
                 continue
             br_symbol = entry.get("s") or msg.get("sy") or ""
-            ohlc      = entry.get("ohlc") or []
-            oi        = entry.get("oi") or []
-            quotes    = entry.get("q") or []
+            ohlc      = entry.get("ohlc")
+            oi        = entry.get("oi")
+            quotes    = entry.get("q")
 
-            def _at(seq, idx):
-                return seq[idx] if len(seq) > idx else None
+            fields: dict = {"average_price": 0, "oi_change": 0}
 
-            updates.append((br_symbol, {
-                "ltp":           _f(entry.get("m")) or spot,
-                "open":          _f(_at(ohlc, 0)),
-                "high":          _f(_at(ohlc, 1)),
-                "low":           _f(_at(ohlc, 2)),
-                "close":         _f(_at(ohlc, 3)),
-                "oi":            _f(_at(oi, 0)),
-                "bid_price":     _f(_at(quotes, 2)),
-                "bid_qty":       _i(_at(quotes, 3)),
-                "ask_price":     _f(_at(quotes, 0)),
-                "ask_qty":       _i(_at(quotes, 1)),
-                "average_price": 0,
-                "oi_change":     0,
-            }))
+            _put(fields, "ltp", entry.get("m") if entry.get("m") is not None else spot)
+            _put_from(fields, ohlc, "open",  _at(ohlc, 0))
+            _put_from(fields, ohlc, "high",  _at(ohlc, 1))
+            _put_from(fields, ohlc, "low",   _at(ohlc, 2))
+            _put_from(fields, ohlc, "close", _at(ohlc, 3))
+            _put_from(fields, oi, "oi",      _at(oi, 0))
+            _put_from(fields, quotes, "bid_price", _at(quotes, 2))
+            _put_from(fields, quotes, "bid_qty",   _at(quotes, 3), _i)
+            _put_from(fields, quotes, "ask_price", _at(quotes, 0))
+            _put_from(fields, quotes, "ask_qty",   _at(quotes, 1), _i)
+
+            updates.append((br_symbol, fields))
 
         return updates
 
@@ -603,16 +631,16 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
     def _merge_into_cache(self, cache_key: str, fields: dict) -> dict:
         """Fold a normalised update into the symbol's cache and return the whole.
 
-        Zero-valued scalars are dropped rather than written, so a ticker frame
-        that omits a field cannot blank out a value another frame supplied.
-        Depth is written whole, including empty sides — a book that has emptied
-        must be published as empty, not left stale.
+        Every field present in the update is written, zeros included — an empty
+        book or a zero bid size is real information and must reach subscribers.
+        Absent fields are what the normalisers omit, so a ticker frame that
+        carries no mark price cannot blank the last good LTP.  The two channels
+        write disjoint key sets (ticker: price/OI/quotes, ob_l2: depth), so
+        neither can overwrite the other's values.
         """
         with self._lock:
             cached = self.last_values.setdefault(cache_key, {})
-            for key, value in fields.items():
-                if key in ("depth", "totalbuyqty", "totalsellqty") or value:
-                    cached[key] = value
+            cached.update(fields)
             return dict(cached)
 
     # ── helpers ───────────────────────────────────────────────────────────────

--- a/broker/deltaexchange/streaming/delta_adapter.py
+++ b/broker/deltaexchange/streaming/delta_adapter.py
@@ -2,13 +2,19 @@
 delta_adapter.py
 OpenAlgo WebSocket adapter for Delta Exchange.
 
-Channels used:
-  v2/ticker    — real-time OHLCV + mark_price + OI + best bid/ask
-  l2_orderbook — 5-level order book (depth mode)
+Two upstream connections, because Delta splits its feed across two endpoints:
 
-Authentication:
-  HMAC-SHA256 auth message sent on every (re)connect.
-  Signature = HMAC-SHA256(api_secret, "GET" + timestamp + "/live")
+  public  (wss://public-socket.india.delta.exchange, no auth)
+      ticker — mark price + 24h OHLC + OI + best bid/ask with sizes
+      ob_l2  — top-15 order book (depth mode)
+
+  private (wss://socket.india.delta.exchange, HMAC-SHA256 auth on every
+           (re)connect, signature = HMAC-SHA256(api_secret, "GET" + ts + "/live"))
+      orders / positions / margins — account-level events
+
+Every symbol subscription carries a ticker subscription, including depth mode:
+ob_l2 has prices and sizes but no traded price, OI or OHLC, so a depth-only
+subscriber would publish those as zero.
 """
 
 import json
@@ -34,18 +40,45 @@ from websocket_proxy.base_adapter import BaseBrokerWebSocketAdapter
 from websocket_proxy.mapping import SymbolMapper
 
 
+def _f(value, default: float = 0.0) -> float:
+    """Parse a Delta numeric field, which may arrive as a string or null."""
+    try:
+        return float(value) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
+def _i(value, default: int = 0) -> int:
+    """Parse a Delta size/quantity field, which may arrive as a string or null."""
+    try:
+        return int(float(value)) if value is not None else default
+    except (TypeError, ValueError):
+        return default
+
+
 class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """Delta Exchange–specific implementation of the BaseBrokerWebSocketAdapter."""
 
     def __init__(self):
         super().__init__()
         self.logger       = logging.getLogger("delta_websocket_adapter")
-        self.ws_client    = None
+        self.ws_client    = None   # private endpoint: orders / positions / margins
+        self.public_ws    = None   # public endpoint: ticker / ob_l2
         self.user_id      = None
         self.broker_name  = "deltaexchange"
         self.running      = False
         self._lock        = threading.Lock()
         self.last_values: dict[str, dict] = {}
+
+        # Batch subscription management — coalesce the burst of per-symbol
+        # subscribe calls the proxy makes (one per symbol) into a single flush,
+        # so an option chain costs one ticker frame instead of one per strike
+        # (zerodha pattern).  ob_l2 still costs a frame per symbol: Delta
+        # rejects any order-book frame carrying more than one.
+        self.subscription_queue: list[tuple[str, str]] = []    # (channel, br_symbol)
+        self.unsubscription_queue: list[tuple[str, str]] = []
+        self.batch_timer: threading.Timer | None = None
+        self.batch_delay  = 0.5   # seconds to collect subscriptions before flushing
 
     # ── BaseBrokerWebSocketAdapter interface ──────────────────────────────────
 
@@ -79,7 +112,27 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.ws_client = DeltaWebSocket(
             api_key    = api_key,
             api_secret = api_secret,
-            on_open    = self._on_open,
+            url        = DeltaWebSocket.PRIVATE_WS_URL,
+            authenticate = True,
+            name       = "private",
+            on_open    = self._on_private_open,
+            on_message = self._on_data,
+            on_error   = self._on_error,
+            on_close   = self._on_close,
+            max_retry_attempt = 5,
+            retry_delay       = 5,
+            retry_multiplier  = 2,
+        )
+
+        # Market data moved to Delta's public endpoint, which takes no auth
+        # frame — sending one there is rejected, so it gets its own client.
+        self.public_ws = DeltaWebSocket(
+            api_key    = api_key,
+            api_secret = api_secret,
+            url        = DeltaWebSocket.PUBLIC_WS_URL,
+            authenticate = False,
+            name       = "public",
+            on_open    = self._on_public_open,
             on_message = self._on_data,
             on_error   = self._on_error,
             on_close   = self._on_close,
@@ -92,17 +145,29 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info("DeltaWebSocketAdapter initialised for user %s", user_id)
 
     def connect(self) -> None:
-        """Spin up the WebSocket connection in a daemon thread."""
-        if not self.ws_client:
+        """Spin up both WebSocket connections in daemon threads."""
+        if not self.ws_client or not self.public_ws:
             self.logger.error("Call initialize() before connect()")
             return
+        threading.Thread(target=self.public_ws.connect, daemon=True).start()
         threading.Thread(target=self.ws_client.connect, daemon=True).start()
 
     def disconnect(self) -> None:
-        """Close connection and clean up ZeroMQ resources."""
+        """Close both connections and clean up ZeroMQ resources."""
         self.running = False
-        if self.ws_client:
-            self.ws_client.close_connection()
+
+        # Cancel the batch timer and drop queued work — the socket is going
+        # away, and DeltaWebSocket replays its own registry on reconnect.
+        with self._lock:
+            if self.batch_timer:
+                self.batch_timer.cancel()
+                self.batch_timer = None
+            self.subscription_queue.clear()
+            self.unsubscription_queue.clear()
+
+        for client in (self.public_ws, self.ws_client):
+            if client:
+                client.close_connection()
         self.cleanup_zmq()
 
     def subscribe(
@@ -116,9 +181,9 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         Subscribe to market data for a single symbol.
 
         Modes:
-          1 — LTP         → v2/ticker
-          2 — Quote       → v2/ticker  (includes bid/ask/OI)
-          3 — Depth       → l2_orderbook
+          1 — LTP         → ticker
+          2 — Quote       → ticker  (includes bid/ask with sizes and OI)
+          3 — Depth       → ob_l2 + ticker
         """
         if not DeltaCapabilityRegistry.supports_mode(mode):
             return self._create_error_response(
@@ -133,7 +198,7 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             )
 
         br_symbol = get_br_symbol(symbol, exchange) or symbol
-        channel   = DeltaModeMapper.get_channel(mode)
+        channels  = DeltaModeMapper.get_channels(mode)
         corr_id   = f"{symbol}_{exchange}_{mode}"
 
         with self._lock:
@@ -142,36 +207,39 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 "exchange":  exchange,
                 "br_symbol": br_symbol,
                 "mode":      mode,
-                "channel":   channel,
+                "channels":  channels,
                 "depth_level": depth_level,
             }
 
-        # Always forward to DeltaWebSocket — its _queue_or_send() handles
-        # both the pre-connect case (buffers in _active_sub_msgs and replays
-        # on connect) and the already-connected case (sends immediately).
-        if self.ws_client:
+        # Queued, not sent: the proxy subscribes one symbol at a time, so a
+        # 41-strike option chain would otherwise be 41 ticker frames.  The flush
+        # coalesces them.  DeltaWebSocket keeps its own symbol registry, so a
+        # subscription queued before the socket is up is still replayed on
+        # connect.
+        if self.public_ws:
             try:
-                if channel == DeltaWebSocket.CHANNEL_TICKER:
-                    self.ws_client.subscribe_ticker([br_symbol])
-                else:
-                    self.ws_client.subscribe_l2_orderbook([br_symbol])
-                self.logger.info("Subscribed: %s.%s mode=%s channel=%s", symbol, exchange, mode, channel)
+                with self._lock:
+                    for channel in channels:
+                        self._queue_op(self.subscription_queue,
+                                       self.unsubscription_queue, channel, br_symbol)
+                self.logger.info("Subscribed: %s.%s mode=%s channels=%s",
+                                 symbol, exchange, mode, ",".join(channels))
             except Exception as exc:
                 self.logger.error("subscribe error %s.%s: %s", symbol, exchange, exc)
                 return self._create_error_response("SUBSCRIPTION_ERROR", str(exc))
 
         return self._create_success_response(
             f"Subscription requested for {symbol}.{exchange}",
-            symbol=symbol, exchange=exchange, mode=mode, channel=channel,
+            symbol=symbol, exchange=exchange, mode=mode, channel=channels[0],
         )
 
     def unsubscribe(self, symbol: str, exchange: str, mode: int = 2) -> dict[str, Any]:
         """Unsubscribe from market data for a symbol."""
-        channel = DeltaModeMapper.get_channel(mode)
-        corr_id = f"{symbol}_{exchange}_{mode}"
+        channels = DeltaModeMapper.get_channels(mode)
+        corr_id  = f"{symbol}_{exchange}_{mode}"
 
-        should_disconnect      = False
-        should_upstream_unsub  = False
+        should_disconnect = False
+        stale_channels: list[str] = []
         with self._lock:
             # Read the stored br_symbol that was resolved at subscribe() time
             # before removing the entry.  This guarantees the upstream unsubscribe
@@ -184,13 +252,16 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
             remaining = list(self.subscriptions.values())
 
-            # Only send the upstream unsubscribe when no remaining subscription
-            # still needs this br_symbol + channel (e.g. mode 1 and mode 2 both
-            # map to v2/ticker — removing one must not kill the shared stream).
-            should_upstream_unsub = not any(
-                s.get("br_symbol") == br_symbol and s.get("channel") == channel
-                for s in remaining
-            )
+            # Only send the upstream unsubscribe for channels no remaining
+            # subscription still needs (e.g. every mode subscribes to ticker,
+            # so dropping one must not kill the shared stream).
+            stale_channels = [
+                channel for channel in channels
+                if not any(
+                    s.get("br_symbol") == br_symbol and channel in s.get("channels", ())
+                    for s in remaining
+                )
+            ]
 
             # Only drop the LTP cache when no other mode for this symbol/exchange
             # remains (the cache is keyed on symbol_exchange, shared across modes).
@@ -204,12 +275,12 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             if not remaining:
                 should_disconnect = True
 
-        if self.ws_client and should_upstream_unsub:
+        if self.public_ws and stale_channels:
             try:
-                if channel == DeltaWebSocket.CHANNEL_TICKER:
-                    self.ws_client.unsubscribe_ticker([br_symbol])
-                else:
-                    self.ws_client.unsubscribe_l2_orderbook([br_symbol])
+                with self._lock:
+                    for channel in stale_channels:
+                        self._queue_op(self.unsubscription_queue,
+                                       self.subscription_queue, channel, br_symbol)
             except Exception as exc:
                 self.logger.error("unsubscribe error %s.%s: %s", symbol, exchange, exc)
                 return self._create_error_response("UNSUBSCRIPTION_ERROR", str(exc))
@@ -222,24 +293,88 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             f"Unsubscribed from {symbol}.{exchange}", symbol=symbol, exchange=exchange, mode=mode
         )
 
+    # ── subscription batching ─────────────────────────────────────────────────
+
+    def _queue_op(self, queue: list, opposite: list, channel: str, br_symbol: str) -> None:
+        """Queue one channel/symbol operation. Caller must hold self._lock.
+
+        An entry still sitting in the opposite queue has not reached the wire
+        yet, so the two cancel out: a subscribe followed by an unsubscribe
+        inside the same window sends nothing at all, rather than sending both
+        and relying on the order they land in.
+        """
+        entry = (channel, br_symbol)
+        if entry in opposite:
+            opposite.remove(entry)
+            return
+        if entry not in queue:
+            queue.append(entry)
+        if self.batch_timer is None:
+            # The window runs from the first queued item rather than sliding
+            # with each new one, so a steady stream still flushes on time.
+            self.batch_timer = threading.Timer(self.batch_delay, self._process_batch)
+            self.batch_timer.daemon = True
+            self.batch_timer.start()
+
+    def _process_batch(self) -> None:
+        """Flush queued work: one frame per channel where the channel allows it."""
+        with self._lock:
+            self.batch_timer = None
+            subs   = self._group_by_channel(self.subscription_queue)
+            unsubs = self._group_by_channel(self.unsubscription_queue)
+            self.subscription_queue.clear()
+            self.unsubscription_queue.clear()
+            client = self.public_ws
+
+        if not client:
+            return
+
+        for channel, symbols in unsubs.items():
+            self._send_batch(client, channel, symbols, subscribe=False)
+        for channel, symbols in subs.items():
+            self._send_batch(client, channel, symbols, subscribe=True)
+
+    @staticmethod
+    def _group_by_channel(queue: list) -> dict[str, list[str]]:
+        """Collapse a queue of (channel, symbol) pairs into channel → symbols."""
+        grouped: dict[str, list[str]] = {}
+        for channel, br_symbol in queue:
+            grouped.setdefault(channel, []).append(br_symbol)
+        return grouped
+
+    def _send_batch(self, client, channel: str, symbols: list[str], subscribe: bool) -> None:
+        verb = "subscribing" if subscribe else "unsubscribing"
+        try:
+            # %s only: SensitiveDataFilter stringifies every log arg, so a %d
+            # here would raise and the line would print unformatted.
+            self.logger.info("Batch %s %s %s symbols", verb, len(symbols), channel)
+            if channel == DeltaWebSocket.CHANNEL_TICKER:
+                (client.subscribe_ticker if subscribe else client.unsubscribe_ticker)(symbols)
+            else:
+                (client.subscribe_orderbook if subscribe else client.unsubscribe_orderbook)(symbols)
+        except Exception as exc:
+            self.logger.error("Batch %s failed for %s: %s", verb, channel, exc)
+
     # ── internal callbacks ────────────────────────────────────────────────────
 
-    def _on_open(self, wsapp) -> None:
-        """Called after (re)connection.
+    def _on_public_open(self, wsapp) -> None:
+        """Called after the market-data connection (re)connects.
 
-        Public channel replay is handled automatically by DeltaWebSocket._ws_on_open,
-        which replays every entry in _active_sub_msgs before invoking this callback.
-        Manually re-subscribing here would create duplicate subscribe messages and
-        accumulate extra aggregated keys in _active_sub_msgs on each reconnect.
-
-        Private feeds are bootstrapped here on first connect via _queue_or_send,
-        which registers them in _active_sub_msgs so subsequent reconnects replay
-        them automatically without needing another explicit call.
+        Channel replay is handled automatically by DeltaWebSocket._ws_on_open,
+        which re-subscribes its whole symbol registry before invoking this
+        callback.  Manually re-subscribing here would only duplicate frames.
         """
-        self.logger.info("DeltaWS connection opened")
+        self.logger.info("DeltaWS public connection opened")
         self.connected = True
 
-        # Subscribe to authenticated private feeds on every (re)connect
+    def _on_private_open(self, wsapp) -> None:
+        """Called after the authenticated connection (re)connects.
+
+        Private feeds are bootstrapped here on first connect; DeltaWebSocket
+        registers them so subsequent reconnects replay them automatically
+        without needing another explicit call.
+        """
+        self.logger.info("DeltaWS private connection opened")
         self._subscribe_private_feeds()
 
     def _on_error(self, wsapp, error) -> None:
@@ -247,7 +382,10 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     def _on_close(self, wsapp) -> None:
         self.logger.info("DeltaWS closed")
-        self.connected = False
+        # Market data is what `connected` reports on; the private connection
+        # closing does not stop ticks from reaching subscribers.
+        if not (self.public_ws and self.public_ws.is_connected):
+            self.connected = False
         # No manual reconnect here — DeltaWebSocket.connect() runs a blocking
         # retry loop that handles all reconnection with proper backoff and the
         # configured max_retry_attempt limit.  Spawning another connect() thread
@@ -259,16 +397,17 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """
         Route incoming messages to the appropriate normaliser.
 
-        Delta ticker shape:
-          { "type": "v2/ticker", "symbol": "BTCUSD",
-            "mark_price": "67000", "open": 66000, "high": 68000,
-            "low": 65000, "close": 66500, "volume": 1234,
-            "oi": "5000", "quotes": { "best_bid": "66990", "best_ask": "67010" } }
+        Delta ticker shape (one frame can carry several contracts in "d"):
+          { "type": "ticker", "sy": "BTCUSD", "sp": "63860.7",
+            "d": [{ "s": "BTCUSD", "m": "63838.06",
+                    "ohlc": [64025.0, 64475.5, 63217.5, 63839.0],
+                    "oi": ["1407713", "307138.71"],
+                    "q": ["63834", "718", "63833", "4388", null] }] }
 
-        Delta l2_orderbook shape:
-          { "type": "l2_orderbook", "symbol": "BTCUSD",
-            "buy":  [{"price": "66990", "size": 1000, "depth": 1}, ...],
-            "sell": [{"price": "67010", "size":  800, "depth": 1}, ...] }
+        Delta ob_l2 shape (asks and bids, price + size, best first):
+          { "type": "ob_l2", "sy": "BTCUSD",
+            "a": [["63834", "718"], ...],
+            "b": [["63833", "4388"], ...] }
 
         Private order event shape:
           { "type": "orders", "action": "fill",
@@ -282,52 +421,58 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             "unrealized_pnl": "400" }
         """
         try:
-            msg_type  = msg.get("type", "")
-            br_symbol = msg.get("symbol", "") or msg.get("product_symbol", "")
+            msg_type = msg.get("type", "")
 
             # ── Private / account-level events (no symbol-level subscription needed) ─────
             if msg_type in ("orders", "positions", "margins"):
                 self._handle_private_event(msg_type, msg)
                 return
 
-            if not br_symbol:
-                return
-
-            # Find ALL OpenAlgo subscriptions matching this broker symbol + channel.
-            # Multiple modes (e.g. 1=LTP and 2=Quote) can share the same v2/ticker
-            # channel, so we must fan out to every subscriber.
-            subscriptions = self._find_subscriptions_by_br_symbol(br_symbol, msg_type)
-            if not subscriptions:
-                self.logger.debug("No subscription for br_symbol=%s type=%s", br_symbol, msg_type)
-                return
-
-            # Normalise once — all subscriptions share the same br_symbol/exchange
-            cache_key = f"{subscriptions[0]['symbol']}_{subscriptions[0]['exchange']}"
-            if msg_type == "v2/ticker":
-                base_data = self._normalise_ticker(msg, cache_key)
-            elif msg_type == "l2_orderbook":
-                base_data = self._normalise_l2_orderbook(msg, cache_key)
+            if msg_type == DeltaWebSocket.CHANNEL_TICKER:
+                updates = self._normalise_ticker(msg)
+            elif msg_type == DeltaWebSocket.CHANNEL_OB_L2:
+                updates = self._normalise_orderbook(msg)
             else:
                 self.logger.debug("Unhandled message type: %s", msg_type)
                 return
 
             ts = int(time.time() * 1000)
-            for subscription in subscriptions:
-                oa_symbol   = subscription["symbol"]
-                oa_exchange = subscription["exchange"]
-                oa_mode     = subscription["mode"]
-                mode_str    = DeltaModeMapper.get_mode_str(oa_mode)
-                topic       = f"{oa_exchange}_{oa_symbol}_{mode_str}"
+            for br_symbol, fields in updates:
+                if not br_symbol:
+                    continue
 
-                market_data = dict(base_data)  # shallow copy per subscriber
-                market_data.update({
-                    "symbol":    oa_symbol,
-                    "exchange":  oa_exchange,
-                    "mode":      oa_mode,
-                    "timestamp": ts,
-                })
+                # Find ALL OpenAlgo subscriptions matching this broker symbol +
+                # channel.  Several modes can share one channel (every mode
+                # subscribes to ticker), so we fan out to every subscriber.
+                subscriptions = self._find_subscriptions_by_br_symbol(br_symbol, msg_type)
+                if not subscriptions:
+                    self.logger.debug("No subscription for br_symbol=%s type=%s", br_symbol, msg_type)
+                    continue
 
-                self.publish_market_data(topic, market_data)
+                # All subscriptions for a br_symbol share one cache entry, which
+                # accumulates the last known value of every field across both
+                # channels.  Publishing the merged entry is what lets a depth
+                # subscriber carry ltp/oi/ohlc (ob_l2 has none of them) and a
+                # quote subscriber carry depth.
+                cache_key   = f"{subscriptions[0]['symbol']}_{subscriptions[0]['exchange']}"
+                merged      = self._merge_into_cache(cache_key, fields)
+
+                for subscription in subscriptions:
+                    oa_symbol   = subscription["symbol"]
+                    oa_exchange = subscription["exchange"]
+                    oa_mode     = subscription["mode"]
+                    mode_str    = DeltaModeMapper.get_mode_str(oa_mode)
+                    topic       = f"{oa_exchange}_{oa_symbol}_{mode_str}"
+
+                    market_data = dict(merged)  # shallow copy per subscriber
+                    market_data.update({
+                        "symbol":    oa_symbol,
+                        "exchange":  oa_exchange,
+                        "mode":      oa_mode,
+                        "timestamp": ts,
+                    })
+
+                    self.publish_market_data(topic, market_data)
 
         except Exception as exc:
             self.logger.error("_on_data error: %s", exc, exc_info=True)
@@ -374,125 +519,116 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
 
     # ── normalisation ─────────────────────────────────────────────────────────
 
-    def _normalise_ticker(self, msg: dict, cache_key: str) -> dict:
+    def _normalise_ticker(self, msg: dict) -> list[tuple[str, dict]]:
         """
-        Map v2/ticker fields to OpenAlgo market data format.
+        Map a ticker frame to OpenAlgo market data, one entry per contract.
 
-        Field mapping:
-            ltp        ← mark_price  (string)
-            open       ← open
-            high       ← high
-            low        ← low
-            close      ← close       (previous session close)
-            volume     ← volume
-            oi         ← oi          (string)
-            bid_price  ← quotes.best_bid
-            ask_price  ← quotes.best_ask
+        Field mapping (compact keys, per the public-endpoint schema):
+            ltp        ← d[].m        mark price, matching the REST quote path
+            open/high/
+            low/close  ← d[].ohlc     rolling 24h window
+            oi         ← d[].oi[0]    open interest in contracts
+            bid_price  ← d[].q[2]     best bid
+            bid_qty    ← d[].q[3]     bid size
+            ask_price  ← d[].q[0]     best ask
+            ask_qty    ← d[].q[1]     ask size
+
+        The channel publishes no traded volume — REST /v2/tickers still does,
+        so anything polling quotes keeps showing it.
         """
-        def _f(v, d=0.0):
-            try: return float(v) if v is not None else d
-            except: return d
+        entries = msg.get("d")
+        if not isinstance(entries, list):
+            entries = []
+        # Spot price is per-frame, not per-contract; it is the LTP fallback for
+        # instruments that publish no mark price.
+        spot = _f(msg.get("sp"))
 
-        def _i(v, d=0):
-            try: return int(float(v)) if v is not None else d
-            except: return d
+        updates: list[tuple[str, dict]] = []
+        for entry in entries:
+            if not isinstance(entry, dict):
+                continue
+            br_symbol = entry.get("s") or msg.get("sy") or ""
+            ohlc      = entry.get("ohlc") or []
+            oi        = entry.get("oi") or []
+            quotes    = entry.get("q") or []
 
-        quotes = msg.get("quotes") or {}
+            def _at(seq, idx):
+                return seq[idx] if len(seq) > idx else None
 
-        with self._lock:
-            cached = self.last_values.get(cache_key, {}).copy()
+            updates.append((br_symbol, {
+                "ltp":           _f(entry.get("m")) or spot,
+                "open":          _f(_at(ohlc, 0)),
+                "high":          _f(_at(ohlc, 1)),
+                "low":           _f(_at(ohlc, 2)),
+                "close":         _f(_at(ohlc, 3)),
+                "oi":            _f(_at(oi, 0)),
+                "bid_price":     _f(_at(quotes, 2)),
+                "bid_qty":       _i(_at(quotes, 3)),
+                "ask_price":     _f(_at(quotes, 0)),
+                "ask_qty":       _i(_at(quotes, 1)),
+                "average_price": 0,
+                "oi_change":     0,
+            }))
 
-        def _cv(key, raw_val, cast=_f, default=0):
-            val = cast(raw_val)
-            if val != 0:
-                return val
-            return cast(cached.get(key, default))
+        return updates
 
-        # LTP: prefer mark_price, fall back to close (last traded price) or spot_price.
-        # Spot instruments may not have mark_price in early ticker messages.
-        raw_ltp = msg.get("mark_price") or msg.get("spot_price")
-
-        result = {
-            "ltp":           _cv("ltp",        raw_ltp,                _f),
-            "open":          _cv("open",        msg.get("open"),        _f),
-            "high":          _cv("high",        msg.get("high"),        _f),
-            "low":           _cv("low",         msg.get("low"),         _f),
-            "close":         _cv("close",       msg.get("close"),       _f),
-            "volume":        _cv("volume",      msg.get("volume"),      _i),
-            "oi":            _cv("oi",          msg.get("oi"),          _f),
-            "bid_price":     _cv("bid_price",   quotes.get("best_bid"), _f),
-            "ask_price":     _cv("ask_price",   quotes.get("best_ask"), _f),
-            "bid_qty":       0,
-            "ask_qty":       0,
-            "average_price": 0,
-            "oi_change":     0,
-        }
-
-        with self._lock:
-            if cache_key not in self.last_values:
-                self.last_values[cache_key] = {}
-            for k, v in result.items():
-                if v != 0:
-                    self.last_values[cache_key][k] = v
-
-        return result
-
-    def _normalise_l2_orderbook(self, msg: dict, cache_key: str) -> dict:
+    def _normalise_orderbook(self, msg: dict) -> list[tuple[str, dict]]:
         """
-        Map l2_orderbook message to OpenAlgo depth format.
+        Map an ob_l2 frame to OpenAlgo depth format.
 
-        Delta l2_orderbook levels:
-          buy/sell: [{"limit_price": str, "size": int, "depth": str}, ...]
+        Delta publishes the top 15 levels per side as ["price", "size"] pairs,
+        best first; OpenAlgo consumes the top 5.
         """
-        def _f(v, d=0.0):
-            try: return float(v) if v is not None else d
-            except: return d
-
         def _parse_levels(side_list, n=5):
             levels = []
             for lvl in (side_list or [])[:n]:
-                levels.append({"price": _f(lvl.get("limit_price")), "quantity": int(lvl.get("size", 0))})
+                if isinstance(lvl, (list, tuple)) and len(lvl) >= 2:
+                    levels.append({"price": _f(lvl[0]), "quantity": _i(lvl[1])})
             while len(levels) < n:
                 levels.append({"price": 0.0, "quantity": 0})
             return levels
 
-        bids = _parse_levels(msg.get("buy",  []))
-        asks = _parse_levels(msg.get("sell", []))
+        bids = _parse_levels(msg.get("b"))
+        asks = _parse_levels(msg.get("a"))
 
-        result = {
+        return [(msg.get("sy") or "", {
             "depth": {
                 "buy":  bids,
                 "sell": asks,
             },
             "totalbuyqty":  sum(lvl["quantity"] for lvl in bids),
             "totalsellqty": sum(lvl["quantity"] for lvl in asks),
-            "ltp": 0,
-        }
+        })]
 
-        # Merge with cached ticker ltp if available
+    def _merge_into_cache(self, cache_key: str, fields: dict) -> dict:
+        """Fold a normalised update into the symbol's cache and return the whole.
+
+        Zero-valued scalars are dropped rather than written, so a ticker frame
+        that omits a field cannot blank out a value another frame supplied.
+        Depth is written whole, including empty sides — a book that has emptied
+        must be published as empty, not left stale.
+        """
         with self._lock:
-            cached = self.last_values.get(cache_key, {})
-        result["ltp"] = _f(cached.get("ltp", 0))
-
-        return result
+            cached = self.last_values.setdefault(cache_key, {})
+            for key, value in fields.items():
+                if key in ("depth", "totalbuyqty", "totalsellqty") or value:
+                    cached[key] = value
+            return dict(cached)
 
     # ── helpers ───────────────────────────────────────────────────────────────
 
     def _find_subscriptions_by_br_symbol(self, br_symbol: str, msg_type: str) -> list[dict]:
         """Return ALL subscriptions whose br_symbol and channel match the incoming message.
 
-        Multiple subscription modes (e.g. mode 1=LTP and mode 2=Quote) can map
-        to the same underlying WebSocket channel (v2/ticker).  Returning every
-        match ensures each subscriber receives its own publish call.
+        Multiple subscription modes map to the same channel — every mode
+        subscribes to ticker, and depth mode additionally subscribes to ob_l2.
+        Returning every match ensures each subscriber receives its own publish
+        call.
         """
-        expected_channel = (
-            DeltaWebSocket.CHANNEL_TICKER if msg_type == "v2/ticker"
-            else DeltaWebSocket.CHANNEL_L2_BOOK
-        )
         with self._lock:
             matched = [
                 sub for sub in self.subscriptions.values()
-                if sub.get("br_symbol") == br_symbol and sub.get("channel") == expected_channel
+                if sub.get("br_symbol") == br_symbol and msg_type in sub.get("channels", ())
             ]
             if not matched:
                 # Fallback: any sub with matching br_symbol regardless of channel

--- a/broker/deltaexchange/streaming/delta_mapping.py
+++ b/broker/deltaexchange/streaming/delta_mapping.py
@@ -34,16 +34,23 @@ class DeltaExchangeMapper:
 class DeltaModeMapper:
     """Maps OpenAlgo subscription mode integers to Delta Exchange channel names."""
 
-    # OpenAlgo mode → Delta WS channel name
+    # OpenAlgo mode → Delta WS channels.
+    #
+    # Depth mode subscribes to ob_l2 *and* ticker: ob_l2 carries price/size
+    # levels only, so without the ticker a depth subscriber would publish
+    # ltp/oi/ohlc as zero and blank out those columns wherever a depth
+    # subscription is the only one for the symbol (the option chain does
+    # exactly this).
     MODE_CHANNELS = {
-        1: "v2/ticker",    # LTP mode
-        2: "v2/ticker",    # Quote mode (also uses ticker; provides bid/ask/OI)
-        3: "l2_orderbook", # Depth mode
+        1: ("ticker",),            # LTP mode
+        2: ("ticker",),            # Quote mode (ticker carries bid/ask + sizes + OI)
+        3: ("ob_l2", "ticker"),    # Depth mode
     }
 
     @staticmethod
-    def get_channel(mode: int) -> str:
-        return DeltaModeMapper.MODE_CHANNELS.get(mode, "v2/ticker")
+    def get_channels(mode: int) -> tuple[str, ...]:
+        """Return every Delta channel a subscription mode needs."""
+        return DeltaModeMapper.MODE_CHANNELS.get(mode, ("ticker",))
 
     @staticmethod
     def get_mode_str(mode: int) -> str:
@@ -62,7 +69,7 @@ class DeltaCapabilityRegistry:
     subscription_modes = [1, 2, 3]
 
     depth_support = {
-        "CRYPTO": [1, 5],  # up to 5-level depth via l2_orderbook channel
+        "CRYPTO": [1, 5],  # ob_l2 publishes 15 levels; OpenAlgo consumes the top 5
     }
 
     @classmethod

--- a/broker/deltaexchange/streaming/delta_websocket.py
+++ b/broker/deltaexchange/streaming/delta_websocket.py
@@ -2,32 +2,45 @@
 delta_websocket.py
 Low-level WebSocket client for Delta Exchange real-time feed.
 
-Endpoint : wss://socket.india.delta.exchange
+Delta runs two endpoints and this client is instantiated once per endpoint:
+
+  wss://public-socket.india.delta.exchange   market data, no auth
+  wss://socket.india.delta.exchange          account channels, auth required
+
+Public market-data channels used to live on the private endpoint under the
+names v2/ticker / l1_orderbook / l2_orderbook.  Delta migrated them to the
+public endpoint (ticker / ob_l1 / ob_l2) and scheduled the old names for
+removal on 31 July 2026; the legacy l2_orderbook also silently caps a
+connection at 20 symbols, which is fewer than one option chain needs.  Both
+reasons make the public endpoint the only viable target.
+
 Protocol : JSON over secure WebSocket
-Auth msg : { "type": "auth", "payload": { "api-key": "...", "signature": "...", "timestamp": "..." } }
+Auth msg : { "type": "key-auth", "payload": { "api-key": "...", "signature": "...", "timestamp": "..." } }
 Signature: HMAC-SHA256(api_secret, "GET" + timestamp + "/live")
 
-Public channels  (no auth needed):
-  subscribe:  { "type": "subscribe", "payload": { "channels": [{ "name": "v2/ticker", "symbols": ["BTCUSD"] }] } }
-  unsubscribe: { "type": "unsubscribe", ... }
-
 Channel names:
-  v2/ticker          -> ticker updates (mark_price, open, high, low, volume, oi, best_bid, best_ask)
-  l2_orderbook       -> level-2 order book (buy/sell lists with price+size)
-  orders             -> order updates (requires auth)
-  positions          -> position updates (requires auth)
+  ticker      -> price/OI/quote snapshot, published every 5s (public endpoint)
+  ob_l2       -> top-15 order book, published every 500ms (public endpoint)
+  orders      -> order updates (private endpoint, requires auth)
+  positions   -> position updates (private endpoint, requires auth)
+  margins     -> wallet / margin updates (private endpoint, requires auth)
+
+Subscribe / unsubscribe frame (same shape on both endpoints):
+  { "type": "subscribe", "payload": { "channels": [{ "name": "ticker", "symbols": ["BTCUSD"] }] } }
 
 Incoming message examples:
-  Ticker:  { "type": "v2/ticker", "symbol": "BTCUSD",
-             "mark_price": "67000", "open": 66000, "high": 68000,
-             "low": 65000, "close": 66500, "volume": 1234,
-             "oi": "5000", "quotes": { "best_bid": "66990", "best_ask": "67010" } }
+  Ticker:  { "type": "ticker", "sy": "BTCUSD", "sp": "63860.7", "ts": 1786521801671015,
+             "d": [{ "s": "BTCUSD", "m": "63838.06", "ohlc": [open, high, low, close],
+                     "oi": [oi_contracts, oi_change_usd_6h],
+                     "q": [best_ask, ask_size, best_bid, bid_size, impact_mid],
+                     "g": [delta, gamma, rho, theta, vega],
+                     "qiv": [ask_iv, bid_iv, mark_iv] }] }
 
-  L2 book: { "type": "l2_orderbook", "symbol": "BTCUSD",
-             "buy":  [{"price": "66990", "size": 1000, "depth": 1}, ...],
-             "sell": [{"price": "67010", "size":  800, "depth": 1}, ...] }
+  Order book: { "type": "ob_l2", "sy": "BTCUSD", "ts": 1786521801671015,
+                "a": [["63834", "718"], ...],    // asks, price + size, best first
+                "b": [["63833", "4388"], ...] }  // bids
 
-References: https://docs.delta.exchange/#websocket-channels
+References: https://docs.delta.exchange/#public-channels
 """
 
 import hashlib
@@ -50,22 +63,31 @@ class DeltaWebSocket:
 
     Usage
     -----
-    ws = DeltaWebSocket(api_key="...", api_secret="...", on_message=cb)
-    ws.connect()
-    ws.subscribe_ticker(["BTCUSD", "ETHUSD"])
-    ws.subscribe_l2_orderbook(["BTCUSD"])
+    md = DeltaWebSocket(url=DeltaWebSocket.PUBLIC_WS_URL, authenticate=False, on_message=cb)
+    md.connect()
+    md.subscribe_ticker(["BTCUSD", "ETHUSD"])
+    md.subscribe_orderbook(["BTCUSD"])
     ...
-    ws.close()
+    md.close_connection()
     """
 
     # ── constants ─────────────────────────────────────────────────────────────
-    WS_URL            = "wss://socket.india.delta.exchange"
+    PUBLIC_WS_URL      = "wss://public-socket.india.delta.exchange"
+    PRIVATE_WS_URL     = "wss://socket.india.delta.exchange"
     HEARTBEAT_INTERVAL = 30      # seconds between pings
     MSG_TYPE_AUTH      = "key-auth"
     MSG_TYPE_SUB       = "subscribe"
     MSG_TYPE_UNSUB     = "unsubscribe"
-    CHANNEL_TICKER     = "v2/ticker"
-    CHANNEL_L2_BOOK    = "l2_orderbook"
+    # Public channels — new public endpoint only
+    CHANNEL_TICKER     = "ticker"
+    CHANNEL_OB_L2      = "ob_l2"
+    # Symbols Delta accepts in a single subscribe frame, per channel.
+    # None = no limit found (ticker took 150 in one frame, verified live
+    # 2026-08-12); ob_l2 rejects anything above one symbol outright.
+    MAX_SYMBOLS_PER_FRAME = {
+        CHANNEL_TICKER: None,
+        CHANNEL_OB_L2:  1,
+    }
     # Private authenticated channels (require auth message to be sent first)
     CHANNEL_ORDERS    = "orders"      # real-time order fill / cancel / modify events
     CHANNEL_POSITIONS = "positions"   # real-time position updates
@@ -82,9 +104,17 @@ class DeltaWebSocket:
         max_retry_attempt: int = 5,
         retry_delay: int = 5,
         retry_multiplier: int = 2,
+        url: str | None = None,
+        authenticate: bool = True,
+        name: str = "private",
     ):
         self.api_key    = api_key
         self.api_secret = api_secret
+        # One client per endpoint; `name` only tags log lines so the two are
+        # distinguishable in the log stream.
+        self.url          = url or self.PRIVATE_WS_URL
+        self.authenticate = authenticate
+        self.name         = name
 
         # User-supplied callbacks
         self.on_message = on_message  or (lambda ws, msg: None)
@@ -100,15 +130,22 @@ class DeltaWebSocket:
         self._lock   = threading.Lock()
         self._connected = False
         self._stop_flag = False
-        # Persistent subscription registry: deterministic_key → raw JSON message.
-        # Serves two purposes:
-        #   1. Pre-connect buffer: messages accumulate here and are sent in
+        # Persistent subscription registry, tracked per symbol rather than per
+        # sent frame.  Serves two purposes:
+        #   1. Pre-connect buffer: symbols accumulate here and are subscribed in
         #      _ws_on_open when the socket first connects.
-        #   2. Reconnect replay: the dict is NEVER cleared, so every reconnect
-        #      (after a disconnect) re-sends all active subscriptions, restoring
-        #      all streams automatically without the caller needing to re-subscribe.
-        # Unsubscribe removes the entry so the channel is not replayed.
-        self._active_sub_msgs: dict[str, str] = {}
+        #   2. Reconnect replay: the registry is NEVER cleared, so every reconnect
+        #      re-subscribes everything still active, restoring all streams
+        #      without the caller needing to re-subscribe.
+        # Tracking symbols (not frames) is what lets one symbol be dropped out of
+        # a batch: a frame-keyed registry would keep replaying the whole batch.
+        self._active_symbols: dict[str, set[str]] = {}   # channel → symbols
+        self._active_private: dict[str, str] = {}        # channel → raw message
+
+    @property
+    def is_connected(self) -> bool:
+        """True while this endpoint's socket is up and able to carry frames."""
+        return self._connected
 
     # ── auth helper ───────────────────────────────────────────────────────────
 
@@ -142,74 +179,71 @@ class DeltaWebSocket:
         }
         return json.dumps(msg)
 
-    def _send(self, text: str) -> None:
-        if self.wsapp and self._connected:
-            try:
-                self.wsapp.send(text)
-            except Exception as exc:
-                logger.error("DeltaWS _send error: %s", exc)
+    def _frames(self, channel: str, symbols: list[str], unsub: bool = False) -> list[str]:
+        """Split a symbol list into as few frames as the channel allows.
 
-    def _queue_or_send(self, key: str, msg: str) -> None:
+        `ticker` takes the whole list in one frame — 150 symbols verified live.
+        `ob_l2` rejects any frame carrying more than one symbol
+        ("subscription forbidden on this channel with more than 1 symbol"), so
+        it always costs one frame per symbol.
         """
-        Register and immediately send (or buffer) a subscription message.
+        size = self.MAX_SYMBOLS_PER_FRAME.get(channel)
+        if not size or size >= len(symbols):
+            return [self._build_sub_msg(channel, symbols, unsub=unsub)] if symbols else []
+        return [
+            self._build_sub_msg(channel, symbols[i:i + size], unsub=unsub)
+            for i in range(0, len(symbols), size)
+        ]
 
-        The key is a deterministic string identifying the subscription
-        (e.g. "ticker:BTCUSD,ETHUSD") so duplicates overwrite rather than
-        stack, and unsubscribes can remove the exact entry.
+    def _send_all(self, msgs: list[str]) -> None:
+        """Send frames, or buffer them for replay when the socket is down.
 
-        Why the lock spans both the registry write AND the send:
-          Holding the lock across the send prevents the TOCTOU race where
+        Why the lock spans both the registry read AND the sends:
+          Holding it across the sends prevents the TOCTOU race where
           _ws_on_close flips _connected=False between our check and the send,
-          causing the message to be dropped from both the wire and the registry.
-
-        On reconnect, _ws_on_open replays the entire _active_sub_msgs dict,
-        so no explicit re-subscribe call from the caller is ever needed.
+          causing frames to be dropped from the wire while the registry still
+          claims they are active.
         """
         with self._lock:
-            self._active_sub_msgs[key] = msg   # persist for reconnect replay
-            if self._connected:
+            if not self._connected or not self.wsapp:
+                logger.debug("DeltaWS[%s] buffered %s frame(s) (not connected)",
+                             self.name, len(msgs))
+                return
+            for msg in msgs:
                 try:
-                    if self.wsapp:
-                        self.wsapp.send(msg)
+                    self.wsapp.send(msg)
                 except Exception as exc:
-                    logger.error("DeltaWS _send error: %s", exc)
-                    # Send failed mid-flight; message already stored in
-                    # _active_sub_msgs and will be replayed on reconnect.
-            else:
-                logger.debug("DeltaWS buffered subscription (not connected): %s", key)
+                    logger.error("DeltaWS[%s] _send error: %s", self.name, exc)
+                    # Send failed mid-flight; the symbol is already in
+                    # _active_symbols and will be replayed on reconnect.
 
     # ── public API ────────────────────────────────────────────────────────────
 
-    @staticmethod
-    def _sub_key(channel: str, symbols: list[str]) -> str:
-        """Deterministic registry key for a public channel subscription."""
-        return f"{channel}:{','.join(sorted(symbols))}"
+    def _subscribe(self, channel: str, symbols: list[str]) -> None:
+        with self._lock:
+            self._active_symbols.setdefault(channel, set()).update(symbols)
+        self._send_all(self._frames(channel, symbols))
+
+    def _unsubscribe(self, channel: str, symbols: list[str]) -> None:
+        with self._lock:
+            active = self._active_symbols.get(channel)
+            if active:
+                active.difference_update(symbols)
+        self._send_all(self._frames(channel, symbols, unsub=True))
 
     def subscribe_ticker(self, symbols: list[str]) -> None:
-        """Subscribe to v2/ticker channel for the given symbols."""
-        self._queue_or_send(
-            self._sub_key(self.CHANNEL_TICKER, symbols),
-            self._build_sub_msg(self.CHANNEL_TICKER, symbols),
-        )
+        """Subscribe to the ticker channel for the given symbols."""
+        self._subscribe(self.CHANNEL_TICKER, symbols)
 
-    def subscribe_l2_orderbook(self, symbols: list[str]) -> None:
-        """Subscribe to l2_orderbook channel for the given symbols."""
-        self._queue_or_send(
-            self._sub_key(self.CHANNEL_L2_BOOK, symbols),
-            self._build_sub_msg(self.CHANNEL_L2_BOOK, symbols),
-        )
+    def subscribe_orderbook(self, symbols: list[str]) -> None:
+        """Subscribe to the ob_l2 (top-15 order book) channel for the given symbols."""
+        self._subscribe(self.CHANNEL_OB_L2, symbols)
 
     def unsubscribe_ticker(self, symbols: list[str]) -> None:
-        key = self._sub_key(self.CHANNEL_TICKER, symbols)
-        with self._lock:
-            self._active_sub_msgs.pop(key, None)
-        self._send(self._build_sub_msg(self.CHANNEL_TICKER, symbols, unsub=True))
+        self._unsubscribe(self.CHANNEL_TICKER, symbols)
 
-    def unsubscribe_l2_orderbook(self, symbols: list[str]) -> None:
-        key = self._sub_key(self.CHANNEL_L2_BOOK, symbols)
-        with self._lock:
-            self._active_sub_msgs.pop(key, None)
-        self._send(self._build_sub_msg(self.CHANNEL_L2_BOOK, symbols, unsub=True))
+    def unsubscribe_orderbook(self, symbols: list[str]) -> None:
+        self._unsubscribe(self.CHANNEL_OB_L2, symbols)
 
     # ── private (authenticated) channel subscriptions ─────────────────────────
 
@@ -227,6 +261,13 @@ class DeltaWebSocket:
             "payload": {"channels": [channel_entry]},
         })
 
+    def _subscribe_private(self, channel: str) -> None:
+        """Register and send an account-channel subscription."""
+        msg = self._build_private_sub_msg(channel)
+        with self._lock:
+            self._active_private[channel] = msg
+        self._send_all([msg])
+
     def subscribe_orders_channel(self) -> None:
         """Subscribe to the authenticated 'orders' channel.
 
@@ -234,7 +275,7 @@ class DeltaWebSocket:
         authenticated user.  The WebSocket session must be authenticated first
         (the auth message is sent automatically in _ws_on_open).
         """
-        self._queue_or_send(self.CHANNEL_ORDERS, self._build_private_sub_msg(self.CHANNEL_ORDERS))
+        self._subscribe_private(self.CHANNEL_ORDERS)
 
     def subscribe_positions_channel(self) -> None:
         """Subscribe to the authenticated 'positions' channel.
@@ -242,7 +283,7 @@ class DeltaWebSocket:
         Delivers real-time position updates (size, entry price, PnL) whenever
         a position changes for the authenticated user.
         """
-        self._queue_or_send(self.CHANNEL_POSITIONS, self._build_private_sub_msg(self.CHANNEL_POSITIONS))
+        self._subscribe_private(self.CHANNEL_POSITIONS)
 
     def subscribe_margins_channel(self) -> None:
         """Subscribe to the authenticated 'margins' channel.
@@ -250,7 +291,7 @@ class DeltaWebSocket:
         Delivers real-time wallet and margin balance updates whenever a fill,
         funding payment, or realised-PnL event changes the account balance.
         """
-        self._queue_or_send(self.CHANNEL_MARGINS, self._build_private_sub_msg(self.CHANNEL_MARGINS))
+        self._subscribe_private(self.CHANNEL_MARGINS)
 
     def connect(self) -> None:
         """Start the WebSocket connection (blocking — run in a thread)."""
@@ -260,9 +301,10 @@ class DeltaWebSocket:
 
         while not self._stop_flag and retry_attempts <= self.max_retry_attempt:
             try:
-                logger.info("DeltaWS connecting to %s (attempt %s)", self.WS_URL, retry_attempts + 1)
+                logger.info("DeltaWS[%s] connecting to %s (attempt %s)",
+                            self.name, self.url, retry_attempts + 1)
                 self.wsapp = websocket.WebSocketApp(
-                    self.WS_URL,
+                    self.url,
                     on_open    = self._ws_on_open,
                     on_message = self._ws_on_message,
                     on_error   = self._ws_on_error,
@@ -277,18 +319,18 @@ class DeltaWebSocket:
                 if self._stop_flag:
                     break
                 retry_attempts += 1
-                logger.warning("DeltaWS disconnected; retry in %ss", delay)
+                logger.warning("DeltaWS[%s] disconnected; retry in %ss", self.name, delay)
                 time.sleep(delay)
                 delay = min(delay * self.retry_multiplier, 60)
 
             except Exception as exc:
-                logger.error("DeltaWS connect error: %s", exc)
+                logger.error("DeltaWS[%s] connect error: %s", self.name, exc)
                 retry_attempts += 1
                 time.sleep(delay)
                 delay = min(delay * self.retry_multiplier, 60)
 
         if retry_attempts > self.max_retry_attempt:
-            logger.error("DeltaWS max reconnect attempts reached; giving up")
+            logger.error("DeltaWS[%s] max reconnect attempts reached; giving up", self.name)
 
     def close_connection(self) -> None:
         """Cleanly stop the WebSocket."""
@@ -302,29 +344,36 @@ class DeltaWebSocket:
     # ── internal WS callbacks ─────────────────────────────────────────────────
 
     def _ws_on_open(self, wsapp) -> None:
-        logger.info("DeltaWS connected")
+        logger.info("DeltaWS[%s] connected", self.name)
 
-        # Authenticate (required for order/position channels)
-        try:
-            wsapp.send(self._build_auth_msg())
-        except Exception as exc:
-            logger.error("DeltaWS auth send error: %s", exc)
+        # Authenticate (required for order/position channels).  The public
+        # market-data endpoint rejects auth frames, so only the private
+        # connection sends one.
+        if self.authenticate:
+            try:
+                wsapp.send(self._build_auth_msg())
+            except Exception as exc:
+                logger.error("DeltaWS[%s] auth send error: %s", self.name, exc)
 
         # Set _connected and replay all active subscriptions atomically.
-        # _active_sub_msgs serves as both the pre-connect buffer (messages
-        # registered before the socket was up) AND the reconnect replay list
-        # (messages registered during a previous session that must be
-        # resubscribed after a disconnect/reconnect).  The dict is never
-        # cleared, so every reconnect restores all streams automatically.
+        # The registry serves as both the pre-connect buffer (symbols registered
+        # before the socket was up) AND the reconnect replay list (symbols
+        # registered during a previous session that must be resubscribed after a
+        # disconnect).  It is never cleared, so every reconnect restores all
+        # streams automatically.  Replay is re-framed from scratch, so a whole
+        # ticker book goes back up in one frame however it was subscribed.
         with self._lock:
             self._connected = True
-            to_replay = list(self._active_sub_msgs.values())
+            to_replay = list(self._active_private.values())
+            for channel, symbols in self._active_symbols.items():
+                if symbols:
+                    to_replay.extend(self._frames(channel, sorted(symbols)))
 
         for msg in to_replay:
             try:
                 wsapp.send(msg)
             except Exception as exc:
-                logger.error("DeltaWS subscription replay send error: %s", exc)
+                logger.error("DeltaWS[%s] subscription replay send error: %s", self.name, exc)
 
         self.on_open(wsapp)
 
@@ -332,28 +381,29 @@ class DeltaWebSocket:
         try:
             msg = json.loads(raw)
         except Exception:
-            logger.debug("DeltaWS non-JSON message: %s", raw[:120])
+            logger.debug("DeltaWS[%s] non-JSON message: %s", self.name, raw[:120])
             return
 
         msg_type = msg.get("type", "")
 
         if msg_type in ("key-auth", "subscriptions"):
-            logger.info("DeltaWS ack: %s", msg_type)
+            logger.debug("DeltaWS[%s] ack: %s", self.name, msg_type)
             return
 
         if msg_type in ("error",):
-            logger.error("DeltaWS server error: %s", msg)
+            logger.error("DeltaWS[%s] server error: %s", self.name, msg)
             return
 
-        logger.debug("DeltaWS dispatching: type=%s symbol=%s", msg_type, msg.get("symbol", ""))
+        logger.debug("DeltaWS[%s] dispatching: type=%s symbol=%s",
+                     self.name, msg_type, msg.get("sy") or msg.get("symbol", ""))
         self.on_message(wsapp, msg)
 
     def _ws_on_error(self, wsapp, error) -> None:
-        logger.error("DeltaWS error: %s", error)
+        logger.error("DeltaWS[%s] error: %s", self.name, error)
         self.on_error(wsapp, error)
 
     def _ws_on_close(self, wsapp, *args) -> None:
-        logger.info("DeltaWS closed")
+        logger.info("DeltaWS[%s] closed", self.name)
         # Acquire the lock before clearing _connected so that any subscribe
         # call currently deciding whether to send vs. queue (also under the
         # same lock via _queue_or_send) completes atomically before we flip

--- a/broker/deltaexchange/streaming/delta_websocket.py
+++ b/broker/deltaexchange/streaming/delta_websocket.py
@@ -195,41 +195,43 @@ class DeltaWebSocket:
             for i in range(0, len(symbols), size)
         ]
 
-    def _send_all(self, msgs: list[str]) -> None:
-        """Send frames, or buffer them for replay when the socket is down.
+    def _send_all_locked(self, msgs: list[str]) -> None:
+        """Send frames, or drop them when the socket is down. Caller must hold _lock.
 
-        Why the lock spans both the registry read AND the sends:
-          Holding it across the sends prevents the TOCTOU race where
-          _ws_on_close flips _connected=False between our check and the send,
-          causing frames to be dropped from the wire while the registry still
-          claims they are active.
+        Why the lock spans both the registry write AND the sends:
+          It prevents the TOCTOU race where _ws_on_close flips _connected=False
+          between our check and the send, causing frames to be dropped from the
+          wire while the registry still claims they are active. It also keeps
+          wire order matching registry order — otherwise an overlapping
+          subscribe and unsubscribe for the same symbol could update the
+          registry in one order and reach Delta in the other, leaving the
+          exchange streaming a symbol the registry says was dropped.
         """
-        with self._lock:
-            if not self._connected or not self.wsapp:
-                logger.debug("DeltaWS[%s] buffered %s frame(s) (not connected)",
-                             self.name, len(msgs))
-                return
-            for msg in msgs:
-                try:
-                    self.wsapp.send(msg)
-                except Exception as exc:
-                    logger.error("DeltaWS[%s] _send error: %s", self.name, exc)
-                    # Send failed mid-flight; the symbol is already in
-                    # _active_symbols and will be replayed on reconnect.
+        if not self._connected or not self.wsapp:
+            logger.debug("DeltaWS[%s] buffered %s frame(s) (not connected)",
+                         self.name, len(msgs))
+            return
+        for msg in msgs:
+            try:
+                self.wsapp.send(msg)
+            except Exception as exc:
+                logger.error("DeltaWS[%s] _send error: %s", self.name, exc)
+                # Send failed mid-flight; the symbol is already in
+                # _active_symbols and will be replayed on reconnect.
 
     # ── public API ────────────────────────────────────────────────────────────
 
     def _subscribe(self, channel: str, symbols: list[str]) -> None:
         with self._lock:
             self._active_symbols.setdefault(channel, set()).update(symbols)
-        self._send_all(self._frames(channel, symbols))
+            self._send_all_locked(self._frames(channel, symbols))
 
     def _unsubscribe(self, channel: str, symbols: list[str]) -> None:
         with self._lock:
             active = self._active_symbols.get(channel)
             if active:
                 active.difference_update(symbols)
-        self._send_all(self._frames(channel, symbols, unsub=True))
+            self._send_all_locked(self._frames(channel, symbols, unsub=True))
 
     def subscribe_ticker(self, symbols: list[str]) -> None:
         """Subscribe to the ticker channel for the given symbols."""
@@ -244,6 +246,18 @@ class DeltaWebSocket:
 
     def unsubscribe_orderbook(self, symbols: list[str]) -> None:
         self._unsubscribe(self.CHANNEL_OB_L2, symbols)
+
+    def forget_subscriptions(self) -> None:
+        """Drop the replay registry.
+
+        The registry deliberately survives a dropped connection so the retry
+        loop can restore every stream on reconnect.  An explicit teardown is
+        different: the subscriptions are gone, so anything left here would be
+        resubscribed by a later connect() with no client behind it.
+        """
+        with self._lock:
+            self._active_symbols.clear()
+            self._active_private.clear()
 
     # ── private (authenticated) channel subscriptions ─────────────────────────
 
@@ -266,7 +280,7 @@ class DeltaWebSocket:
         msg = self._build_private_sub_msg(channel)
         with self._lock:
             self._active_private[channel] = msg
-        self._send_all([msg])
+            self._send_all_locked([msg])
 
     def subscribe_orders_channel(self) -> None:
         """Subscribe to the authenticated 'orders' channel.

--- a/services/option_chain_service.py
+++ b/services/option_chain_service.py
@@ -529,6 +529,8 @@ def get_option_chain(
         # cache/DB and live prices stream over the WebSocket feed, avoiding a slow
         # per-strike broker multiquote (e.g. Flattrade throttles to 10 quotes/sec).
         quotes_map = {}
+        quotes_response: dict = {}
+        success = False
         if with_quotes:
             logger.info(f"Fetching quotes for {len(symbols_to_fetch)} option symbols")
             if exchange.upper() in CRYPTO_EXCHANGES:
@@ -605,16 +607,19 @@ def get_option_chain(
                         symbols=symbols_to_fetch, api_key=api_key
                     )
 
-                    # Build quote lookup map
-                    if success and "results" in quotes_response:
-                        for result in quotes_response["results"]:
-                            symbol = result.get("symbol")
-                            if symbol:
-                                # Handle both formats: direct data or nested data
-                                if "data" in result:
-                                    quotes_map[symbol] = result["data"]
-                                elif "error" not in result:
-                                    quotes_map[symbol] = result
+            # Build the quote lookup map from whichever branch produced results.
+            # The Fyers fast path is the only one that fills quotes_map itself;
+            # both the crypto per-symbol loop and the generic multiquotes call
+            # hand back a results list that still has to be indexed here.
+            if not quotes_map and success and "results" in quotes_response:
+                for result in quotes_response["results"]:
+                    symbol = result.get("symbol")
+                    if symbol:
+                        # Handle both formats: direct data or nested data
+                        if "data" in result:
+                            quotes_map[symbol] = result["data"]
+                        elif "error" not in result:
+                            quotes_map[symbol] = result
         else:
             logger.info(
                 f"Structure-only option chain ({len(symbols_to_fetch)} symbols); skipping live quotes"


### PR DESCRIPTION
fix(deltaexchange): move market data to the public WS endpoint and batch subscriptions, (optionchain): build the quote lookup and add weighted rate limiting across every REST call  map for crypto chains

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switches Delta market data to the public WebSocket and batches subscriptions; adds weighted rate limiting with separate public/private buckets; fixes crypto option-chain quote lookup; and repairs Definedge history by preventing missing days and aligning resampling to each segment’s session open. Drops duplicate 429 retries in Definedge history to avoid overloading the API.

- Streaming: two sockets (public `ticker`/`ob_l2`; private orders/positions/margins). Depth mode also subscribes to `ticker`. 0.5s batch flush (single list for `ticker`, one-symbol frames for `ob_l2`). Per-symbol registry coalesces subscribe/unsubscribe; disconnect clears replay. Cache merge emits zeros only for present arrays and omits absent fields.
- Rate limits: shared weighted limiter with public/private buckets. `consume()` runs before signing and retries re-sign. 429 handling honors `X-RATE-LIMIT-RESET`, caps all waits (including `Retry-After`) to `MAX_WAIT_SECONDS`, and skips retries when server-requested delay exceeds the cap. Probes `/v2/rate_limits/quota` via `BASE_URL`. Margin calculation aborts with 429 instead of partial totals.
- Data: master contracts set `name` from `underlying_asset.symbol`; `/v2/products` counts against the public bucket. Crypto option-chain quote map builds correctly across both quote paths.
- Definedge history: snap intraday chunk ends to end-of-day, advance next chunk to the following day, and retry transient 4xx (408/425) with backoff; 429 is handled by the inner rate-limited request. Resampling aligns to each segment’s open (09:00 for MCX/CDS/BCD; 09:15 for NSE/BSE), preventing misaligned bars; 5m/15m unaffected. Bounds use full calendar day per segment and logs identify gaps; request logs avoid redacting the instrument id.

**Rollout**
- Action: Re-download the Delta master contract table to repopulate `name` with the underlying root.
- Action: Allow outbound access to `wss://public-socket.india.delta.exchange`.
- Monitor: Rate-limit logs (“Delta quota check”, “Delta rate-limited (429) …”) and Definedge history warnings for named gaps.

<sup>Written for commit 37a53b3ae742a3c7fb8fc87bfcc070dd2e2cc303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

