### PR TITLE
refactor: add type hints to data schemas validators

### DIFF
--- a/docs/devsprint/participants.md
+++ b/docs/devsprint/participants.md
@@ -51,3 +51,4 @@ git push --force-with-lease
 | Rajandran R | [@marketcalls](https://github.com/marketcalls) | maintainer |
 |Padma Balaji L| [@PadmaBalajiL](https://github.com/PadmaBalajiL)|python|
 |Niranjan | [@cracker314](https://github.com/cracker314)|python|
+| Navadeep Marella | [@NavadeepDj](https://github.com/NavadeepDj) | python, backtesting |

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -6,7 +6,7 @@ from utils.constants import VALID_EXCHANGES
 
 
 # Custom validator for date or timestamp string
-def validate_date_or_timestamp(data):
+def validate_date_or_timestamp(data: str) -> None:
     """
     Validates that the input string is either in 'YYYY-MM-DD' format or a numeric timestamp.
     """
@@ -19,7 +19,7 @@ def validate_date_or_timestamp(data):
 
 
 # Custom validator for option offset
-def validate_option_offset(data):
+def validate_option_offset(data: str) -> bool:
     """
     Validates option offset: ATM, ITM1-ITM50, OTM1-OTM50
     """

--- a/test/test_data_schemas_validation.py
+++ b/test/test_data_schemas_validation.py
@@ -1,0 +1,85 @@
+import pytest
+from marshmallow import ValidationError
+
+from restx_api.data_schemas import validate_date_or_timestamp, validate_option_offset
+
+
+class TestValidateDateOrTimestamp:
+    """Tests for validate_date_or_timestamp validation function."""
+
+    @pytest.mark.parametrize(
+        "valid_input",
+        [
+            "2026-08-22",
+            "1999-01-01",
+            "2030-12-31",
+            "1724300000",  # 10-digit epoch timestamp
+            "1724300000000",  # 13-digit millisecond timestamp
+        ],
+    )
+    def test_valid_date_or_timestamp(self, valid_input: str):
+        # Should execute without raising ValidationError
+        result = validate_date_or_timestamp(valid_input)
+        assert result is None
+
+    @pytest.mark.parametrize(
+        "invalid_input",
+        [
+            "2026/08/22",
+            "22-08-2026",
+            "2026-8-2",
+            "invalid_string",
+            "",
+            "12345",  # Too short for timestamp
+            "123456789012345",  # Too long for timestamp
+            None,
+            1724300000,  # Integer type instead of string
+        ],
+    )
+    def test_invalid_date_or_timestamp(self, invalid_input):
+        with pytest.raises(ValidationError):
+            validate_date_or_timestamp(invalid_input)
+
+
+class TestValidateOptionOffset:
+    """Tests for validate_option_offset validation function."""
+
+    @pytest.mark.parametrize(
+        "valid_offset",
+        [
+            "ATM",
+            "atm",
+            "ITM1",
+            "itm1",
+            "ITM25",
+            "itm25",
+            "ITM50",
+            "itm50",
+            "OTM1",
+            "otm1",
+            "OTM25",
+            "otm25",
+            "OTM50",
+            "otm50",
+        ],
+    )
+    def test_valid_option_offset(self, valid_offset: str):
+        assert validate_option_offset(valid_offset) is True
+
+    @pytest.mark.parametrize(
+        "invalid_offset",
+        [
+            "ITM0",
+            "ITM51",
+            "ITM100",
+            "OTM0",
+            "OTM51",
+            "OTM100",
+            "ATM1",
+            "INVALID",
+            "",
+        ],
+    )
+    def test_invalid_option_offset(self, invalid_offset: str):
+        with pytest.raises(ValidationError):
+            validate_option_offset(invalid_offset)


### PR DESCRIPTION
### Summary
Added parameter and return type annotations to custom validation functions in `restx_api/data_schemas.py` and added a unit test suite to verify validation logic across all edge cases.

- `validate_date_or_timestamp(data: str) -> None`
- `validate_option_offset(data: str) -> bool`

### Issue Linked
Closes #893

### Testing
- `uv run ruff check restx_api/data_schemas.py test/test_data_schemas_validation.py` (Passed)
- `uv run pytest test/test_data_schemas_validation.py` (37 passed)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Annotates validator functions in restx_api/data_schemas.py with type hints and adds tests to lock in behavior. This clarifies the contract (string inputs only) and prevents regressions without changing runtime behavior.

- validate_date_or_timestamp now takes str and returns None; it raises ValidationError for non-YYYY-MM-DD strings or non-length-valid numeric timestamps.
- validate_option_offset now takes str and returns bool; it raises ValidationError for invalid offsets and returns True for valid ATM/ITM1–ITM50/OTM1–OTM50 (case-insensitive).

<sup>Written for commit eb7dd60a2b2bd3525973c4da310609d7cce987ef. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

