### PR TITLE
fix: redact API keys from core logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,6 +52,7 @@ jobs:
             test/test_telegram_api_contract.py \
             test/test_multi_option_greeks_regression.py \
             test/test_history_format.py \
+            test/test_core_credential_logging.py \
             -v --timeout=60
 
   # Frontend linting

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -103,7 +103,7 @@ class MultiOptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for multi option greeks: {api_key[:10]}...")
+                logger.warning("Invalid API key used for multi option greeks")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/restx_api/option_greeks.py
+++ b/restx_api/option_greeks.py
@@ -113,7 +113,7 @@ class OptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for option greeks: {api_key[:10]}...")
+                logger.warning("Invalid API key used for option greeks")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/services/websocket_client.py
+++ b/services/websocket_client.py
@@ -574,9 +574,9 @@ def get_websocket_client(
 def close_all_clients():
     """Close all WebSocket client connections"""
     with _client_lock:
-        for api_key, client in _client_instances.items():
+        for _api_key, client in _client_instances.items():
             try:
                 client.disconnect()
-            except Exception as e:
-                logger.exception(f"Error closing client for API key {api_key}: {e}")
+            except Exception:
+                logger.exception("Error closing WebSocket client")
         _client_instances.clear()

--- a/test/test_core_credential_logging.py
+++ b/test/test_core_credential_logging.py
@@ -12,6 +12,7 @@ def request_context():
 class RecordingLogger:
     def __init__(self):
         self.messages = []
+        self.error_messages = []
 
     def warning(self, message, *args):
         self.messages.append(message % args if args else message)
@@ -19,7 +20,8 @@ class RecordingLogger:
     def exception(self, message, *args):
         self.messages.append(message % args if args else message)
 
-    error = exception
+    def error(self, message, *args):
+        self.error_messages.append(message % args if args else message)
 
 
 def test_option_greeks_invalid_key_is_not_logged(monkeypatch):
@@ -81,4 +83,5 @@ def test_websocket_close_error_does_not_log_api_key(monkeypatch):
     websocket_client.close_all_clients()
 
     assert logger.messages == ["Error closing WebSocket client"]
+    assert logger.error_messages == []
     assert TEST_KEY not in " ".join(logger.messages)

--- a/test/test_core_credential_logging.py
+++ b/test/test_core_credential_logging.py
@@ -1,0 +1,84 @@
+"""Regression tests for credential-safe core service logging."""
+
+from flask import Flask
+
+TEST_KEY = "test-token-not-real-1234567890"
+
+
+def request_context():
+    return Flask(__name__).test_request_context("/", method="POST", json={"apikey": TEST_KEY})
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, message, *args):
+        self.messages.append(message % args if args else message)
+
+    def exception(self, message, *args):
+        self.messages.append(message % args if args else message)
+
+    error = exception
+
+
+def test_option_greeks_invalid_key_is_not_logged(monkeypatch):
+    from restx_api import option_greeks
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(option_greeks, "logger", logger)
+    monkeypatch.setattr(
+        option_greeks.option_greeks_schema,
+        "load",
+        lambda data: {"apikey": TEST_KEY, "symbol": "NIFTY", "exchange": "NFO"},
+    )
+    monkeypatch.setattr(option_greeks, "verify_api_key", lambda api_key: False)
+
+    with request_context():
+        response = option_greeks.OptionGreeks().post()
+
+    assert response.status_code == 401
+    assert logger.messages == ["Invalid API key used for option greeks"]
+    assert TEST_KEY not in " ".join(logger.messages)
+
+
+def test_multi_option_greeks_invalid_key_is_not_logged(monkeypatch):
+    from restx_api import multi_option_greeks
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(multi_option_greeks, "logger", logger)
+    monkeypatch.setattr(
+        multi_option_greeks.multi_option_greeks_schema,
+        "load",
+        lambda data: {"apikey": TEST_KEY, "symbols": []},
+    )
+    monkeypatch.setattr(multi_option_greeks, "verify_api_key", lambda api_key: False)
+
+    with request_context():
+        response = multi_option_greeks.MultiOptionGreeks().post()
+
+    assert response.status_code == 401
+    assert logger.messages == ["Invalid API key used for multi option greeks"]
+    assert TEST_KEY not in " ".join(logger.messages)
+
+
+def test_websocket_close_error_does_not_log_api_key(monkeypatch):
+    from services import websocket_client
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(websocket_client, "logger", logger)
+
+    class FailingClient:
+        def disconnect(self):
+            raise RuntimeError(f"disconnect failed for {TEST_KEY}")
+
+    monkeypatch.setattr(
+        websocket_client,
+        "_client_instances",
+        {TEST_KEY: FailingClient()},
+    )
+
+    websocket_client.close_all_clients()
+
+    assert logger.messages == ["Error closing WebSocket client"]
+    assert TEST_KEY not in " ".join(logger.messages)


### PR DESCRIPTION
Closes #1855

Removes full and partial API keys from WebSocket close errors and both option Greeks invalid-key warnings. WebSocket cleanup now uses `logger.exception` with a message that contains no key or exception text, while preserving the traceback for diagnostics. Adds focused regression tests for HTTP 401 preservation and credential-free logging, including an exception message containing a test API key.

Tests:
- `python -m pytest test/test_core_credential_logging.py -q` - 3 passed
- `python -m compileall` on changed files - passed
- `python -m ruff check test/test_core_credential_logging.py` - passed
- `git diff --check` - passed

CI ran the new tests successfully. Four pre-existing Ruff warnings remain in `websocket_client.py` and are unrelated to this change.
