### PR TITLE
fix(frontend): add role="status" and aria-hidden to PageLoader (#1834)

### DIFF
--- a/frontend/src/components/ui/page-loader.test.tsx
+++ b/frontend/src/components/ui/page-loader.test.tsx
@@ -30,11 +30,19 @@ describe('PageLoader', () => {
   })
 
   describe('accessibility', () => {
-    it('has accessible loading indicator', () => {
+    it('has accessible loading indicator with status role', () => {
       render(<PageLoader />)
 
-      // Check for text content that screen readers can announce
-      expect(screen.getByText('Loading...')).toBeInTheDocument()
+      // Check for text content and status role for screen readers
+      const statusElement = screen.getByRole('status')
+      expect(statusElement).toBeInTheDocument()
+      expect(statusElement).toHaveTextContent('Loading...')
+    })
+
+    it('marks spinner icon as decorative with aria-hidden', () => {
+      const { container } = render(<PageLoader />)
+      const spinner = container.querySelector('.animate-spin')
+      expect(spinner).toHaveAttribute('aria-hidden', 'true')
     })
   })
 })

--- a/frontend/src/components/ui/page-loader.tsx
+++ b/frontend/src/components/ui/page-loader.tsx
@@ -4,8 +4,11 @@ export function PageLoader() {
   return (
     <div className="min-h-screen flex items-center justify-center bg-background">
       <div className="flex flex-col items-center gap-4">
-        <Loader2 className="h-8 w-8 animate-spin text-primary" />
-        <p className="text-sm text-muted-foreground">Loading...</p>
+        <Loader2 className="h-8 w-8 animate-spin text-primary" aria-hidden="true" />
+        {/* biome-ignore lint/a11y/useSemanticElements: accessibility status role for screen readers */}
+        <p className="text-sm text-muted-foreground" role="status">
+          Loading...
+        </p>
       </div>
     </div>
   )


### PR DESCRIPTION
### Summary of Changes
- Added `role="status"` to the `Loading...` text in the `PageLoader` component to provide an accessible status live region for screen readers.
- Added `aria-hidden="true"` to the decorative `<Loader2 />` spinner icon.
- Updated accessibility unit tests in `page-loader.test.tsx` to verify `role="status"` and `aria-hidden="true"`.

Fixes #1834

### Checks & Verification
- [x] Executed local unit tests (`npx vitest run src/components/ui/page-loader.test.tsx`) - All 5 tests passed successfully.
- [x] Executed Biome linter/formatter check (`npx biome check`) - Passed with 0 errors.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves PageLoader accessibility by adding role="status" to the Loading... text and marking the spinner icon aria-hidden. Previously, screen readers could announce the spinner and not treat the message as a live status; now they announce a polite status and ignore the spinner, with no visual changes.

- Verify PageLoader renders an element with role="status" containing "Loading...".
- Confirm the `.animate-spin` spinner has `aria-hidden="true"`.
- Tests in `frontend/src/components/ui/page-loader.test.tsx` cover both cases.

<sup>Written for commit f0add97e3a50cd6f3a7d1b8fd0c867609e71f33e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

