### PR TITLE
test: convert history format script into pytest coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -50,6 +50,7 @@ jobs:
             test/test_auth_resume.py test/test_auth_upsert_multisession.py \
             test/sandbox/test_execution_backlog.py test/test_event_bus_bounded.py \
             test/test_telegram_api_contract.py \
+            test/test_history_format.py \
             -v --timeout=60
 
   # Frontend linting

--- a/test/test_history_format.py
+++ b/test/test_history_format.py
@@ -1,46 +1,94 @@
-import os
-import sys
+"""The history service always returns records shaped the same way, whatever the broker sends.
 
-# Add parent directory to path for imports
-sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
-
-from datetime import datetime, timedelta
+Every broker's BrokerData.get_history returns its own DataFrame, so
+get_history_with_auth is the single place that normalises the result: it rejects
+anything that is not a DataFrame, stamps in an 'oi' column when the broker omits
+one, and serialises to a list of records. These tests pin that contract down with
+a stub broker module, so no server, network or credentials are involved.
+"""
 
 import pandas as pd
-from openalgo import api
+import pytest
 
-# Test the history API to see the response format
-client = api(
-    api_key=os.getenv("OPENALGO_API_KEY"),
-    host="http://127.0.0.1:5000",
-)
+from services import history_service
 
-# Get history data
-end_date = datetime.now()
-start_date = end_date - timedelta(days=5)
+CANDLE = {
+    "timestamp": 1_700_000_000,
+    "open": 100.0,
+    "high": 101.5,
+    "low": 99.5,
+    "close": 101.0,
+    "volume": 1_000,
+}
 
-response = client.history(
-    symbol="RELIANCE",
-    exchange="NSE",
-    interval="5m",
-    start_date=start_date.strftime("%Y-%m-%d"),
-    end_date=end_date.strftime("%Y-%m-%d"),
-)
 
-print("History API Response Type:", type(response))
+def stub_broker(df):
+    """Build a stand-in for a broker's api.data module whose get_history returns df."""
 
-if isinstance(response, pd.DataFrame):
-    print("\nResponse is a DataFrame!")
-    print("Shape:", response.shape)
-    print("Columns:", list(response.columns))
-    print("\nFirst 5 rows:")
-    print(response.head())
-elif isinstance(response, dict):
-    print("\nResponse is a dictionary with keys:", response.keys())
-    if "data" in response:
-        data = response["data"]
-        print("Data type:", type(data))
-        if isinstance(data, pd.DataFrame):
-            print("Data is a DataFrame with columns:", list(data.columns))
-else:
-    print("Unexpected response type:", type(response))
+    class BrokerData:
+        def __init__(self, auth_token, feed_token=None):
+            self.auth_token = auth_token
+            self.feed_token = feed_token
+
+        def get_history(self, symbol, exchange, interval, start_date, end_date):
+            return df
+
+    return type("StubBrokerModule", (), {"BrokerData": BrokerData})
+
+
+@pytest.fixture
+def broker(monkeypatch):
+    """Install a stub broker module and a resolvable symbol; return a caller for the service."""
+
+    def call(df):
+        monkeypatch.setattr(history_service, "get_token", lambda _symbol, _exchange: "12345")
+        monkeypatch.setattr(
+            history_service, "import_broker_module", lambda _broker: stub_broker(df)
+        )
+        return history_service.get_history_with_auth(
+            auth_token="token",
+            feed_token="feed",
+            broker="stub",
+            symbol="RELIANCE",
+            exchange="NSE",
+            interval="5m",
+            start_date="2026-01-01",
+            end_date="2026-01-05",
+        )
+
+    return call
+
+
+def test_history_is_returned_as_success_records(broker):
+    success, response, status = broker(pd.DataFrame([CANDLE]))
+
+    assert success is True
+    assert status == 200
+    assert response["status"] == "success"
+    assert response["data"] == [{**CANDLE, "oi": 0}]
+
+
+def test_missing_oi_column_defaults_to_zero(broker):
+    success, response, status = broker(pd.DataFrame([CANDLE, CANDLE]))
+
+    assert (success, status) == (True, 200)
+    assert [record["oi"] for record in response["data"]] == [0, 0]
+
+
+def test_broker_supplied_oi_is_preserved(broker):
+    success, response, status = broker(pd.DataFrame([{**CANDLE, "oi": 4_200}]))
+
+    assert (success, status) == (True, 200)
+    assert response["data"][0]["oi"] == 4_200
+
+
+@pytest.mark.parametrize("malformed", [None, {"data": [CANDLE]}, [CANDLE], "not a dataframe"])
+def test_non_dataframe_from_broker_is_reported_as_an_error(broker, malformed):
+    success, response, status = broker(malformed)
+
+    assert success is False
+    assert status == 500
+    assert response == {
+        "status": "error",
+        "message": "Invalid data format returned from broker",
+    }


### PR DESCRIPTION
## Description

`test/test_history_format.py` was a manual reconnaissance script rather than a test. Everything ran at import time: it built an `openalgo` client against a live server on `127.0.0.1:5000` using `OPENALGO_API_KEY`, derived its date range from `datetime.now()`, and printed whatever came back. Nothing was asserted.

Because the filename matches pytest's `python_files = ["test_*.py"]` pattern, pytest imported the module, paid the cost of the network call, and then collected zero tests.

This replaces it with hermetic tests around `get_history_with_auth` (`services/history_service.py:76`). A stub broker module stands in for `broker.<name>.api.data`, and `get_token` is patched, so no server, network, or credentials are involved.

Coverage (7 cases from 4 test functions):

| Test | Asserts |
| --- | --- |
| `test_history_is_returned_as_success_records` | `(True, {"status": "success", "data": [...]}, 200)` and the record keys |
| `test_missing_oi_column_defaults_to_zero` | the `oi = 0` fallback at `history_service.py:134-136` |
| `test_broker_supplied_oi_is_preserved` | the fallback does not overwrite broker-supplied `oi` |
| `test_non_dataframe_from_broker_is_reported_as_an_error` | parametrized over `None`, dict, list and str: `(False, error, 500)` with the documented message |

No production code is changed.

`.github/workflows/ci.yml` gains one line so `backend-test` actually runs the new file: its allowlist is explicit, so without the entry the tests would never execute upstream. Added against the list as it stands today, per the review note on ordering with #1888 and #1874.

## Related Issues

Closes #1827

## Testing

```
uv run pytest test/test_history_format.py -v
7 passed in 0.76s

uv run pytest test/test_history_format.py --collect-only
7 tests collected in 0.68s      (was: 0 items, exit code 5, 8.50s)

uv run ruff check test/test_history_format.py
All checks passed!

uv run ruff format --check test/test_history_format.py
1 file already formatted
```

The full CI-safe allowlist, as `backend-test` now runs it: **47 passed in 13.09s**.

The `--collect-only` time drops from 8.50s to 0.68s because the import-time HTTP call is gone.

To confirm the assertions are not vacuous, the two behaviours under test were deliberately broken in `services/history_service.py` and the suite was re-run:

- disabling `df["oi"] = 0` at `services/history_service.py:135-136` fails 2 tests: `test_missing_oi_column_defaults_to_zero` with `KeyError: 'oi'` (test/test_history_format.py:75), and `test_history_is_returned_as_success_records` with an `AssertionError` on the whole-dict compare (line 68)
- changing the `ValueError` message fails all 4 malformed-input cases

Both mutations were reverted. The PR touches two files only: `test/test_history_format.py` and the single added line in `.github/workflows/ci.yml`. No application code is modified.

## Checklist

- [x] One fix per pull request
- [x] Follows Conventional Commits (`test:`)
- [x] Tests pass locally with `uv run pytest`
- [x] `ruff check` and `ruff format` are clean
- [x] No network access or credentials required by the tests
- [x] No production code modified
- [x] New test file registered in the `ci.yml` CI-safe allowlist
- [ ] Screenshots - not applicable, no UI change
