### PR TITLE
docs: add documentation-only contribution workflow

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -384,6 +384,9 @@ git commit -m "refactor: optimize order processing pipeline"
 
 ### 5. Test Your Changes
 
+For a documentation-only change, see [Documentation-only changes](#documentation-only-changes)
+instead of this checklist.
+
 ```bash
 # Fast backend check (same maintained selection used by CI)
 uv run pytest test/test_log_location.py test/test_navigation_update.py \
@@ -934,8 +937,8 @@ git commit -m "docs: clarify order constants"
 
 Use the same style for the pull request title. In its description, link the
 issue (for example, `Closes #123`), summarize the reader-visible improvement,
-list the files reviewed, and report validation explicitly, including “code
-tests not run (Markdown-only change)” when applicable.
+list the files reviewed, and report validation explicitly, including "code
+tests not run (Markdown-only change)" when applicable.
 
 ### Code Documentation
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -907,12 +907,17 @@ Keep the pull request focused on one documentation outcome. While editing:
 - run any command shown in a changed example when it is safe and does not
   require broker credentials or other secrets.
 
-Before committing, review the changed-file list, open each changed local link
-and anchor, and check the diff for whitespace errors:
+Before committing, inspect the working tree so new, untracked Markdown files
+are visible. Stage only the intended documentation, then review and check the
+exact content that will be committed. Open each changed local link and anchor
+as part of that review:
 
 ```bash
-git diff --name-only
 git diff --check
+git status --short
+git add docs/prompt/order-constants.md
+git diff --cached --name-only
+git diff --cached --check
 ```
 
 When the diff contains only Markdown, the backend pytest suite and frontend
@@ -924,7 +929,6 @@ request instead.
 Use a Conventional Commit with the `docs:` type:
 
 ```bash
-git add docs/prompt/order-constants.md
 git commit -m "docs: clarify order constants"
 ```
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -885,6 +885,54 @@ npm run check
 
 ## Documentation
 
+### Documentation-only changes
+
+Start with [`docs/INDEX.md`](docs/INDEX.md), the map of OpenAlgo's canonical
+documentation. Follow it to the existing source for the topic and update that
+file instead of copying the same guidance into a second page. Use a `docs/`
+branch for a documentation-only change, for example:
+
+```bash
+git checkout -b docs/clarify-order-constants
+```
+
+Keep the pull request focused on one documentation outcome. While editing:
+
+- resolve relative links from the directory containing the changed Markdown
+  file, and preserve the exact case of repository paths;
+- check every changed heading link against the rendered GitHub anchor (for
+  example, `## Order Types` becomes `#order-types`);
+- preview the changed Markdown to catch broken lists, tables, code fences, and
+  callouts; and
+- run any command shown in a changed example when it is safe and does not
+  require broker credentials or other secrets.
+
+Before committing, review the changed-file list, open each changed local link
+and anchor, and check the diff for whitespace errors:
+
+```bash
+git diff --name-only
+git diff --check
+```
+
+When the diff contains only Markdown, the backend pytest suite and frontend
+test/build commands are not required: they do not validate prose, links, or
+anchors. If the documentation changes an executable example, API contract, or
+generated artifact, run the smallest relevant check and record it in the pull
+request instead.
+
+Use a Conventional Commit with the `docs:` type:
+
+```bash
+git add docs/prompt/order-constants.md
+git commit -m "docs: clarify order constants"
+```
+
+Use the same style for the pull request title. In its description, link the
+issue (for example, `Closes #123`), summarize the reader-visible improvement,
+list the files reviewed, and report validation explicitly, including “code
+tests not run (Markdown-only change)” when applicable.
+
 ### Code Documentation
 
 1. **Python Docstrings** - Use Google-style:


### PR DESCRIPTION
## Summary

- identify `docs/INDEX.md` as the map to canonical documentation
- add a focused Markdown-only edit, link/anchor review, and validation workflow
- include untracked Markdown through `git status --short`, deliberate staging, and cached diff checks
- explain when backend/frontend tests are unnecessary and when a scoped executable check is still required
- include valid `docs:` commit and pull request guidance

## Validation

- `git diff --check`
- `git diff --cached --check`
- verified `docs/INDEX.md` and the example documentation path exist
- reviewed the rendered Markdown structure and changed local link
- code tests not run locally (Markdown-only change); hosted CI covers backend, frontend, E2E, and security jobs

Closes #1846