### PR TITLE
fix: validate SIP inputs before loading prices

### DIFF
--- a/services/sip_service.py
+++ b/services/sip_service.py
@@ -48,6 +48,7 @@ from utils.logging import get_logger
 logger = get_logger(__name__)
 
 MAX_SIP_YEARS = 30
+INVALID_AMOUNT_MESSAGE = "amount must be a positive number"
 
 
 def _error(message: str, status: int = 400) -> tuple[bool, dict[str, Any], int]:
@@ -145,9 +146,12 @@ def run_sip_backtest(
             (the base symbol -- ``INFY``, ``SBIN``, ``TATAMOTORS``).
         start_date, end_date: ``YYYY-MM-DD``. ``start_date`` is the date the
             SIP begins; the first installment lands on or after it.
-        amount: the installment before any step-up.
+        amount: the installment before any step-up. Direct callers must provide
+            a finite, positive number or receive a 400 response.
         frequency: weekly, fortnightly, monthly or quarterly.
-        day_of_month: target day for monthly and quarterly SIPs, 1-28.
+        day_of_month: target day for monthly and quarterly SIPs. Direct callers
+            must provide an integer from 1 through 28 or receive a 400 response
+            before prices are loaded.
         step_up_percent: annual increase applied on each anniversary.
         brokerage_percent, brokerage_flat: charged per installment.
         benchmark, benchmark_exchange: an index to run the *same schedule*
@@ -172,9 +176,9 @@ def run_sip_backtest(
     try:
         investment_amount = float(amount)
     except (TypeError, ValueError, OverflowError):
-        return _error("amount must be a positive number")
+        return _error(INVALID_AMOUNT_MESSAGE)
     if not math.isfinite(investment_amount) or investment_amount <= 0:
-        return _error("amount must be a positive number")
+        return _error(INVALID_AMOUNT_MESSAGE)
     if frequency not in FREQUENCIES:
         return _error(f"frequency must be one of {', '.join(FREQUENCIES)}")
     if frequency in ("monthly", "quarterly") and (

--- a/services/sip_service.py
+++ b/services/sip_service.py
@@ -15,6 +15,7 @@ for the same question.
 from __future__ import annotations
 
 import dataclasses
+import math
 from datetime import date, datetime
 from typing import Any
 
@@ -40,7 +41,7 @@ from sip.analytics import (
 )
 from sip.crisis import crisis_sip_analysis, crisis_summary
 from sip.engine import SipError, run_sip
-from sip.schedule import FREQUENCIES, ScheduleError
+from sip.schedule import FREQUENCIES, MAX_DAY_OF_MONTH, ScheduleError
 from sip.xirr import xirr_or_none
 from utils.logging import get_logger
 
@@ -168,10 +169,20 @@ def run_sip_backtest(
         return _error("end_date must be after start_date")
     if (end - start).days > MAX_SIP_YEARS * 366:
         return _error(f"SIP window cannot exceed {MAX_SIP_YEARS} years")
-    if amount is None or float(amount) <= 0:
+    try:
+        investment_amount = float(amount)
+    except (TypeError, ValueError, OverflowError):
+        return _error("amount must be a positive number")
+    if not math.isfinite(investment_amount) or investment_amount <= 0:
         return _error("amount must be a positive number")
     if frequency not in FREQUENCIES:
         return _error(f"frequency must be one of {', '.join(FREQUENCIES)}")
+    if frequency in ("monthly", "quarterly") and (
+        isinstance(day_of_month, bool)
+        or not isinstance(day_of_month, int)
+        or not 1 <= day_of_month <= MAX_DAY_OF_MONTH
+    ):
+        return _error(f"day_of_month must be an integer between 1 and {MAX_DAY_OF_MONTH}")
     exchange = (exchange or "NSE").upper()
     if exchange not in SUPPORTED_EXCHANGES:
         return _error(
@@ -225,7 +236,7 @@ def run_sip_backtest(
 
     try:
         result = run_sip(
-            closes, symbol, exchange, start, end, float(amount),
+            closes, symbol, exchange, start, end, investment_amount,
             warnings=[str(w) for w in warnings], **sip_kw,
         )
     except (SipError, ScheduleError) as exc:
@@ -238,7 +249,7 @@ def run_sip_backtest(
             "exchange": exchange,
             "start_date": str(start),
             "end_date": str(end),
-            "amount": float(amount),
+            "amount": investment_amount,
             "frequency": frequency,
             "day_of_month": day_of_month,
             "step_up_percent": step_up_percent,
@@ -264,7 +275,7 @@ def run_sip_backtest(
             "exchange": cost_exchange,
         },
         "frequency_comparison": frequency_comparison(
-            closes, start, end, float(amount),
+            closes, start, end, investment_amount,
             **{k: v for k, v in sip_kw.items() if k != "frequency"},
         ),
         "curves": {
@@ -289,24 +300,24 @@ def run_sip_backtest(
     }
 
     if include_grids:
-        payload["rolling_xirr"] = rolling_xirr(closes, float(amount), **sip_kw)
+        payload["rolling_xirr"] = rolling_xirr(closes, investment_amount, **sip_kw)
         payload["start_date_heatmap"] = start_date_heatmap(
-            closes, float(amount), **sip_kw
+            closes, investment_amount, **sip_kw
         )
-        crisis_rows = crisis_sip_analysis(closes, float(amount), sip_kw=sip_kw)
+        crisis_rows = crisis_sip_analysis(closes, investment_amount, sip_kw=sip_kw)
         payload["crisis"] = {
             "summary": crisis_summary(crisis_rows),
             "periods": crisis_rows,
         }
         payload["sip_date_heatmap"] = (
-            sip_date_heatmap(closes, start, end, float(amount), **sip_kw)
+            sip_date_heatmap(closes, start, end, investment_amount, **sip_kw)
             if frequency in ("monthly", "quarterly")
             else None
         )
 
     if benchmark:
         payload["benchmark"] = _benchmark_sip(
-            benchmark, benchmark_exchange.upper(), start, end, float(amount),
+            benchmark, benchmark_exchange.upper(), start, end, investment_amount,
             result, source, creds, sip_kw,
         )
 

--- a/test/test_sip_service_validation.py
+++ b/test/test_sip_service_validation.py
@@ -1,0 +1,107 @@
+import pandas as pd
+import pytest
+
+from portfolio.data import PriceMatrix
+from services import sip_service
+
+
+def _request(**updates):
+    request = {
+        "symbol": "INFY",
+        "exchange": "NSE",
+        "start_date": "2024-01-01",
+        "end_date": "2024-04-30",
+        "amount": 1000,
+        "include_grids": False,
+    }
+    request.update(updates)
+    return request
+
+
+def _prices() -> PriceMatrix:
+    index = pd.bdate_range("2024-01-01", "2024-04-30")
+    return PriceMatrix(
+        closes=pd.DataFrame({"INFY": 100.0}, index=index),
+        source="db",
+        start=index[0].date(),
+        end=index[-1].date(),
+    )
+
+
+@pytest.mark.parametrize(
+    "amount",
+    [
+        "invalid",
+        None,
+        "nan",
+        "inf",
+        float("nan"),
+        float("inf"),
+        float("-inf"),
+        pytest.param(10**1000, id="overflow"),
+        0,
+        -1,
+    ],
+)
+def test_invalid_amounts_do_not_load_prices(monkeypatch, amount):
+    monkeypatch.setattr(
+        sip_service,
+        "load_prices",
+        lambda *_args, **_kwargs: pytest.fail("price loader should not be called"),
+    )
+
+    success, response, status = sip_service.run_sip_backtest(**_request(amount=amount))
+
+    assert success is False
+    assert status == 400
+    assert response["message"] == "amount must be a positive number"
+
+
+@pytest.mark.parametrize(
+    ("frequency", "day_of_month"),
+    [
+        ("monthly", 0),
+        ("monthly", 29),
+        ("monthly", "1"),
+        ("monthly", 1.5),
+        ("monthly", True),
+        ("quarterly", 0),
+        ("quarterly", 29),
+    ],
+)
+def test_invalid_sip_days_do_not_load_prices(monkeypatch, frequency, day_of_month):
+    monkeypatch.setattr(
+        sip_service,
+        "load_prices",
+        lambda *_args, **_kwargs: pytest.fail("price loader should not be called"),
+    )
+
+    success, response, status = sip_service.run_sip_backtest(
+        **_request(frequency=frequency, day_of_month=day_of_month)
+    )
+
+    assert success is False
+    assert status == 400
+    assert response["message"] == "day_of_month must be an integer between 1 and 28"
+
+
+@pytest.mark.parametrize("day_of_month", [1, 28])
+def test_boundary_sip_days_load_prices_for_valid_requests(monkeypatch, day_of_month):
+    calls = []
+
+    def load_prices(*args, **kwargs):
+        calls.append((args, kwargs))
+        return _prices()
+
+    monkeypatch.setattr(sip_service, "load_prices", load_prices)
+
+    success, response, status = sip_service.run_sip_backtest(
+        **_request(day_of_month=day_of_month)
+    )
+
+    assert success is True
+    assert status == 200
+    assert response["request"]["amount"] == 1000.0
+    assert calls == [
+        ((["INFY"], ["NSE"], "2024-01-01", "2024-04-30"), {"source": "db", "api_key": None, "auth_token": None, "feed_token": None, "broker": None})
+    ]

--- a/test/test_sip_service_validation.py
+++ b/test/test_sip_service_validation.py
@@ -95,13 +95,12 @@ def test_boundary_sip_days_load_prices_for_valid_requests(monkeypatch, day_of_mo
 
     monkeypatch.setattr(sip_service, "load_prices", load_prices)
 
-    success, response, status = sip_service.run_sip_backtest(
-        **_request(day_of_month=day_of_month)
-    )
+    success, response, status = sip_service.run_sip_backtest(**_request(day_of_month=day_of_month))
 
     assert success is True
     assert status == 200
     assert response["request"]["amount"] == 1000.0
-    assert calls == [
-        ((["INFY"], ["NSE"], "2024-01-01", "2024-04-30"), {"source": "db", "api_key": None, "auth_token": None, "feed_token": None, "broker": None})
-    ]
+    assert len(calls) == 1
+    args, kwargs = calls[0]
+    assert args == (["INFY"], ["NSE"], "2024-01-01", "2024-04-30")
+    assert kwargs["source"] == "db"


### PR DESCRIPTION
## Summary

Validate SIP investment amounts and SIP days before loading historical prices.

## Related issue

Closes #1823

## Changes

- Safely convert the SIP amount once at the service boundary.
- Reject malformed, non-finite, zero, negative, and overflow amounts with a `400` client error.
- Validate monthly and quarterly SIP days before the price loader runs.
- Require a monthly or quarterly SIP day to be an integer from `1` through `28`.
- Reuse the validated amount throughout the remaining calculation.

## Coverage

- Invalid amounts do not reach the price loader.
- Invalid monthly and quarterly SIP days do not reach the price loader.
- Amount coverage includes malformed input, `NaN`, infinities, overflow, zero, and negatives.
- SIP-day coverage includes both boundaries (`1`, `28`), out-of-range days, and wrong input types.
- Valid boundary requests load prices and complete successfully.

## Testing

- [x] `env -u LOG_FORMAT uv run pytest test/test_sip_service_validation.py -v`
  - 19 passed
- [x] `uv run ruff check services/sip_service.py test/test_sip_service_validation.py`
  - passed
- [x] `git diff --check`
  - passed

## Local environment note

This machine sets `LOG_FORMAT=json`, which conflicts with the repository logging setup during test collection. The focused test was run with that local-only environment variable removed; no project configuration was changed.

## Checklist

- [x] This PR contains one focused bug fix.
- [x] Amount and SIP-day validation occur before any price lookup.
- [x] Invalid calls are covered with a mocked price loader.
- [x] Valid boundary requests retain existing behavior.
- [x] No broker credentials or sensitive data are included.
- [x] No UI change is included; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate SIP amount and SIP day at the service boundary before any price load. Previously, malformed amounts or SIP days could reach the price loader; now the service returns 400 with clear messages and skips price fetches.

- Parse and validate the amount once; reject non-numeric, non-finite (NaN/±Inf), overflow, zero, and negative values with 400 "amount must be a positive number"; reuse the validated amount across results, grids, and benchmarks.
- For "monthly" and "quarterly", require `day_of_month` to be an integer 1–28; explicitly reject bool; return 400 "day_of_month must be an integer between 1 and 28".
- Bound SIP-day validation using `sip.schedule.MAX_DAY_OF_MONTH` to keep behavior consistent with scheduling rules.
- Tests verify the price loader is not called on invalid inputs and that boundary days (1, 28) succeed with no behavior changes.
- Client requirement: send a positive numeric `amount` and, for monthly/quarterly SIPs, an integer `day_of_month` in 1–28.

<sup>Written for commit 25490b2006ff6ce93f99669461e8f74d8d0fc55c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1884?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

