### PR TITLE
docs: add PadmaBalajiL to devsprint participants

### DIFF
--- a/docs/devsprint/participants.md
+++ b/docs/devsprint/participants.md
@@ -49,3 +49,4 @@ git push --force-with-lease
 | Name | GitHub | Interested in |
 | --- | --- | --- |
 | Rajandran R | [@marketcalls](https://github.com/marketcalls) | maintainer |
+|Padma Balaji L| [@PadmaBalajiL](https://github.com/PadmaBalajiL)|python|


### PR DESCRIPTION
Adding my details to the participants list. 

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Padma Balaji L to the Devsprint participants list to keep the roster current and surface Python interest for pairing.

Updates only docs/devsprint/participants.md; no code or build behavior changes.

<sup>Written for commit a00fdfa8a76c58ab419bf262ca67af5e7f2f4861. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

