### PR TITLE
test: cover option chain view mode toggle

### DIFF
--- a/frontend/src/components/option-chain/ViewModeToggle.test.tsx
+++ b/frontend/src/components/option-chain/ViewModeToggle.test.tsx
@@ -1,0 +1,48 @@
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/test-utils'
+import { ViewModeToggle } from './ViewModeToggle'
+
+describe('ViewModeToggle', () => {
+  it.each([
+    {
+      initialMode: 'price' as const,
+      selectedLabel: 'Price',
+      otherLabel: 'Greeks',
+      expectedMode: 'greeks' as const,
+    },
+    {
+      initialMode: 'greeks' as const,
+      selectedLabel: 'Greeks',
+      otherLabel: 'Price',
+      expectedMode: 'price' as const,
+    },
+  ])(
+    'shows $initialMode as selected and changes to $expectedMode',
+    async ({ initialMode, selectedLabel, otherLabel, expectedMode }) => {
+      const onViewModeChange = vi.fn()
+      const user = userEvent.setup()
+
+      render(
+        <ViewModeToggle
+          viewMode={initialMode}
+          onViewModeChange={onViewModeChange}
+        />
+      )
+
+      expect(
+        screen.getByRole('group', { name: 'Chain view mode' })
+      ).toBeInTheDocument()
+
+      const selectedButton = screen.getByRole('button', { name: selectedLabel })
+      const otherButton = screen.getByRole('button', { name: otherLabel })
+
+      expect(selectedButton).toHaveAttribute('aria-pressed', 'true')
+      expect(otherButton).toHaveAttribute('aria-pressed', 'false')
+
+      await user.click(otherButton)
+
+      expect(onViewModeChange).toHaveBeenCalledTimes(1)
+      expect(onViewModeChange).toHaveBeenCalledWith(expectedMode)
+    }
+  )
+})


### PR DESCRIPTION
## Summary

Add focused React Testing Library coverage for the Option Chain Price and Greeks view-mode toggle.

No production component behavior is changed.

## Related issue

Closes #1837

## Coverage

- Confirms the toggle group has the accessible name `Chain view mode`.
- Confirms both controls are discoverable by their accessible names: `Price` and `Greeks`.
- Confirms the selected mode has `aria-pressed="true"`.
- Confirms the other mode has `aria-pressed="false"`.
- Confirms clicking the other control calls the callback once with the correct mode value.
- Covers both initial modes: Price and Greeks.

## Testing

- [x] `npm run test:run -- src/components/option-chain/ViewModeToggle.test.tsx`
  - 2 passed
- [x] `npm run lint`
  - passed
- [x] `npm run build`
  - passed
- [x] `git diff --check`
  - passed

## Full-suite note

`npm run test:run` completed with 965 passing tests and one unrelated existing failure in `src/pages/StrategyBuilder.test.tsx`. The failing test cannot find `NIFTY18AUG2624600CE`; this PR changes only the new Option Chain test file and does not modify Strategy Builder code.

## Checklist

- [x] This PR contains one focused test addition.
- [x] Both initial toggle modes are covered.
- [x] Accessible names and `aria-pressed` state are covered.
- [x] The callback payload and call count are covered.
- [x] Frontend lint

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds focused tests for the Option Chain view-mode toggle (Price vs Greeks). Confirms accessible labeling, pressed-state semantics, and callback payloads for both initial modes.

- Adds `frontend/src/components/option-chain/ViewModeToggle.test.tsx` only; no production code changes.
- Verifies the group name "Chain view mode" and button names "Price" and "Greeks".
- Ensures the selected button has aria-pressed="true", the other has "false", and clicking the other calls onViewModeChange once with the expected mode.

<sup>Written for commit f2898a837434cffbe683e796f195995ff1371252. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1876?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

