### PR TITLE
fix: expire rate limiter calls at the window boundary

### DIFF
--- a/frontend/src/lib/rateLimiter.test.ts
+++ b/frontend/src/lib/rateLimiter.test.ts
@@ -1,0 +1,33 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { createRateLimiter } from './rateLimiter'
+
+describe('createRateLimiter', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('expires a call exactly at the window boundary', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const limiter = createRateLimiter(1, 1000)
+    expect(limiter.call()).toBe(true)
+
+    vi.advanceTimersByTime(1000)
+
+    expect(limiter.canCall()).toBe(true)
+  })
+
+  it('retains a call that is still inside the window', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+
+    const limiter = createRateLimiter(1, 1000)
+    expect(limiter.call()).toBe(true)
+
+    vi.advanceTimersByTime(999)
+
+    expect(limiter.canCall()).toBe(false)
+  })
+})

--- a/frontend/src/lib/rateLimiter.ts
+++ b/frontend/src/lib/rateLimiter.ts
@@ -80,7 +80,7 @@ export function createRateLimiter(maxCalls: number, windowMs: number) {
 
   function cleanup() {
     const now = Date.now()
-    while (timestamps.length > 0 && timestamps[0] < now - windowMs) {
+    while (timestamps.length > 0 && timestamps[0] <= now - windowMs) {
       timestamps.shift()
     }
   }


### PR DESCRIPTION
## Summary

- expire rate-limiter timestamps when they are exactly one window old
- add deterministic fake-timer coverage for the exact boundary
- retain coverage for timestamps that are still inside the window

Closes #1830

## Testing

Using Node 22, matching CI:

- Vitest focused test: 2 passed
- Full Vitest suite: 939 passed
- Full Vitest coverage run: 939 passed
- Biome lint
- TypeScript check and Vite production build

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expire rate-limiter entries exactly at the window boundary to fix an off-by-one that over-throttled calls at t = windowMs. Previously, entries exactly one window old were retained; now they expire at the boundary, allowing the next call.

- Behavior: changes cleanup comparison from `<` to `<=`, so `canCall()` is true exactly at the boundary; calls still inside the window are retained.
- Tests: adds deterministic fake-timer coverage for the boundary case and the inside-window case.

<sup>Written for commit 91c99a8eabee58c0aed87b2708d1f6886edb9500. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1868?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

