### PR TITLE
ci: test against Python 3.12-3.14 and Node 20/22/24

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,14 +33,19 @@ jobs:
         continue-on-error: true  # Pre-existing formatting in broker modules
 
   # Backend tests (CI-safe subset - no broker credentials needed)
+  # Matrixed across every Python the project supports (pyproject requires-python >=3.12).
   backend-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.12", "3.13", "3.14"]
     steps:
       - uses: actions/checkout@v6
       - uses: astral-sh/setup-uv@v7
         with:
           enable-cache: true
-          python-version: "3.12"
+          python-version: ${{ matrix.python-version }}
       - run: uv sync
       - name: Run CI-safe tests
         run: |
@@ -71,8 +76,13 @@ jobs:
       - run: npm run lint
 
   # Frontend build (includes TypeScript check)
+  # Matrixed across the LTS majors declared in frontend/package.json engines.
   frontend-build:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24']
     defaults:
       run:
         working-directory: frontend
@@ -80,20 +90,24 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
       - run: npm run build
       - uses: actions/upload-artifact@v6
         with:
-          name: frontend-dist
+          name: frontend-dist-node${{ matrix.node-version }}
           path: frontend/dist/
           retention-days: 7
 
   # Frontend unit tests
   frontend-test:
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        node-version: ['20', '22', '24']
     defaults:
       run:
         working-directory: frontend
@@ -101,7 +115,7 @@ jobs:
       - uses: actions/checkout@v6
       - uses: actions/setup-node@v7
         with:
-          node-version: '22'
+          node-version: ${{ matrix.node-version }}
           cache: 'npm'
           cache-dependency-path: frontend/package-lock.json
       - run: npm ci
@@ -109,7 +123,7 @@ jobs:
       - run: npm run test:coverage
       - uses: actions/upload-artifact@v6
         with:
-          name: coverage-report
+          name: coverage-report-node${{ matrix.node-version }}
           path: frontend/coverage/
           retention-days: 7
 


### PR DESCRIPTION
## Problem

CI pinned a single Python `3.12` and a single Node `22`, so nothing verified that the project still works across the versions it advertises:

- `pyproject.toml` declares `requires-python = ">=3.12"`
- `frontend/package.json` declares `engines.node = ">=20.20.0 || >=22.22.0 || >=24.13.0"`

Only one point in each range was ever exercised. Notably, the maintainer's own working venv runs Python 3.14, which CI never tested.

## Feasibility, checked before writing this

`uv pip compile pyproject.toml --python-platform linux --python-version {3.12,3.13,3.14}` resolves to an **identical 166 package set** on all three. Every pin already has Linux wheels for 3.13 and 3.14, so this is coverage, not a porting effort.

Node floors from the lockfile:

| package | engines.node |
| --- | --- |
| vite 8.0.16 | `^20.19.0 \|\| >=22.12.0` |
| vitest 4.1.8 | `^20.0.0 \|\| ^22.0.0 \|\| >=24.0.0` |
| jsdom 27.4.0 | `^20.19.0 \|\| ^22.12.0 \|\| >=24.0.0` |

All three LTS majors are in range. Odd majors (21, 23) are excluded: vite 8 does not cover 21, and they are not LTS.

## What changed

| job | matrix |
| --- | --- |
| `backend-test` | Python 3.12, 3.13, 3.14 |
| `frontend-build` | Node 20, 22, 24 |
| `frontend-test` | Node 20, 22, 24 |

`fail-fast: false` so one version failing still reports the others. Artifact names are suffixed per matrix leg, which `upload-artifact` v4+ requires for uniqueness. Nothing consumes those artifacts downstream, so the rename is safe.

Left single-version on purpose:

- `backend-lint`, `security-scan`: Ruff, Bandit and pip-audit results do not vary by interpreter.
- `frontend-lint`: Biome ships as a native binary.
- `frontend-e2e`: slowest job, least version sensitive.
- `commit-dist`: must publish one deterministic `dist` build to `main`.

Fork PRs go from 7 jobs to 13.

## Note for branch protection

Matrix jobs report as `backend-test (3.12)`, `frontend-test (20)` and so on, not `backend-test` / `frontend-test`. Any required status check list has to use the expanded names.

## Separate finding, not fixed here

`pyproject.toml:152` pins `zmq==0.0.0`. That is a dead placeholder package on PyPI whose only purpose is to tell you to install `pyzmq`, which is already correctly pinned at line 120. Worth removing in its own PR.