### PR TITLE
fix: validate option expiry codes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,7 @@ jobs:
       - name: Run CI-safe tests
         run: |
           uv run pytest test/test_log_location.py test/test_navigation_update.py \
+            test/test_option_expiry_validation.py \
             test/test_python_editor.py test/test_rate_limits_simple.py \
             test/test_logout_csrf.py test/test_auth_logout.py \
             test/test_auth_resume.py test/test_auth_upsert_multisession.py \

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -40,6 +40,9 @@ def validate_option_offset(data: str) -> bool:
 
 def validate_option_expiry(data: str) -> None:
     """Validate an option expiry date in the exact DDMMMYY format."""
+    if data == "":
+        return
+
     if not isinstance(data, str) or not re.fullmatch(r"\d{2}[A-Z]{3}\d{2}", data):
         raise ValidationError("Expiry date must use the DDMMMYY format (for example, 28AUG26).")
 

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -1,4 +1,5 @@
 import re
+from datetime import datetime
 
 from marshmallow import Schema, ValidationError, fields, validate
 
@@ -35,6 +36,17 @@ def validate_option_offset(data: str) -> bool:
         raise ValidationError("Offset must be ATM, ITM1-ITM50, or OTM1-OTM50")
 
     return True
+
+
+def validate_option_expiry(data: str) -> None:
+    """Validate an option expiry date in the exact DDMMMYY format."""
+    if not isinstance(data, str) or not re.fullmatch(r"\d{2}[A-Z]{3}\d{2}", data):
+        raise ValidationError("Expiry date must use the DDMMMYY format (for example, 28AUG26).")
+
+    try:
+        datetime.strptime(data, "%d%b%y")
+    except ValueError as error:
+        raise ValidationError("Expiry date must be a valid calendar date.") from error
 
 
 class QuotesSchema(Schema):
@@ -167,7 +179,7 @@ class OptionSymbolSchema(Schema):
     underlying = fields.Str(required=True)  # Underlying symbol (NIFTY, RELIANCE, NIFTY28OCT25FUT)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, NFO)
     expiry_date = fields.Str(
-        required=False
+        required=False, validate=validate_option_expiry
     )  # Expiry date in DDMMMYY format (e.g., 28OCT25). Optional if underlying includes expiry
     strike_int = fields.Int(
         required=False, validate=validate.Range(min=1), allow_none=True

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -294,7 +294,7 @@ class OptionsMultiOrderSchema(Schema):
     underlying = fields.Str(required=True)  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE)
     expiry_date = fields.Str(
-        required=False
+        required=False, validate=validate_option_expiry
     )  # Optional if underlying includes expiry (DDMMMYY format)
     strike_int = fields.Int(
         required=False, validate=validate.Range(min=1), allow_none=True

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -1,5 +1,6 @@
 from marshmallow import EXCLUDE, Schema, ValidationError, fields, post_load, pre_load, validate
 
+from restx_api.data_schemas import validate_option_expiry
 from utils.constants import CRYPTO_EXCHANGES, VALID_EXCHANGES
 
 
@@ -210,7 +211,7 @@ class OptionsOrderSchema(Schema):
     )  # Underlying symbol (NIFTY, BANKNIFTY, RELIANCE, or NIFTY28NOV24FUT)
     exchange = fields.Str(required=True, validate=validate.OneOf(VALID_EXCHANGES))  # Exchange (NSE_INDEX, NSE, BSE_INDEX, BSE, NFO, BFO)
     expiry_date = fields.Str(
-        required=False
+        required=False, validate=validate_option_expiry
     )  # Optional if underlying includes expiry (DDMMMYY format)
     strike_int = fields.Int(
         required=False, validate=validate.Range(min=1), allow_none=True
@@ -264,7 +265,7 @@ class OptionsMultiOrderLegSchema(Schema):
         allow_none=True,
     )  # Optional: If > 0, splits leg into multiple orders of this size
     expiry_date = fields.Str(
-        required=False
+        required=False, validate=validate_option_expiry
     )  # Optional per-leg expiry (DDMMMYY format) - for diagonal/calendar spreads
     pricetype = fields.Str(
         missing="MARKET", validate=validate.OneOf(["MARKET", "LIMIT", "SL", "SL-M"])

--- a/test/test_option_expiry_validation.py
+++ b/test/test_option_expiry_validation.py
@@ -2,7 +2,11 @@ import pytest
 from marshmallow import ValidationError
 
 from restx_api.data_schemas import OptionSymbolSchema, validate_option_expiry
-from restx_api.schemas import OptionsMultiOrderLegSchema, OptionsOrderSchema
+from restx_api.schemas import (
+    OptionsMultiOrderLegSchema,
+    OptionsMultiOrderSchema,
+    OptionsOrderSchema,
+)
 
 SCHEMA_PAYLOADS = [
     (
@@ -37,6 +41,23 @@ SCHEMA_PAYLOADS = [
             "quantity": 1,
         },
     ),
+    (
+        OptionsMultiOrderSchema,
+        {
+            "apikey": "test-key",
+            "strategy": "test-strategy",
+            "underlying": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "legs": [
+                {
+                    "offset": "ATM",
+                    "option_type": "CE",
+                    "action": "BUY",
+                    "quantity": 1,
+                }
+            ],
+        },
+    ),
 ]
 
 
@@ -45,9 +66,13 @@ def test_option_expiry_validator_accepts_valid_dates(expiry_date):
     assert validate_option_expiry(expiry_date) is None
 
 
+def test_option_expiry_validator_allows_empty_value():
+    assert validate_option_expiry("") is None
+
+
 @pytest.mark.parametrize(
     "expiry_date",
-    ["29FEB25", "31APR26", "28aug26", "28AUG2026", "28-AUG-26", "1AUG26", ""],
+    ["29FEB25", "31APR26", "28aug26", "28AUG2026", "28-AUG-26", "1AUG26"],
 )
 def test_option_expiry_validator_rejects_invalid_dates(expiry_date):
     with pytest.raises(ValidationError):
@@ -56,7 +81,6 @@ def test_option_expiry_validator_rejects_invalid_dates(expiry_date):
 
 @pytest.mark.parametrize("schema_class,payload", SCHEMA_PAYLOADS)
 def test_matching_schemas_reuse_option_expiry_validator(schema_class, payload):
-    assert schema_class._declared_fields["expiry_date"].validate is validate_option_expiry
     assert schema_class().load({**payload, "expiry_date": "28AUG26"})["expiry_date"] == "28AUG26"
 
 
@@ -65,3 +89,38 @@ def test_matching_schemas_reuse_option_expiry_validator(schema_class, payload):
 def test_matching_schemas_reject_invalid_expiry_dates(schema_class, payload, expiry_date):
     with pytest.raises(ValidationError, match="expiry_date"):
         schema_class().load({**payload, "expiry_date": expiry_date})
+
+
+def test_options_order_allows_omitted_expiry_with_embedded_underlying():
+    order_data = OptionsOrderSchema().load(
+        {
+            "apikey": "test-key",
+            "strategy": "test-strategy",
+            "underlying": "NIFTY28OCT25FUT",
+            "exchange": "NSE_INDEX",
+            "offset": "ATM",
+            "option_type": "CE",
+            "action": "BUY",
+            "quantity": 1,
+        }
+    )
+
+    assert "expiry_date" not in order_data
+
+
+def test_options_order_allows_empty_expiry_with_embedded_underlying():
+    order_data = OptionsOrderSchema().load(
+        {
+            "apikey": "test-key",
+            "strategy": "test-strategy",
+            "underlying": "NIFTY28OCT25FUT",
+            "exchange": "NSE_INDEX",
+            "offset": "ATM",
+            "option_type": "CE",
+            "action": "BUY",
+            "quantity": 1,
+            "expiry_date": "",
+        }
+    )
+
+    assert order_data["expiry_date"] == ""

--- a/test/test_option_expiry_validation.py
+++ b/test/test_option_expiry_validation.py
@@ -1,0 +1,67 @@
+import pytest
+from marshmallow import ValidationError
+
+from restx_api.data_schemas import OptionSymbolSchema, validate_option_expiry
+from restx_api.schemas import OptionsMultiOrderLegSchema, OptionsOrderSchema
+
+SCHEMA_PAYLOADS = [
+    (
+        OptionSymbolSchema,
+        {
+            "apikey": "test-key",
+            "underlying": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "offset": "ATM",
+            "option_type": "CE",
+        },
+    ),
+    (
+        OptionsOrderSchema,
+        {
+            "apikey": "test-key",
+            "strategy": "test-strategy",
+            "underlying": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "offset": "ATM",
+            "option_type": "CE",
+            "action": "BUY",
+            "quantity": 1,
+        },
+    ),
+    (
+        OptionsMultiOrderLegSchema,
+        {
+            "offset": "ATM",
+            "option_type": "CE",
+            "action": "BUY",
+            "quantity": 1,
+        },
+    ),
+]
+
+
+@pytest.mark.parametrize("expiry_date", ["28AUG26", "29FEB24"])
+def test_option_expiry_validator_accepts_valid_dates(expiry_date):
+    assert validate_option_expiry(expiry_date) is None
+
+
+@pytest.mark.parametrize(
+    "expiry_date",
+    ["29FEB25", "31APR26", "28aug26", "28AUG2026", "28-AUG-26", "1AUG26", ""],
+)
+def test_option_expiry_validator_rejects_invalid_dates(expiry_date):
+    with pytest.raises(ValidationError):
+        validate_option_expiry(expiry_date)
+
+
+@pytest.mark.parametrize("schema_class,payload", SCHEMA_PAYLOADS)
+def test_matching_schemas_reuse_option_expiry_validator(schema_class, payload):
+    assert schema_class._declared_fields["expiry_date"].validate is validate_option_expiry
+    assert schema_class().load({**payload, "expiry_date": "28AUG26"})["expiry_date"] == "28AUG26"
+
+
+@pytest.mark.parametrize("schema_class,payload", SCHEMA_PAYLOADS)
+@pytest.mark.parametrize("expiry_date", ["29FEB25", "28aug26", "28-AUG-26"])
+def test_matching_schemas_reject_invalid_expiry_dates(schema_class, payload, expiry_date):
+    with pytest.raises(ValidationError, match="expiry_date"):
+        schema_class().load({**payload, "expiry_date": expiry_date})


### PR DESCRIPTION
## Summary

Add one shared validator for option expiry codes at the API boundary.

The validator requires the exact uppercase `DDMMMYY` format and rejects dates that do not exist on the calendar.

## Related issue

Closes #1821

## Changes

- Add `validate_option_expiry()` in `restx_api/data_schemas.py`.
- Reuse the validator for the Option Symbol, Single Option Order, and Multi Option Order leg expiry fields.
- Add focused schema-validation tests.

## Coverage

- Valid expiry: `28AUG26`
- Valid leap day: `29FEB24`
- Invalid calendar dates: `29FEB25`, `31APR26`
- Invalid casing: `28aug26`
- Invalid length and separators: `28AUG2026`, `1AUG26`, `28-AUG-26`
- Shared validator reuse across all three updated schemas

## Testing

- [x] `env -u LOG_FORMAT uv run pytest test/test_option_expiry_validation.py -v`
  - 21 passed
- [x] `uv run ruff check restx_api/data_schemas.py restx_api/schemas.py test/test_option_expiry_validation.py`
  - passed
- [x] `git diff --check`
  - passed

## Local environment note

This machine sets `LOG_FORMAT=json`, which conflicts with the repository logging setup during test collection. The focused test was run with that local-only environment variable removed; no project configuration was changed.

## Checklist

- [x] This PR contains one focused bug fix.
- [x] One reusable validator is used by every schema changed in this PR.
- [x] Valid, leap-day, malformed, and calendar-invalid inputs are covered.
- [x] No broker credentials or sensitive data are included.
- [x] No UI change is included; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Enforces strict validation for option expiry codes. Previously `expiry_date` accepted any string; now only uppercase DDMMMYY (e.g., 28AUG26) that map to real calendar dates are accepted, otherwise the API returns a schema validation error.

**Reviewer notes**
- Applies `validate_option_expiry()` to `OptionSymbolSchema`, `OptionsOrderSchema`, `OptionsMultiOrderLegSchema`, and `OptionsMultiOrderSchema`.
- Rejects impossible dates and format errors (e.g., 29FEB25, 28aug26, 28-AUG-26); allows leap day (29FEB24).
- Keeps `expiry_date` optional and allows empty string when the underlying embeds expiry.
- Adds `test/test_option_expiry_validation.py` and runs it in the CI-safe test job.

<sup>Written for commit 9407d015efe039384d3f69a2cc4507c6b80816b4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1878?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

