### PR TITLE
fix: redact API keys from core logs

### DIFF
--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -103,7 +103,7 @@ class MultiOptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for multi option greeks: {api_key[:10]}...")
+                logger.warning("Invalid API key used for multi option greeks")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/restx_api/option_greeks.py
+++ b/restx_api/option_greeks.py
@@ -113,7 +113,7 @@ class OptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for option greeks: {api_key[:10]}...")
+                logger.warning("Invalid API key used for option greeks")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/services/websocket_client.py
+++ b/services/websocket_client.py
@@ -574,9 +574,9 @@ def get_websocket_client(
 def close_all_clients():
     """Close all WebSocket client connections"""
     with _client_lock:
-        for api_key, client in _client_instances.items():
+        for _api_key, client in _client_instances.items():
             try:
                 client.disconnect()
-            except Exception as e:
-                logger.exception(f"Error closing client for API key {api_key}: {e}")
+            except Exception:
+                logger.exception("Error closing WebSocket client")
         _client_instances.clear()

--- a/test/test_core_credential_logging.py
+++ b/test/test_core_credential_logging.py
@@ -1,0 +1,84 @@
+"""Regression tests for credential-safe core service logging."""
+
+from flask import Flask
+
+TEST_KEY = "test-token-not-real-1234567890"
+
+
+def request_context():
+    return Flask(__name__).test_request_context("/", method="POST", json={"apikey": TEST_KEY})
+
+
+class RecordingLogger:
+    def __init__(self):
+        self.messages = []
+
+    def warning(self, message, *args):
+        self.messages.append(message % args if args else message)
+
+    def exception(self, message, *args):
+        self.messages.append(message % args if args else message)
+
+    error = exception
+
+
+def test_option_greeks_invalid_key_is_not_logged(monkeypatch):
+    from restx_api import option_greeks
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(option_greeks, "logger", logger)
+    monkeypatch.setattr(
+        option_greeks.option_greeks_schema,
+        "load",
+        lambda data: {"apikey": TEST_KEY, "symbol": "NIFTY", "exchange": "NFO"},
+    )
+    monkeypatch.setattr(option_greeks, "verify_api_key", lambda api_key: False)
+
+    with request_context():
+        response = option_greeks.OptionGreeks().post()
+
+    assert response.status_code == 401
+    assert logger.messages == ["Invalid API key used for option greeks"]
+    assert TEST_KEY not in " ".join(logger.messages)
+
+
+def test_multi_option_greeks_invalid_key_is_not_logged(monkeypatch):
+    from restx_api import multi_option_greeks
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(multi_option_greeks, "logger", logger)
+    monkeypatch.setattr(
+        multi_option_greeks.multi_option_greeks_schema,
+        "load",
+        lambda data: {"apikey": TEST_KEY, "symbols": []},
+    )
+    monkeypatch.setattr(multi_option_greeks, "verify_api_key", lambda api_key: False)
+
+    with request_context():
+        response = multi_option_greeks.MultiOptionGreeks().post()
+
+    assert response.status_code == 401
+    assert logger.messages == ["Invalid API key used for multi option greeks"]
+    assert TEST_KEY not in " ".join(logger.messages)
+
+
+def test_websocket_close_error_does_not_log_api_key(monkeypatch):
+    from services import websocket_client
+
+    logger = RecordingLogger()
+    monkeypatch.setattr(websocket_client, "logger", logger)
+
+    class FailingClient:
+        def disconnect(self):
+            raise RuntimeError(f"disconnect failed for {TEST_KEY}")
+
+    monkeypatch.setattr(
+        websocket_client,
+        "_client_instances",
+        {TEST_KEY: FailingClient()},
+    )
+
+    websocket_client.close_all_clients()
+
+    assert logger.messages == ["Error closing WebSocket client"]
+    assert TEST_KEY not in " ".join(logger.messages)


### PR DESCRIPTION
## Summary\n\n- Remove API key material from the option Greeks invalid-key warnings.\n- Preserve exception logging for WebSocket client cleanup without interpolating credentials.\n- Add focused regression coverage for credential-free logging.\n\n## Validation\n\n- python -m pytest test/test_core_credential_logging.py -q (3 passed)\n- python -m ruff format --check --diff test/test_core_credential_logging.py\n- python -m ruff check test/test_core_credential_logging.py\n- git diff --check\n\nBased on the current upstream main branch; frontend chart dependency files are unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redacts API keys from core logs to prevent credential leakage. Previously, invalid-key warnings logged a key prefix and WebSocket close errors included the key; now both emit generic messages without credentials, with no change to API responses (still 401 on invalid keys).

- Invalid-key warnings in `option_greeks` and `multi_option_greeks` now use static messages without API key material.
- `websocket_client.close_all_clients` logs a generic exception message without interpolating keys; stack traces are preserved.
- Adds regression tests to ensure logs never include API keys for these paths.

<sup>Written for commit f45650f8207897bafc405de05236b2406bb896d4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1893?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

