### PR TITLE
docs: align contributor test commands with CI

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,7 +384,7 @@ uv run pytest test/test_log_location.py test/test_navigation_update.py \
   test/sandbox/test_execution_backlog.py test/test_event_bus_bounded.py \
   test/test_telegram_api_contract.py -v --timeout=60
 
-# Full backend suite (slower)
+# Full backend suite (not CI-safe; not green on a clean checkout)
 uv run pytest test/ -v
 
 # Run React tests once (CI/completion check)
@@ -406,7 +406,7 @@ npm run e2e
 - [ ] Application starts without errors (`uv run app.py`)
 - [ ] All existing features still work
 - [ ] New feature works as expected
-- [ ] Python tests pass (`uv run pytest test/ -v`)
+- [ ] CI-safe backend tests pass (the pytest selection above)
 - [ ] Frontend tests pass (`cd frontend && npm run test:run`)
 - [ ] No TypeScript errors (`cd frontend && npm run build`)
 - [ ] No linting errors (Ruff for Python, Biome for frontend)
@@ -427,7 +427,6 @@ git push origin feature/your-feature-name
 ```
 
 ### 7. Create a Pull Request
-
 1. Go to your fork on GitHub
 2. Click **"Compare & pull request"**
 3. Fill out the PR template:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -427,6 +427,7 @@ git push origin feature/your-feature-name
 ```
 
 ### 7. Create a Pull Request
+
 1. Go to your fork on GitHub
 2. Click **"Compare & pull request"**
 3. Fill out the PR template:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -376,12 +376,20 @@ git commit -m "refactor: optimize order processing pipeline"
 ### 5. Test Your Changes
 
 ```bash
-# Run Python tests
+# Fast backend check (same maintained selection used by CI)
+uv run pytest test/test_log_location.py test/test_navigation_update.py \
+  test/test_python_editor.py test/test_rate_limits_simple.py \
+  test/test_logout_csrf.py test/test_auth_logout.py \
+  test/test_auth_resume.py test/test_auth_upsert_multisession.py \
+  test/sandbox/test_execution_backlog.py test/test_event_bus_bounded.py \
+  test/test_telegram_api_contract.py -v --timeout=60
+
+# Full backend suite (slower)
 uv run pytest test/ -v
 
-# Run React tests
+# Run React tests once (CI/completion check)
 cd frontend
-npm test
+npm run test:run
 
 # Run end-to-end tests
 npm run e2e
@@ -399,7 +407,7 @@ npm run e2e
 - [ ] All existing features still work
 - [ ] New feature works as expected
 - [ ] Python tests pass (`uv run pytest test/ -v`)
-- [ ] Frontend tests pass (`cd frontend && npm test`)
+- [ ] Frontend tests pass (`cd frontend && npm run test:run`)
 - [ ] No TypeScript errors (`cd frontend && npm run build`)
 - [ ] No linting errors (Ruff for Python, Biome for frontend)
 - [ ] API endpoints return correct responses


### PR DESCRIPTION
Aligns the contributor test instructions with the maintained CI-safe backend selection and one-shot frontend test command. Keeps the change docs-only.\n\nRefs #1841.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Aligns CONTRIBUTING test commands with CI to reduce local/CI mismatches and flakiness. Replaces the full backend suite and `npm test` with the CI-maintained backend selection (`--timeout=60` via `uv`/`pytest`) and a one‑shot `npm run test:run`; preserves guide formatting and addresses #1841.

- Backend: direct contributors to the CI-safe fast check; keep `uv run pytest test/ -v` as optional and note it’s not CI-safe and may be red on a clean checkout.
- Frontend: use `npm run test:run` and update the checklist to reference the CI-safe backend selection and one-shot frontend run.
- Docs-only; review is limited to verifying docs accuracy and CI parity.

<sup>Written for commit 96fc97265c0e1b2af1f3f6b3e4b873fbf2589e0d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1889?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

