### PR TITLE
test(strategy-builder): await the Greeks tab instead of querying it synchronously

### DIFF
--- a/frontend/src/pages/StrategyBuilder.test.tsx
+++ b/frontend/src/pages/StrategyBuilder.test.tsx
@@ -564,7 +564,7 @@ describe('StrategyBuilder live request orchestration', () => {
     expect(screen.getAllByText('₹125.00').length).toBeGreaterThan(0)
     expect(screen.queryByText('₹225.00')).not.toBeInTheDocument()
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     const rows = await screen.findAllByRole('row')
     const row = rows.find((item) => item.textContent?.includes('24600CE'))
     expect(row).toBeDefined()
@@ -922,7 +922,7 @@ describe('StrategyBuilder live request orchestration', () => {
 
     expect(screen.getAllByText('₹125.00').length).toBeGreaterThan(0)
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     const greekRows = await screen.findAllByRole('row')
     const positionRow = greekRows.find((row) => row.textContent?.includes('13AUG26 24600CE'))
     expect(positionRow).toBeDefined()
@@ -1004,7 +1004,7 @@ describe('StrategyBuilder live request orchestration', () => {
     expect(screen.getAllByText('18AUG26').length).toBeGreaterThan(0)
     expect(screen.getAllByText('₹225.00').length).toBeGreaterThan(0)
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     const greekRows = await screen.findAllByRole('row')
     const farGreekRow = greekRows.find((row) => row.textContent?.includes('18AUG26 24600CE'))
     expect(farGreekRow).toBeDefined()
@@ -1055,7 +1055,7 @@ describe('StrategyBuilder live request orchestration', () => {
       { withGreeks: true }
     )
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     let rows = await screen.findAllByRole('row')
     let farRow = rows.find((row) => row.textContent?.includes('18AUG26 24600CE'))
     const nearRow = rows.find((row) => row.textContent?.includes('13AUG26 24600CE'))
@@ -1152,7 +1152,7 @@ describe('StrategyBuilder live request orchestration', () => {
       expect(screen.getAllByRole('button', { name: 'Remove position' })).toHaveLength(2)
     )
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     let rows = await screen.findAllByRole('row')
     let farRow = rows.find((row) => row.textContent?.includes('18AUG26 24600CE'))
     const initialGreeks = within(farRow as HTMLElement)
@@ -1305,7 +1305,7 @@ describe('StrategyBuilder live request orchestration', () => {
     fireEvent.click(await screen.findByRole('option', { name: 'PE' }))
     await user.click(within(dialog).getByRole('button', { name: 'Modify' }))
 
-    await user.click(screen.getByRole('tab', { name: 'Greeks' }))
+    await user.click(await screen.findByRole('tab', { name: 'Greeks' }))
     const rows = await screen.findAllByRole('row')
     const editedRow = rows.find((row) => row.textContent?.includes('18AUG26 24600PE'))
     expect(editedRow).toBeDefined()


### PR DESCRIPTION
## What this does

Fixes the intermittent `frontend-test` failure in `StrategyBuilder.test.tsx`:

```
TestingLibraryElementError: Unable to find an accessible element with the
role "tab" and name "Greeks"
```

## Why it flakes

```js
await user.click(screen.getByRole('tab', { name: 'Greeks' }))
```

`getByRole` is synchronous. It throws on the first miss instead of retrying, so on a slow runner the query fires before the Greeks tab has rendered.

This is also why `2d8edfd0e` ("give the calendar Greek-snapshot test the slow timeout") did not settle it. `SLOW_INTEGRATION_TEST_TIMEOUT` raises the *test's* budget, not the query's patience, and the test that failed most recently already carried that timeout.

`findByRole` retries until the element appears or the timeout expires, which is what every other `await` in these tests already relies on.

All six occurrences in the file share the defect, so all six are converted rather than only the one that happened to flake.

## Evidence

On run `32810191859`, `frontend-test (20)` failed while `(22)` and `(24)` passed on the same commit, with 967 of 968 tests green. The Node 20 leg took 58s, the slowest of the three.

Locally, with the fix:

```
src/pages/StrategyBuilder.test.tsx   33 passed (33)   three consecutive runs
full frontend suite                 968 passed (968)
npx biome lint ./src                416 files, no findings
```

## Scope

One file, six lines, test-only. No production code and no behaviour change.

Found while working on #1866, which changes no frontend file. Raising it separately rather than folding it in, since it is unrelated to that change.

### What I have not verified

- I cannot re-run the failed CI job to confirm the flake disappears there, since that needs admin on this repository. The reasoning above rests on the local runs and on the same-commit split across Node legs.
- `biome check` reports pre-existing formatting differences in this file on `main` as well. `ruff`-style reformatting was not applied, and CI runs `biome lint`, which is clean.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes Strategy Builder tests by awaiting the Greeks tab before clicking it. Previously we used a synchronous query that failed if the tab hadn’t rendered yet; now the test waits for the tab to appear, eliminating CI flakes.

**Bug Fixes**
- Replaces six `getByRole('tab', { name: 'Greeks' })` calls with `await findByRole('tab', { name: 'Greeks' })`.
- Fixes intermittent “Unable to find an accessible element with the role 'tab' and name 'Greeks'” failures on slower CI runners.
- Test-only change in `frontend/src/pages/StrategyBuilder.test.tsx`; no production code impacted.

<sup>Written for commit 4e7d1c9503c402242a2b32f36518608a5a3c1303. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1903?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

