### PR TITLE
docs: use a partial clone in the install instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -319,7 +319,7 @@ OpenAlgo uses the modern `uv` package manager for faster, more reliable installa
 
 ```bash
 # Clone the repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 
 # Install UV package manager

--- a/docs/design/12-ubuntu-server/README.md
+++ b/docs/design/12-ubuntu-server/README.md
@@ -77,7 +77,7 @@ sudo chown $USER:$USER /opt/openalgo
 
 # Clone repository
 cd /opt/openalgo
-git clone https://github.com/marketcalls/openalgo.git .
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git .
 ```
 
 ### 2. Setup Python Environment

--- a/docs/test/MANUAL_TESTING_GUIDE.md
+++ b/docs/test/MANUAL_TESTING_GUIDE.md
@@ -8,7 +8,7 @@ A systematic testing procedure to ensure quality and catch bugs effectively.
 
 ```bash
 # 1. Setup
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 cp .sample.env .env
 # Edit .env with your broker credentials

--- a/docs/userguide/04-installation/README.md
+++ b/docs/userguide/04-installation/README.md
@@ -10,7 +10,7 @@ If you're comfortable with command line, here's the fastest way:
 
 ```bash
 # 1. Clone the repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 
 # 2. Install UV package manager
@@ -22,6 +22,15 @@ cp .sample.env .env
 # 4. Run OpenAlgo
 uv run app.py
 ```
+
+> **Why `--filter=blob:none`?** It makes a [partial clone](https://git-scm.com/docs/partial-clone):
+> git downloads the full history of commits but only the file contents the
+> checkout actually needs, fetching anything older on demand. That is about
+> **20 MB instead of 280 MB**, and roughly 8 seconds instead of 36. Everything
+> still works normally: `git pull` to upgrade, checking out any branch or
+> release tag, and rolling back to any commit. Drop the flag if you want the
+> entire history on disk up front, or if you are cloning from a git host that
+> does not support filtering (it will simply fall back to a full clone).
 
 Open `http://127.0.0.1:5000` in your browser. That's it!
 
@@ -62,7 +71,7 @@ Open Command Prompt (search "cmd") and run:
 cd C:\Users\YourName\Documents
 
 # Clone the repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 
 # Enter the folder
 cd openalgo
@@ -120,7 +129,7 @@ python3.12 --version
 
 ```bash
 # Clone repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 ```
 
@@ -160,7 +169,7 @@ brew install python@3.12 git
 
 ```bash
 # Clone repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 
 # Install UV
@@ -210,7 +219,7 @@ ZMQ_PORT='5555'
 
 ```bash
 # Clone repository
-git clone https://github.com/marketcalls/openalgo.git
+git clone --filter=blob:none https://github.com/marketcalls/openalgo.git
 cd openalgo
 
 # Create environment file
@@ -825,7 +834,7 @@ sudo sh get-docker.sh
 
 **Clone and Build:**
 ```bash
-git clone https://github.com/marketcalls/openalgo
+git clone --filter=blob:none https://github.com/marketcalls/openalgo
 cd openalgo
 cp .sample.env .env
 # Edit .env with your broker credentials


### PR DESCRIPTION
## Problem

#1897 fixes this for the install scripts, but anyone following the README or the installation guide by hand still runs a plain `git clone` and downloads the full history:

```
git clone <url>                       280 MB   36s
git clone --filter=blob:none <url>     20 MB    8s
```

Nearly all of that 280 MB is superseded `frontend/dist` bundles accumulated over ~4,800 commits, which someone running OpenAlgo never reads.

## Change

`--filter=blob:none` on the **nine user-facing** clone commands:

| File | Count |
| --- | --- |
| `README.md` | 1 |
| `docs/userguide/04-installation/README.md` | 6 |
| `docs/design/12-ubuntu-server/README.md` | 1 |
| `docs/test/MANUAL_TESTING_GUIDE.md` | 1 |

Plus a short note in the installation guide explaining what the flag does, so it is not copied blindly.

**The two in `docs/devsprint/` are deliberately left alone.** They clone a contributor's own fork (`YOUR_USERNAME/openalgo`), and contributor work wants full history on disk for `blame`, `bisect` and rebasing.

## Why this is safe

A partial clone downloads every commit and tree, omitting only file *contents* outside the current checkout, which are then fetched on demand. Verified against a real partial clone of this repo:

- `git pull` fast-forwards and stays 20 MB
- `git log`, `git log --stat` and `git tag` resolve **with no network**
- `git checkout HEAD~50` and release-tag checkouts work, lazily fetching blobs
- All 62 tags and 107 branches are present, unlike a shallow clone which fetches none

A git host without filter support falls back to a full clone with a warning and exit 0, so this is never worse than the current instruction.

Docs only, no code changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)