### PR TITLE
docs: eliminate contradictory hard-coded broker plugin counts

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -237,7 +237,7 @@ openalgo/
 │   ├── auth.py               # Authentication routes
 │   ├── react_app.py          # Serves React SPA from frontend/dist/
 │   └── ...
-├── broker/                   # Broker integrations (34 brokers)
+├── broker/                   # Broker integrations (36 plugins)
 │   ├── zerodha/              # Reference implementation
 │   ├── dhan/                 # Modern API design
 │   ├── angel/                # AngelOne integration

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
 
 ## What is OpenAlgo?
 
-OpenAlgo is a free, open source, self-hosted **trading platform**, not just a broker bridge. Built on Python Flask + React 19, it gives traders a full-stack environment to **design, host, and execute strategies** through **34 broker plugins**: 33 securities integrations and Delta Exchange for crypto derivatives. Whether you write Python, prefer drag-and-drop, or trade options, OpenAlgo provides a common interface without tying strategy code to one adapter.
+OpenAlgo is a free, open source, self-hosted **trading platform**, not just a broker bridge. Built on Python Flask + React 19, it gives traders a full-stack environment to **design, host, and execute strategies** through **36 broker plugins**: 35 securities integrations and Delta Exchange for crypto derivatives. Whether you write Python, prefer drag-and-drop, or trade options, OpenAlgo provides a common interface without tying strategy code to one adapter.
 
 OpenAlgo is no longer just "an API layer in front of your broker." Today it combines four trading surfaces in one self-hosted instance, sharing the active broker session, market-data infrastructure, and six operational data stores across the journey from idea to testing and live execution.
 
@@ -20,7 +20,7 @@ OpenAlgo is no longer just "an API layer in front of your broker." Today it comb
 
 | Surface | Route | Who it's for |
 | --- | --- | --- |
-| **Unified Broker API** | `/api/v1/` | External platforms: TradingView, Amibroker, ChartInk, Excel, Google Sheets, Python, Java, Go, .NET, Node.js, MetaTrader, GoCharting, N8N. One contract across 34 plugins, with optional operations varying by adapter. |
+| **Unified Broker API** | `/api/v1/` | External platforms: TradingView, Amibroker, ChartInk, Excel, Google Sheets, Python, Java, Go, .NET, Node.js, MetaTrader, GoCharting, N8N. One contract across 36 plugins, with optional operations varying by adapter. |
 | **Python Strategy Host** | `/python` | Traders who code: paste any Python script into the in-browser CodeMirror editor, schedule it on IST start/stop times, run multiple strategies in parallel with process isolation, watch real-time logs. No external server, no Docker, no cron. |
 | **Flow: No-Code Strategy Builder** | `/flow` | Traders who don't code: drag-and-drop nodes for market data, indicators, conditions, order execution, and notifications. Webhook triggers for TradingView and external signals built in. JSON import/export for sharing strategies. |
 | **Options Trading Suite** | `/tools` | Options traders: twelve built-in analytical tools (Strategy Builder with payoff diagrams & live Greeks, Option Chain, IV Smile, Max Pain, Vol Surface, GEX dashboard, OI Tracker, OI Profile, Straddle Chart, Straddle PnL simulator, Option Greeks history). Each one streams from your connected broker. |
@@ -43,7 +43,7 @@ Order workflows from the REST API, hosted strategies, and Flow can use Analyzer 
 
 **Requires Python 3.12 or newer.**
 
-## Supported Brokers (35 plugins)
+## Supported Brokers (36 plugins)
 
 <details>
 <summary>View All Supported Brokers</summary>
@@ -60,6 +60,7 @@ Order workflows from the REST API, hosted strategies, and Flow can use Analyzer 
 - Flattrade
 - Fyers
 - Groww
+- HDFC Securities
 - HDFC Sky
 - IBulls
 - IIFL

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -31,7 +31,7 @@ need → drill into the specific file. Don't load everything at once.
 | Ubuntu server install | [installation-guidelines/getting-started/ubuntu-server-installation.md](installation-guidelines/getting-started/ubuntu-server-installation.md) |
 | Docker | [docker/README.md](docker/README.md) |
 | Upgrade / SMTP / TOTP / forgot-password | https://docs.openalgo.in/installation-guidelines/getting-started/ |
-| Broker integration (34 plugins) | [broker-integration-guide.md](broker-integration-guide.md) |
+| Broker integration (36 plugins) | [broker-integration-guide.md](broker-integration-guide.md) |
 | Release notes & changelog | [releases/](releases/) · [CHANGELOG.md](CHANGELOG.md) |
 
 ## Feature surfaces

--- a/docs/bdd/README.md
+++ b/docs/bdd/README.md
@@ -7,7 +7,7 @@ These Gherkin files describe current OpenAlgo behavior for review, acceptance-te
 | File | Domain | Definitions |
 |---|---|---:|
 | `rest_api_inventory.feature` | All 57 registered REST v1 method/path pairs | 1 outline |
-| `broker_plugin_inventory.feature` | All 34 broker plugins | 1 outline |
+| `broker_plugin_inventory.feature` | All 36 broker plugins | 1 outline |
 | `auth_and_setup.feature` | Setup, login, TOTP, route order, DB readiness, logout | 7 |
 | `session_lifecycle.feature` | Multi-session cap, heartbeat, rollover, reconnect | 5 |
 | `broker_sessions.feature` | Broker login, callbacks, credentials, capabilities | 4 |

--- a/docs/broker-integration-guide.md
+++ b/docs/broker-integration-guide.md
@@ -1008,7 +1008,7 @@ A new broker must be registered in **all** of the following locations:
 Add your broker to the "Supported Brokers" section (alphabetical order):
 
 ```markdown
-## Supported Brokers (34 plugins)
+## Supported Brokers (36 plugins)
 
 <details>
 <summary>View All Supported Brokers</summary>
@@ -1455,9 +1455,18 @@ Study these implementations for the pattern closest to your broker:
 
 ---
 
-## Appendix: Complete Plugin Inventory (34)
+## Appendix: Complete Plugin Inventory (36)
 
 This inventory is derived from `broker/*/plugin.json`. Authentication requirements must be read from the adapter and the broker's current developer instructions rather than copied from a static cross-broker table.
+
+> **Maintainer note:** To verify the current broker plugin count and ensure documentation remains consistent across releases, run:
+> ```bash
+> # Count all broker plugin definitions
+> find broker -name "plugin.json" | wc -l
+>
+> # Check for hard-coded counts across documentation
+> rg -n "\b(3[0-9])\s+(plugins?|brokers?)\b" README.md CONTRIBUTING.md docs/INDEX.md docs/broker-integration-guide.md
+> ```
 
 | # | Directory | Type |
 |---:|---|---|
@@ -1475,23 +1484,25 @@ This inventory is derived from `broker/*/plugin.json`. Authentication requiremen
 | 12 | `flattrade` | Securities |
 | 13 | `fyers` | Securities |
 | 14 | `groww` | Securities |
-| 15 | `ibulls` | Securities |
-| 16 | `iifl` | Securities |
-| 17 | `iiflcapital` | Securities |
-| 18 | `indmoney` | Securities |
-| 19 | `jainamxts` | Securities |
-| 20 | `kotak` | Securities |
-| 21 | `motilal` | Securities |
-| 22 | `mstock` | Securities |
-| 23 | `nubra` | Securities |
-| 24 | `paytm` | Securities |
-| 25 | `pocketful` | Securities |
-| 26 | `rmoney` | Securities |
-| 27 | `samco` | Securities |
-| 28 | `shoonya` | Securities |
-| 29 | `tradejini` | Securities |
-| 30 | `tradesmart` | Securities |
-| 31 | `upstox` | Securities |
-| 32 | `wisdom` | Securities |
-| 33 | `zebu` | Securities |
-| 34 | `zerodha` | Securities |
+| 15 | `hdfcsecurities` | Securities |
+| 16 | `hdfcsky` | Securities |
+| 17 | `ibulls` | Securities |
+| 18 | `iifl` | Securities |
+| 19 | `iiflcapital` | Securities |
+| 20 | `indmoney` | Securities |
+| 21 | `jainamxts` | Securities |
+| 22 | `kotak` | Securities |
+| 23 | `motilal` | Securities |
+| 24 | `mstock` | Securities |
+| 25 | `nubra` | Securities |
+| 26 | `paytm` | Securities |
+| 27 | `pocketful` | Securities |
+| 28 | `rmoney` | Securities |
+| 29 | `samco` | Securities |
+| 30 | `shoonya` | Securities |
+| 31 | `tradejini` | Securities |
+| 32 | `tradesmart` | Securities |
+| 33 | `upstox` | Securities |
+| 34 | `wisdom` | Securities |
+| 35 | `zebu` | Securities |
+| 36 | `zerodha` | Securities |

--- a/docs/design/09-rest-api/README.md
+++ b/docs/design/09-rest-api/README.md
@@ -64,7 +64,7 @@ All are environment/configuration values; compound limits are supported.
 
 ## Response Boundaries
 
-OpenAlgo normalizes wrapper status and core fields, but broker-specific payload data is not exhaustively identical for all 34 plugins. Some endpoints intentionally return CSV, plain text, or empty webhook acknowledgements. Clients must use the endpoint contract rather than assuming every response is `{status,data}`.
+OpenAlgo normalizes wrapper status and core fields, but broker-specific payload data is not exhaustively identical for all 36 plugins. Some endpoints intentionally return CSV, plain text, or empty webhook acknowledgements. Clients must use the endpoint contract rather than assuming every response is `{status,data}`.
 
 ## Adding A Resource
 

--- a/docs/design/20-design-principles/README.md
+++ b/docs/design/20-design-principles/README.md
@@ -8,7 +8,7 @@ Examples in design pages explain boundaries; they are not substitute implementat
 
 ## Broker-Agnostic Contract
 
-The public API remains stable across the current 34 broker plugins. Each plugin maps OpenAlgo symbols, products, actions, and price types into its broker's contract, then normalizes broker responses back into OpenAlgo shapes.
+The public API remains stable across the current 36 broker plugins. Each plugin maps OpenAlgo symbols, products, actions, and price types into its broker's contract, then normalizes broker responses back into OpenAlgo shapes.
 
 Plugin presence does not imply that every optional operation, exchange, or WebSocket depth level is supported. `plugin.json` capability metadata and the broker implementation determine the available subset.
 

--- a/docs/design/33-broker-folder/README.md
+++ b/docs/design/33-broker-folder/README.md
@@ -30,7 +30,7 @@ broker/
 │   └── ... (same structure)
 ├── angel/
 │   └── ... (same structure)
-└── ... (34 broker plugins total)
+└── ... (36 broker plugins total)
 ```
 
 ## File Explanations

--- a/docs/design/51-broker-system-config/README.md
+++ b/docs/design/51-broker-system-config/README.md
@@ -26,7 +26,7 @@ The UI is part of `frontend/src/pages/Profile.tsx`. Broker selection/login uses 
 
 ## Capability Loading
 
-At startup `utils/plugin_loader.py` caches metadata for all 34 plugin directories. `/api/broker/capabilities` resolves the current session broker. A missing capability record falls back to a minimal `IN_stock` object with no exchanges.
+At startup `utils/plugin_loader.py` caches metadata for all 36 plugin directories. `/api/broker/capabilities` resolves the current session broker. A missing capability record falls back to a minimal `IN_stock` object with no exchanges.
 
 ## Security Boundaries
 

--- a/docs/design/README.md
+++ b/docs/design/README.md
@@ -2,7 +2,7 @@
 
 This directory describes the implemented architecture of OpenAlgo `2.0.1.4`. OpenAlgo is a self-hosted, single-user trading application with a Flask/Flask-RESTX backend, React 19 frontend, broker plugins, a separate WebSocket proxy, sandbox execution, hosted strategies, Flow automation, analytics tools, and optional local or remote MCP access.
 
-The current plugin inventory contains 34 broker directories with `plugin.json`. Broker capabilities are metadata-driven; a plugin's presence does not imply every optional broker operation is supported.
+The current plugin inventory contains 36 broker directories with `plugin.json`. Broker capabilities are metadata-driven; a plugin's presence does not imply every optional broker operation is supported.
 
 ## Documentation Policy
 

--- a/docs/devsprint/README.md
+++ b/docs/devsprint/README.md
@@ -393,7 +393,7 @@ git push --force-with-lease
 These are not style preferences. They are the things maintainers actually send PRs
 back for.
 
-**One feature or one fix per pull request.** OpenAlgo supports 35 brokers, and
+**One feature or one fix per pull request.** OpenAlgo supports 36 broker plugins, and
 every change has to be validated across that surface. Large combined PRs are not
 reviewable and will be asked to be split. The one exception is a brand new broker
 integration, which is self-contained inside its own `broker/` directory.

--- a/docs/prd/CONFLICTS.md
+++ b/docs/prd/CONFLICTS.md
@@ -31,13 +31,13 @@ This file records unresolved implementation/documentation conflicts and delibera
 - RESTX Swagger is disabled with `doc=False`. `/api/docs` is intentionally absent and must not be treated as a broken route.
 - `mcp/mcpserver.py::check_holiday` is registered as an MCP tool but calls the absent `/api/v1/checkholiday` route. The internal `services.market_calendar_service.check_holiday()` function exists; the public REST contract does not. MCP/user documentation omits this tool until its implementation uses a supported path or service.
 - Analyzer GTT place, modify, cancel, and orderbook return 501 even though sandbox GTT tables exist.
-- Blueprint-route BDD coverage is representative. The complete 57-method RESTX inventory and all 34 broker plugins have explicit scenario-outline rows.
+- Blueprint-route BDD coverage is representative. The complete 57-method RESTX inventory and all 36 broker plugins have explicit scenario-outline rows.
 
 ## Resolved During This Sweep
 
 - Added Action Center dispatch and broker-result tracking for `optionsmultiorder` and `placegttorder`; unsupported GTT brokers still fail through the service's HTTP 501 capability gate.
 - Added a complete RESTX method/path inventory in `docs/bdd/rest_api_inventory.feature`.
-- Added a 34-plugin broker inventory in `docs/bdd/broker_plugin_inventory.feature`.
+- Added a 36-plugin broker inventory in `docs/bdd/broker_plugin_inventory.feature`.
 - Added live account, margin, open-position, and REST depth behavior in `docs/bdd/account_and_depth.feature`.
 - Corrected WebSocket source attribution and documented the ZeroMQ bind/connect topology.
 - Expanded analyzer GTT unsupported coverage to place, modify, cancel, and orderbook.

--- a/docs/prd/PRD.md
+++ b/docs/prd/PRD.md
@@ -230,11 +230,11 @@ OpenAlgo is configured as a self-hosted application with session routes and API-
 
 ## Out Of Scope And Known Gaps
 
-- Broker-specific response payload shapes are not exhaustively verified for all 34 brokers.
+- Broker-specific response payload shapes are not exhaustively verified for all 36 brokers.
 - Static route inventory may differ from runtime registration when Remote MCP is disabled or `frontend/dist` is absent.
 - `HISTORIFY_DATABASE_URL` in `.sample.env` and `HISTORIFY_DATABASE_PATH` in implementation need review before one env var is documented as authoritative.
 - Sandbox GTT tables exist, but analyzer GTT services return 501.
-- `docs/broker-integration-guide.md`, the code inventory, and `.sample.env` must stay aligned on the current 34 plugin directories.
+- `docs/broker-integration-guide.md`, the code inventory, and `.sample.env` must stay aligned on the current 36 plugin directories.
 - Blueprint-route BDD coverage remains representative rather than one scenario per route. The RESTX method/path inventory and broker-plugin inventory are explicitly covered by scenario outlines.
 - `/pnltracker/legacy` references a template that is absent from the current source tree and is not a supported fallback UI.
 - Telegram REST webhook dispatch and broadcast fan-out are registered placeholders, not completed delivery paths.

--- a/docs/userguide/01-what-is-openalgo/README.md
+++ b/docs/userguide/01-what-is-openalgo/README.md
@@ -2,7 +2,7 @@
 
 ## Introduction
 
-**OpenAlgo** is a free, open-source algorithmic trading platform that bridges your trading ideas with execution. Built with Python Flask and a modern React frontend, it provides a unified API layer across 34 broker plugins: 33 securities integrations and Delta Exchange for crypto derivatives. Strategies can connect through TradingView, Amibroker, Python scripts, Excel, and AI agents.
+**OpenAlgo** is a free, open-source algorithmic trading platform that bridges your trading ideas with execution. Built with Python Flask and a modern React frontend, it provides a unified API layer across 36 broker plugins: 35 securities integrations and Delta Exchange for crypto derivatives. Strategies can connect through TradingView, Amibroker, Python scripts, Excel, and AI agents.
 
 **Website**: [https://openalgo.in](https://openalgo.in)
 **GitHub**: [https://github.com/marketcalls/openalgo](https://github.com/marketcalls/openalgo)
@@ -72,7 +72,7 @@ All in under 1 second!
 | Feature | Description |
 |---------|-------------|
 | **Smart Order Placement** | Execute trades with position sizing, split orders, and bracket orders |
-| **Multi-Broker Support** | Connect through 34 broker plugins using a unified API |
+| **Multi-Broker Support** | Connect through 36 broker plugins using a unified API |
 | **Multi-Exchange Trading** | NSE, NFO, BSE, BFO, MCX, CDS, BCD, NCDEX |
 | **Real-Time Streaming** | WebSocket-based live quotes, depth, and order updates |
 | **Auto Square-Off** | Time-based and one-click position square-off |
@@ -156,9 +156,9 @@ All in under 1 second!
 └─────────────────────────────────────────────────────────────────────────┘
 ```
 
-## Supported Brokers (34 plugins)
+## Supported Brokers (36 plugins)
 
-The repository contains 34 broker plugin directories: 33 securities integrations and one Delta Exchange crypto-derivatives integration. The runtime broker selector is generated from these installed plugins, so it remains the authoritative list for a deployed version.
+The repository contains 36 broker plugin directories: 35 securities integrations and one Delta Exchange crypto-derivatives integration. The runtime broker selector is generated from these installed plugins, so it remains the authoritative list for a deployed version.
 
 **Benefit**: Switch brokers without changing your strategy code - OpenAlgo's unified API handles the translation.
 
@@ -294,7 +294,7 @@ Ready to begin? Here's your path:
 | Aspect | OpenAlgo |
 |--------|----------|
 | **Cost** | Free and open source (AGPL v3.0) |
-| **Brokers** | 34 plugins: 33 securities integrations and Delta Exchange crypto |
+| **Brokers** | 36 plugins: 35 securities integrations and Delta Exchange crypto |
 | **Exchanges** | NSE, NFO, BSE, BFO, MCX, CDS, BCD, NCDEX |
 | **Signal Sources** | TradingView, Amibroker, ChartInk, Python, AI |
 | **Strategy Building** | Flow (Visual), Python Hosting, External Webhooks |

--- a/docs/userguide/02-why-build-with-openalgo/README.md
+++ b/docs/userguide/02-why-build-with-openalgo/README.md
@@ -56,7 +56,7 @@ The **Analyzer Mode** works like a local sandbox—test signals, APIs, and strat
 
 ### Multi-Broker, Multi-Platform
 
-OpenAlgo ships **34 broker plugins**: 33 securities integrations and Delta Exchange for crypto derivatives. The securities plugins share a unified API and normalized WebSocket layer, reducing broker-specific strategy code.
+OpenAlgo ships **36 broker plugins**: 35 securities integrations and Delta Exchange for crypto derivatives. The securities plugins share a unified API and normalized WebSocket layer, reducing broker-specific strategy code.
 
 ```
 ┌─────────────────────────────────────────────────────────────────┐
@@ -184,7 +184,7 @@ With direct broker APIs, you'd have to build:
 | **Trade Dashboard** | React UI, real-time updates | Full React frontend included |
 | **Log Storage** | Database, query interface | SQLite with traffic logs |
 | **Latency Tracking** | Timing, metrics, alerts | Latency monitor built-in |
-| **Multi-Broker Support** | N broker integrations | 34 plugins in the repository |
+| **Multi-Broker Support** | N broker integrations | 36 plugins in the repository |
 | **Security Layer** | Auth, rate limiting, CSRF | Enterprise security included |
 | **Notifications** | Telegram, alerts | Telegram bot integrated |
 

--- a/docs/userguide/06-broker-connection/README.md
+++ b/docs/userguide/06-broker-connection/README.md
@@ -2,16 +2,17 @@
 
 ## Overview
 
-OpenAlgo loads broker adapters from `broker/<name>/`. The current repository contains 34 plugin directories: 33 securities integrations and Delta Exchange for crypto derivatives. One OpenAlgo instance uses one configured broker at a time.
+OpenAlgo loads broker adapters from `broker/<name>/`. The current repository contains 36 plugin directories: 35 securities integrations and Delta Exchange for crypto derivatives. One OpenAlgo instance uses one configured broker at a time.
 
 The installed plugin directories are the authoritative inventory:
 
 ```text
 aliceblue, angel, arrow, compositedge, definedge, deltaexchange,
 dhan, dhan_sandbox, firstock, fivepaisa, fivepaisaxts, flattrade,
-fyers, groww, ibulls, iifl, iiflcapital, indmoney, jainamxts,
-kotak, motilal, mstock, nubra, paytm, pocketful, rmoney, samco,
-shoonya, tradejini, tradesmart, upstox, wisdom, zebu, zerodha
+fyers, groww, hdfcsecurities, hdfcsky, ibulls, iifl, iiflcapital,
+indmoney, jainamxts, kotak, motilal, mstock, nubra, paytm,
+pocketful, rmoney, samco, shoonya, tradejini, tradesmart,
+upstox, wisdom, zebu, zerodha
 ```
 
 Each `plugin.json` declares the adapter's supported exchanges, broker type, and whether leverage configuration is available. The application caches these capabilities at startup and exposes the active broker's values to the frontend.

--- a/docs/userguide/30-faqs/README.md
+++ b/docs/userguide/30-faqs/README.md
@@ -12,7 +12,7 @@ Yes. OpenAlgo is released under the AGPL v3.0 license. Broker API access, market
 
 ### Which brokers are supported?
 
-The current repository contains 34 plugin directories: 33 securities integrations and Delta Exchange for crypto derivatives. See [Broker Connection](../06-broker-connection/README.md) for the authoritative plugin identifiers. Supported exchanges and features vary by plugin.
+The current repository contains 36 plugin directories: 35 securities integrations and Delta Exchange for crypto derivatives. See [Broker Connection](../06-broker-connection/README.md) for the authoritative plugin identifiers. Supported exchanges and features vary by plugin.
 
 ### Can I use live trading?
 


### PR DESCRIPTION
Closes #1844

### Summary of Changes
- Updated broker plugin counts from contradictory 34/35 figures to the current 36 plugins (35 securities integrations + 1 crypto derivatives integration) matching `broker/*/plugin.json`.
- Added missing `hdfcsecurities` and `hdfcsky` into the appendix inventory table in `docs/broker-integration-guide.md` and renumbered table rows 1 to 36.
- Added `HDFC Securities` into the supported brokers list in `README.md`.
- Added a short maintainer verification note with shell commands in `docs/broker-integration-guide.md` to prevent count drift across releases.
- Synchronized plugin counts across all related reference documentation.

### Verification
- `find broker -name "plugin.json" | wc -l` (verified 36 plugins)
- `rg -n "34|35|36" README.md CONTRIBUTING.md docs/INDEX.md docs/broker-integration-guide.md`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Standardizes documentation to the current broker plugin inventory (36) to replace contradictory 34/35 counts and keep docs aligned with the actual `broker/*/plugin.json` inventory.

- Updates plugin counts across README, CONTRIBUTING, index, design pages, user guides, BDD features, PRD, and conflicts docs.
- Adds HDFC Securities to Supported Brokers and completes the appendix with `hdfcsecurities` and `hdfcsky`, renumbering entries 1–36.
- Adds a maintainer verification snippet with shell commands in the broker integration guide to prevent future count drift.
- Aligns capability and inventory references in BDD/design with the 36 count.
- No runtime behavior changes; documentation only.

<sup>Written for commit 9463a71eb5aad9b5a558fbd150cc64fea92bbc82. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1906?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

