### PR TITLE
fix: reject cross-origin referrers in CSRF and admin rate-limit redirects

### DIFF
--- a/app.py
+++ b/app.py
@@ -548,6 +548,8 @@ def create_app():
         """Custom handler for CSRF errors (400 Bad Request)"""
         from flask import flash, jsonify, redirect, request, url_for
 
+        from utils.safe_redirect import safe_local_redirect_target
+
         error_description = str(error)
 
         logger.warning(f"CSRF Error on {request.path}: {error_description}")
@@ -563,7 +565,9 @@ def create_app():
                 ), 400
             else:
                 flash("Security token expired. Please try again.", "error")
-                return redirect(request.referrer or url_for("auth.login"))
+                fallback = url_for("auth.login")
+                target = safe_local_redirect_target(request.referrer, fallback, request.host)
+                return redirect(target)
 
         # For other 400 errors
         return str(error), 400

--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -27,6 +27,7 @@ from database.qty_freeze_db import (
 from database.qty_freeze_db import db_session as freeze_db_session
 from limiter import limiter
 from utils.logging import get_logger
+from utils.safe_redirect import safe_local_redirect_target
 from utils.session import check_session_validity
 
 logger = get_logger(__name__)
@@ -41,7 +42,11 @@ admin_bp = Blueprint("admin_bp", __name__, url_prefix="/admin")
 def ratelimit_handler(e):
     """Handle rate limit exceeded errors"""
     flash("Rate limit exceeded. Please try again later.", "error")
-    return redirect(request.referrer or url_for("admin_bp.index"))
+    # "admin_bp.index" doesn't exist: the Jinja admin routes were migrated to
+    # React, and the admin dashboard is now served by react.react_admin_index.
+    fallback = url_for("react.react_admin_index")
+    target = safe_local_redirect_target(request.referrer, fallback, request.host)
+    return redirect(target)
 
 
 # ============================================================================

--- a/test/test_safe_error_redirects.py
+++ b/test/test_safe_error_redirects.py
@@ -1,0 +1,147 @@
+"""Regression tests for the CSRF and admin rate-limit error redirects.
+
+Both handlers used to redirect straight to ``request.referrer``. The Referer
+header is attacker-controlled on any request the attacker crafts directly, so
+an external, protocol-relative, or backslash-disguised referrer turned the
+error path into an open redirect. Both handlers now resolve their target
+through ``utils.safe_redirect.safe_local_redirect_target`` instead.
+"""
+
+import os
+import sys
+
+import pytest
+from flask import Flask, abort
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import blueprints.admin as admin_bp_module  # noqa: E402
+import blueprints.react_app as react_app_module  # noqa: E402
+from utils.safe_redirect import safe_local_redirect_target  # noqa: E402
+
+HOST = "app.example.com"
+
+
+# --- safe_local_redirect_target: unit coverage -----------------------------
+
+
+@pytest.mark.parametrize(
+    "candidate",
+    [
+        None,
+        "",
+        "   ",
+        "http://evil.com",
+        "https://evil.com/phish",
+        "http://evil.com/app.example.com",  # host is only a path segment here
+        "HTTP://EVIL.COM",
+        "http://app.example.com.evil.com/phish",  # suffix trick, not a subdomain match
+        "http://app.example.com@evil.com/phish",  # userinfo trick
+        "//evil.com",
+        "//evil.com/phish",
+        "//app.example.com/phish",  # protocol-relative is never a real Referer
+        "/\\evil.com",
+        "\\/evil.com",
+        "\\\\evil.com",
+        "%2F%2Fevil.com",
+        "%2f%2Fevil.com/phish",
+        "/%5c%5cevil.com",
+        "javascript:alert(1)",
+        "data:text/html,<script>alert(1)</script>",
+        "ftp://app.example.com/phish",
+        "https:evil.com",
+        "https:///evil.com",
+        "relative/without/leading/slash",
+        "/redirect\r\nSet-Cookie: pwned=1",
+        "/redirect\nLocation: http://evil.com",
+    ],
+)
+def test_unsafe_targets_fall_back(candidate):
+    assert safe_local_redirect_target(candidate, "/fallback", HOST) == "/fallback"
+
+
+@pytest.mark.parametrize(
+    ("candidate", "expected"),
+    [
+        ("/dashboard", "/dashboard"),
+        ("/settings/profile", "/settings/profile"),
+        ("/search?q=orders", "/search?q=orders"),
+        ("/search?q=hello%20world", "/search?q=hello world"),
+        ("/orders#history", "/orders#history"),
+        ("  /dashboard  ", "/dashboard"),
+        # Real browsers send an absolute URL, not a bare path.
+        ("http://app.example.com/dashboard", "/dashboard"),
+        ("https://app.example.com/settings/profile?tab=security", "/settings/profile?tab=security"),
+        ("HTTP://APP.EXAMPLE.COM/dashboard", "/dashboard"),
+        ("http://app.example.com", "/"),
+    ],
+)
+def test_safe_same_origin_targets_are_preserved(candidate, expected):
+    assert safe_local_redirect_target(candidate, "/fallback", HOST) == expected
+
+
+def test_missing_referrer_uses_fallback():
+    assert safe_local_redirect_target(None, "/admin", HOST) == "/admin"
+
+
+# --- admin_bp rate-limit handler: end-to-end wiring -------------------------
+
+
+# admin_bp has no active route left that raises 429 directly (they were all
+# migrated to React), so add a throwaway one purely to exercise the
+# blueprint's own @admin_bp.errorhandler(429) through a real request. This
+# has to happen once at import time: Flask locks a blueprint against further
+# route additions after its first registration to an app.
+@admin_bp_module.admin_bp.route("/_test/trigger-429")
+def _trigger_429():
+    abort(429)
+
+
+def _admin_app():
+    app = Flask(__name__)
+    app.secret_key = "test-secret"
+    app.register_blueprint(admin_bp_module.admin_bp)
+    # The handler's fallback resolves react.react_admin_index via url_for(),
+    # so that blueprint has to be registered too for a real request to work.
+    app.register_blueprint(react_app_module.react_bp)
+    return app
+
+
+def test_admin_ratelimit_handler_rejects_external_referrer():
+    app = _admin_app()
+    with app.test_client() as client:
+        response = client.get(
+            "/admin/_test/trigger-429", headers={"Referer": "https://evil.com/phish"}
+        )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/admin"
+
+
+def test_admin_ratelimit_handler_rejects_protocol_relative_referrer():
+    app = _admin_app()
+    with app.test_client() as client:
+        response = client.get("/admin/_test/trigger-429", headers={"Referer": "//evil.com"})
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/admin"
+
+
+def test_admin_ratelimit_handler_keeps_same_origin_referrer():
+    app = _admin_app()
+    with app.test_client() as client:
+        response = client.get(
+            "/admin/_test/trigger-429", headers={"Referer": "http://localhost/admin/holidays"}
+        )
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/admin/holidays"
+
+
+def test_admin_ratelimit_handler_falls_back_without_referrer():
+    app = _admin_app()
+    with app.test_client() as client:
+        response = client.get("/admin/_test/trigger-429")
+
+    assert response.status_code == 302
+    assert response.headers["Location"] == "/admin"

--- a/utils/safe_redirect.py
+++ b/utils/safe_redirect.py
@@ -1,0 +1,86 @@
+import re
+from urllib.parse import unquote, urlsplit
+
+# C0 controls and DEL. A CR/LF here could smuggle an extra header into the
+# redirect response; none of them belong in a same-origin path.
+_CONTROL_CHARS = re.compile(r"[\x00-\x1f\x7f]")
+
+_ALLOWED_ABSOLUTE_SCHEMES = {"http", "https"}
+
+
+def safe_local_redirect_target(candidate: str | None, fallback: str, host: str) -> str:
+    """Resolve an untrusted redirect target to a safe, same-origin path.
+
+    The CSRF and admin rate-limit error handlers redirect back to
+    ``request.referrer`` on the assumption that the referrer is always a
+    same-origin page the user just came from. That assumption doesn't hold:
+    the Referer header is attacker-controlled on any request the attacker
+    crafts directly, so redirecting to it unchecked turns an error path into
+    an open redirect that can support phishing.
+
+    A real browser's Referer is always a full absolute URL, so this accepts
+    one whose host matches ``host`` (scheme differences are not treated as
+    cross-origin here) as well as a bare same-origin path. Anything else - a
+    different host, a protocol-relative ``//host`` target, a backslash
+    variant of one (``/\\host``, which several browsers still normalize to
+    ``//host``), or a percent-encoded form of any of those - falls back to
+    ``fallback``.
+
+    Args:
+        candidate: The untrusted target, typically ``request.referrer``.
+        fallback: The internal URL to use when ``candidate`` is missing or
+            isn't a safe same-origin target.
+        host: The current request's host (``request.host``), used to decide
+            whether an absolute ``candidate`` is same-origin.
+
+    Returns:
+        A same-origin absolute path (scheme and host stripped) derived from
+        ``candidate``, or ``fallback``.
+    """
+    if not candidate:
+        return fallback
+
+    # The Referer header can itself be percent-encoded, so a bypass like
+    # "/%2F%2Fevil.com" must be judged on what it decodes to, not on its
+    # encoded shape.
+    decoded = unquote(candidate.strip())
+    if not decoded or _CONTROL_CHARS.search(decoded):
+        return fallback
+
+    # Normalize backslashes to forward slashes before parsing, closing the
+    # "/\evil.com" bypass some browsers still treat like "//evil.com". A real
+    # Referer is never protocol-relative, so treat any leading "//" as unsafe
+    # outright rather than trying to resolve it against `host`.
+    normalized = decoded.replace("\\", "/")
+    if normalized.startswith("//"):
+        return fallback
+
+    try:
+        parts = urlsplit(normalized)
+    except ValueError:
+        return fallback
+
+    scheme = parts.scheme.lower()
+    if scheme:
+        # An absolute URL must both use http(s) and explicitly name our own
+        # host - "https:///evil.com" (empty authority) is rejected here too,
+        # not treated as schemeless. `netloc` never carries userinfo for a
+        # genuine same-origin URL, so a trick like "http://host@evil.com/"
+        # (netloc "host@evil.com") also fails this comparison.
+        if scheme not in _ALLOWED_ABSOLUTE_SCHEMES or parts.netloc.lower() != host.lower():
+            return fallback
+    elif parts.netloc:
+        # Reachable only for a malformed edge case the "//" check above
+        # didn't already catch; treat as unsafe rather than guess.
+        return fallback
+
+    path = parts.path or "/"
+    if not path.startswith("/"):
+        return fallback
+
+    local = path
+    if parts.query:
+        local += f"?{parts.query}"
+    if parts.fragment:
+        local += f"#{parts.fragment}"
+    return local


### PR DESCRIPTION
## What changed

Two error handlers redirected straight to `request.referrer` with no validation:

- `app.py:566` (CSRF error handler) — `redirect(request.referrer or url_for("auth.login"))`
- `blueprints/admin.py:44` (admin rate-limit handler) — `redirect(request.referrer or url_for("admin_bp.index"))`

`Referer` is an ordinary, attacker-controllable HTTP header on any request the attacker crafts directly (it isn't limited to same-origin browser navigation), so an external referrer turned these error paths into an open redirect — useful for phishing or for confusing post-error navigation off the site.

This adds a single shared helper, `utils/safe_redirect.safe_local_redirect_target(candidate, fallback, host)`, and both handlers now route their target through it instead of using the referrer directly. It:

- Accepts a same-origin absolute URL (what a real browser's `Referer` actually looks like) or a bare same-origin path, and returns just the local `path[?query][#fragment]`.
- Rejects any other host, `javascript:`/`data:`/other non-http(s) schemes, and malformed input, falling back to the handler's intended internal route instead.
- Rejects protocol-relative targets (`//evil.com`), backslash-disguised ones (`/\evil.com`, still normalized to `//evil.com` by some browsers), and percent-encoded forms of either (`%2F%2Fevil.com`), since a naive check that only inspects the raw string is bypassable through any of these.
- Strips CR/LF and other control characters, closing off header-injection via a crafted referrer.

While wiring the admin handler, I also found its existing fallback, `url_for("admin_bp.index")`, was itself broken — that endpoint was removed when the Jinja admin routes were migrated to React, so calling it raises a `BuildError`. That made the "safe" fallback unreachable in exactly the case this fix needed it (an unsafe or missing referrer), so I pointed it at the current route, `react.react_admin_index`, instead.

## Why I prioritized this

It's a live open-redirect vulnerability (CWE-601) in a self-hosted trading platform's error paths — exactly the kind of issue where a plausible-looking phishing link (`https://your-openalgo-instance/...` triggering a CSRF error with a malicious `Referer`) can redirect a logged-in user off the real site. It's also small and self-contained (one new utility module, two call sites), matching the repo's one-fix-per-PR contribution policy, and doesn't touch broker integrations or require broker credentials to verify.

## Testing

`test/test_safe_error_redirects.py` covers:

- The helper directly: external hosts, protocol-relative, backslash, and percent-encoded variants, `javascript:`/`data:`/`ftp:` schemes, userinfo tricks (`http://host@evil.com`), suffix tricks (`app.example.com.evil.com`), CRLF injection, and — on the accept side — same-origin absolute URLs (including query/fragment) and bare relative paths.
- An end-to-end pass through the actual registered `admin_bp` `429` error handler (a throwaway route triggers `abort(429)`), checking the real `Location` header for an external referrer, a protocol-relative referrer, a same-origin referrer, and a missing referrer.

```
uv run pytest test/test_safe_error_redirects.py -v   # 41 passed
uv run ruff check app.py blueprints/admin.py utils/safe_redirect.py test/test_safe_error_redirects.py   # all checks passed
uv run pytest test/ -q   # no regressions vs. main (same pre-existing failures/errors on both, from missing optional deps - eventlet, pytest-asyncio - unrelated to this change)
```

Closes #1852

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rejects cross-origin referrers in CSRF and admin rate-limit error redirects to close an open-redirect vulnerability. Previously both handlers redirected to request.referrer; now they validate and only allow same-origin paths, falling back to the intended internal route.

- Add `utils/safe_redirect.safe_local_redirect_target(candidate, fallback, host)` to normalize and validate targets, returning a local path.
- Use the helper in the CSRF handler and the admin rate-limit handler instead of the raw referrer.
- Reject cross-origin hosts, non-http(s) schemes, protocol-relative (`//...`), backslash/percent-encoded variants, and control chars; accept same-origin absolute URLs and local paths.
- Fix the admin fallback: replace `url_for("admin_bp.index")` (removed endpoint) with `url_for("react.react_admin_index")` to avoid `BuildError`.
- Add tests for helper edge cases and end-to-end admin handler behavior.

<sup>Written for commit 2bf6d7a1910c2536c02706035c51047adbf1461d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1882?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

