### PR TITLE
docs: add Navadeep Marella to devsprint participants

### DIFF
--- a/docs/devsprint/participants.md
+++ b/docs/devsprint/participants.md
@@ -51,3 +51,4 @@ git push --force-with-lease
 | Rajandran R | [@marketcalls](https://github.com/marketcalls) | maintainer |
 |Padma Balaji L| [@PadmaBalajiL](https://github.com/PadmaBalajiL)|python|
 |Niranjan | [@cracker314](https://github.com/cracker314)|python|
+| Navadeep Marella | [@NavadeepDj](https://github.com/NavadeepDj) | python, backtesting |


### PR DESCRIPTION
Adds my details to `docs/devsprint/participants.md` for the DevSprint warm-up exercise.

- **Name**: Navadeep Marella
- **GitHub**: @NavadeepDj
- **Interests**: python, backtesting


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds Navadeep Marella to `docs/devsprint/participants.md` to keep the DevSprint participants list current.

**Review notes**
- Appends one table row with name, GitHub handle `@NavadeepDj`, and interests: python, backtesting.
- Verify table formatting and placement at the end of the list; no other files changed.

<sup>Written for commit 6ec50a090ba1df07b2a4513742c9217b794aa809. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

