### PR TITLE
fix(options): validate strike interval and option type at the resolver boundary

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             test/test_multi_option_greeks_regression.py \
             test/test_history_format.py \
             test/test_precompress_assets.py \
+            test/test_option_symbol_service_validation.py \
             -v --timeout=60
 
   # Frontend linting

--- a/services/option_symbol_service.py
+++ b/services/option_symbol_service.py
@@ -34,6 +34,7 @@ Example Usage (OLD METHOD - Legacy):
 """
 
 import importlib
+import math
 import re
 from datetime import datetime
 from typing import Any, Optional
@@ -169,6 +170,85 @@ def resolve_underlying_quote(base_symbol: str, exchange: str) -> tuple[str, str]
     return (fut["symbol"], fut["exchange"])
 
 
+# ============================================================================
+# INPUT VALIDATION - Guards for the resolver boundary
+# ============================================================================
+#: Option types this resolver understands. Every strike calculation below
+#: branches on CE and treats anything else as a put, so an unrecognised type
+#: such as "CALL", "C" or None used to resolve to the put strike instead of
+#: being refused. The symbol built around it then failed the master-contract
+#: lookup, so the caller saw a confusing "not found" where the real fault was
+#: the option type.
+VALID_OPTION_TYPES = ("CE", "PE")
+
+
+def _is_finite_number(value: Any) -> bool:
+    """Whether a value is a real number that is neither NaN nor infinite.
+
+    math.isfinite() is used rather than an isinstance() check so that a numpy
+    scalar off a pandas or DuckDB path is still accepted - np.int64 is not an
+    int - while strings, None and sequences raise TypeError and are refused.
+    bool is excluded explicitly because it is an int subclass, so True would
+    otherwise pass as a strike interval of 1.
+
+    OverflowError and ValueError are refused alongside TypeError: an int too
+    large to convert to a float raises OverflowError, and Decimal("sNaN")
+    raises ValueError. Both are reachable from the public endpoint, because
+    OptionSymbolSchema validates a range, not a magnitude or a numeric type.
+    """
+    if isinstance(value, bool):
+        return False
+    try:
+        return math.isfinite(value)
+    except (TypeError, OverflowError, ValueError):
+        return False
+
+
+def validate_option_type(option_type: Any) -> str:
+    """Normalize an option type to CE or PE.
+
+    Args:
+        option_type: Option type supplied by the caller, in any case.
+
+    Returns:
+        "CE" or "PE".
+
+    Raises:
+        ValueError: If the option type is missing or unsupported.
+    """
+    if isinstance(option_type, str):
+        normalized = option_type.strip().upper()
+        if normalized in VALID_OPTION_TYPES:
+            return normalized
+
+    raise ValueError(f"Invalid option_type: {option_type!r}. Supported option types are CE and PE.")
+
+
+def validate_strike_interval(strike_int: Any) -> float:
+    """Validate a strike interval before it is used as a divisor.
+
+    Args:
+        strike_int: Strike interval supplied by the caller.
+
+    Returns:
+        The strike interval as a float, so every caller is guaranteed a value
+        it can divide by. Returning it unchanged would not be: Decimal("50")
+        is finite and positive, but float / Decimal raises TypeError. The
+        conversion also covers Fraction and numpy scalars uniformly.
+
+    Raises:
+        ValueError: If the interval is not a positive finite number. Zero
+            raises ZeroDivisionError inside the ATM calculation, and a
+            negative, NaN or infinite interval produces a strike that no
+            exchange lists.
+    """
+    if not _is_finite_number(strike_int) or strike_int <= 0:
+        raise ValueError(
+            f"Invalid strike_int: {strike_int!r}. Strike interval must be a positive number."
+        )
+    return float(strike_int)
+
+
 def get_atm_strike(ltp: float, strike_int: int) -> float:
     """
     Calculate ATM strike price based on LTP and strike interval.
@@ -180,10 +260,14 @@ def get_atm_strike(ltp: float, strike_int: int) -> float:
     Returns:
         ATM strike price rounded to nearest strike interval
 
+    Raises:
+        ValueError: If strike_int is not a positive finite number.
+
     Example:
         LTP = 23587.50, strike_int = 50
         ATM = round(23587.50 / 50) * 50 = 23600
     """
+    strike_int = validate_strike_interval(strike_int)
     atm_strike = round(ltp / strike_int) * strike_int
     logger.info(f"Calculated ATM: LTP={ltp}, strike_int={strike_int}, ATM={atm_strike}")
     return atm_strike
@@ -213,12 +297,17 @@ def calculate_offset_strike(
             - ITM: ATM + (N * strike_int)  [Higher strike]
             - OTM: ATM - (N * strike_int)  [Lower strike]
 
+    Raises:
+        ValueError: If option_type is not CE or PE, if strike_int is not a
+            positive finite number, or if the offset is unrecognised.
+
     Example:
         ATM = 23600, strike_int = 50, option_type = "CE", offset = "ITM2"
         Target = 23600 - (2 * 50) = 23500
     """
+    option_type = validate_option_type(option_type)
+    strike_int = validate_strike_interval(strike_int)
     offset = offset.upper()
-    option_type = option_type.upper()
 
     if offset == "ATM":
         target_strike = atm_strike
@@ -468,6 +557,12 @@ def find_atm_strike_from_actual(ltp: float, available_strikes: list) -> float | 
         logger.warning("No available strikes to find ATM")
         return None
 
+    if not _is_finite_number(ltp):
+        # min() with a NaN key compares false against every strike and returns
+        # the first one, which would then be reported as the ATM strike.
+        logger.error(f"Cannot find ATM strike from a non-numeric LTP: {ltp!r}")
+        return None
+
     # Find the strike closest to LTP
     atm_strike = min(available_strikes, key=lambda x: abs(x - ltp))
 
@@ -490,6 +585,9 @@ def calculate_offset_strike_from_actual(
     Returns:
         Target strike price or None if offset is out of range
 
+    Raises:
+        ValueError: If option_type is not CE or PE.
+
     Logic:
         For CE (Call):
             - ITM: Lower strikes (traverse down the list from ATM)
@@ -507,12 +605,13 @@ def calculate_offset_strike_from_actual(
         For CE ITM2: Move 2 positions DOWN from ATM
         Result: 23400 (actual strike from database)
     """
+    option_type = validate_option_type(option_type)
+
     if not available_strikes or atm_strike not in available_strikes:
         logger.error(f"ATM strike {atm_strike} not found in available strikes")
         return None
 
     offset = offset.upper()
-    option_type = option_type.upper()
 
     # Find the index of ATM in the sorted strikes list
     atm_index = available_strikes.index(atm_strike)
@@ -623,6 +722,15 @@ def get_option_symbol(
         Tuple of (success, response_data, status_code)
     """
     try:
+        # Step 0: Refuse unusable inputs before spending a quote request or a
+        # database lookup on them. Flow, multi-leg orders and MCP call this
+        # resolver directly, without the REST schema that checks these two
+        # fields, so the resolver validates them for itself. The ValueErrors
+        # raised here are answered as HTTP 400 at the bottom of this function.
+        option_type = validate_option_type(option_type)
+        if strike_int is not None:
+            strike_int = validate_strike_interval(strike_int)
+
         # Step 1: Parse underlying to extract base symbol and expiry
         base_symbol, embedded_expiry = parse_underlying_symbol(underlying)
 
@@ -722,6 +830,19 @@ def get_option_symbol(
                 )
 
             logger.info(f"Got LTP: {ltp} for {quote_symbol}")
+
+        # A non-finite LTP resolves to a strike no exchange lists, so stop
+        # here rather than constructing a symbol around NaN or infinity.
+        if not _is_finite_number(ltp):
+            logger.error(f"Unusable LTP {ltp!r} for {quote_symbol}")
+            return (
+                False,
+                {
+                    "status": "error",
+                    "message": f"Could not determine a usable LTP for {quote_symbol}.",
+                },
+                500,
+            )
 
         # Step 4: Map to options exchange
         options_exchange = get_option_exchange(quote_exchange)

--- a/test/test_option_symbol_service_validation.py
+++ b/test/test_option_symbol_service_validation.py
@@ -1,0 +1,347 @@
+"""The option-symbol resolver refuses unusable strikes and option types.
+
+Two defects lived in the strike calculations. The legacy strike_int path
+divided the underlying LTP by the caller's interval with no guard, so a zero
+interval raised ZeroDivisionError and a NaN or infinite one produced a strike
+that formats into a symbol no exchange lists. Separately, every offset
+calculation branches on CE and treats anything else as a put, so an option
+type of "CALL", "C" or None resolved to the put strike. The symbol built
+around it then failed the master-contract lookup, so the caller saw a
+confusing "not found in NFO" where the real fault was the option type.
+
+The REST schema validates both fields, but services/flow_openalgo_client.py
+calls get_option_symbol() in process and bypasses it, so the fix and these
+tests sit at the resolver boundary rather than in the schema.
+
+The tests are fully local: no broker credentials, no network, and no database
+rows - the quote fetch and the symbol lookup are stubbed.
+"""
+
+import math
+import os
+import sys
+from decimal import Decimal
+
+import numpy
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+from services import option_symbol_service as oss  # noqa: E402
+from services.option_symbol_service import (  # noqa: E402
+    VALID_OPTION_TYPES,
+    calculate_offset_strike,
+    calculate_offset_strike_from_actual,
+    find_atm_strike_from_actual,
+    get_atm_strike,
+    get_option_symbol,
+    validate_option_type,
+    validate_strike_interval,
+)
+
+#: A realistic NIFTY chain: 50-point strikes either side of a 23600 ATM.
+STRIKES = [23400.0, 23450.0, 23500.0, 23550.0, 23600.0, 23650.0, 23700.0, 23750.0]
+
+#: Values that are not a usable divisor. Zero and the negatives are the
+#: reported defect; True is included because bool is an int subclass and would
+#: otherwise slip through as an interval of 1.
+UNUSABLE_INTERVALS = [
+    0,
+    0.0,
+    -50,
+    -0.5,
+    float("nan"),
+    float("inf"),
+    float("-inf"),
+    None,
+    "50",
+    "",
+    True,
+    [50],
+    #: math.isfinite() raises rather than returning False for these two: an int
+    #: too large to convert to a float raises OverflowError, and a signalling
+    #: NaN raises ValueError. Both are reachable from the public endpoint.
+    10**400,
+    Decimal("sNaN"),
+]
+
+#: Everything the resolver must refuse rather than silently price as a put.
+UNSUPPORTED_OPTION_TYPES = ["CALL", "PUT", "C", "P", "XX", "", "  ", None, 0, 1, ["CE"]]
+
+
+class TestValidateOptionType:
+    @pytest.mark.parametrize(
+        ("supplied", "expected"),
+        [("CE", "CE"), ("PE", "PE"), ("ce", "CE"), ("pe", "PE"), ("Ce", "CE"), (" pe ", "PE")],
+    )
+    def test_supported_types_normalize_to_canonical_case(self, supplied, expected):
+        assert validate_option_type(supplied) == expected
+
+    @pytest.mark.parametrize("supplied", UNSUPPORTED_OPTION_TYPES)
+    def test_unsupported_types_raise(self, supplied):
+        with pytest.raises(ValueError, match="option_type"):
+            validate_option_type(supplied)
+
+    def test_only_ce_and_pe_are_supported(self):
+        assert VALID_OPTION_TYPES == ("CE", "PE")
+
+
+class TestValidateStrikeInterval:
+    @pytest.mark.parametrize("interval", [1, 50, 100, 2.5, 0.05])
+    def test_positive_finite_intervals_keep_their_value(self, interval):
+        assert validate_strike_interval(interval) == interval
+
+    @pytest.mark.parametrize("interval", UNUSABLE_INTERVALS)
+    def test_unusable_intervals_raise(self, interval):
+        with pytest.raises(ValueError, match="strike_int"):
+            validate_strike_interval(interval)
+
+    def test_a_numpy_scalar_is_accepted(self):
+        """np.int64 is not an int, but it divides an LTP perfectly well."""
+        assert validate_strike_interval(numpy.int64(50)) == 50
+
+    @pytest.mark.parametrize("interval", [50, 2.5, numpy.int64(50), Decimal("50")])
+    def test_an_accepted_interval_is_returned_as_a_usable_divisor(self, interval):
+        """The point of the validator is that the next line can divide by it.
+
+        Decimal is the case that proves it: finite and positive, so it passes
+        the checks, but float / Decimal raises TypeError.
+        """
+        validated = validate_strike_interval(interval)
+
+        assert isinstance(validated, float)
+        assert 23587.50 / validated == 23587.50 / float(interval)
+
+    def test_a_decimal_interval_resolves_the_same_strike_as_an_int(self):
+        assert get_atm_strike(23587.50, Decimal("50")) == get_atm_strike(23587.50, 50)
+
+
+class TestGetAtmStrike:
+    @pytest.mark.parametrize(
+        ("ltp", "interval", "expected"),
+        [
+            (23587.50, 50, 23600),
+            (23574.00, 50, 23550),
+            (292.30, 2.5, 292.5),
+            (44000.00, 100, 44000),
+        ],
+    )
+    def test_valid_input_is_unaffected(self, ltp, interval, expected):
+        assert get_atm_strike(ltp, interval) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("interval", UNUSABLE_INTERVALS)
+    def test_unusable_interval_raises_valueerror_not_zerodivisionerror(self, interval):
+        """ValueError is what get_option_symbol() answers as HTTP 400."""
+        with pytest.raises(ValueError, match="strike_int"):
+            get_atm_strike(23587.50, interval)
+
+
+class TestCalculateOffsetStrike:
+    """The legacy strike_int path."""
+
+    @pytest.mark.parametrize(
+        ("offset", "option_type", "expected"),
+        [
+            ("ATM", "CE", 23600),
+            ("ATM", "PE", 23600),
+            ("ITM2", "CE", 23500),
+            ("OTM2", "CE", 23700),
+            ("ITM2", "PE", 23700),
+            ("OTM2", "PE", 23500),
+            ("itm1", "ce", 23550),
+            ("otm1", "pe", 23550),
+        ],
+    )
+    def test_valid_calls_and_puts_are_unchanged(self, offset, option_type, expected):
+        assert calculate_offset_strike(23600, offset, 50, option_type) == pytest.approx(expected)
+
+    @pytest.mark.parametrize("option_type", UNSUPPORTED_OPTION_TYPES)
+    def test_unsupported_option_type_is_rejected_not_treated_as_a_put(self, option_type):
+        with pytest.raises(ValueError, match="option_type"):
+            calculate_offset_strike(23600, "ITM2", 50, option_type)
+
+    @pytest.mark.parametrize("interval", UNUSABLE_INTERVALS)
+    def test_unusable_interval_is_rejected(self, interval):
+        with pytest.raises(ValueError, match="strike_int"):
+            calculate_offset_strike(23600, "ITM2", interval, "CE")
+
+    def test_unknown_offset_still_raises(self):
+        with pytest.raises(ValueError, match="offset"):
+            calculate_offset_strike(23600, "DEEP3", 50, "CE")
+
+
+class TestFindAtmStrikeFromActual:
+    @pytest.mark.parametrize(
+        ("ltp", "expected"), [(23587.50, 23600.0), (23574.00, 23550.0), (23400.0, 23400.0)]
+    )
+    def test_nearest_strike_is_unchanged(self, ltp, expected):
+        assert find_atm_strike_from_actual(ltp, STRIKES) == expected
+
+    @pytest.mark.parametrize("ltp", [float("nan"), float("inf"), float("-inf"), None, "23587.50"])
+    def test_non_finite_ltp_returns_none_instead_of_the_first_strike(self, ltp):
+        """NaN compares false against every strike, so min() returned STRIKES[0]."""
+        assert find_atm_strike_from_actual(ltp, STRIKES) is None
+
+    def test_a_numpy_ltp_still_resolves(self):
+        assert find_atm_strike_from_actual(numpy.float64(23587.50), STRIKES) == 23600.0
+
+
+class TestCalculateOffsetStrikeFromActual:
+    """The actual-strikes path, which shares the same CE/else branching."""
+
+    @pytest.mark.parametrize(
+        ("offset", "option_type", "expected"),
+        [
+            ("ATM", "CE", 23600.0),
+            ("ITM2", "CE", 23500.0),
+            ("OTM2", "CE", 23700.0),
+            ("ITM2", "PE", 23700.0),
+            ("OTM2", "PE", 23500.0),
+            ("itm1", "ce", 23550.0),
+        ],
+    )
+    def test_valid_calls_and_puts_are_unchanged(self, offset, option_type, expected):
+        assert (
+            calculate_offset_strike_from_actual(23600.0, offset, option_type, STRIKES) == expected
+        )
+
+    @pytest.mark.parametrize("option_type", UNSUPPORTED_OPTION_TYPES)
+    def test_unsupported_option_type_is_rejected_not_treated_as_a_put(self, option_type):
+        with pytest.raises(ValueError, match="option_type"):
+            calculate_offset_strike_from_actual(23600.0, "ITM2", option_type, STRIKES)
+
+    def test_offset_out_of_range_still_returns_none(self):
+        assert calculate_offset_strike_from_actual(23600.0, "OTM9", "CE", STRIKES) is None
+
+    def test_unknown_offset_still_returns_none(self):
+        assert calculate_offset_strike_from_actual(23600.0, "DEEP3", "CE", STRIKES) is None
+
+
+@pytest.fixture
+def stub_resolver(monkeypatch):
+    """Stub every outbound call get_option_symbol() makes.
+
+    Returns the list of quote requests, so a test can assert that a rejected
+    request never reached the broker.
+    """
+    import database.qty_freeze_db as qty_freeze_db
+
+    quote_calls = []
+
+    def fake_get_quotes(symbol, exchange, api_key):
+        quote_calls.append((symbol, exchange))
+        return True, {"status": "success", "data": {"ltp": 23587.50}}, 200
+
+    monkeypatch.setattr(oss, "get_quotes", fake_get_quotes)
+    monkeypatch.setattr(oss, "get_available_strikes", lambda *args, **kwargs: list(STRIKES))
+    monkeypatch.setattr(
+        oss,
+        "find_option_in_database",
+        lambda symbol, exchange: {
+            "symbol": symbol,
+            "exchange": exchange,
+            "lotsize": 75,
+            "tick_size": 0.05,
+        },
+    )
+    monkeypatch.setattr(qty_freeze_db, "get_freeze_qty_for_option", lambda symbol, exchange: 1800)
+    return quote_calls
+
+
+class TestGetOptionSymbolBoundary:
+    """Both legacy paths reject at the boundary, before any broker call."""
+
+    def _request(self, **overrides):
+        request = {
+            "underlying": "NIFTY",
+            "exchange": "NSE_INDEX",
+            "expiry_date": "28OCT25",
+            "strike_int": None,
+            "offset": "ITM2",
+            "option_type": "CE",
+            "api_key": "test-api-key-not-real",
+        }
+        request.update(overrides)
+        return request
+
+    def test_actual_strikes_path_resolves_as_before(self, stub_resolver):
+        success, response, status_code = get_option_symbol(**self._request())
+
+        assert (success, status_code) == (True, 200)
+        assert response["symbol"] == "NIFTY28OCT2523500CE"
+        assert response["underlying_ltp"] == 23587.50
+
+    def test_strike_int_path_resolves_as_before(self, stub_resolver):
+        success, response, status_code = get_option_symbol(**self._request(strike_int=50))
+
+        assert (success, status_code) == (True, 200)
+        assert response["symbol"] == "NIFTY28OCT2523500CE"
+
+    def test_lowercase_option_type_still_resolves(self, stub_resolver):
+        success, response, status_code = get_option_symbol(
+            **self._request(option_type="pe", offset="ATM")
+        )
+
+        assert (success, status_code) == (True, 200)
+        assert response["symbol"] == "NIFTY28OCT2523600PE"
+
+    @pytest.mark.parametrize("option_type", ["CALL", "C", "", None, 1])
+    def test_unsupported_option_type_is_a_client_error(self, stub_resolver, option_type):
+        success, response, status_code = get_option_symbol(**self._request(option_type=option_type))
+
+        assert (success, status_code) == (False, 400)
+        assert response["status"] == "error"
+        assert "option_type" in response["message"]
+        assert stub_resolver == [], "a rejected request must not reach the broker"
+
+    @pytest.mark.parametrize(
+        "strike_int", [0, -50, float("nan"), float("inf"), "50", 10**400, Decimal("sNaN")]
+    )
+    def test_unusable_strike_interval_is_a_client_error(self, stub_resolver, strike_int):
+        success, response, status_code = get_option_symbol(**self._request(strike_int=strike_int))
+
+        assert (success, status_code) == (False, 400)
+        assert response["status"] == "error"
+        assert "strike_int" in response["message"]
+        assert stub_resolver == [], "a rejected request must not reach the broker"
+
+    @pytest.mark.parametrize("ltp", [float("nan"), float("inf")])
+    def test_non_finite_ltp_is_reported_instead_of_resolving_a_symbol(self, stub_resolver, ltp):
+        success, response, status_code = get_option_symbol(**self._request(underlying_ltp=ltp))
+
+        assert (success, status_code) == (False, 500)
+        assert "LTP" in response["message"]
+
+    def test_a_valid_pre_fetched_ltp_skips_the_quote_request(self, stub_resolver):
+        success, response, _ = get_option_symbol(**self._request(underlying_ltp=23574.00))
+
+        assert success is True
+        assert response["symbol"] == "NIFTY28OCT2523450CE"
+        assert stub_resolver == []
+
+
+class TestNoSilentPutFallback:
+    """The regression itself: an unrecognised type must never price as a put."""
+
+    def test_legacy_interval_path_no_longer_resolves_call_to_the_put_strike(self):
+        put_strike = calculate_offset_strike(23600, "ITM2", 50, "PE")
+
+        with pytest.raises(ValueError):
+            calculate_offset_strike(23600, "ITM2", 50, "CALL")
+
+        assert put_strike == 23700, "the put branch itself is unchanged"
+
+    def test_actual_strikes_path_no_longer_resolves_call_to_the_put_strike(self):
+        put_strike = calculate_offset_strike_from_actual(23600.0, "ITM2", "PE", STRIKES)
+
+        with pytest.raises(ValueError):
+            calculate_offset_strike_from_actual(23600.0, "ITM2", "CALL", STRIKES)
+
+        assert put_strike == 23700.0, "the put branch itself is unchanged"
+
+    def test_zero_interval_no_longer_raises_zerodivisionerror(self):
+        with pytest.raises(ValueError):
+            get_atm_strike(23587.50, 0)
+
+    def test_nan_ltp_no_longer_resolves_to_the_lowest_strike(self):
+        assert find_atm_strike_from_actual(math.nan, STRIKES) is None


### PR DESCRIPTION
## Summary

Closes #1829.

The legacy option-symbol resolver trusted two inputs it should not have.

**1. The strike interval was used as a divisor with no guard.**
`get_atm_strike()` computes `round(ltp / strike_int) * strike_int`. A `strike_int` of `0` raised `ZeroDivisionError`, and a negative, NaN or infinite interval produced a strike that formats into a symbol no exchange lists. Both reached the client as an HTTP 500 with a traceback instead of a client error.

**2. An unrecognised option type was silently priced as a put.**
Every offset calculation branches on `CE` and takes the `else` branch for everything else, in both legacy paths (`calculate_offset_strike()` and `calculate_offset_strike_from_actual()`). An option type of `"CALL"`, `"C"` or `None` therefore resolved to the *put* strike. The symbol built around it carries the same bogus suffix, so `find_option_in_database()` returns 404 and the request fails closed - no wrong leg is placed. The harm is the diagnosis: the caller is told the symbol was "not found in NFO" when the real fault was the option type, and the resolver spends a broker quote call before saying so.

The same shape of failure existed for a non-finite LTP in `find_atm_strike_from_actual()`: `NaN` compares false against every strike, so `min()` returned the *lowest* strike in the chain and reported it as ATM.

Behaviour on `main`, before this change:

```
CE ITM2          -> 23500
PE ITM2          -> 23700
CALL ITM2        -> 23700      <- the put strike, no error
actual CALL ITM2 -> 23700.0    <- same in the actual-strikes path
strike_int=0     -> ZeroDivisionError: division by zero
NaN LTP ATM      -> 23400.0    <- the lowest strike in the chain, reported as ATM
```

## Why the fix belongs in the service, not the schema

`OptionSymbolSchema` validates `strike_int` and `option_type` for `POST /api/v1/optionsymbol`, and the options-order endpoints validate their own legs (`OptionsOrderSchema`, `OptionsMultiOrderLegSchema`, both `OneOf(["CE","PE","ce","pe"])` with `strike_int` on `Range(min=1)`).

The in-process bypass is `services/flow_openalgo_client.py:397`, which calls `get_option_symbol()` directly. Its caller, `services/flow_executor_service.py:2086`, reads `optionType` through `get_str()` with no enum check - unlike the options-order nodes in the same file, which check against `frozenset({"CE", "PE"})`. A Flow graph can therefore reach the resolver with any string at all.

The other direct callers were checked and are **not** bypasses: `mcp/mcpserver.py` goes over HTTP through the `openalgo` SDK client, and `services/synthetic_future_service.py` hardcodes `strike_int=None` and `option_type="CE"/"PE"`.

Validating at the resolver boundary covers the Flow path and every future caller in one place, instead of adding a fourth schema.

Range validation alone is also not enough at the boundary. `strike_int` is `fields.Int` with `Range(min=1)`, which accepts a 401-digit integer; `math.isfinite()` raises `OverflowError` on that, and `ValueError` on `Decimal("sNaN")`, so both have to be refused explicitly rather than assumed away.

## Changes

`services/option_symbol_service.py`

- Add `VALID_OPTION_TYPES`, `validate_option_type()` and `validate_strike_interval()`.
- Apply both at the top of `get_option_symbol()`, **before** the quote request and the database lookup, so a rejected request never reaches the broker. The raised `ValueError` is answered by the existing handler as HTTP 400 with the reason.
- Apply them defensively inside `get_atm_strike()`, `calculate_offset_strike()` and `calculate_offset_strike_from_actual()` too, so the helpers are safe for any caller.
- `validate_strike_interval()` returns `float(strike_int)`, not the value unchanged, so the next line is guaranteed to be able to divide by it: `Decimal("50")` is finite and positive but `float / Decimal` raises `TypeError`. The same conversion makes the numpy-scalar acceptance uniform and covers `Fraction` for free.
- `_is_finite_number()` uses `math.isfinite()` rather than an `isinstance()` check so a numpy scalar off a pandas or DuckDB path still passes (`np.int64` is not an `int`), while strings, `None` and sequences are refused. It catches `(TypeError, OverflowError, ValueError)`, so an int too large to convert to a float (previously a 500) and a signalling NaN (previously a 400 reading `cannot convert signaling NaN to float`) are both refused with the interval's own error message. `bool` is excluded explicitly, since it is an `int` subclass and `True` would otherwise pass as an interval of 1.
- Refuse a non-finite LTP with a controlled error instead of building a symbol around `NaN` or infinity.

Contract change worth calling out: `find_atm_strike_from_actual()` now returns `None` for a non-numeric LTP where it previously raised `TypeError`. Every caller (`custom_straddle_service.py:138`, `iv_chart_service.py:242` and `:548`, `option_chain_service.py:491`, `straddle_chart_service.py:219`, `vol_surface_service.py:141`) already branches on `None`, so a bad underlying LTP now degrades to a clean "no data" answer instead of a 500.

## What does not change

Valid input is untouched: calls and puts, lowercase `ce`/`pe`, fractional strike intervals such as `2.5`, the `ATM`/`ITM`/`OTM` maths, out-of-range offsets still returning `None`, and the existing error contracts. The only new rejections are values that previously crashed or resolved to the wrong strike.

## Testing

`test/test_option_symbol_service_validation.py` (new, 145 cases) covers both legacy paths:

- Valid calls, puts, lowercase types and fractional intervals resolve exactly as before.
- Zero, negative, NaN, infinite, `None`, string and `bool` intervals raise `ValueError`, as do a 401-digit integer and `Decimal("sNaN")`.
- An accepted interval comes back as something the caller can divide by, `Decimal("50")` included, and resolves the same strike as the equivalent `int`.
- Unsupported option types are rejected in both offset calculations instead of being priced as puts.
- At the boundary, `get_option_symbol()` returns `(False, {...}, 400)` and the quote stub records **no** call, proving the broker is never contacted for a rejected request.
- A non-finite LTP is reported rather than resolved into a symbol.

No broker credentials, no network, no database rows: the quote fetch, strike lookup and symbol lookup are stubbed with `monkeypatch`, and test values are obvious dummies (`test-api-key-not-real`).

```
uv run pytest test/test_option_symbol_service_validation.py -v
145 passed

uv run ruff check services/option_symbol_service.py test/test_option_symbol_service_validation.py
All checks passed!
```

Run against the unfixed source, 12 of the 13 new cases fail; the single case that passes on both is the positive-contract test.

Regression check on the neighbouring suites, plus the full CI-safe list, all green:

```
uv run pytest test/test_mcx_underlying_resolution.py test/test_data_schemas_validation.py \
  test/test_flow_qa_regressions.py test/test_flow_workflow_validator.py \
  test/test_multi_option_greeks_regression.py
568 passed

# the CI-safe subset from ci.yml, including the new file
217 passed
```

The new file is added to the CI-safe list in `.github/workflows/ci.yml`, following the same pattern as `test_event_bus_bounded.py` and `test_telegram_api_contract.py`. The branch is rebased onto current `main`, which resolves the `ci.yml` conflict with the new Python 3.12-3.14 test matrix.

## Checklist

- [x] One fix, self-contained, no unrelated changes
- [x] Conventional Commit message
- [x] Python tests added and passing, with no broker credentials or network access
- [x] `ruff check` clean on both touched Python files (the file's pre-existing `ruff format` differences are left alone to keep the diff reviewable)
- [x] No new dependencies
- [x] No API contract change for valid requests

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Validate strike interval and option type at the option-symbol resolver to prevent wrong-leg placements and 500s. Previously, invalid intervals crashed or produced invalid symbols and unknown types defaulted to puts; now we reject these with 400 and report non-finite LTPs without symbol resolution (500).

- Apply input guards at the start of get_option_symbol() and inside get_atm_strike(), calculate_offset_strike(), and calculate_offset_strike_from_actual(); add VALID_OPTION_TYPES, exclude bools from numeric checks, and return a float from strike interval validation so callers can safely divide.
- find_atm_strike_from_actual() returns None for non-finite/non-numeric LTPs instead of selecting the lowest strike.
- Non-finite LTPs in get_option_symbol() return a controlled 500 without constructing a symbol; rejected requests never hit the broker.
- Valid CE/PE (any case), fractional intervals, offsets, and existing error contracts are unchanged.
- Tests: add test/test_option_symbol_service_validation.py; include it in CI.

<sup>Written for commit da5c6c3fc1f1178b9626bd0d475cf03c927e2c25. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1892?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

