### PR TITLE
docs: add Niranjan to Devsprint participants list

### DIFF
--- a/docs/devsprint/participants.md
+++ b/docs/devsprint/participants.md
@@ -50,3 +50,4 @@ git push --force-with-lease
 | --- | --- | --- |
 | Rajandran R | [@marketcalls](https://github.com/marketcalls) | maintainer |
 |Padma Balaji L| [@PadmaBalajiL](https://github.com/PadmaBalajiL)|python|
+|Niranjan | [@cracker314](https://github.com/cracker314)|python|


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Adds Niranjan (`@cracker314`) to the DevSprint participants list under Python. Keeps the roster current for coordination and recognition.

<sup>Written for commit 7a64495887efeed192e538dc1ea93693559603d9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

