### PR TITLE
fix(python): key multi-option Greeks batch state by leg index

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             test/test_auth_resume.py test/test_auth_upsert_multisession.py \
             test/sandbox/test_execution_backlog.py test/test_event_bus_bounded.py \
             test/test_telegram_api_contract.py \
+            test/test_multi_option_greeks_regression.py \
             -v --timeout=60
 
   # Frontend linting

--- a/services/option_greeks_service.py
+++ b/services/option_greeks_service.py
@@ -1001,18 +1001,19 @@ def get_multi_option_greeks(
     failed_count = 0
 
     # Step 1: Parse all symbols and group by underlying for spot price fetch
-    parsed_symbols = {}  # symbol -> (base_symbol, expiry, strike, opt_type)
+    parsed_symbols = {}  # (symbol, exchange) -> (base_symbol, expiry, strike, opt_type)
     spot_keys = {}  # (spot_symbol, spot_exchange) -> spot_price
-    symbol_to_spot_key = {}  # symbol -> (spot_symbol, spot_exchange)
-    symbol_forward = {}  # symbol -> Black-76 forward (synthetic future)
+    symbol_to_spot_key = {}  # (symbol, exchange) -> (spot_symbol, spot_exchange)
+    symbol_forward = {}  # (symbol, exchange) -> Black-76 forward (synthetic future)
     synth_cache = {}  # (base, underlying_exchange, expiry_code) -> synthetic future
 
     for sym_req in symbols:
         symbol = sym_req.get("symbol")
         exchange = sym_req.get("exchange")
         try:
+            batch_key = (symbol, exchange)
             base_symbol, expiry, strike, opt_type = parse_option_symbol(symbol, exchange, expiry_time)
-            parsed_symbols[symbol] = (base_symbol, expiry, strike, opt_type)
+            parsed_symbols[batch_key] = (base_symbol, expiry, strike, opt_type)
 
             # Determine spot symbol/exchange for this option (also the fallback
             # if the synthetic future cannot be computed for an index weekly)
@@ -1021,7 +1022,7 @@ def get_multi_option_greeks(
             spot_exchange = sym_req.get("underlying_exchange") or get_underlying_exchange(base_symbol, exchange)
             spot_key = (spot_symbol, spot_exchange)
             spot_keys[spot_key] = None  # will be filled with price
-            symbol_to_spot_key[symbol] = spot_key
+            symbol_to_spot_key[batch_key] = spot_key
 
             # Black-76 forward = per-expiry synthetic future for all F&O; spot
             # fallback. Skipped if the caller passed a custom underlying
@@ -1031,7 +1032,7 @@ def get_multi_option_greeks(
                     base_symbol, exchange, spot_exchange, expiry, api_key, synth_cache
                 )
                 if forward:
-                    symbol_forward[symbol] = forward
+                    symbol_forward[batch_key] = forward
         except Exception as e:
             logger.warning(f"Failed to parse symbol {symbol}: {e}")
             failed_count += 1
@@ -1063,13 +1064,14 @@ def get_multi_option_greeks(
     option_symbols_to_fetch = []
     for sym_req in symbols:
         symbol = sym_req.get("symbol")
-        if symbol in parsed_symbols:  # only if parsing succeeded
+        exchange = sym_req.get("exchange")
+        if (symbol, exchange) in parsed_symbols:  # only if parsing succeeded
             option_symbols_to_fetch.append({
                 "symbol": symbol,
-                "exchange": sym_req.get("exchange"),
+                "exchange": exchange,
             })
 
-    option_prices = {}  # symbol -> ltp
+    option_prices = {}  # (symbol, exchange) -> ltp
     if option_symbols_to_fetch:
         logger.info(f"Batch fetching {len(option_symbols_to_fetch)} option prices via multiquotes")
         try:
@@ -1079,10 +1081,11 @@ def get_multi_option_greeks(
             if mq_success and "results" in mq_response:
                 for result in mq_response["results"]:
                     sym = result.get("symbol")
+                    exch = result.get("exchange")
                     if sym and "data" in result:
                         ltp = result["data"].get("ltp")
                         if ltp:
-                            option_prices[sym] = ltp
+                            option_prices[(sym, exch)] = ltp
         except Exception as e:
             logger.warning(f"Multiquotes fetch failed: {e}")
 
@@ -1090,15 +1093,16 @@ def get_multi_option_greeks(
     for sym_req in symbols:
         symbol = sym_req.get("symbol")
         exchange = sym_req.get("exchange")
+        batch_key = (symbol, exchange)
 
         # Skip if already failed during parsing
-        if symbol not in parsed_symbols:
+        if batch_key not in parsed_symbols:
             continue
 
         # Forward price: synthetic future for index weeklies, else spot.
         # Falls back to spot if the synthetic future could not be computed.
-        spot_key = symbol_to_spot_key.get(symbol)
-        spot_price = symbol_forward.get(symbol) or (spot_keys.get(spot_key) if spot_key else None)
+        spot_key = symbol_to_spot_key.get(batch_key)
+        spot_price = symbol_forward.get(batch_key) or (spot_keys.get(spot_key) if spot_key else None)
         if not spot_price:
             failed_count += 1
             results.append({
@@ -1110,7 +1114,7 @@ def get_multi_option_greeks(
             continue
 
         # Get option price
-        option_price = option_prices.get(symbol)
+        option_price = option_prices.get(batch_key)
         if not option_price:
             failed_count += 1
             results.append({
@@ -1136,7 +1140,7 @@ def get_multi_option_greeks(
                 success_count += 1
             else:
                 if _is_expired_option_response(calc_response):
-                    base_symbol, expiry, strike, opt_type = parsed_symbols[symbol]
+                    base_symbol, expiry, strike, opt_type = parsed_symbols[batch_key]
                     calc_response = _expired_option_greeks_response(
                         option_symbol=symbol,
                         exchange=exchange,
@@ -1165,8 +1169,8 @@ def get_multi_option_greeks(
             })
 
     # Sort results to maintain original order
-    symbol_order = {sym["symbol"]: idx for idx, sym in enumerate(symbols)}
-    results.sort(key=lambda x: symbol_order.get(x.get("symbol"), 999))
+    symbol_order = {(sym["symbol"], sym.get("exchange")): idx for idx, sym in enumerate(symbols)}
+    results.sort(key=lambda x: symbol_order.get((x.get("symbol"), x.get("exchange")), 999))
 
     response = {
         "status": "success" if failed_count == 0 else "partial" if success_count > 0 else "error",

--- a/services/option_greeks_service.py
+++ b/services/option_greeks_service.py
@@ -996,22 +996,22 @@ def get_multi_option_greeks(
             200,
         )
 
-    results = []
+    results = [None] * len(symbols)
     success_count = 0
     failed_count = 0
 
     # Step 1: Parse all symbols and group by underlying for spot price fetch
-    parsed_symbols = {}  # (symbol, exchange) -> (base_symbol, expiry, strike, opt_type)
+    parsed_symbols = {}  # leg index -> (base_symbol, expiry, strike, opt_type)
     spot_keys = {}  # (spot_symbol, spot_exchange) -> spot_price
-    symbol_to_spot_key = {}  # (symbol, exchange) -> (spot_symbol, spot_exchange)
-    symbol_forward = {}  # (symbol, exchange) -> Black-76 forward (synthetic future)
+    symbol_to_spot_key = {}  # leg index -> (spot_symbol, spot_exchange)
+    symbol_forward = {}  # leg index -> Black-76 forward (synthetic future)
     synth_cache = {}  # (base, underlying_exchange, expiry_code) -> synthetic future
 
-    for sym_req in symbols:
+    for idx, sym_req in enumerate(symbols):
         symbol = sym_req.get("symbol")
         exchange = sym_req.get("exchange")
         try:
-            batch_key = (symbol, exchange)
+            batch_key = idx
             base_symbol, expiry, strike, opt_type = parse_option_symbol(symbol, exchange, expiry_time)
             parsed_symbols[batch_key] = (base_symbol, expiry, strike, opt_type)
 
@@ -1036,12 +1036,12 @@ def get_multi_option_greeks(
         except Exception as e:
             logger.warning(f"Failed to parse symbol {symbol}: {e}")
             failed_count += 1
-            results.append({
+            results[idx] = {
                 "status": "error",
                 "symbol": symbol,
                 "exchange": exchange,
                 "message": f"Failed to parse option symbol: {str(e)}",
-            })
+            }
 
     # Step 2: Fetch spot prices — one API call per unique underlying
     for spot_key in spot_keys:
@@ -1062,14 +1062,26 @@ def get_multi_option_greeks(
 
     # Step 3: Batch fetch all option prices via get_multiquotes()
     option_symbols_to_fetch = []
-    for sym_req in symbols:
+    seen_quotes = set()
+    for idx, sym_req in enumerate(symbols):
         symbol = sym_req.get("symbol")
         exchange = sym_req.get("exchange")
-        if (symbol, exchange) in parsed_symbols:  # only if parsing succeeded
+        if idx in parsed_symbols and (symbol, exchange) not in seen_quotes:
+            seen_quotes.add((symbol, exchange))
             option_symbols_to_fetch.append({
                 "symbol": symbol,
                 "exchange": exchange,
             })
+
+    # Fallback exchange per requested symbol. Every broker adapter echoes the
+    # requested exchange today, but a result that omitted it would key every
+    # price under (symbol, None) and fail the whole batch rather than one leg.
+    # A symbol requested on two exchanges maps to None: guessing either one
+    # would reintroduce the collision, so only those legs go unpriced.
+    requested_exchange = {}
+    for item in option_symbols_to_fetch:
+        sym_name = item["symbol"]
+        requested_exchange[sym_name] = None if sym_name in requested_exchange else item["exchange"]
 
     option_prices = {}  # (symbol, exchange) -> ltp
     if option_symbols_to_fetch:
@@ -1081,7 +1093,7 @@ def get_multi_option_greeks(
             if mq_success and "results" in mq_response:
                 for result in mq_response["results"]:
                     sym = result.get("symbol")
-                    exch = result.get("exchange")
+                    exch = result.get("exchange") or requested_exchange.get(sym)
                     if sym and "data" in result:
                         ltp = result["data"].get("ltp")
                         if ltp:
@@ -1090,10 +1102,10 @@ def get_multi_option_greeks(
             logger.warning(f"Multiquotes fetch failed: {e}")
 
     # Step 4: Calculate Greeks for each symbol using fetched prices
-    for sym_req in symbols:
+    for idx, sym_req in enumerate(symbols):
         symbol = sym_req.get("symbol")
         exchange = sym_req.get("exchange")
-        batch_key = (symbol, exchange)
+        batch_key = idx
 
         # Skip if already failed during parsing
         if batch_key not in parsed_symbols:
@@ -1102,27 +1114,29 @@ def get_multi_option_greeks(
         # Forward price: synthetic future for index weeklies, else spot.
         # Falls back to spot if the synthetic future could not be computed.
         spot_key = symbol_to_spot_key.get(batch_key)
-        spot_price = symbol_forward.get(batch_key) or (spot_keys.get(spot_key) if spot_key else None)
+        spot_price = symbol_forward.get(batch_key) or (
+            spot_keys.get(spot_key) if spot_key else None
+        )
         if not spot_price:
             failed_count += 1
-            results.append({
+            results[idx] = {
                 "status": "error",
                 "symbol": symbol,
                 "exchange": exchange,
                 "message": f"Failed to fetch underlying price for {spot_key[0] if spot_key else 'unknown'}",
-            })
+            }
             continue
 
         # Get option price
-        option_price = option_prices.get(batch_key)
+        option_price = option_prices.get((symbol, exchange))
         if not option_price:
             failed_count += 1
-            results.append({
+            results[idx] = {
                 "status": "error",
                 "symbol": symbol,
                 "exchange": exchange,
                 "message": "Option LTP not available",
-            })
+            }
             continue
 
         # Calculate Greeks (pure math, no API calls)
@@ -1157,20 +1171,17 @@ def get_multi_option_greeks(
                     failed_count += 1
                     calc_response.setdefault("symbol", symbol)
                     calc_response.setdefault("exchange", exchange)
-            results.append(calc_response)
+            results[idx] = calc_response
         except Exception as e:
             logger.exception(f"Error calculating Greeks for {symbol}: {e}")
             failed_count += 1
-            results.append({
+            results[idx] = {
                 "status": "error",
                 "symbol": symbol,
                 "exchange": exchange,
                 "message": str(e),
-            })
+            }
 
-    # Sort results to maintain original order
-    symbol_order = {(sym["symbol"], sym.get("exchange")): idx for idx, sym in enumerate(symbols)}
-    results.sort(key=lambda x: symbol_order.get((x.get("symbol"), x.get("exchange")), 999))
 
     response = {
         "status": "success" if failed_count == 0 else "partial" if success_count > 0 else "error",

--- a/test/test_multi_option_greeks_regression.py
+++ b/test/test_multi_option_greeks_regression.py
@@ -59,7 +59,8 @@ def test_multi_option_greeks_converts_expired_legs_to_zero_greeks(monkeypatch):
             {
                 "status": "success",
                 "results": [
-                    {"symbol": item["symbol"], "data": {"ltp": 16.4}} for item in symbols
+                    {"symbol": item["symbol"], "exchange": item["exchange"], "data": {"ltp": 16.4}}
+                    for item in symbols
                 ],
             },
             200,
@@ -85,3 +86,83 @@ def test_multi_option_greeks_converts_expired_legs_to_zero_greeks(monkeypatch):
     assert all(item["implied_volatility"] == 0 for item in response["data"])
     assert all(item["greeks"] == {"delta": 0, "gamma": 0, "theta": 0, "vega": 0, "rho": 0} for item in response["data"])
     assert all("expired" in item["note"] for item in response["data"])
+
+
+def test_multi_option_greeks_keeps_per_exchange_state_for_duplicate_symbols(monkeypatch):
+    symbols = [
+        {"symbol": "RELIANCE28MAR243000CE", "exchange": "NFO"},
+        {"symbol": "RELIANCE28MAR243000CE", "exchange": "BFO"},
+    ]
+    spot_by_exchange = {"NSE": 3010.0, "BSE": 3040.0}
+    ltp_by_exchange = {"NFO": 41.5, "BFO": 63.25}
+
+    monkeypatch.setattr(
+        greeks_service,
+        "parse_option_symbol",
+        lambda symbol, exchange, expiry_time=None: (
+            "RELIANCE",
+            datetime(2026, 3, 28, 15, 30),
+            3000.0,
+            "CE",
+        ),
+    )
+    monkeypatch.setattr(
+        greeks_service,
+        "get_underlying_exchange",
+        lambda base_symbol, options_exchange: "NSE" if options_exchange == "NFO" else "BSE",
+    )
+    monkeypatch.setattr(greeks_service, "_resolve_forward_price", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.quotes_service.get_quotes",
+        lambda symbol, exchange, api_key=None: (
+            True,
+            {"status": "success", "data": {"ltp": spot_by_exchange[exchange]}},
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        "services.quotes_service.get_multiquotes",
+        lambda symbols, api_key=None: (
+            True,
+            {
+                "status": "success",
+                "results": [
+                    {
+                        "symbol": item["symbol"],
+                        "exchange": item["exchange"],
+                        "data": {"ltp": ltp_by_exchange[item["exchange"]]},
+                    }
+                    for item in symbols
+                ],
+            },
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        greeks_service,
+        "calculate_greeks",
+        lambda **kwargs: (
+            True,
+            {
+                "status": "success",
+                "symbol": kwargs["option_symbol"],
+                "exchange": kwargs["exchange"],
+                "spot_price": kwargs["spot_price"],
+                "option_price": kwargs["option_price"],
+            },
+            200,
+        ),
+    )
+
+    success, response, status_code = greeks_service.get_multi_option_greeks(symbols)
+
+    assert success is True
+    assert set(response) == {"status", "data", "summary"}
+    assert response["summary"] == {"total": 2, "success": 2, "failed": 0}
+
+    by_exchange = {item["exchange"]: item for item in response["data"]}
+    assert set(by_exchange) == {"NFO", "BFO"}
+    assert by_exchange["NFO"]["option_price"] == 41.5
+    assert by_exchange["BFO"]["option_price"] == 63.25
+    assert by_exchange["NFO"]["spot_price"] == 3010.0
+    assert by_exchange["BFO"]["spot_price"] == 3040.0

--- a/test/test_multi_option_greeks_regression.py
+++ b/test/test_multi_option_greeks_regression.py
@@ -93,7 +93,6 @@ def test_multi_option_greeks_keeps_per_exchange_state_for_duplicate_symbols(monk
         {"symbol": "RELIANCE28MAR243000CE", "exchange": "NFO"},
         {"symbol": "RELIANCE28MAR243000CE", "exchange": "BFO"},
     ]
-    spot_by_exchange = {"NSE": 3010.0, "BSE": 3040.0}
     ltp_by_exchange = {"NFO": 41.5, "BFO": 63.25}
 
     monkeypatch.setattr(
@@ -106,17 +105,12 @@ def test_multi_option_greeks_keeps_per_exchange_state_for_duplicate_symbols(monk
             "CE",
         ),
     )
-    monkeypatch.setattr(
-        greeks_service,
-        "get_underlying_exchange",
-        lambda base_symbol, options_exchange: "NSE" if options_exchange == "NFO" else "BSE",
-    )
     monkeypatch.setattr(greeks_service, "_resolve_forward_price", lambda *a, **k: None)
     monkeypatch.setattr(
         "services.quotes_service.get_quotes",
         lambda symbol, exchange, api_key=None: (
             True,
-            {"status": "success", "data": {"ltp": spot_by_exchange[exchange]}},
+            {"status": "success", "data": {"ltp": 3010.0}},
             200,
         ),
     )
@@ -147,7 +141,6 @@ def test_multi_option_greeks_keeps_per_exchange_state_for_duplicate_symbols(monk
                 "status": "success",
                 "symbol": kwargs["option_symbol"],
                 "exchange": kwargs["exchange"],
-                "spot_price": kwargs["spot_price"],
                 "option_price": kwargs["option_price"],
             },
             200,
@@ -164,5 +157,192 @@ def test_multi_option_greeks_keeps_per_exchange_state_for_duplicate_symbols(monk
     assert set(by_exchange) == {"NFO", "BFO"}
     assert by_exchange["NFO"]["option_price"] == 41.5
     assert by_exchange["BFO"]["option_price"] == 63.25
-    assert by_exchange["NFO"]["spot_price"] == 3010.0
-    assert by_exchange["BFO"]["spot_price"] == 3040.0
+
+
+def test_multi_option_greeks_falls_back_to_requested_exchange(monkeypatch):
+    symbols = [
+        {"symbol": "NIFTY28MAR2420800CE", "exchange": "NFO"},
+        {"symbol": "NIFTY28MAR2420900CE", "exchange": "NFO"},
+    ]
+
+    monkeypatch.setattr(
+        greeks_service,
+        "parse_option_symbol",
+        lambda symbol, exchange, expiry_time=None: (
+            "NIFTY",
+            datetime(2026, 3, 28, 15, 30),
+            20800.0 if "20800" in symbol else 20900.0,
+            "CE",
+        ),
+    )
+    monkeypatch.setattr(greeks_service, "_resolve_forward_price", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.quotes_service.get_quotes",
+        lambda symbol, exchange, api_key=None: (
+            True,
+            {"status": "success", "data": {"ltp": 20750.0}},
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        "services.quotes_service.get_multiquotes",
+        lambda symbols, api_key=None: (
+            True,
+            {
+                "status": "success",
+                "results": [
+                    {"symbol": item["symbol"], "data": {"ltp": 145.3}} for item in symbols
+                ],
+            },
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        greeks_service,
+        "calculate_greeks",
+        lambda **kwargs: (
+            True,
+            {
+                "status": "success",
+                "symbol": kwargs["option_symbol"],
+                "exchange": kwargs["exchange"],
+                "option_price": kwargs["option_price"],
+            },
+            200,
+        ),
+    )
+
+    success, response, status_code = greeks_service.get_multi_option_greeks(symbols)
+
+    assert success is True
+    assert response["summary"] == {"total": 2, "success": 2, "failed": 0}
+    assert all(item["option_price"] == 145.3 for item in response["data"])
+
+
+def test_multi_option_greeks_does_not_guess_ambiguous_exchange(monkeypatch):
+    symbols = [
+        {"symbol": "RELIANCE28MAR243000CE", "exchange": "NFO"},
+        {"symbol": "RELIANCE28MAR243000CE", "exchange": "BFO"},
+        {"symbol": "RELIANCE28MAR243100CE", "exchange": "NFO"},
+    ]
+
+    monkeypatch.setattr(
+        greeks_service,
+        "parse_option_symbol",
+        lambda symbol, exchange, expiry_time=None: (
+            "RELIANCE",
+            datetime(2026, 3, 28, 15, 30),
+            3000.0 if "3000" in symbol else 3100.0,
+            "CE",
+        ),
+    )
+    monkeypatch.setattr(greeks_service, "_resolve_forward_price", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.quotes_service.get_quotes",
+        lambda symbol, exchange, api_key=None: (
+            True,
+            {"status": "success", "data": {"ltp": 3010.0}},
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        "services.quotes_service.get_multiquotes",
+        lambda symbols, api_key=None: (
+            True,
+            {
+                "status": "success",
+                "results": [
+                    {"symbol": item["symbol"], "data": {"ltp": 41.5}} for item in symbols
+                ],
+            },
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        greeks_service,
+        "calculate_greeks",
+        lambda **kwargs: (
+            True,
+            {
+                "status": "success",
+                "symbol": kwargs["option_symbol"],
+                "exchange": kwargs["exchange"],
+                "option_price": kwargs["option_price"],
+            },
+            200,
+        ),
+    )
+
+    success, response, status_code = greeks_service.get_multi_option_greeks(symbols)
+
+    assert response["summary"] == {"total": 3, "success": 1, "failed": 2}
+    priced = [item for item in response["data"] if item["status"] == "success"]
+    assert len(priced) == 1
+    assert priced[0]["symbol"] == "RELIANCE28MAR243100CE"
+
+
+def test_multi_option_greeks_keeps_per_leg_underlying_for_identical_symbols(monkeypatch):
+    symbols = [
+        {"symbol": "NIFTY30DEC2524000CE", "exchange": "NFO"},
+        {
+            "symbol": "NIFTY30DEC2524000CE",
+            "exchange": "NFO",
+            "underlying_symbol": "NIFTY30DEC25FUT",
+            "underlying_exchange": "NFO",
+        },
+    ]
+    spot_by_symbol = {"NIFTY": 24000.0, "NIFTY30DEC25FUT": 24500.0}
+
+    monkeypatch.setattr(
+        greeks_service,
+        "parse_option_symbol",
+        lambda symbol, exchange, expiry_time=None: (
+            "NIFTY",
+            datetime(2025, 12, 30, 15, 30),
+            24000.0,
+            "CE",
+        ),
+    )
+    monkeypatch.setattr(greeks_service, "_resolve_forward_price", lambda *a, **k: None)
+    monkeypatch.setattr(
+        "services.quotes_service.get_quotes",
+        lambda symbol, exchange, api_key=None: (
+            True,
+            {"status": "success", "data": {"ltp": spot_by_symbol[symbol]}},
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        "services.quotes_service.get_multiquotes",
+        lambda symbols, api_key=None: (
+            True,
+            {
+                "status": "success",
+                "results": [
+                    {"symbol": item["symbol"], "exchange": item["exchange"], "data": {"ltp": 100.0}}
+                    for item in symbols
+                ],
+            },
+            200,
+        ),
+    )
+    monkeypatch.setattr(
+        greeks_service,
+        "calculate_greeks",
+        lambda **kwargs: (
+            True,
+            {
+                "status": "success",
+                "symbol": kwargs["option_symbol"],
+                "exchange": kwargs["exchange"],
+                "spot_price": kwargs["spot_price"],
+            },
+            200,
+        ),
+    )
+
+    success, response, status_code = greeks_service.get_multi_option_greeks(symbols)
+
+    assert success is True
+    assert response["summary"] == {"total": 2, "success": 2, "failed": 0}
+    assert [item["spot_price"] for item in response["data"]] == [24000.0, 24500.0]


### PR DESCRIPTION
## What this does

`get_multi_option_greeks()` stored its intermediate batch state under symbol-only keys, so two legs of one request could overwrite each other and be priced from the wrong entry. No error surfaced - the caller simply received wrong Greeks.

Per-leg state is now keyed by the leg's index in the request, which cannot collide.

## Why

Closes #1819

## Validation status

**CI has never run on this branch.** The workflows are waiting on maintainer approval, so the only evidence is local: my runs and the reviewer's independent reproduction. Everything below was run on this machine.

## Approach

The issue asked for `(symbol, exchange)`. That was the first commit, and review showed it does not close the defect class: two legs sharing a symbol *and* an exchange but differing by `underlying_symbol` / `underlying_exchange` still collapse onto one key, and that is the endpoint's own documented example at `restx_api/multi_option_greeks.py:53`. The second commit moves to the leg index.

| State | Key | Why |
| --- | --- | --- |
| `parsed_symbols` | leg index | per leg |
| `symbol_to_spot_key` | leg index | per leg - this is what differs in the documented example |
| `symbol_forward` | leg index | per leg |
| `option_prices` | `(symbol, exchange)` | a price belongs to a contract, not to a leg |

Two things fall out of the index key:

**The sort disappears.** `results` is now an indexed slot list, so every leg lands in request order by construction. `symbol_order` and the final `results.sort()` are gone. This also means the reviewer's note about the sort key being safe no longer applies to anything.

**The quote fetch dedupes.** Two legs sharing a contract need one quote, not two, so `seen_quotes` skips the repeat.

## Multiquotes exchange fallback

`option_prices` takes the exchange from the broker result, falling back to the requested exchange when the result omits it, so a future adapter degrades one leg rather than failing the whole batch.

A symbol requested on *two* exchanges maps to `None` rather than to either one. Guessing would silently reintroduce the collision this change exists to remove; leaving those legs unpriced is the safer failure. Covered by `test_multi_option_greeks_does_not_guess_ambiguous_exchange`.

To be accurate about where the guarantee lives: `services/quotes_service.py` sets `exchange` itself only on the paths it builds - the invalid-symbol entry (`:275`) and the per-symbol fallback (`:290`, `:297`). On the broker-native path it passes the adapter's list through untouched (`:311`). So the guarantee that `exchange` is present comes from the 35 adapters under `broker/*/api/data.py`, not from `quotes_service.py`. It holds in all 35 today, which is why the fallback is hardening rather than a bug fix. An earlier version of this description got that wrong.

## CI registration

`test/test_multi_option_greeks_regression.py` was not in the `backend-test` file list in `.github/workflows/ci.yml`, so the test would never have run upstream. It is now registered. The file predates this PR and was already unregistered on main.

## The response shape is unchanged

All the batch dictionaries are local to this function and never escape it. Verified by diffing the full JSON response for a single-exchange batch against the same run on main - byte-identical. The test also pins the top-level keys with `assert set(response) == {"status", "data", "summary"}`.

## How I tested

```
uv run pytest test/test_multi_option_greeks_regression.py -v
6 passed

uv run pytest <the 11 CI files> test/test_multi_option_greeks_regression.py --timeout=60
46 passed

uv run ruff check services/option_greeks_service.py test/test_multi_option_greeks_regression.py
All checks passed!

uv run pytest test/ -q
No new failures compared to the same run on main.
```

Six tests, none needing broker credentials or network access. Each one fails when its own fix is reverted - I checked them individually rather than assuming:

| Test | Guards |
| --- | --- |
| `..._keeps_per_exchange_state_for_duplicate_symbols` | the original #1819 defect; fails with `assert 63.25 == 41.5` |
| `..._keeps_per_leg_underlying_for_identical_symbols` | the documented-example case; fails with `[24500.0, 24500.0]` |
| `..._falls_back_to_requested_exchange` | a result that omits `exchange` |
| `..._does_not_guess_ambiguous_exchange` | 3 legs in, the one unambiguous leg still prices |
| `..._converts_expired_legs_to_zero_greeks` | pre-existing |
| `..._treats_naive_expiry_as_ist` | pre-existing |

The mock that contradicted production is gone. `get_underlying_exchange` is no longer patched, so it runs for real and returns NSE for both legs exactly as it would in production; the option-price assertions still pin the defect.

## Not covered

- Nothing else in this 1199-line file
- No schema or migration; no build artifacts
- Independent of #1866: different files, no overlap

## Checklist

- [x] One fix per PR
- [x] Conventional commit messages
- [x] Public response shape unchanged
- [x] Every new test fails without its corresponding fix
- [x] Tests need no broker credentials or network access
- [x] `ruff check` clean on the changed files
- [x] New test registered in CI
