### PR TITLE
fix(deltaexchange): keep the pooled feed alive after the last unsubsribe

### DIFF
--- a/broker/deltaexchange/streaming/delta_adapter.py
+++ b/broker/deltaexchange/streaming/delta_adapter.py
@@ -244,7 +244,6 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
         channels = DeltaModeMapper.get_channels(mode)
         corr_id  = f"{symbol}_{exchange}_{mode}"
 
-        should_disconnect = False
         stale_channels: list[str] = []
         with self._lock:
             # Read the stored br_symbol that was resolved at subscribe() time
@@ -278,9 +277,6 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
             ):
                 self.last_values.pop(cache_key, None)
 
-            if not remaining:
-                should_disconnect = True
-
         if self.public_ws and stale_channels:
             try:
                 with self._lock:
@@ -291,9 +287,17 @@ class DeltaWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.logger.error("unsubscribe error %s.%s: %s", symbol, exchange, exc)
                 return self._create_error_response("UNSUBSCRIPTION_ERROR", str(exc))
 
-        if should_disconnect:
-            self.logger.info("No subscriptions remaining — disconnecting.")
-            self.disconnect()
+        # Deliberately NOT disconnecting when the last subscription goes away.
+        # The connection pool (websocket_proxy/connection_manager.py) owns this
+        # adapter's lifecycle and keeps reusing the same instance: dropping to
+        # zero symbols is routine (an option chain switching expiry/strikes
+        # unsubscribes every symbol before subscribing the new set).  Tearing
+        # the sockets down here left the pool holding a dead adapter — the WS
+        # retry loop exits on _stop_flag and the ZMQ publisher is closed, so
+        # every later subscribe was accepted, queued, and silently buffered
+        # with no socket to carry it and no path back to connected.  An idle
+        # connection with no subscriptions costs nothing; explicit teardown
+        # still happens through disconnect().
 
         return self._create_success_response(
             f"Unsubscribed from {symbol}.{exchange}", symbol=symbol, exchange=exchange, mode=mode

--- a/broker/deltaexchange/streaming/delta_websocket.py
+++ b/broker/deltaexchange/streaming/delta_websocket.py
@@ -130,6 +130,9 @@ class DeltaWebSocket:
         self._lock   = threading.Lock()
         self._connected = False
         self._stop_flag = False
+        # Set by _ws_on_open; the retry loop reads it to tell "this connection
+        # was healthy and later dropped" apart from "we never got through".
+        self._connect_succeeded = False
         # Persistent subscription registry, tracked per symbol rather than per
         # sent frame.  Serves two purposes:
         #   1. Pre-connect buffer: symbols accumulate here and are subscribed in
@@ -332,6 +335,15 @@ class DeltaWebSocket:
                 # run_forever returns when connection closes
                 if self._stop_flag:
                     break
+                # A connection that came up healthy and only later dropped
+                # restores the full retry budget.  Without this the counter is
+                # cumulative over the process lifetime, so a long-lived feed
+                # that reconnects once a day silently exhausts the budget after
+                # max_retry_attempt drops and never comes back.
+                if self._connect_succeeded:
+                    self._connect_succeeded = False
+                    retry_attempts = 0
+                    delay = self.retry_delay
                 retry_attempts += 1
                 logger.warning("DeltaWS[%s] disconnected; retry in %ss", self.name, delay)
                 time.sleep(delay)
@@ -378,6 +390,7 @@ class DeltaWebSocket:
         # ticker book goes back up in one frame however it was subscribed.
         with self._lock:
             self._connected = True
+            self._connect_succeeded = True
             to_replay = list(self._active_private.values())
             for channel, symbols in self._active_symbols.items():
                 if symbols:


### PR DESCRIPTION
Subscribing to an option chain stopped delivering ticks: the subscription was accepted and logged, but no data ever arrived and the proxy reported "Stale feed ... connected but no ticks".

The adapter tore down its own transport in unsubscribe() once its symbol count reached zero, while the connection pool kept holding and reusing the same instance. disconnect() sets _stop_flag, so the DeltaWebSocket retry loop exits permanently, and _get_adapter_with_capacity() reuses the dead adapter with no health check. Every later subscribe was then queued and silently buffered by _send_all_locked with no socket to carry it and no path back to connected. Option chains hit this because switching expiry or strikes unsubscribes the whole set before subscribing the new one; a watchlist rarely drops to zero.

Drop the self-teardown and let the pool own the adapter lifecycle. Explicit teardown still runs through pool.disconnect() and initialize(force=True), both of which call adapter.disconnect(). Queued unsubscribe frames now also reach Delta instead of being discarded with the cancelled batch timer.

Also reset the WebSocket retry budget after a healthy connection. The counter was cumulative for the life of the process, so a long-lived feed that reconnects occasionally exhausted max_retry_attempt and never came back.

Verified live against Delta with BTC options: LTP, quote, and depth modes stream, a full unsubscribe stops the stream at the exchange, and a resubscribe on the same pooled adapter resumes ticks.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keeps the Delta pooled feed alive after the last unsubscribe and restores the WebSocket retry budget so long‑lived feeds recover. Previously, the adapter auto‑disconnected at zero symbols, the pool reused a dead instance, retries stopped, and later subscribes queued with no ticks; now the pool owns lifecycle and healthy reconnects reset retry attempts.

**Review notes**
- In `delta_adapter.unsubscribe`: removed auto‑disconnect at zero subscriptions; still clears caches and now sends pending unsubscribe frames. Explicit teardown remains via the pool (`disconnect()` or `initialize(force=True)`).
- In `delta_websocket`: added `_connect_succeeded` and reset of `retry_attempts`/delay after a healthy open, preserving reconnection over time without changing backoff behavior.

<sup>Written for commit 8139e5f52f2a9d1e7a2fb350739eb76cbb68241a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

