### PR TITLE
fix(frontend): sanitize error report URLs

### DIFF
--- a/blueprints/admin.py
+++ b/blueprints/admin.py
@@ -2,6 +2,7 @@ import json
 import os
 from datetime import date, datetime, timedelta
 from pathlib import Path
+from urllib.parse import parse_qsl, urlencode, urlsplit, urlunsplit
 
 from flask import Blueprint, flash, jsonify, redirect, render_template, request, url_for
 
@@ -855,6 +856,27 @@ _MAX_CLIENT_URL_LEN = 2000
 _MAX_CLIENT_COMPONENT_STACK_LEN = 5000
 _MAX_CLIENT_USER_AGENT_LEN = 500
 _CLIENT_LEVEL_ALLOWLIST = frozenset({"ERROR", "WARN"})
+_REDACTED_CLIENT_URL_VALUE = "[redacted]"
+_SENSITIVE_CLIENT_URL_QUERY_PARAMETER_NAMES = frozenset(
+    {
+        "token",
+        "code",
+        "requesttoken",
+        "accesstoken",
+        "authtoken",
+        "refreshtoken",
+        "resettoken",
+        "apikey",
+        "email",
+        "state",
+        "password",
+        "otp",
+        "secret",
+        "clientsecret",
+        "idtoken",
+        "jwt",
+    }
+)
 
 # Logger dedicated to browser-reported errors. Distinct name so they're easy
 # to filter in errors.jsonl and in the grouped view.
@@ -877,6 +899,32 @@ def _scrub_control_chars(text):
     return "".join(ch for ch in text if ch == "\n" or ch == "\t" or (ch.isprintable()))
 
 
+def _sanitize_client_error_url(url):
+    """Redact sensitive query values and remove fragments before logging a URL."""
+    try:
+        parsed = urlsplit(url)
+    except ValueError:
+        return url.split("?", 1)[0].split("#", 1)[0]
+
+    if parsed.scheme in {"", "http", "https"}:
+        query = urlencode(
+            [
+                (
+                    key,
+                    _REDACTED_CLIENT_URL_VALUE
+                    if key.lower().replace("_", "").replace("-", "")
+                    in _SENSITIVE_CLIENT_URL_QUERY_PARAMETER_NAMES
+                    else value,
+                )
+                for key, value in parse_qsl(parsed.query, keep_blank_values=True)
+            ]
+        )
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, query, ""))
+    if parsed.scheme.endswith("-extension"):
+        return urlunsplit((parsed.scheme, parsed.netloc, parsed.path, "", ""))
+    return f"{parsed.scheme}:"
+
+
 @admin_bp.route("/api/errors/client", methods=["POST"])
 @check_session_validity
 @limiter.limit(_CLIENT_REPORT_RATE)
@@ -897,7 +945,9 @@ def api_errors_client_report():
 
         message = _scrub_control_chars(str(data.get("message") or ""))[:_MAX_CLIENT_MESSAGE_LEN]
         stack = _scrub_control_chars(str(data.get("stack") or ""))[:_MAX_CLIENT_STACK_LEN]
-        url = _scrub_control_chars(str(data.get("url") or ""))[:_MAX_CLIENT_URL_LEN]
+        url = _sanitize_client_error_url(
+            _scrub_control_chars(str(data.get("url") or ""))
+        )[:_MAX_CLIENT_URL_LEN]
         component_stack = _scrub_control_chars(str(data.get("component_stack") or ""))[
             :_MAX_CLIENT_COMPONENT_STACK_LEN
         ]

--- a/frontend/src/utils/errorReporter.test.ts
+++ b/frontend/src/utils/errorReporter.test.ts
@@ -1,0 +1,53 @@
+import { waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { reportClientError, sanitizeErrorReportUrl } from './errorReporter'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  window.history.replaceState(null, '', '/')
+})
+
+describe('sanitizeErrorReportUrl', () => {
+  it('removes query strings and fragments from current-page reports', async () => {
+    const fakeToken = 'test-token-not-real'
+    window.history.replaceState(null, '', `/oauth/callback?code=${fakeToken}#complete`)
+    const fetchMock = vi
+      .fn<typeof fetch>()
+      .mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ csrf_token: 'csrf-token-not-real' }),
+      } as Response)
+      .mockResolvedValueOnce({ status: 200 } as Response)
+    vi.stubGlobal('fetch', fetchMock)
+
+    reportClientError({ message: 'Test client error report' })
+
+    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+
+    const request = fetchMock.mock.calls[1]?.[1]
+    const body = JSON.parse(String(request?.body))
+
+    expect(body.url).toBe(`${window.location.origin}/oauth/callback`)
+    expect(body.url).not.toContain(fakeToken)
+    expect(body.url).not.toContain('?')
+    expect(body.url).not.toContain('#')
+  })
+
+  it('sanitizes absolute and relative script URLs', () => {
+    const fakeResetToken = 'reset-token-not-real'
+
+    expect(
+      sanitizeErrorReportUrl(
+        `https://cdn.example.com/assets/app.js?token=${fakeResetToken}#chunk`,
+      ),
+    ).toBe('https://cdn.example.com/assets/app.js')
+    expect(sanitizeErrorReportUrl(`/assets/app.js?token=${fakeResetToken}#chunk`)).toBe(
+      `${window.location.origin}/assets/app.js`,
+    )
+  })
+
+  it('keeps a plain asset filename useful without throwing', () => {
+    expect(sanitizeErrorReportUrl('app.js')).toBe(`${window.location.origin}/app.js`)
+  })
+})

--- a/frontend/src/utils/errorReporter.test.ts
+++ b/frontend/src/utils/errorReporter.test.ts
@@ -1,53 +1,126 @@
 import { waitFor } from '@testing-library/react'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-import { reportClientError, sanitizeErrorReportUrl } from './errorReporter'
+import { handleWindowError, reportClientError, sanitizeErrorReportUrl } from './errorReporter'
 
 afterEach(() => {
   vi.unstubAllGlobals()
   window.history.replaceState(null, '', '/')
 })
 
-describe('sanitizeErrorReportUrl', () => {
-  it('removes query strings and fragments from current-page reports', async () => {
+function mockSuccessfulReportFetch() {
+  const fetchMock = vi
+    .fn<typeof fetch>()
+    .mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ csrf_token: 'csrf-token-not-real' }),
+    } as Response)
+    .mockResolvedValueOnce({ status: 200 } as Response)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+async function reportedPayload(fetchMock: ReturnType<typeof mockSuccessfulReportFetch>) {
+  await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+  const request = fetchMock.mock.calls[1]?.[1]
+  return JSON.parse(String(request?.body))
+}
+
+describe('client error URL sanitization', () => {
+  it('redacts sensitive query values and fragments from current-page reports', async () => {
     const fakeToken = 'test-token-not-real'
-    window.history.replaceState(null, '', `/oauth/callback?code=${fakeToken}#complete`)
-    const fetchMock = vi
-      .fn<typeof fetch>()
-      .mockResolvedValueOnce({
-        ok: true,
-        json: async () => ({ csrf_token: 'csrf-token-not-real' }),
-      } as Response)
-      .mockResolvedValueOnce({ status: 200 } as Response)
-    vi.stubGlobal('fetch', fetchMock)
+    window.history.replaceState(
+      null,
+      '',
+      `/oauth/callback?code=${fakeToken}&next=dashboard#complete`
+    )
+    const fetchMock = mockSuccessfulReportFetch()
 
     reportClientError({ message: 'Test client error report' })
 
-    await waitFor(() => expect(fetchMock).toHaveBeenCalledTimes(2))
+    const body = await reportedPayload(fetchMock)
+    const reportedUrl = new URL(body.url)
 
-    const request = fetchMock.mock.calls[1]?.[1]
-    const body = JSON.parse(String(request?.body))
-
-    expect(body.url).toBe(`${window.location.origin}/oauth/callback`)
+    expect(`${reportedUrl.origin}${reportedUrl.pathname}`).toBe(
+      `${window.location.origin}/oauth/callback`
+    )
+    expect(reportedUrl.searchParams.get('code')).toBe('[redacted]')
+    expect(reportedUrl.searchParams.get('next')).toBe('dashboard')
     expect(body.url).not.toContain(fakeToken)
-    expect(body.url).not.toContain('?')
     expect(body.url).not.toContain('#')
   })
 
-  it('sanitizes absolute and relative script URLs', () => {
+  it('redacts sensitive values in explicit payload URLs', async () => {
+    const fakeToken = 'reset-token-not-real'
+    const fetchMock = mockSuccessfulReportFetch()
+
+    reportClientError({
+      message: 'Explicit URL test',
+      url: `https://app.example.com/search?symbol=INFY&token=${fakeToken}&apiKey=${fakeToken}#results`,
+    })
+
+    const body = await reportedPayload(fetchMock)
+    const reportedUrl = new URL(body.url)
+
+    expect(`${reportedUrl.origin}${reportedUrl.pathname}`).toBe('https://app.example.com/search')
+    expect(reportedUrl.searchParams.get('symbol')).toBe('INFY')
+    expect(reportedUrl.searchParams.get('token')).toBe('[redacted]')
+    expect(reportedUrl.searchParams.get('apiKey')).toBe('[redacted]')
+    expect(body.url).not.toContain(fakeToken)
+    expect(body.url).not.toContain('#')
+  })
+
+  it('sanitizes window error filenames before reporting them', async () => {
+    const fakeToken = 'extension-token-not-real'
+    const fetchMock = mockSuccessfulReportFetch()
+
+    handleWindowError(
+      new ErrorEvent('error', {
+        message: 'Extension script failed',
+        filename: `chrome-extension://abcdef/content.js?token=${fakeToken}#line-1`,
+      })
+    )
+
+    const body = await reportedPayload(fetchMock)
+
+    expect(body.url).toBe('chrome-extension://abcdef/content.js')
+    expect(body.url).not.toContain(fakeToken)
+    expect(body.url).not.toContain('#')
+  })
+
+  it('redacts absolute and relative script URLs while preserving safe context', () => {
     const fakeResetToken = 'reset-token-not-real'
 
-    expect(
+    const absolute = new URL(
       sanitizeErrorReportUrl(
-        `https://cdn.example.com/assets/app.js?token=${fakeResetToken}#chunk`,
-      ),
-    ).toBe('https://cdn.example.com/assets/app.js')
-    expect(sanitizeErrorReportUrl(`/assets/app.js?token=${fakeResetToken}#chunk`)).toBe(
-      `${window.location.origin}/assets/app.js`,
+        `https://cdn.example.com/assets/app.js?token=${fakeResetToken}&build=123#chunk`
+      )
     )
+    const relative = new URL(
+      sanitizeErrorReportUrl(`/assets/app.js?token=${fakeResetToken}&build=123#chunk`)
+    )
+
+    expect(`${absolute.origin}${absolute.pathname}`).toBe('https://cdn.example.com/assets/app.js')
+    expect(absolute.searchParams.get('token')).toBe('[redacted]')
+    expect(absolute.searchParams.get('build')).toBe('123')
+    expect(`${relative.origin}${relative.pathname}`).toBe(`${window.location.origin}/assets/app.js`)
+    expect(relative.searchParams.get('token')).toBe('[redacted]')
+    expect(relative.searchParams.get('build')).toBe('123')
+  })
+
+  it('keeps extension URLs actionable and reduces opaque schemes safely', () => {
+    expect(
+      sanitizeErrorReportUrl('moz-extension://guid/inject.js?token=test-token-not-real#chunk')
+    ).toBe('moz-extension://guid/inject.js')
+    expect(sanitizeErrorReportUrl('data:text/html;base64,PAYLOAD')).toBe('data:')
+    expect(sanitizeErrorReportUrl('blob:http://host/uuid')).toBe('blob:')
   })
 
   it('keeps a plain asset filename useful without throwing', () => {
     expect(sanitizeErrorReportUrl('app.js')).toBe(`${window.location.origin}/app.js`)
+  })
+
+  it('falls back safely for malformed URLs', () => {
+    expect(sanitizeErrorReportUrl('http://[')).toBe('http://[')
   })
 })

--- a/frontend/src/utils/errorReporter.ts
+++ b/frontend/src/utils/errorReporter.ts
@@ -6,8 +6,8 @@
  * crash the app — every codepath is wrapped, and the reporter refuses to
  * recurse into itself.
  *
- * Privacy: only message + stack + a query/fragment-free URL + component stack
- * are sent. No DOM, no localStorage, no form values, no breadcrumbs.
+ * Privacy: only message + stack + a redacted URL + component stack are sent.
+ * No DOM, no localStorage, no form values, no breadcrumbs.
  *
  * Throttling: dedups identical messages within 30s. Caps at 30 reports/min
  * (server enforces too).
@@ -31,6 +31,26 @@ const ENDPOINT = '/admin/api/errors/client'
 const DEDUP_WINDOW_MS = 30_000
 const MAX_REPORTS_PER_MINUTE = 30
 const RECENT_TTL_MS = 60_000
+const REDACTED_QUERY_VALUE = '[redacted]'
+const WEB_PROTOCOLS = new Set(['http:', 'https:'])
+const SENSITIVE_QUERY_PARAMETER_NAMES = new Set([
+  'token',
+  'code',
+  'requesttoken',
+  'accesstoken',
+  'authtoken',
+  'refreshtoken',
+  'resettoken',
+  'apikey',
+  'email',
+  'state',
+  'password',
+  'otp',
+  'secret',
+  'clientsecret',
+  'idtoken',
+  'jwt',
+])
 
 // Patterns that are noise — never report these.
 const IGNORE_PATTERNS = [
@@ -69,6 +89,10 @@ function pruneDedup(): void {
   for (const [key, ts] of recentSends.entries()) {
     if (now - ts > DEDUP_WINDOW_MS) recentSends.delete(key)
   }
+}
+
+function isSensitiveQueryParameter(name: string): boolean {
+  return SENSITIVE_QUERY_PARAMETER_NAMES.has(name.toLowerCase().replaceAll(/[_-]/g, ''))
 }
 
 async function fetchCSRFTokenSafe(): Promise<string | null> {
@@ -124,7 +148,18 @@ async function send(payload: ClientErrorPayload): Promise<void> {
 export function sanitizeErrorReportUrl(value: string): string {
   try {
     const url = new URL(value, window.location.origin)
-    return `${url.origin}${url.pathname}`
+    if (WEB_PROTOCOLS.has(url.protocol)) {
+      for (const [key] of [...url.searchParams]) {
+        if (isSensitiveQueryParameter(key)) {
+          url.searchParams.set(key, REDACTED_QUERY_VALUE)
+        }
+      }
+      return `${url.origin}${url.pathname}${url.search}`
+    }
+    if (url.protocol.endsWith('-extension:')) {
+      return `${url.protocol}//${url.host}${url.pathname}`
+    }
+    return url.protocol
   } catch {
     return value.split(/[?#]/, 1)[0]
   }
@@ -149,6 +184,18 @@ export function reportClientError(payload: ClientErrorPayload): void {
 
 let installed = false
 
+export function handleWindowError(event: ErrorEvent): void {
+  reportClientError({
+    message: event.message || 'Uncaught error',
+    stack: event.error?.stack,
+    url: event.filename || window.location.href,
+  })
+  // Stale-bundle recovery: if a top-level script tag failed to load
+  // (e.g. preload of the new entry chunk after a deploy), reload once
+  // to fetch the fresh index.html.
+  tryAutoReloadOnChunkError(event.message)
+}
+
 export function installGlobalErrorReporter(): void {
   if (installed) return
   installed = true
@@ -157,17 +204,7 @@ export function installGlobalErrorReporter(): void {
   // produce noise that isn't representative of production.
   if (import.meta.env.DEV) return
 
-  window.addEventListener('error', (event: ErrorEvent) => {
-    reportClientError({
-      message: event.message || 'Uncaught error',
-      stack: event.error?.stack,
-      url: event.filename || window.location.href,
-    })
-    // Stale-bundle recovery: if a top-level script tag failed to load
-    // (e.g. preload of the new entry chunk after a deploy), reload once
-    // to fetch the fresh index.html.
-    tryAutoReloadOnChunkError(event.message)
-  })
+  window.addEventListener('error', handleWindowError)
 
   window.addEventListener('unhandledrejection', (event: PromiseRejectionEvent) => {
     const reason = event.reason

--- a/frontend/src/utils/errorReporter.ts
+++ b/frontend/src/utils/errorReporter.ts
@@ -6,8 +6,8 @@
  * crash the app — every codepath is wrapped, and the reporter refuses to
  * recurse into itself.
  *
- * Privacy: only message + stack + URL + component stack are sent. No DOM,
- * no localStorage, no form values, no breadcrumbs.
+ * Privacy: only message + stack + a query/fragment-free URL + component stack
+ * are sent. No DOM, no localStorage, no form values, no breadcrumbs.
  *
  * Throttling: dedups identical messages within 30s. Caps at 30 reports/min
  * (server enforces too).
@@ -121,6 +121,15 @@ async function send(payload: ClientErrorPayload): Promise<void> {
   }
 }
 
+export function sanitizeErrorReportUrl(value: string): string {
+  try {
+    const url = new URL(value, window.location.origin)
+    return `${url.origin}${url.pathname}`
+  } catch {
+    return value.split(/[?#]/, 1)[0]
+  }
+}
+
 export function reportClientError(payload: ClientErrorPayload): void {
   try {
     const message = (payload.message || '').slice(0, 2000)
@@ -129,7 +138,7 @@ export function reportClientError(payload: ClientErrorPayload): void {
       level: payload.level ?? 'ERROR',
       message,
       stack: payload.stack?.slice(0, 20_000),
-      url: (payload.url || window.location.href).slice(0, 2000),
+      url: sanitizeErrorReportUrl(payload.url || window.location.href).slice(0, 2000),
       component_stack: payload.component_stack?.slice(0, 5000),
       user_agent: navigator.userAgent.slice(0, 500),
     })

--- a/test/test_admin_client_error_url.py
+++ b/test/test_admin_client_error_url.py
@@ -1,0 +1,37 @@
+"""Tests for server-side URL sanitization of browser error reports."""
+
+from urllib.parse import parse_qs, urlsplit
+
+from blueprints.admin import _sanitize_client_error_url
+
+
+def test_server_redacts_sensitive_query_values_and_fragments():
+    """Keep safe query context while redacting sensitive values before logging."""
+    sanitized = _sanitize_client_error_url(
+        "https://app.example.com/search?symbol=INFY&token=test-token-not-real&apiKey=test-token-not-real#results"
+    )
+    parsed = urlsplit(sanitized)
+
+    assert f"{parsed.scheme}://{parsed.netloc}{parsed.path}" == "https://app.example.com/search"
+    assert parse_qs(parsed.query) == {
+        "symbol": ["INFY"],
+        "token": ["[redacted]"],
+        "apiKey": ["[redacted]"],
+    }
+    assert parsed.fragment == ""
+    assert "test-token-not-real" not in sanitized
+
+
+def test_server_handles_extension_and_opaque_urls_safely():
+    """Keep extension filenames but drop opaque URL content."""
+    assert (
+        _sanitize_client_error_url("chrome-extension://abcdef/content.js?token=test-token-not-real")
+        == "chrome-extension://abcdef/content.js"
+    )
+    assert _sanitize_client_error_url("data:text/html;base64,PAYLOAD") == "data:"
+    assert _sanitize_client_error_url("blob:http://host/uuid") == "blob:"
+
+
+def test_server_falls_back_for_malformed_urls():
+    """Avoid raising or retaining a fragment when URL parsing fails."""
+    assert _sanitize_client_error_url("http://[?token=test-token-not-real#fragment") == "http://["


### PR DESCRIPTION
## Summary

Sanitize client error-report URLs before they are sent to the backend.

Reports now retain only the URL origin and pathname, preventing query-string and fragment values from being copied into diagnostics.

## Related issue

Closes #1851

## Changes

- Add a shared URL sanitizer for client error reporting.
- Remove query strings and fragments from current-page and script URLs.
- Handle absolute URLs, relative URLs, and plain asset filenames safely.
- Route every client report path through the sanitized reporting boundary.
- Add regression tests using only clearly fake OAuth/reset values.

## Testing

- [x] `npm run test:run -- src/utils/errorReporter.test.ts`
  - 3 passed
- [x] `npm run lint`
  - passed
- [x] `npm run test:run`
  - 48 test files, 967 tests passed
- [x] `git diff --check`
  - passed

## Checklist

- [x] This PR contains one focused security fix.
- [x] The change is covered by unit tests.
- [x] No real secrets, credentials, or sensitive values are included.
- [x] No UI change is included; screenshots are not applicable.
- [x] No generated frontend build artifacts are included.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Sanitizes client error-report URLs and adds server-side enforcement to prevent leaking tokens or PII. Previously we logged the full URL; now the client redacts sensitive query values and strips fragments, and the server re-sanitizes before logging.

- Redacts sensitive query parameters (e.g., token, code, apiKey, jwt) and strips fragments while keeping non-sensitive params for context; server endpoint sanitizes again before logging.
- Normalizes absolute, relative, and bare filenames; keeps `*-extension` URLs actionable without query/fragment; collapses opaque schemes like `data:` and `blob:` to scheme only; safe fallback for malformed inputs.
- Reporter uses a shared `sanitizeErrorReportUrl` and `handleWindowError`; payload shape unchanged, but `url` may retain safe query context.
- Adds frontend and backend tests for OAuth/reset flows, asset URLs, browser extensions, and malformed URLs; no migrations or UI changes.

<sup>Written for commit d8f2cdbaefb3fedb5529a4cf6ab8571a425919d5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

