### PR TITLE
test: cover interval service contracts

### DIFF
--- a/test/test_intervals_service.py
+++ b/test/test_intervals_service.py
@@ -1,3 +1,5 @@
+"""Regression tests for interval service response contracts."""
+
 from types import SimpleNamespace
 
 import services.intervals_service as intervals_service
@@ -10,6 +12,7 @@ def broker_module_with_timeframes(timeframe_map):
 
 
 def test_intervals_group_and_sort_canonical_timeframes(monkeypatch):
+    """Sort canonical intervals within their response categories."""
     timeframe_map = {
         "15m": "provider-15-minute",
         "1h": "provider-60-minute",
@@ -49,20 +52,19 @@ def test_intervals_group_and_sort_canonical_timeframes(monkeypatch):
 
 
 def test_intervals_look_up_broker_from_api_key(monkeypatch):
+    """Resolve the broker name before loading its interval plugin."""
     requested_brokers = []
     monkeypatch.setattr(
         intervals_service,
         "get_auth_token_broker",
         lambda api_key: ("test-auth-token", "test-broker"),
     )
-    monkeypatch.setattr(
-        intervals_service,
-        "import_broker_module",
-        lambda broker: (
-            requested_brokers.append(broker)
-            or broker_module_with_timeframes({"1m": "provider-1-minute"})
-        ),
-    )
+
+    def import_broker_module(broker):
+        requested_brokers.append(broker)
+        return broker_module_with_timeframes({"1m": "provider-1-minute"})
+
+    monkeypatch.setattr(intervals_service, "import_broker_module", import_broker_module)
 
     success, response, status_code = intervals_service.get_intervals(api_key="test-api-key")
 
@@ -73,6 +75,7 @@ def test_intervals_look_up_broker_from_api_key(monkeypatch):
 
 
 def test_intervals_return_404_when_broker_module_is_missing(monkeypatch):
+    """Return the documented error when a broker plugin is unavailable."""
     monkeypatch.setattr(intervals_service, "import_broker_module", lambda broker: None)
 
     success, response, status_code = intervals_service.get_intervals_with_auth(
@@ -85,6 +88,8 @@ def test_intervals_return_404_when_broker_module_is_missing(monkeypatch):
 
 
 def test_intervals_return_500_when_broker_plugin_fails(monkeypatch):
+    """Return the documented error when plugin setup raises an exception."""
+
     def raise_plugin_error(auth_token):
         raise RuntimeError("plugin initialization failed")
 
@@ -101,3 +106,23 @@ def test_intervals_return_500_when_broker_plugin_fails(monkeypatch):
     assert success is False
     assert status_code == 500
     assert response == {"status": "error", "message": "plugin initialization failed"}
+
+
+def test_intervals_reject_invalid_api_key(monkeypatch):
+    """Reject an API key that cannot be resolved to a broker token."""
+    monkeypatch.setattr(intervals_service, "get_auth_token_broker", lambda api_key: (None, None))
+
+    success, response, status_code = intervals_service.get_intervals(api_key="bad-key")
+
+    assert success is False
+    assert status_code == 403
+    assert response == {"status": "error", "message": "Invalid openalgo apikey"}
+
+
+def test_intervals_reject_missing_parameters():
+    """Require an API key or a complete direct-authentication pair."""
+    success, response, status_code = intervals_service.get_intervals()
+
+    assert success is False
+    assert status_code == 400
+    assert response["message"] == "Either api_key or both auth_token and broker must be provided"

--- a/test/test_intervals_service.py
+++ b/test/test_intervals_service.py
@@ -1,0 +1,103 @@
+from types import SimpleNamespace
+
+import services.intervals_service as intervals_service
+
+
+def broker_module_with_timeframes(timeframe_map):
+    return SimpleNamespace(
+        BrokerData=lambda auth_token: SimpleNamespace(timeframe_map=timeframe_map)
+    )
+
+
+def test_intervals_group_and_sort_canonical_timeframes(monkeypatch):
+    timeframe_map = {
+        "15m": "provider-15-minute",
+        "1h": "provider-60-minute",
+        "60m": "provider-60-minute",
+        "5m": "provider-5-minute",
+        "4h": "provider-4-hour",
+        "D": "provider-day",
+        "1m": "provider-1-minute",
+        "W": "provider-week",
+        "M": "provider-month",
+        "30s": "provider-30-second",
+        "5s": "provider-5-second",
+    }
+    monkeypatch.setattr(
+        intervals_service,
+        "import_broker_module",
+        lambda broker: broker_module_with_timeframes(timeframe_map),
+    )
+
+    success, response, status_code = intervals_service.get_intervals_with_auth(
+        "test-auth-token", "test-broker"
+    )
+
+    assert success is True
+    assert status_code == 200
+    assert response == {
+        "status": "success",
+        "data": {
+            "seconds": ["5s", "30s"],
+            "minutes": ["1m", "5m", "15m", "60m"],
+            "hours": ["1h", "4h"],
+            "days": ["D"],
+            "weeks": ["W"],
+            "months": ["M"],
+        },
+    }
+
+
+def test_intervals_look_up_broker_from_api_key(monkeypatch):
+    requested_brokers = []
+    monkeypatch.setattr(
+        intervals_service,
+        "get_auth_token_broker",
+        lambda api_key: ("test-auth-token", "test-broker"),
+    )
+    monkeypatch.setattr(
+        intervals_service,
+        "import_broker_module",
+        lambda broker: (
+            requested_brokers.append(broker)
+            or broker_module_with_timeframes({"1m": "provider-1-minute"})
+        ),
+    )
+
+    success, response, status_code = intervals_service.get_intervals(api_key="test-api-key")
+
+    assert success is True
+    assert status_code == 200
+    assert response["data"]["minutes"] == ["1m"]
+    assert requested_brokers == ["test-broker"]
+
+
+def test_intervals_return_404_when_broker_module_is_missing(monkeypatch):
+    monkeypatch.setattr(intervals_service, "import_broker_module", lambda broker: None)
+
+    success, response, status_code = intervals_service.get_intervals_with_auth(
+        "test-auth-token", "unknown-broker"
+    )
+
+    assert success is False
+    assert status_code == 404
+    assert response == {"status": "error", "message": "Broker-specific module not found"}
+
+
+def test_intervals_return_500_when_broker_plugin_fails(monkeypatch):
+    def raise_plugin_error(auth_token):
+        raise RuntimeError("plugin initialization failed")
+
+    monkeypatch.setattr(
+        intervals_service,
+        "import_broker_module",
+        lambda broker: SimpleNamespace(BrokerData=raise_plugin_error),
+    )
+
+    success, response, status_code = intervals_service.get_intervals_with_auth(
+        "test-auth-token", "failing-broker"
+    )
+
+    assert success is False
+    assert status_code == 500
+    assert response == {"status": "error", "message": "plugin initialization failed"}


### PR DESCRIPTION
## Summary

Add credential-free unit coverage for interval-service sorting, categories, broker lookup, and failure contracts.

No production behavior is changed.

## Related issue

Closes #1828

## Changes

- Mock API-key broker lookup and broker-plugin loading.
- Cover numeric sorting across seconds, minutes, and hours.
- Verify day, week, and month categories.
- Verify canonical OpenAlgo interval labels remain correct when broker-facing values repeat.
- Cover the documented missing-plugin `404` response.
- Cover the documented plugin-failure `500` response.

## Testing

- [x] `env -u LOG_FORMAT uv run pytest test/test_intervals_service.py -v`
  - 4 passed
- [x] `uv run ruff check test/test_intervals_service.py`
  - passed
- [x] `git diff --check`
  - passed

## Full-suite note

`env -u LOG_FORMAT uv run pytest test/ -v` was attempted. Collection is currently blocked by two unrelated existing issues:

- `test/test_bot_web.py` imports missing `get_telegram_bot`.
- `test/test_telegram_startup.py` requires unavailable `eventlet`.

Neither failure is in this PR's changed file.

## Checklist

- [x] This PR contains one focused test-only change.
- [x] The tests are credential-free and fully local.
- [x] No production behavior was changed.
- [x] Python linting passes for the changed file.
- [x] No credentials or sensitive data are included.
- [x] No UI change is included; screenshots are not applicable.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds credential-free unit tests for the intervals service to lock down grouping/sorting, broker lookup, and error/input-validation contracts. No production behavior changes; addresses #1828.

- Groups into seconds/minutes/hours/days/weeks/months and sorts numerically; preserves canonical labels when provider values repeat (e.g., `60m` and `1h`).
- Resolves broker from API key before loading the plugin and verifies the resolved broker is used.
- Asserts error responses: 404 for missing broker module, 500 for plugin init failure, 403 for invalid API key, and 400 when required parameters are missing.
- Mocks API-key broker lookup and broker module loading to run locally without credentials.

<sup>Written for commit 25b2d7cf73da56221374af7f2b14ec049f5ec0e6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1888?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

