### PR TITLE
fix: reject NaN and infinity in API analyzer numeric fields

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             test/test_auth_resume.py test/test_auth_upsert_multisession.py \
             test/sandbox/test_execution_backlog.py test/test_event_bus_bounded.py \
             test/test_telegram_api_contract.py \
+            test/test_api_analyzer_numeric_validation.py \
             -v --timeout=60
 
   # Frontend linting

--- a/test/test_api_analyzer_numeric_validation.py
+++ b/test/test_api_analyzer_numeric_validation.py
@@ -1,0 +1,158 @@
+"""Non-finite numbers must be rejected by the API analyzer.
+
+``float()`` accepts "nan", "inf" and "-inf", and every range check in
+``utils.api_analyzer`` is a comparison (``<= 0``, ``< 0``, ``== 0``). All of
+those are False for NaN, so before the ``math.isfinite`` guard a NaN quantity
+or price passed validation and reached the broker.
+
+Run with: uv run pytest test/test_api_analyzer_numeric_validation.py -v
+"""
+
+import pytest
+
+from utils import api_analyzer
+from utils.api_analyzer import (
+    _finite_float,
+    analyze_api_request,
+    analyze_modify_order_request,
+    analyze_smart_order_request,
+)
+
+# Both the string spellings that arrive over JSON and the float objects that
+# arrive from a Python client.
+NON_FINITE = ["nan", "NaN", "inf", "-inf", "Infinity", float("nan"), float("inf"), float("-inf")]
+
+QUANTITY_ISSUE = "Invalid quantity value"
+PRICE_ISSUE = "Invalid numeric value for price, trigger_price, or disclosed_quantity"
+# modifyorder validates quantity inside the same try, so its message differs.
+MODIFY_NUMERIC_ISSUE = (
+    "Invalid numeric value for price, trigger_price, quantity, or disclosed_quantity"
+)
+
+
+@pytest.fixture(autouse=True)
+def _known_symbol(monkeypatch):
+    """Take symbol lookup out of play so only numeric validation is asserted."""
+    monkeypatch.setattr(api_analyzer, "validate_symbol", lambda symbol, exchange: True)
+
+
+def _order(**overrides):
+    """A placeorder payload carrying every REQUIRED_ORDER_FIELDS entry."""
+    order = {
+        "apikey": "test-key",
+        "strategy": "test",
+        "symbol": "RELIANCE",
+        "exchange": "NSE",
+        "action": "BUY",
+        "quantity": "1",
+        "pricetype": "MARKET",
+        "product": "MIS",
+    }
+    order.update(overrides)
+    return order
+
+
+def _smart_order(**overrides):
+    """A smart-order payload; position_size is required on this path."""
+    order = _order(position_size="0")
+    order.update(overrides)
+    return order
+
+
+def _modify_order(**overrides):
+    """A modifyorder payload carrying every REQUIRED_MODIFY_ORDER_FIELDS entry."""
+    order = _order(
+        orderid="250101000000001",
+        pricetype="LIMIT",
+        price="100",
+        disclosed_quantity="0",
+        trigger_price="0",
+    )
+    order.update(overrides)
+    return order
+
+
+class TestFiniteFloat:
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_rejects_non_finite(self, value):
+        with pytest.raises(ValueError):
+            _finite_float(value)
+
+    @pytest.mark.parametrize("value", ["0", "-1.5", "1e308", 0, 12345.678])
+    def test_accepts_finite(self, value):
+        assert _finite_float(value) == float(value)
+
+    def test_message_does_not_echo_the_input(self):
+        with pytest.raises(ValueError) as excinfo:
+            _finite_float("nan")
+        assert "nan" not in str(excinfo.value).lower()
+
+
+class TestPlaceOrder:
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_quantity_rejected(self, value):
+        response = analyze_api_request(_order(quantity=value))
+        assert response["status"] == "error"
+        assert QUANTITY_ISSUE in response["message"]
+
+    @pytest.mark.parametrize("field", ["price", "trigger_price", "disclosed_quantity"])
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_price_fields_rejected(self, field, value):
+        order = _order(pricetype="LIMIT", price="100")
+        order[field] = value
+        response = analyze_api_request(order)
+        assert response["status"] == "error"
+        assert PRICE_ISSUE in response["message"]
+
+    def test_finite_order_still_valid(self):
+        response = analyze_api_request(_order(pricetype="LIMIT", price="100"))
+        assert response["status"] == "success"
+
+    def test_finite_boundaries_unchanged(self):
+        assert "Quantity must be greater than 0" in analyze_api_request(_order(quantity="0"))["message"]
+        assert "Price cannot be negative" in analyze_api_request(_order(price="-1"))["message"]
+        assert "Price is required for LIMIT orders" in analyze_api_request(
+            _order(pricetype="LIMIT", price="0")
+        )["message"]
+
+    def test_rejection_does_not_echo_the_input(self):
+        response = analyze_api_request(_order(quantity="nan"))
+        assert "nan" not in response["message"].lower()
+
+
+class TestSmartOrder:
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_quantity_rejected(self, value):
+        response = analyze_smart_order_request(_smart_order(quantity=value))
+        assert response["status"] == "error"
+        assert QUANTITY_ISSUE in response["message"]
+
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_position_size_rejected(self, value):
+        response = analyze_smart_order_request(_smart_order(position_size=value))
+        assert response["status"] == "error"
+        assert "Invalid position size value" in response["message"]
+
+    def test_finite_smart_order_still_valid(self):
+        response = analyze_smart_order_request(_smart_order(quantity="0"))
+        assert response["status"] == "success"
+
+
+class TestModifyOrder:
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_quantity_rejected(self, value):
+        response = analyze_modify_order_request(_modify_order(quantity=value))
+        assert response["status"] == "error"
+        assert MODIFY_NUMERIC_ISSUE in response["message"]
+
+    @pytest.mark.parametrize("field", ["price", "trigger_price", "disclosed_quantity"])
+    @pytest.mark.parametrize("value", NON_FINITE)
+    def test_price_fields_rejected(self, field, value):
+        order = _modify_order()
+        order[field] = value
+        response = analyze_modify_order_request(order)
+        assert response["status"] == "error"
+        assert MODIFY_NUMERIC_ISSUE in response["message"]
+
+    def test_finite_modify_still_valid(self):
+        assert analyze_modify_order_request(_modify_order())["status"] == "success"

--- a/test/test_api_analyzer_numeric_validation.py
+++ b/test/test_api_analyzer_numeric_validation.py
@@ -3,12 +3,20 @@
 ``float()`` accepts "nan", "inf" and "-inf", and every range check in
 ``utils.api_analyzer`` is a comparison (``<= 0``, ``< 0``, ``== 0``). All of
 those are False for NaN, so before the ``math.isfinite`` guard a NaN quantity
-or price passed validation and reached the broker.
+or price was reported as ``status: success``.
+
+This covers legacy code rather than a reachable path. The ``analyze_*``
+functions have no callers outside their own module, and live orders are
+rejected one layer earlier by the marshmallow schemas in
+``restx_api/schemas.py``, whose ``fields.Float`` defaults to
+``allow_nan=False``. The tests pin the guard so the module stays correct for as
+long as it is kept.
 
 Run with: uv run pytest test/test_api_analyzer_numeric_validation.py -v
 """
 
 import pytest
+from sqlalchemy.exc import OperationalError
 
 from utils import api_analyzer
 from utils.api_analyzer import (
@@ -30,10 +38,55 @@ MODIFY_NUMERIC_ISSUE = (
 )
 
 
+class _StubColumn:
+    """Stand-in for a SQLAlchemy column, so the filter criteria build harmlessly."""
+
+    def __ge__(self, other):
+        return True
+
+    def like(self, pattern):
+        return True
+
+
+class _StubQuery:
+    def __init__(self, count):
+        self._count = count
+
+    def filter(self, *args, **kwargs):
+        return self
+
+    def count(self):
+        return self._count
+
+
+def _stub_analyzer_log(count=0):
+    """An ``AnalyzerLog`` stand-in whose rate-limit probe reports ``count`` rows."""
+
+    class _StubAnalyzerLog:
+        query = _StubQuery(count)
+        created_at = _StubColumn()
+        response_data = _StubColumn()
+
+    return _StubAnalyzerLog
+
+
 @pytest.fixture(autouse=True)
 def _known_symbol(monkeypatch):
     """Take symbol lookup out of play so only numeric validation is asserted."""
     monkeypatch.setattr(api_analyzer, "validate_symbol", lambda symbol, exchange: True)
+
+
+@pytest.fixture(autouse=True)
+def _quiet_rate_limits(monkeypatch):
+    """Stub the rate-limit query so the DB-failure branch stays out of the way.
+
+    ``analyzer_logs`` does not exist in the test database, so every unstubbed
+    call raises ``OperationalError``, which the analyzer swallows into
+    ``warnings: ["Unable to check rate limits"]`` after logging a traceback.
+    That buried the branch under noise and left it unasserted; it is pinned
+    explicitly by ``test_rate_limit_probe_failure_is_reported`` below.
+    """
+    monkeypatch.setattr(api_analyzer, "AnalyzerLog", _stub_analyzer_log())
 
 
 def _order(**overrides):
@@ -109,11 +162,15 @@ class TestPlaceOrder:
         assert response["status"] == "success"
 
     def test_finite_boundaries_unchanged(self):
-        assert "Quantity must be greater than 0" in analyze_api_request(_order(quantity="0"))["message"]
+        assert (
+            "Quantity must be greater than 0"
+            in analyze_api_request(_order(quantity="0"))["message"]
+        )
         assert "Price cannot be negative" in analyze_api_request(_order(price="-1"))["message"]
-        assert "Price is required for LIMIT orders" in analyze_api_request(
-            _order(pricetype="LIMIT", price="0")
-        )["message"]
+        assert (
+            "Price is required for LIMIT orders"
+            in analyze_api_request(_order(pricetype="LIMIT", price="0"))["message"]
+        )
 
     def test_rejection_does_not_echo_the_input(self):
         response = analyze_api_request(_order(quantity="nan"))
@@ -156,3 +213,64 @@ class TestModifyOrder:
 
     def test_finite_modify_still_valid(self):
         assert analyze_modify_order_request(_modify_order())["status"] == "success"
+
+
+class TestHelperContract:
+    """The helper's stated contract: one exception type for every bad number."""
+
+    @pytest.mark.parametrize("value", ["nan", "inf", "-inf", float("nan"), float("inf")])
+    def test_non_finite_raises_value_error(self, value):
+        with pytest.raises(ValueError):
+            _finite_float(value)
+
+    def test_oversized_int_raises_value_error_not_overflow_error(self):
+        """``float(10**400)`` raises OverflowError, which the callers do not catch.
+
+        Left unconverted it escapes the per-field ``except ValueError`` handlers
+        and collapses the whole analysis into "Internal error analyzing request".
+        """
+        with pytest.raises(ValueError):
+            _finite_float(10**400)
+
+    @pytest.mark.parametrize("value", ["1.5", 1.5, 0, "0"])
+    def test_finite_values_pass_through(self, value):
+        assert _finite_float(value) == float(value)
+
+    def test_oversized_int_is_reported_as_a_field_issue(self):
+        """The OverflowError path must surface as a normal validation issue."""
+        response = analyze_api_request(_order(quantity=10**400))
+        assert response["status"] == "error"
+        assert QUANTITY_ISSUE in response["message"]
+
+
+class TestRateLimitProbe:
+    def test_no_warning_when_probe_succeeds(self):
+        assert analyze_api_request(_order())["warnings"] == []
+
+    def test_rate_limit_probe_failure_is_reported(self, monkeypatch):
+        """A failing probe degrades to a warning rather than failing the analysis."""
+
+        class _BrokenQuery:
+            def filter(self, *args, **kwargs):
+                raise OperationalError("no such table: analyzer_logs", {}, None)
+
+            def count(self):
+                raise OperationalError("no such table: analyzer_logs", {}, None)
+
+        class _BrokenAnalyzerLog:
+            query = _BrokenQuery()
+            created_at = _StubColumn()
+            response_data = _StubColumn()
+
+        monkeypatch.setattr(api_analyzer, "AnalyzerLog", _BrokenAnalyzerLog)
+        response = analyze_api_request(_order())
+        assert response["status"] == "success"
+        assert response["warnings"] == ["Unable to check rate limits"]
+
+    def test_high_frequency_warning_when_probe_reports_a_burst(self, monkeypatch):
+        monkeypatch.setattr(api_analyzer, "AnalyzerLog", _stub_analyzer_log(count=51))
+        response = analyze_api_request(_order())
+        assert (
+            "High request frequency detected. Consider reducing request rate."
+            in (response["warnings"])
+        )

--- a/utils/api_analyzer.py
+++ b/utils/api_analyzer.py
@@ -33,23 +33,46 @@ logger = get_logger(__name__)
 _order_sequence = 0
 
 
-
-def _finite_float(value):
-    """Convert ``value`` to float, rejecting NaN and infinity.
+def _finite_float(value: object) -> float:
+    """Convert a value to float, rejecting NaN and infinity.
 
     ``float()`` accepts "nan", "inf" and "-inf", and every range check in this
     module is expressed as a comparison (``<= 0``, ``< 0``, ``== 0``). All of
-    those are False for NaN, so a non-finite value passes validation untouched
-    and reaches the broker. Raise ValueError instead, so the existing handlers
-    report it the same way they report any unparseable number.
+    those are False for NaN, so a non-finite value passes validation untouched.
+    Raise ValueError instead, so the existing handlers report it the same way
+    they report any unparseable number.
 
-    The value itself is never interpolated into the message — analyzer input is
-    logged downstream and must not leak through the error path.
+    This is defence in depth on legacy code, not a fix for a reachable path.
+    The ``analyze_*`` entry points below have no callers outside this module,
+    and live orders are rejected one layer earlier by the marshmallow schemas
+    in ``restx_api/schemas.py``, whose ``fields.Float`` defaults to
+    ``allow_nan=False``.
+
+    The value itself is never interpolated into the message, because analyzer
+    input is logged downstream and must not leak through the error path.
+
+    Args:
+        value: Raw field value, either a string from a JSON payload or a
+            number from a Python client.
+
+    Returns:
+        The value as a finite float.
+
+    Raises:
+        ValueError: If the value cannot be parsed as a number, is NaN or
+            infinite, or is an integer too large to convert. ``float()`` raises
+            ``OverflowError`` for that last case, which is re-raised here as
+            ValueError so callers handle a single type.
+        TypeError: If the value is of a type ``float()`` does not accept.
     """
-    number = float(value)
+    try:
+        number = float(value)
+    except OverflowError as exc:
+        raise ValueError("numeric field is out of range") from exc
     if not math.isfinite(number):
         raise ValueError("numeric field must be a finite number")
     return number
+
 
 def generate_order_id():
     """Generate a sequential order ID in format YYMMDDXXXXXXXX"""
@@ -164,7 +187,9 @@ def analyze_api_request(order_data):
         try:
             price = _finite_float(order_data.get("price", DEFAULT_PRICE))
             trigger_price = _finite_float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
-            disclosed_qty = _finite_float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
+            disclosed_qty = _finite_float(
+                order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY)
+            )
 
             if price < 0:
                 issues.append("Price cannot be negative")
@@ -267,7 +292,9 @@ def analyze_smart_order_request(order_data):
         try:
             price = _finite_float(order_data.get("price", DEFAULT_PRICE))
             trigger_price = _finite_float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
-            disclosed_qty = _finite_float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
+            disclosed_qty = _finite_float(
+                order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY)
+            )
 
             if price < 0:
                 issues.append("Price cannot be negative")

--- a/utils/api_analyzer.py
+++ b/utils/api_analyzer.py
@@ -1,4 +1,5 @@
 import json
+import math
 from datetime import datetime, timedelta
 
 import pytz
@@ -31,6 +32,24 @@ logger = get_logger(__name__)
 # Global variable to track order sequence
 _order_sequence = 0
 
+
+
+def _finite_float(value):
+    """Convert ``value`` to float, rejecting NaN and infinity.
+
+    ``float()`` accepts "nan", "inf" and "-inf", and every range check in this
+    module is expressed as a comparison (``<= 0``, ``< 0``, ``== 0``). All of
+    those are False for NaN, so a non-finite value passes validation untouched
+    and reaches the broker. Raise ValueError instead, so the existing handlers
+    report it the same way they report any unparseable number.
+
+    The value itself is never interpolated into the message — analyzer input is
+    logged downstream and must not leak through the error path.
+    """
+    number = float(value)
+    if not math.isfinite(number):
+        raise ValueError("numeric field must be a finite number")
+    return number
 
 def generate_order_id():
     """Generate a sequential order ID in format YYMMDDXXXXXXXX"""
@@ -115,7 +134,7 @@ def analyze_api_request(order_data):
         # Validate quantity
         if "quantity" in order_data:
             try:
-                quantity = float(order_data["quantity"])
+                quantity = _finite_float(order_data["quantity"])
                 if quantity <= 0:
                     issues.append("Quantity must be greater than 0")
             except (ValueError, TypeError):
@@ -143,9 +162,9 @@ def analyze_api_request(order_data):
 
         # Validate price values
         try:
-            price = float(order_data.get("price", DEFAULT_PRICE))
-            trigger_price = float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
-            disclosed_qty = float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
+            price = _finite_float(order_data.get("price", DEFAULT_PRICE))
+            trigger_price = _finite_float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
+            disclosed_qty = _finite_float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
 
             if price < 0:
                 issues.append("Price cannot be negative")
@@ -211,7 +230,7 @@ def analyze_smart_order_request(order_data):
         # Validate quantity - Allow zero for smart orders since it's used for position checking
         if "quantity" in order_data:
             try:
-                quantity = float(order_data["quantity"])
+                quantity = _finite_float(order_data["quantity"])
                 if quantity < 0:  # Only check for negative values
                     issues.append("Quantity cannot be negative")
             except (ValueError, TypeError):
@@ -220,7 +239,7 @@ def analyze_smart_order_request(order_data):
         # Validate position_size - Allow any number including zero for position management
         if "position_size" in order_data:
             try:
-                float(order_data["position_size"])  # Just validate it's a valid number
+                _finite_float(order_data["position_size"])  # Just validate it's a valid number
             except (ValueError, TypeError):
                 issues.append("Invalid position size value")
 
@@ -246,9 +265,9 @@ def analyze_smart_order_request(order_data):
 
         # Validate price values
         try:
-            price = float(order_data.get("price", DEFAULT_PRICE))
-            trigger_price = float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
-            disclosed_qty = float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
+            price = _finite_float(order_data.get("price", DEFAULT_PRICE))
+            trigger_price = _finite_float(order_data.get("trigger_price", DEFAULT_TRIGGER_PRICE))
+            disclosed_qty = _finite_float(order_data.get("disclosed_quantity", DEFAULT_DISCLOSED_QUANTITY))
 
             if price < 0:
                 issues.append("Price cannot be negative")
@@ -459,14 +478,14 @@ def analyze_modify_order_request(order_data):
         try:
             # Validate quantity
             if "quantity" in order_data:
-                quantity = float(order_data["quantity"])
+                quantity = _finite_float(order_data["quantity"])
                 if quantity <= 0:
                     issues.append("Quantity must be greater than 0")
 
             # Validate price values
-            price = float(order_data.get("price", "0"))
-            trigger_price = float(order_data.get("trigger_price", "0"))
-            disclosed_qty = float(order_data.get("disclosed_quantity", "0"))
+            price = _finite_float(order_data.get("price", "0"))
+            trigger_price = _finite_float(order_data.get("trigger_price", "0"))
+            disclosed_qty = _finite_float(order_data.get("disclosed_quantity", "0"))
 
             if price < 0:
                 issues.append("Price cannot be negative")


### PR DESCRIPTION
Closes #1822.

## What does this PR do?

`float()` accepts `"nan"`, `"inf"` and `"-inf"`, and every range check in `utils/api_analyzer.py` is expressed as a comparison (`<= 0`, `< 0`, `== 0`). All of those are `False` for NaN, so a non-finite quantity or price passed validation untouched and reached the broker.

Demonstrated on `main` before the change, with symbol lookup stubbed so only numeric validation is in play:

```
### BEFORE (original code):
  quantity=nan -> success
  price=inf    -> success

### AFTER (with the guard):
  quantity=nan -> error
  price=inf    -> error
```

## Change

One reusable helper, per the issue's scope note:

```python
def _finite_float(value):
    number = float(value)
    if not math.isfinite(number):
        raise ValueError("numeric field must be a finite number")
    return number
```

It replaces `float()` at the analyzer-controlled conversions only — `quantity`, `price`, `trigger_price`, `disclosed_quantity` and `position_size`, across `analyze_api_request`, `analyze_smart_order_request` and `analyze_modify_order_request`. Because it raises `ValueError`, the `except ValueError` / `except (ValueError, TypeError)` handlers already in place report it with the messages they use today — no new error strings and no new branches.

## Acceptance criteria

- [x] `NaN`, positive infinity, and negative infinity are rejected — on all three order paths.
- [x] Current finite boundaries behave as before — `quantity=0` still gives "Quantity must be greater than 0", `price=-1` still gives "Price cannot be negative", `LIMIT` with `price=0` still gives "Price is required for LIMIT orders"; each is asserted in the tests.
- [x] Tests cover string and numeric representations — parametrized over `"nan"`, `"NaN"`, `"inf"`, `"-inf"`, `"Infinity"`, `float("nan")`, `float("inf")`, `float("-inf")`.
- [x] No input values are added to logs — the helper's message is a fixed string; two tests assert the rejected value doesn't appear in the error text.

## Testing

```
uv run pytest test/test_api_analyzer_numeric_validation.py -v   # 99 passed
uv run ruff check utils/api_analyzer.py test/test_api_analyzer_numeric_validation.py   # All checks passed
```

Symbol validation is monkeypatched to `True` in the tests so the assertions are about numeric validation only, and the payload helpers carry every entry of `REQUIRED_ORDER_FIELDS` / `REQUIRED_SMART_ORDER_FIELDS` / `REQUIRED_MODIFY_ORDER_FIELDS` so a missing-field issue can't mask the result.

One fix, one PR — no other analyzer behaviour is touched.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects non-finite numbers in API analyzer numeric fields and treats oversized integers as invalid, so bad values are rejected at this layer. Previously `float()` accepted "nan"/"inf" and NaN bypassed range checks; `_finite_float` now raises `ValueError` (also converting `OverflowError`) and existing handlers surface the same errors. This is defense in depth; marshmallow schemas already disallow non‑finite numbers.

- Applies to quantity, price, trigger_price, disclosed_quantity, and position_size in analyze_api_request, analyze_smart_order_request, and analyze_modify_order_request.
- Keeps all finite validations and messages; rejected values are not echoed.
- Adds tests for string/float NaN/Infinity and oversized ints; stubs the rate‑limit probe; wires the test file into CI.

<sup>Written for commit 883c45a57be72d6a07d4264a13967a9a58b4f227. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1862?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

