### PR TITLE
fix(historify): drop unused market_data secondary indexes

### DIFF
--- a/database/historify_db.py
+++ b/database/historify_db.py
@@ -240,19 +240,10 @@ def init_database():
             )
         """)
 
-        # Create indexes for common query patterns
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_timestamp
-            ON market_data (timestamp)
-        """)
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_exchange_time
-            ON market_data (exchange, timestamp)
-        """)
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_interval_time
-            ON market_data (interval, timestamp)
-        """)
+        # No secondary indexes on market_data: every query leads with
+        # `symbol`, DuckDB serves range scans from per-row-group zone maps,
+        # and ART index memory stays fully resident as the table grows,
+        # which OOMs large 1m backfills. See #1779.
         conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_job_items_job_id
             ON job_items (job_id)

--- a/upgrade/migrate_all.py
+++ b/upgrade/migrate_all.py
@@ -71,6 +71,7 @@ MIGRATIONS = [
     ("migrate_zerodha_new_exchanges.py", "Zerodha NCO/GLOBAL_INDEX & GIFTNIFTY Cleanup"),
     ("add_totp_purpose_flags.py", "Per-Purpose 2FA Flags (login/MCP/reset)"),
     ("migrate_gtt_sandbox.py", "Sandbox GTT Support & CAS F&O Close (15:40)"),
+    ("migrate_historify_drop_indexes.py", "Historify Unused Index Removal (#1779)"),
 ]
 
 

--- a/upgrade/migrate_historify.py
+++ b/upgrade/migrate_historify.py
@@ -187,20 +187,13 @@ def create_database():
         """)
         logger.info("Created symbol_metadata table")
 
-        # Create indexes for common query patterns
+        # No secondary indexes on market_data: every query leads with
+        # `symbol`, DuckDB serves range scans from per-row-group zone maps,
+        # and ART index memory stays fully resident as the table grows,
+        # which OOMs large 1m backfills. Existing installs get the three
+        # legacy indexes dropped by migrate_historify_drop_indexes.py.
+        # See #1779.
         logger.info("Creating indexes...")
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_timestamp
-            ON market_data (timestamp)
-        """)
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_exchange_time
-            ON market_data (exchange, timestamp)
-        """)
-        conn.execute("""
-            CREATE INDEX IF NOT EXISTS idx_market_data_interval_time
-            ON market_data (interval, timestamp)
-        """)
         conn.execute("""
             CREATE INDEX IF NOT EXISTS idx_job_items_job_id
             ON job_items (job_id)

--- a/upgrade/migrate_historify_drop_indexes.py
+++ b/upgrade/migrate_historify_drop_indexes.py
@@ -1,0 +1,227 @@
+#!/usr/bin/env python
+"""
+Historify Secondary Index Removal Migration for OpenAlgo
+
+Drops the three unused secondary indexes on market_data that keep DuckDB
+ART index memory fully resident as the table grows, which causes
+out-of-memory failures on large 1m backfills (#1779):
+
+- idx_market_data_timestamp
+- idx_market_data_exchange_time
+- idx_market_data_interval_time
+
+Every query against market_data leads with `symbol`; none of these
+indexes contains that column, the planner never selects them, and range
+scans are served by DuckDB's per-row-group zone maps. Measured in #1779,
+removing them roughly halves the database file, speeds up ingest about
+1.6x, and costs no query performance. The primary key on
+(symbol, exchange, interval, timestamp) is untouched and remains
+enforced after the drop.
+
+DROP INDEX is a catalog-only operation - it never reads or rewrites
+table data. An explicit CHECKPOINT follows the drop so the file size
+actually shrinks.
+
+Usage:
+    cd upgrade
+    uv run migrate_historify_drop_indexes.py           # Apply migration
+    uv run migrate_historify_drop_indexes.py --status  # Check status
+
+Migration: 012
+Created: 2026-08-18
+Issue: #1779
+"""
+
+import argparse
+import os
+import sys
+from datetime import datetime
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from dotenv import load_dotenv
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Migration metadata
+MIGRATION_NAME = "historify_drop_unused_indexes"
+MIGRATION_VERSION = "012"
+
+# The unused secondary indexes on market_data (see #1779).
+# The primary key's implicit index is NOT listed: it is required for
+# duplicate protection and is not visible in duckdb_indexes() anyway.
+SECONDARY_INDEXES = [
+    "idx_market_data_timestamp",
+    "idx_market_data_exchange_time",
+    "idx_market_data_interval_time",
+]
+
+# Load environment
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(parent_dir, ".env"))
+
+# Database path
+HISTORIFY_DB_PATH = os.getenv("HISTORIFY_DATABASE_PATH", "db/historify.duckdb")
+
+
+def get_db_path():
+    """Get absolute path to the DuckDB database file."""
+    if os.path.isabs(HISTORIFY_DB_PATH):
+        return HISTORIFY_DB_PATH
+    return os.path.join(parent_dir, HISTORIFY_DB_PATH)
+
+
+def check_duckdb_available():
+    """Check if DuckDB is installed."""
+    try:
+        import duckdb
+
+        logger.info(f"DuckDB version: {duckdb.__version__}")
+        return True
+    except ImportError:
+        logger.error("DuckDB is not installed. Please run: pip install duckdb")
+        return False
+
+
+def existing_secondary_indexes(conn):
+    """Return which of the target secondary indexes currently exist."""
+    rows = conn.execute(
+        "SELECT index_name FROM duckdb_indexes() WHERE table_name = 'market_data'"
+    ).fetchall()
+    present = {row[0] for row in rows}
+    return [name for name in SECONDARY_INDEXES if name in present]
+
+
+def drop_indexes():
+    """Drop the unused secondary indexes on market_data."""
+    import duckdb
+
+    db_path = get_db_path()
+
+    # Most installs have never opened Historify - nothing to migrate.
+    if not os.path.exists(db_path):
+        logger.info(f"No Historify database at {db_path} - nothing to migrate")
+        return True
+
+    try:
+        conn = duckdb.connect(db_path)
+    except duckdb.IOException as e:
+        logger.error(
+            "Historify database is locked by another process (most likely a "
+            "running OpenAlgo server). Stop OpenAlgo first, then re-run this "
+            f"migration. Details: {e}"
+        )
+        return False
+
+    try:
+        existing = existing_secondary_indexes(conn)
+
+        if not existing:
+            logger.info("Unused secondary indexes already absent - nothing to do")
+            return True
+
+        for index_name in existing:
+            conn.execute(f'DROP INDEX IF EXISTS "{index_name}"')
+
+        # Reclaim the space the dropped index ARTs occupied. Without an
+        # explicit CHECKPOINT the file keeps its old size and the
+        # migration looks like it did nothing.
+        conn.execute("CHECKPOINT")
+
+        logger.info(
+            f"Dropped {len(existing)} unused secondary index(es) on market_data: "
+            + ", ".join(existing)
+        )
+        logger.info(f"Migration {MIGRATION_NAME} completed at {datetime.now().isoformat()}")
+        return True
+
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        return False
+    finally:
+        conn.close()
+
+
+def status():
+    """Check migration status."""
+    import duckdb
+
+    db_path = get_db_path()
+
+    if not os.path.exists(db_path):
+        logger.info(f"No Historify database at {db_path} - nothing to migrate")
+        return True
+
+    try:
+        conn = duckdb.connect(db_path)
+
+        try:
+            existing = existing_secondary_indexes(conn)
+            db_size = os.path.getsize(db_path)
+            db_size_mb = round(db_size / (1024 * 1024), 2)
+
+            if existing:
+                logger.info(f"Unused secondary indexes still present: {', '.join(existing)}")
+                logger.info("   Migration needed")
+                conn.close()
+                return False
+
+            logger.info("No unused secondary indexes on market_data")
+            logger.info(f"   Database Size: {db_size_mb} MB")
+            logger.info("   Migration already applied")
+            conn.close()
+            return True
+
+        except Exception as e:
+            logger.error(f"Error checking status: {e}")
+            conn.close()
+            return False
+
+    except duckdb.IOException as e:
+        logger.error(
+            "Historify database is locked by another process (most likely a "
+            "running OpenAlgo server). Stop OpenAlgo first, then re-run this "
+            f"status check. Details: {e}"
+        )
+        return False
+    except Exception as e:
+        logger.error(f"Status check failed: {e}")
+        return False
+
+
+def upgrade():
+    """Apply the Historify secondary index removal migration."""
+    try:
+        logger.info(f"Starting migration: {MIGRATION_NAME} (v{MIGRATION_VERSION})")
+
+        if not check_duckdb_available():
+            return False
+
+        return drop_indexes()
+
+    except Exception as e:
+        logger.error(f"Migration failed: {e}")
+        import traceback
+
+        traceback.print_exc()
+        return False
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(
+        description=f"Migration: {MIGRATION_NAME} (v{MIGRATION_VERSION})",
+        formatter_class=argparse.RawDescriptionHelpFormatter,
+    )
+    parser.add_argument("--status", action="store_true", help="Check migration status")
+
+    args = parser.parse_args()
+
+    if args.status:
+        success = status()
+    else:
+        success = upgrade()
+
+    sys.exit(0 if success else 1)


### PR DESCRIPTION
Refs #1779

## What

Historify's `market_data` table carries three secondary indexes (`idx_market_data_timestamp`, `idx_market_data_exchange_time`, `idx_market_data_interval_time`) that no query uses: every lookup leads with `symbol`, DuckDB serves range scans from per-row-group zone maps, and ART index memory stays fully resident as the table grows — which is what OOMs large 1m backfills (#1779). Per the measurements in the issue, dropping them speeds up ingest 1.6x and shrinks the file 2.4x with no query cost.

## Fix (Tier 1 from the issue: automatic migration, safe for every install)

- **`upgrade/migrate_historify_drop_indexes.py`** (new, migration `012`, registered in `migrate_all.py`): drops the three indexes on existing installs. `DROP INDEX` is catalog-only (never reads or rewrites table data), followed by an explicit `CHECKPOINT` so the file actually shrinks. Idempotent, supports `--status`, returns quietly when no Historify DB exists (most installs never opened Historify), and a locked DB (running server) exits with "Stop OpenAlgo first" instead of a raw `IOException`.
- **Index creation removed from both fresh-install paths** — `database/historify_db.py::init_database()` and `upgrade/migrate_historify.py::create_database()` (the statements were duplicated across the two files) — so new installs never create them and a fresh DB is schema-identical to a migrated one.

The primary key on `(symbol, exchange, interval, timestamp)` is untouched; non-`market_data` indexes (`idx_job_items_job_id`, ...) are untouched.

Tier 1b from the issue (DuckDB connection tuning in `get_connection()` — `memory_limit`/`threads`/`preserve_insertion_order`/`temp_directory` — and chunked `download_data()`) is deliberately not in this PR, per the issue's own risk-tier separation of the two halves.

## Verification

Acceptance suite against a synthetic 720k-row old-schema `historify.duckdb` (repo-pinned `duckdb==1.5.4`, same version as the report) — **all checks passed**:

| Check | Result |
| --- | --- |
| `--status` before / after | "Migration needed" (exit 1) / "already applied" (exit 0) |
| Apply drops exactly the 3 indexes | PASS — `duckdb_indexes()` shows none left |
| File shrinks after `CHECKPOINT` | 35.4 MB → 10.5 MB |
| Idempotent re-run | "already absent", exit 0 |
| Row content identical | md5 equal before/after, 500k rows preserved |
| Primary key still enforced | duplicate insert rejected |
| Non-`market_data` indexes untouched | `idx_job_items_job_id` still present |
| Absent DB file | quiet no-op, exit 0 |
| Locked DB (held by another process) | exit 1 + "Stop OpenAlgo first" |
| Fresh install (patched `migrate_historify.py` and standalone `init_database()`) | none of the 3 indexes created; fresh schema identical to migrated |
| `ruff check` on the new file | clean |


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove three unused secondary indexes on Historify’s `market_data` and stop creating them on fresh installs to prevent OOMs during large 1m backfills and improve ingest speed and file size. Previously we created `idx_market_data_timestamp`, `idx_market_data_exchange_time`, and `idx_market_data_interval_time`; now a migration drops them and issues a CHECKPOINT. Query behavior is unchanged (lookups lead with `symbol`), and the primary key remains enforced.

**Migration and review notes**
- Adds migration 012 (`upgrade/migrate_historify_drop_indexes.py`, registered in `upgrade/migrate_all.py`) to drop the indexes and CHECKPOINT; idempotent, quiet no-op if the DB is absent, and surfaces a clear “Stop OpenAlgo first” message if the DB is locked.
- Removes index creation from `database/historify_db.py::init_database()` and `upgrade/migrate_historify.py::create_database()` so fresh and migrated schemas match.
- Scope limited to `market_data` secondary indexes; the `(symbol, exchange, interval, timestamp)` primary key and non-`market_data` indexes (e.g., `idx_job_items_job_id`) are unchanged.
- Rollout: stop OpenAlgo, run the standard upgrade; `--status` is available to check application. Addresses #1779 (Tier 1).

<sup>Written for commit 82833e9c08553ce1a1d98d8b0c2335cb244af2d6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1803?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->