### PR TITLE
fix: prevent caching API key responses

### DIFF
--- a/blueprints/apikey.py
+++ b/blueprints/apikey.py
@@ -23,6 +23,7 @@ from database.auth_db import (
     verify_api_key,
 )
 from utils.logging import get_logger
+from utils.response import make_no_store_response
 from utils.session import check_session_validity
 
 # Path to React frontend
@@ -56,27 +57,31 @@ def manage_api_key():
 
         # Return JSON if Accept header requests it (for React frontend)
         if request.headers.get("Accept") == "application/json":
-            return jsonify(
-                {
-                    "login_username": login_username,
-                    "has_api_key": has_api_key,
-                    "api_key": api_key,
-                    "order_mode": order_mode,
-                }
+            return make_no_store_response(
+                jsonify(
+                    {
+                        "login_username": login_username,
+                        "has_api_key": has_api_key,
+                        "api_key": api_key,
+                        "order_mode": order_mode,
+                    }
+                )
             )
 
         # Serve React app for browser navigation
         index_path = FRONTEND_DIST / "index.html"
         if index_path.exists():
-            return send_file(index_path, mimetype="text/html")
+            return make_no_store_response(send_file(index_path, mimetype="text/html"))
 
         # Fallback to old template if React build not available
-        return render_template(
-            "apikey.html",
-            login_username=login_username,
-            has_api_key=has_api_key,
-            api_key=api_key,
-            order_mode=order_mode,
+        return make_no_store_response(
+            render_template(
+                "apikey.html",
+                login_username=login_username,
+                has_api_key=has_api_key,
+                api_key=api_key,
+                order_mode=order_mode,
+            )
         )
     else:
         user_id = request.json.get("user_id")
@@ -92,8 +97,14 @@ def manage_api_key():
 
         if key_id is not None:
             logger.info(f"API key updated successfully for user: {user_id}")
-            return jsonify(
-                {"message": "API key updated successfully.", "api_key": api_key, "key_id": key_id}
+            return make_no_store_response(
+                jsonify(
+                    {
+                        "message": "API key updated successfully.",
+                        "api_key": api_key,
+                        "key_id": key_id,
+                    }
+                )
             )
         else:
             logger.error(f"Failed to update API key for user: {user_id}")

--- a/blueprints/apikey.py
+++ b/blueprints/apikey.py
@@ -71,7 +71,7 @@ def manage_api_key():
         # Serve React app for browser navigation
         index_path = FRONTEND_DIST / "index.html"
         if index_path.exists():
-            return make_no_store_response(send_file(index_path, mimetype="text/html"))
+            return send_file(index_path, mimetype="text/html")
 
         # Fallback to old template if React build not available
         return make_no_store_response(

--- a/blueprints/playground.py
+++ b/blueprints/playground.py
@@ -8,6 +8,7 @@ from flask import Blueprint, current_app, jsonify, redirect, session, url_for
 
 from database.auth_db import get_api_key_for_tradingview
 from utils.logging import get_logger
+from utils.response import make_no_store_response
 from utils.session import check_session_validity
 
 logger = get_logger(__name__)
@@ -305,7 +306,7 @@ def get_api_key():
         return jsonify({"error": "Not authenticated"}), 401
 
     api_key = get_api_key_for_tradingview(login_username)
-    return jsonify({"api_key": api_key or ""})
+    return make_no_store_response(jsonify({"api_key": api_key or ""}))
 
 
 @playground_bp.route("/collections")

--- a/blueprints/websocket_example.py
+++ b/blueprints/websocket_example.py
@@ -25,6 +25,7 @@ from services.websocket_service import (
     unsubscribe_from_symbols,
 )
 from utils.logging import get_logger
+from utils.response import make_no_store_response
 from utils.session import check_session_validity
 
 # Initialize logger
@@ -180,7 +181,7 @@ def api_get_websocket_apikey():
             {"status": "error", "message": "No API key found. Please generate an API key first."}
         ), 404
 
-    return jsonify({"status": "success", "api_key": api_key}), 200
+    return make_no_store_response((jsonify({"status": "success", "api_key": api_key}), 200))
 
 
 @websocket_bp.route("/api/websocket/config", methods=["GET"])

--- a/test/test_api_key_cache_headers.py
+++ b/test/test_api_key_cache_headers.py
@@ -87,6 +87,25 @@ def test_apikey_html_response_prevents_caching_credentials(client, monkeypatch, 
     assert response.headers["Pragma"] == "no-cache"
 
 
+def test_apikey_react_shell_response_is_unchanged(client, monkeypatch, tmp_path):
+    """The static React shell contains no credential and should remain cacheable."""
+    tmp_path.joinpath("index.html").write_text("app shell", encoding="utf-8")
+    monkeypatch.setattr(apikey_blueprint, "FRONTEND_DIST", tmp_path)
+    monkeypatch.setattr(
+        apikey_blueprint,
+        "get_api_key_for_tradingview",
+        lambda username: "test-token-not-real",
+    )
+    monkeypatch.setattr(apikey_blueprint, "get_order_mode", lambda username: "auto")
+
+    response = client.get("/apikey")
+
+    assert response.status_code == 200
+    assert response.get_data(as_text=True) == "app shell"
+    assert "no-store" not in response.headers.get("Cache-Control", "")
+    assert "Pragma" not in response.headers
+
+
 def test_playground_api_key_prevents_caching_credentials(client, monkeypatch):
     """The playground key endpoint must not be cached."""
     monkeypatch.setattr(

--- a/test/test_api_key_cache_headers.py
+++ b/test/test_api_key_cache_headers.py
@@ -1,0 +1,133 @@
+"""Regression tests for cache headers on API-key responses."""
+
+import pytest
+from flask import Flask
+
+import blueprints.apikey as apikey_blueprint
+import blueprints.playground as playground_blueprint
+import blueprints.websocket_example as websocket_blueprint
+import database.auth_db as auth_db
+
+
+@pytest.fixture
+def app(monkeypatch):
+    """Create a minimal app with an authenticated API-key route."""
+    monkeypatch.setenv("DISABLE_SESSION_EXPIRY", "true")
+
+    app = Flask(__name__)
+    app.secret_key = "test-secret-not-real"  # pragma: allowlist secret
+    app.register_blueprint(apikey_blueprint.api_key_bp)
+    app.register_blueprint(playground_blueprint.playground_bp)
+    app.register_blueprint(websocket_blueprint.websocket_bp)
+    return app
+
+
+@pytest.fixture
+def client(app):
+    """Return a client with a locally authenticated test session."""
+    with app.test_client() as client:
+        with client.session_transaction() as session:
+            session["user"] = "test-user"
+            session["logged_in"] = True
+            session["login_time"] = "2026-01-01T00:00:00+05:30"
+        yield client
+
+
+def test_apikey_get_prevents_caching_credentials(client, monkeypatch):
+    """The JSON response containing an existing key must not be cached."""
+    monkeypatch.setattr(
+        apikey_blueprint,
+        "get_api_key_for_tradingview",
+        lambda username: "test-token-not-real",
+    )
+    monkeypatch.setattr(apikey_blueprint, "get_order_mode", lambda username: "auto")
+
+    response = client.get("/apikey", headers={"Accept": "application/json"})
+
+    assert response.status_code == 200
+    assert response.get_json()["api_key"] == "test-token-not-real"  # pragma: allowlist secret
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_apikey_post_prevents_caching_new_credentials(client, monkeypatch):
+    """A newly generated key must not be cached."""
+    monkeypatch.setattr(
+        apikey_blueprint,
+        "generate_api_key",
+        lambda: "new-test-token-not-real",
+    )
+    monkeypatch.setattr(apikey_blueprint, "upsert_api_key", lambda user_id, api_key: 42)
+
+    response = client.post("/apikey", json={"user_id": "test-user"})
+
+    assert response.status_code == 200
+    assert (
+        response.get_json()["api_key"] == "new-test-token-not-real"  # pragma: allowlist secret
+    )
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_apikey_html_response_prevents_caching_credentials(client, monkeypatch, tmp_path):
+    """The legacy HTML page, which embeds the current key, must not be cached."""
+    monkeypatch.setattr(apikey_blueprint, "FRONTEND_DIST", tmp_path)
+    monkeypatch.setattr(
+        apikey_blueprint,
+        "get_api_key_for_tradingview",
+        lambda username: "test-token-not-real",
+    )
+    monkeypatch.setattr(apikey_blueprint, "get_order_mode", lambda username: "auto")
+    monkeypatch.setattr(apikey_blueprint, "render_template", lambda *args, **kwargs: "key page")
+
+    response = client.get("/apikey")
+
+    assert response.status_code == 200
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_playground_api_key_prevents_caching_credentials(client, monkeypatch):
+    """The playground key endpoint must not be cached."""
+    monkeypatch.setattr(
+        playground_blueprint,
+        "get_api_key_for_tradingview",
+        lambda username: "test-token-not-real",
+    )
+
+    response = client.get("/playground/api-key")
+
+    assert response.status_code == 200
+    assert response.get_json()["api_key"] == "test-token-not-real"  # pragma: allowlist secret
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_websocket_api_key_prevents_caching_credentials(client, monkeypatch):
+    """The WebSocket authentication key endpoint must not be cached."""
+    monkeypatch.setattr(
+        auth_db,
+        "get_api_key_for_tradingview",
+        lambda username: "test-token-not-real",
+    )
+
+    response = client.get("/api/websocket/apikey")
+
+    assert response.status_code == 200
+    assert response.get_json()["api_key"] == "test-token-not-real"  # pragma: allowlist secret
+    assert response.headers["Cache-Control"] == "no-store, max-age=0"
+    assert response.headers["Pragma"] == "no-cache"
+
+
+def test_non_sensitive_api_key_mode_response_is_unchanged(client, monkeypatch):
+    """The no-store helper must remain scoped to responses carrying credentials."""
+    monkeypatch.setattr(apikey_blueprint, "update_order_mode", lambda user_id, mode: True)
+
+    response = client.post(
+        "/apikey/mode",
+        json={"user_id": "test-user", "mode": "auto"},
+    )
+
+    assert response.status_code == 200
+    assert "no-store" not in response.headers.get("Cache-Control", "")
+    assert "Pragma" not in response.headers

--- a/utils/response.py
+++ b/utils/response.py
@@ -1,0 +1,19 @@
+"""Utilities for building HTTP responses."""
+
+from flask import Response, make_response
+from flask.typing import ResponseReturnValue
+
+
+def make_no_store_response(response: ResponseReturnValue) -> Response:
+    """Return a response with browser and intermediary storage disabled.
+
+    Args:
+        response: Any value accepted by Flask's ``make_response``.
+
+    Returns:
+        A Flask response carrying modern and legacy no-cache headers.
+    """
+    no_store_response = make_response(response)
+    no_store_response.headers["Cache-Control"] = "no-store, max-age=0"
+    no_store_response.headers["Pragma"] = "no-cache"
+    return no_store_response


### PR DESCRIPTION
## Summary

Adds explicit no-store headers to every response that returns a decrypted or newly generated API key.

## Changes

- Add a reusable `make_no_store_response` Flask helper.
- Apply it to the JSON, credential-bearing HTML fallback, and successful POST paths for `/apikey`.
- Apply it to `/playground/api-key` and `/api/websocket/apikey`.
- Add regression coverage for all credential-bearing paths.
- Verify that the static React shell and the non-sensitive `/apikey/mode` response remain unchanged.
- Preserve all existing response bodies and status codes.

## Tests

- `python -m pytest -p no:cacheprovider test/test_api_key_cache_headers.py -q` — 7 passed
- `ruff format --no-cache --check blueprints/apikey.py blueprints/playground.py blueprints/websocket_example.py utils/response.py test/test_api_key_cache_headers.py` — passed
- `ruff check --no-cache --ignore F841 blueprints/apikey.py blueprints/playground.py blueprints/websocket_example.py utils/response.py test/test_api_key_cache_headers.py` — passed
- `detect-secrets-hook --no-verify --baseline .secrets.baseline ...` — passed
- Broader suite: 1,313 passed and 38 skipped; remaining failures/errors are existing environment/integration tests requiring external services, fixtures, or async plugins.

## Notes

The exact unignored Ruff command also reports two pre-existing `F841` violations in `blueprints/websocket_example.py` at the example-only assignments around lines 452 and 458; this PR does not modify those lines.

Tests use only explicit non-real values such as `test-token-not-real`.

Closes #1850


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents caching of API-key responses by adding explicit no-store headers wherever credentials are returned. Previously, some API-key endpoints were cacheable; now those responses send Cache-Control: no-store, max-age=0 and Pragma: no-cache, while non-sensitive endpoints keep prior caching behavior.

- Introduces `utils/response.make_no_store_response`.
- Applies to `/apikey` JSON, the legacy HTML fallback, successful `POST /apikey`, `/playground/api-key`, and `/api/websocket/apikey`.
- Leaves the static React shell and `/apikey/mode` responses unchanged.
- Preserves all response bodies and status codes.
- Adds regression tests covering credential-bearing and non-sensitive paths.

<sup>Written for commit b90b9474d0e77a5ffe42cdda4c40103085442265. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

