### PR TITLE
fix: expose active navigation route

### DIFF
--- a/frontend/src/components/layout/MobileBottomNav.test.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.test.tsx
@@ -54,6 +54,7 @@ describe('MobileBottomNav', () => {
 
       const dashboardLink = screen.getByRole('link', { name: /dashboard/i })
       expect(dashboardLink).toHaveClass('text-primary')
+      expect(dashboardLink).toHaveAttribute('aria-current', 'page')
     })
 
     it('highlights Positions when on positions route', () => {

--- a/frontend/src/components/layout/MobileBottomNav.tsx
+++ b/frontend/src/components/layout/MobileBottomNav.tsx
@@ -20,6 +20,7 @@ export function MobileBottomNav() {
                   ? 'text-primary'
                   : 'text-muted-foreground hover:text-foreground active:bg-muted'
               )}
+              aria-current={active ? 'page' : undefined}
             >
               <item.icon className="h-5 w-5" />
               <span className="text-[10px] font-medium">{item.label}</span>

--- a/frontend/src/components/layout/Navbar.test.tsx
+++ b/frontend/src/components/layout/Navbar.test.tsx
@@ -37,7 +37,12 @@ describe('Navbar', () => {
 
     expect(strategy).toHaveAttribute('aria-current', 'page')
     expect(dashboard).not.toHaveAttribute('aria-current')
-    expect(currentLinks(document.body)).toEqual([strategy])
+    const desktopNav = screen
+      .getAllByRole('navigation')
+      .find((nav) => nav.classList.contains('md:flex'))
+
+    expect(desktopNav).toBeDefined()
+    expect(currentLinks(desktopNav!)).toEqual([strategy])
   })
 
   it('marks only the active sheet navigation link as current', async () => {

--- a/frontend/src/components/layout/Navbar.test.tsx
+++ b/frontend/src/components/layout/Navbar.test.tsx
@@ -1,0 +1,72 @@
+import { render, screen, within } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { MemoryRouter } from 'react-router'
+import { describe, expect, it, vi } from 'vitest'
+import { Navbar } from './Navbar'
+
+vi.mock('@/hooks/useProfileMenuItems', () => ({
+  useProfileMenuItems: () => [
+    {
+      href: '/profile',
+      label: 'Profile',
+      icon: () => null,
+    },
+  ],
+}))
+
+function renderNavbar(pathname: string) {
+  return render(
+    <MemoryRouter initialEntries={[pathname]}>
+      <Navbar />
+    </MemoryRouter>
+  )
+}
+
+function currentLinks(container: HTMLElement) {
+  return within(container)
+    .getAllByRole('link')
+    .filter((link) => link.getAttribute('aria-current') === 'page')
+}
+
+describe('Navbar', () => {
+  it('marks only the nested Strategy route as current in desktop navigation', () => {
+    renderNavbar('/strategy/builder')
+
+    const strategy = screen.getByRole('link', { name: 'Strategy' })
+    const dashboard = screen.getByRole('link', { name: 'Dashboard' })
+
+    expect(strategy).toHaveAttribute('aria-current', 'page')
+    expect(dashboard).not.toHaveAttribute('aria-current')
+    expect(currentLinks(document.body)).toEqual([strategy])
+  })
+
+  it('marks only the active sheet navigation link as current', async () => {
+    const user = userEvent.setup()
+    renderNavbar('/trading')
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+
+    const sheet = await screen.findByRole('dialog', { name: 'Navigation Menu' })
+    const trading = within(sheet).getByRole('link', { name: 'Trading' })
+    const platforms = within(sheet).getByRole('link', { name: 'Platforms' })
+
+    expect(trading).toHaveAttribute('aria-current', 'page')
+    expect(platforms).not.toHaveAttribute('aria-current')
+    expect(currentLinks(sheet)).toEqual([trading])
+  })
+
+  it('marks the active quick-access sheet link as current', async () => {
+    const user = userEvent.setup()
+    renderNavbar('/profile')
+
+    await user.click(screen.getByRole('button', { name: 'Toggle menu' }))
+
+    const sheet = await screen.findByRole('dialog', { name: 'Navigation Menu' })
+    const profile = within(sheet).getByRole('link', { name: 'Profile' })
+    const trading = within(sheet).getByRole('link', { name: 'Trading' })
+
+    expect(profile).toHaveAttribute('aria-current', 'page')
+    expect(trading).not.toHaveAttribute('aria-current')
+    expect(currentLinks(sheet)).toEqual([profile])
+  })
+})

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -104,9 +104,10 @@ export function Navbar() {
                   Navigation
                 </div>
                 {mobileSheetItems.map((item) => {
+                  const active = isActive(item.href)
                   const cls = cn(
                     'flex items-center gap-3 rounded-lg px-3 py-3 text-sm transition-colors min-h-[44px] touch-manipulation',
-                    isActive(item.href)
+                    active
                       ? 'bg-primary text-primary-foreground'
                       : 'hover:bg-muted active:bg-muted'
                   )
@@ -122,6 +123,7 @@ export function Navbar() {
                       href={item.href}
                       onClick={() => setMobileOpen(false)}
                       className={cls}
+                      aria-current={active ? 'page' : undefined}
                     >
                       {inner}
                     </a>
@@ -131,6 +133,7 @@ export function Navbar() {
                       to={item.href}
                       onClick={() => setMobileOpen(false)}
                       className={cls}
+                      aria-current={active ? 'page' : undefined}
                     >
                       {inner}
                     </Link>
@@ -154,6 +157,7 @@ export function Navbar() {
                         ? 'bg-primary text-primary-foreground'
                         : 'hover:bg-muted active:bg-muted'
                     )}
+                    aria-current={isActive(item.href) ? 'page' : undefined}
                   >
                     <item.icon className="h-4 w-4" />
                     {item.label}
@@ -186,9 +190,10 @@ export function Navbar() {
             the profile menu off-screen; full labels from xl up (issue #1384). */}
         <nav className="hidden md:flex items-center gap-1">
           {navItems.map((item) => {
+            const active = isActive(item.href)
             const className = cn(
               'flex items-center gap-2 rounded-md px-3 py-2 text-sm font-medium transition-colors',
-              isActive(item.href)
+              active
                 ? 'bg-primary text-primary-foreground'
                 : 'text-muted-foreground hover:bg-muted hover:text-foreground'
             )
@@ -201,11 +206,23 @@ export function Navbar() {
             // Flask-served pages (e.g. /trading) need a full page load,
             // not client-side routing.
             return item.external ? (
-              <a key={item.href} href={item.href} title={item.label} className={className}>
+              <a
+                key={item.href}
+                href={item.href}
+                title={item.label}
+                className={className}
+                aria-current={active ? 'page' : undefined}
+              >
                 {content}
               </a>
             ) : (
-              <Link key={item.href} to={item.href} title={item.label} className={className}>
+              <Link
+                key={item.href}
+                to={item.href}
+                title={item.label}
+                className={className}
+                aria-current={active ? 'page' : undefined}
+              >
                 {content}
               </Link>
             )

--- a/frontend/src/components/layout/Navbar.tsx
+++ b/frontend/src/components/layout/Navbar.tsx
@@ -146,23 +146,26 @@ export function Navbar() {
                 <div className="px-3 py-2 text-xs font-medium text-muted-foreground uppercase tracking-wider">
                   Quick Access
                 </div>
-                {filteredProfileMenuItems.map((item) => (
-                  <Link
-                    key={item.href}
-                    to={item.href}
-                    onClick={() => setMobileOpen(false)}
-                    className={cn(
-                      'flex items-center gap-3 rounded-lg px-3 py-3 text-sm transition-colors min-h-[44px] touch-manipulation',
-                      isActive(item.href)
-                        ? 'bg-primary text-primary-foreground'
-                        : 'hover:bg-muted active:bg-muted'
-                    )}
-                    aria-current={isActive(item.href) ? 'page' : undefined}
-                  >
-                    <item.icon className="h-4 w-4" />
-                    {item.label}
-                  </Link>
-                ))}
+                {filteredProfileMenuItems.map((item) => {
+                  const active = isActive(item.href)
+                  return (
+                    <Link
+                      key={item.href}
+                      to={item.href}
+                      onClick={() => setMobileOpen(false)}
+                      className={cn(
+                        'flex items-center gap-3 rounded-lg px-3 py-3 text-sm transition-colors min-h-[44px] touch-manipulation',
+                        active
+                          ? 'bg-primary text-primary-foreground'
+                          : 'hover:bg-muted active:bg-muted'
+                      )}
+                      aria-current={active ? 'page' : undefined}
+                    >
+                      <item.icon className="h-4 w-4" />
+                      {item.label}
+                    </Link>
+                  )
+                })}
                 <a
                   href="https://docs.openalgo.in"
                   target="_blank"


### PR DESCRIPTION
## Summary

Expose the visually active navigation route to assistive technology with `aria-current="page"`.

## Related issue

Closes #1833

## Changes

- Reuse the existing active-route calculation for accessibility state.
- Add `aria-current="page"` to the active desktop navigation link.
- Add the same state to active links in the navigation sheet.
- Cover both the sheet’s main navigation and Quick Access link paths.
- Leave inactive links without an `aria-current` attribute.

## Coverage

- Exactly one desktop link is marked current for a nested Strategy route.
- Inactive desktop links do not receive `aria-current`.
- Exactly one active main-navigation sheet link is marked current.
- Exactly one active Quick Access sheet link is marked current.
- Existing nested-route behavior remains aligned with the visual active state.

## Testing

- [x] `npm run test:run -- src/components/layout/Navbar.test.tsx`
  - 3 passed
- [x] `npm run lint`
  - passed
- [x] `git diff --check`
  - passed

## Checklist

- [x] This PR contains one focused accessibility fix.
- [x] Active desktop and sheet links expose `aria-current="page"`.
- [x] Inactive links do not expose `aria-current`.
- [x] Nested route behavior is covered.
- [x] No routing or visual active-state behavior changed.
- [x] No UI redesign is included; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Expose the visually active navigation route to assistive technology using aria-current="page". Previously no link declared the current page; now exactly one active link in desktop navigation, the mobile navigation sheet (main navigation and Quick Access), and the mobile bottom navigation sets aria-current="page", improving screen reader context without changing routing or visuals. Fixes #1833.

- Reuses the existing active-route logic; inactive links omit aria-current.
- Adds tests to verify exactly one current link per context (desktop, mobile sheet, mobile bottom nav) and that nested routes match the visual active state.

<sup>Written for commit ad50bee1e105bccf4db72af8732503ae19d1ad23. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

