### PR TITLE
fix: reject unsupported history sources

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run CI-safe tests
         run: |
           uv run pytest test/test_log_location.py test/test_navigation_update.py \
+            test/test_history_service_source_validation.py \
             test/test_python_editor.py test/test_rate_limits_simple.py \
             test/test_logout_csrf.py test/test_auth_logout.py \
             test/test_auth_resume.py test/test_auth_upsert_multisession.py \

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -242,13 +242,16 @@ def get_history(
         auth_token: Direct broker authentication token (for internal calls)
         feed_token: Direct broker feed token (for internal calls)
         broker: Direct broker name (for internal calls)
-        source: Data source - 'api' (broker, default) or 'db' (DuckDB/Historify)
+        source: Data source - 'api' (broker, default) or 'db' (DuckDB/Historify).
+            Unsupported values return 400 before a provider is called.
 
     Returns:
         Tuple containing:
         - Success status (bool)
         - Response data (dict)
         - HTTP status code (int)
+
+        Unsupported source values return a 400 error before either provider is called.
     """
     if not isinstance(source, str) or source not in {"api", "db"}:
         return (

--- a/services/history_service.py
+++ b/services/history_service.py
@@ -1,6 +1,6 @@
 import importlib
 import time
-from typing import Any, Dict, List, Optional, Tuple, Union
+from typing import Any
 
 import pandas as pd
 
@@ -250,6 +250,13 @@ def get_history(
         - Response data (dict)
         - HTTP status code (int)
     """
+    if not isinstance(source, str) or source not in {"api", "db"}:
+        return (
+            False,
+            {"status": "error", "message": "Source must be either 'api' or 'db'."},
+            400,
+        )
+
     # Source: 'db' - Fetch from DuckDB/Historify database
     if source == "db":
         return get_history_from_db(

--- a/test/test_history_service_source_validation.py
+++ b/test/test_history_service_source_validation.py
@@ -1,0 +1,114 @@
+import pytest
+
+from services import history_service
+
+
+def _history_request() -> dict:
+    return {
+        "symbol": "NIFTY",
+        "exchange": "NSE_INDEX",
+        "interval": "1m",
+        "start_date": "2026-08-01",
+        "end_date": "2026-08-22",
+        "auth_token": "test-token",
+        "feed_token": "test-feed-token",
+        "broker": "test-broker",
+    }
+
+
+def test_api_source_calls_api_provider(monkeypatch):
+    provider_calls = []
+    monkeypatch.setattr(history_service, "_enforce_rate_limit", lambda: None)
+    monkeypatch.setattr(
+        history_service,
+        "get_history_with_auth",
+        lambda *args: provider_calls.append(args) or (True, {"provider": "api"}, 200),
+    )
+
+    result = history_service.get_history(**_history_request(), source="api")
+
+    assert result == (True, {"provider": "api"}, 200)
+    assert provider_calls == [
+        (
+            "test-token",
+            "test-feed-token",
+            "test-broker",
+            "NIFTY",
+            "NSE_INDEX",
+            "1m",
+            "2026-08-01",
+            "2026-08-22",
+        )
+    ]
+
+
+def test_default_source_calls_api_provider(monkeypatch):
+    monkeypatch.setattr(history_service, "_enforce_rate_limit", lambda: None)
+    monkeypatch.setattr(
+        history_service,
+        "get_history_with_auth",
+        lambda *args: (True, {"provider": "api"}, 200),
+    )
+
+    assert history_service.get_history(**_history_request()) == (
+        True,
+        {"provider": "api"},
+        200,
+    )
+
+
+def test_db_source_calls_database_provider(monkeypatch):
+    provider_calls = []
+
+    def fake_database_provider(**kwargs):
+        provider_calls.append(kwargs)
+        return True, {"provider": "db"}, 200
+
+    monkeypatch.setattr(
+        history_service,
+        "get_history_from_db",
+        fake_database_provider,
+    )
+
+    result = history_service.get_history(**_history_request(), source="db")
+
+    assert result == (True, {"provider": "db"}, 200)
+    assert provider_calls == [
+        {
+            "symbol": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "interval": "1m",
+            "start_date": "2026-08-01",
+            "end_date": "2026-08-22",
+        }
+    ]
+
+
+@pytest.mark.parametrize("source", ["cache", "", None, 123, [], {}])
+def test_invalid_sources_call_neither_provider(monkeypatch, source):
+    monkeypatch.setattr(
+        history_service,
+        "get_history_from_db",
+        lambda *args, **kwargs: pytest.fail("database provider should not be called"),
+    )
+    monkeypatch.setattr(
+        history_service,
+        "get_history_with_auth",
+        lambda *args, **kwargs: pytest.fail("API provider should not be called"),
+    )
+    monkeypatch.setattr(
+        history_service,
+        "_enforce_rate_limit",
+        lambda: pytest.fail("rate limiting should not run for an invalid source"),
+    )
+
+    success, response, status_code = history_service.get_history(
+        **_history_request(), source=source
+    )
+
+    assert success is False
+    assert status_code == 400
+    assert response == {
+        "status": "error",
+        "message": "Source must be either 'api' or 'db'.",
+    }


### PR DESCRIPTION
## Summary

Validate the `source` argument in `get_history()` before provider selection.

Only `api` and `db` are accepted. Unknown, empty, and non-string values now return a `400` client error without calling a provider.

## Related issue

Closes #1826

## Changes

- Preserve `source="api"` and the existing default API behavior.
- Preserve `source="db"` and the local database behavior.
- Reject unsupported sources before the API provider, database provider, or rate limiter can run.
- Add focused service tests for valid, default, and invalid source values.
- Remove unused legacy type imports in the same service file as a lint-only cleanup.

## Testing

- [x] `env -u LOG_FORMAT uv run pytest test/test_history_service_source_validation.py -v`
  - 9 passed
- [x] `uv run ruff check services/history_service.py test/test_history_service_source_validation.py`
  - passed
- [x] `git diff --check`
  - passed

## Full-suite note

`env -u LOG_FORMAT uv run pytest test/ -v` was also attempted. Collection is currently blocked by two unrelated existing environment/repository issues:

- `test/test_bot_web.py` imports `get_telegram_bot`, which is not present in `services.telegram_bot_service`.
- `test/test_telegram_startup.py` requires the unavailable `eventlet` package.

Neither failure is in this PR's changed files.

## Checklist

- [x] This PR contains one focused bug fix.
- [x] The change is covered by focused pytest tests.
- [x] Python linting passes for the changed files.
- [x] No credentials or sensitive data are included.
- [x] No UI change is included; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects unsupported history sources in get_history to return clear client errors and avoid unintended provider calls. Old: unknown or non-string sources could reach provider selection; new: only 'api' (default) and 'db' are accepted, others return 400 with "Source must be either 'api' or 'db'."

- Invalid sources short-circuit before the API provider, DB provider, and rate limiter run.
- Adds focused tests for valid/default/invalid sources and runs them in CI.

**Migration**
- If a client sends any source other than 'api' or 'db', update it to use 'api' or 'db' to avoid 400 responses.

<sup>Written for commit 5a97bdcb39393caa94e46339f735e4989b8902ac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1875?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

