### PR TITLE
chore(deps): drop the dead zmq==0.0.0 stub

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -149,7 +149,6 @@ dependencies = [
   "wsproto==1.3.2",
   "WTForms==3.2.2",
   "zipp==3.23.1",
-  "zmq==0.0.0",
   "opengreeks>=0.2.0",
   "openstatz==0.4.1",
 ]

--- a/requirements-nginx.txt
+++ b/requirements-nginx.txt
@@ -144,6 +144,5 @@ wrapt==1.16.0
 wsproto==1.3.2
 WTForms==3.2.2
 zipp==3.23.1
-zmq==0.0.0
 gunicorn>=25.0,<26
 eventlet

--- a/requirements.txt
+++ b/requirements.txt
@@ -144,7 +144,6 @@ wrapt==1.16.0
 wsproto==1.3.2
 WTForms==3.2.2
 zipp==3.23.1
-zmq==0.0.0
 
 # Portfolio analytics for the Portfolio Backtester (metrics + tearsheets).
 # Pure-NumPy kernels -- no Numba, so nothing pins numpy's upper bound.

--- a/uv.lock
+++ b/uv.lock
@@ -2177,7 +2177,6 @@ dependencies = [
     { name = "wsproto" },
     { name = "wtforms" },
     { name = "zipp" },
-    { name = "zmq" },
 ]
 
 [package.dev-dependencies]
@@ -2350,7 +2349,6 @@ requires-dist = [
     { name = "wsproto", specifier = "==1.3.2" },
     { name = "wtforms", specifier = "==3.2.2" },
     { name = "zipp", specifier = "==3.23.1" },
-    { name = "zmq", specifier = "==0.0.0" },
 ]
 
 [package.metadata.requires-dev]
@@ -4091,12 +4089,3 @@ sdist = { url = "https://files.pythonhosted.org/packages/30/21/093488dfc7cc8964d
 wheels = [
     { url = "https://files.pythonhosted.org/packages/08/8a/0861bec20485572fbddf3dfba2910e38fe249796cb73ecdeb74e07eeb8d3/zipp-3.23.1-py3-none-any.whl", hash = "sha256:0b3596c50a5c700c9cb40ba8d86d9f2cc4807e9bedb06bcdf7fac85633e444dc", size = 10378, upload-time = "2026-04-13T23:21:45.386Z" },
 ]
-
-[[package]]
-name = "zmq"
-version = "0.0.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "pyzmq" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/6e/78/833b2808793c1619835edb1a4e17a023d5d625f4f97ff25ffff986d1f472/zmq-0.0.0.tar.gz", hash = "sha256:6b1a1de53338646e8c8405803cffb659e8eb7bb02fff4c9be62a7acfac8370c9", size = 966, upload-time = "2015-05-21T17:34:26.603Z" }


### PR DESCRIPTION
## What

`pyproject.toml`, `requirements.txt` and `requirements-nginx.txt` each pinned **both** `pyzmq==27.1.0` and `zmq==0.0.0`. Only the first is real.

`zmq==0.0.0` is a placeholder on PyPI: a **966 byte sdist uploaded 2015-05-21** whose entire content is a dependency on `pyzmq`. Its wheel installs 8 files, all of them inside `zmq-0.0.0.dist-info/`, and no module whatsoever.

## Why it is safe

The `zmq` module that every ZeroMQ call site imports is provided by `pyzmq`, not by this package. Checked against the live environment before touching anything:

```
importlib.metadata.packages_distributions()["zmq"]  ->  ['pyzmq']
import zmq  ->  site-packages/zmq/__init__.py, __version__ 27.1.0
distribution("zmq").files  ->  8 files, all zmq-0.0.0.dist-info/*
```

The lock entry says the same thing:

```toml
[[package]]
name = "zmq"
version = "0.0.0"
dependencies = [{ name = "pyzmq" }]
```

## Verification after removal

- `uv pip compile --python-platform linux` on Python **3.12, 3.13 and 3.14**: each goes 166 -> 165 packages, and the only line that disappears is `zmq==0.0.0`. `pyzmq==27.1.0` still resolves on all three.
- `uv sync` uninstalls the stub. `import zmq` still gives pyzmq 27.1.0, and a live SUB-bind plus PUB-connect round trip still works (the fan-in invariant from CLAUDE.md).
- `websocket_proxy.base_adapter`, `.connection_manager` and `.app_integration` all still import cleanly. The other importers are `broker/fyers/streaming/fyers_websocket_adapter.py` and `broker/groww/streaming/groww_adapter.py`, same `import zmq`.
- CI-safe suite: **53 passed**.

## Scope

Three tracked manifests plus the regenerated `uv.lock` (11 lines: the `openalgoui` dependency entry, the `requires-dist` entry, and the `[[package]]` block).

`openalgoUI.egg-info/requires.txt` lists it too but is untracked build output and regenerates on the next build, so it is deliberately not touched.

No source file changes. Nothing imports the stub, because there is nothing in it to import.