### PR TITLE
feat(flow): default to NRML on derivative segments

### DIFF
--- a/docs/prompt/flow-import-format.md
+++ b/docs/prompt/flow-import-format.md
@@ -567,6 +567,27 @@ positive `triggerPrice`. A missing, blank, zero, or negative required price is
 rejected. A `{{variable}}` price passes import validation and is checked after
 interpolation before the broker call.
 
+#### Product defaults
+
+`product` is optional on every order and position node. **Omit it and the
+node's `exchange` decides**: a derivative segment — `NFO`, `BFO`, `CDS`, `BCD`,
+`MCX`, `NCDEX`, `NCO` — defaults to `NRML`, and everything else to `MIS`.
+
+Write `product` only to override that. It is used exactly as given, so `MIS` on
+an `NFO` order really is an intraday order that the broker squares off at the
+close. An index pseudo-exchange (`NSE_INDEX`, ...) is not a segment orders are
+placed on and defaults to `MIS`.
+
+Two nodes do not follow their `exchange`, because on them that field names
+where the *underlying* is quoted rather than where the contract trades:
+`optionsOrder` and `optionsMultiOrder` default to `NRML` outright.
+
+`basketOrder` decides per row: with no `product` on the node, each row follows
+its own `exchange`, so one basket can mix an `MIS` cash row and an `NRML`
+commodity row. A `product` on the node covers every row that does not set its
+own. Present-but-blank is still an error — that is a `{{variable}}` that failed
+to resolve, and the node refuses rather than guessing.
+
 #### placeOrder — Place Order
 
 Single-leg order on any segment.
@@ -578,7 +599,7 @@ Single-leg order on any segment.
 | `action` | `"BUY"` \| `"SELL"` | `"BUY"` | |
 | `quantity` | int | `1` | In shares (not lots). |
 | `priceType` | `"MARKET"` \| `"LIMIT"` \| `"SL"` \| `"SL-M"` | `"MARKET"` | |
-| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | `"MIS"` | |
+| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | by `exchange` | See **Product defaults**. |
 | `price` | number | `0` | Required for `LIMIT`/`SL`. |
 | `triggerPrice` | number | `0` | Required for `SL`/`SL-M`. |
 | `outputVariable` | string | — | If set, exposes `{{name.orderid}}`, `{{name.status}}`. |
@@ -649,7 +670,7 @@ Single-leg options order resolved from underlying + offset + option type.
 | `action` | `"BUY"` \| `"SELL"` | `"BUY"` | |
 | `quantity` | int | `1` | **In lots** (executor multiplies by lot size). |
 | `priceType` | `"MARKET"` \| `"LIMIT"` \| `"SL"` \| `"SL-M"` | `"MARKET"` | |
-| `product` | `"MIS"` \| `"NRML"` | `"NRML"` | |
+| `product` | `"MIS"` \| `"NRML"` | `"NRML"` | Always a derivative; does not follow `exchange`. |
 | `price` | number | `0` | For `LIMIT`/`SL`. |
 | `triggerPrice` | number | `0` | For `SL`/`SL-M`. |
 | `splitSize` | int | `0` | If >0, splits into chunks. |
@@ -718,7 +739,7 @@ spreads / custom).
 | `action` | `"BUY"` \| `"SELL"` | — | Direction for the strategy (BUY=long volatility, SELL=short volatility). |
 | `quantity` | int | `1` | Lots per leg. |
 | `priceType` | `"MARKET"` \| `"LIMIT"` \| `"SL"` \| `"SL-M"` | `"MARKET"` | Common price type; generated legs do not support `SL`/`SL-M`, while custom legs may inherit all four types. |
-| `product` | `"MIS"` \| `"NRML"` | `"NRML"` | |
+| `product` | `"MIS"` \| `"NRML"` | `"NRML"` | Always a derivative; does not follow `exchange`. |
 | `price` | number | `0` | Common leg price. Must be positive when the effective price type is `LIMIT`/`SL`. |
 | `triggerPrice` | number | `0` | Common custom-leg trigger. Must be positive when the effective price type is `SL`/`SL-M`. |
 | `legs` | `Leg[]` | `[]` | **Required for `strategy="custom"`.** See **Custom legs** below. |
@@ -768,7 +789,7 @@ value, so write no key at all rather than an empty string. A leg naming neither
 `offset` nor `strike` cannot execute and is refused.
 
 The editor shows every inherited field as the value it currently resolves to -
-its expiry, product and price type read as `25AUG26`, `MIS`, `MARKET` rather
+its expiry, product and price type read as `25AUG26`, `NRML`, `MARKET` rather
 than naming the inheritance - and writes nothing until the field is changed. So
 a leg left alone keeps following the node, and adjusting the node still carries
 to it.
@@ -843,7 +864,7 @@ Place multiple orders in a single API call.
 |---|---|---|---|
 | `basketName` | string | `"flow_basket"` | |
 | `orders` | string \| `Order[]` | — | The editor writes multi-line `SYMBOL,EXCHANGE,ACTION,QTY` CSV. Imported arrays may set per-row `product`, `pricetype`, `price`, and `triggerprice`; common node values fill only omitted row fields. |
-| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | `"MIS"` | |
+| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | by `exchange` | See **Product defaults**. |
 | `priceType` | `"MARKET"` \| `"LIMIT"` \| `"SL"` \| `"SL-M"` | `"MARKET"` | Common to every CSV row. |
 | `price` | number | `0` | Common row price. Must be positive for `LIMIT`/`SL`. |
 | `triggerPrice` | number | `0` | Common row trigger price. Must be positive for `SL`/`SL-M`. |
@@ -966,7 +987,7 @@ products. With a `symbol`, closes only that position.
 |---|---|---|---|
 | `symbol` | string | `""` | Blank closes everything. Set it to scope the close. |
 | `exchange` | string | `NSE` | Only meaningful alongside `symbol`. |
-| `product` | string | `MIS` | Only meaningful alongside `symbol`. |
+| `product` | string | by `exchange` | Only meaningful alongside `symbol`. See **Product defaults**. |
 
 `exchange` and `product` do not filter on their own — without a `symbol` this is
 an unconditional square-off however they are set.
@@ -1009,7 +1030,7 @@ the same as any other failing node. A condition that evaluates cleanly to
 |---|---|---|---|
 | `symbol` | string | required | |
 | `exchange` | string | required | |
-| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | `"MIS"` | |
+| `product` | `"MIS"` \| `"CNC"` \| `"NRML"` | by `exchange` | See **Product defaults**. |
 | `condition` | `"exists"` \| `"not_exists"` \| `"quantity_above"` \| `"quantity_below"` \| `"pnl_above"` \| `"pnl_below"` | required | |
 | `threshold` | number | `0` | Only used by the `quantity_*` and `pnl_*` modes. |
 
@@ -2438,7 +2459,7 @@ OpenAlgo standardizes broker-specific symbols to the following format. See
 For convenience in one place:
 
 - **Action:** `BUY`, `SELL`
-- **Product:** `CNC` (cash & carry / delivery), `NRML` (futures & options carry), `MIS` (intraday)
+- **Product:** `CNC` (cash & carry / delivery), `NRML` (futures & options carry), `MIS` (intraday). Omit it and the node's `exchange` decides - see **Product defaults** in 7.2.
 - **Price type:** `MARKET`, `LIMIT`, `SL` (stop-loss limit), `SL-M` (stop-loss market)
 - **Option type:** `CE`, `PE`
 - **Strike offset:** `ATM`, `ITM1`–`ITM5`, `OTM1`–`OTM10`

--- a/frontend/src/components/flow/nodes/ClosePositionsNode.tsx
+++ b/frontend/src/components/flow/nodes/ClosePositionsNode.tsx
@@ -16,8 +16,8 @@ interface ClosePositionsNodeProps {
 
 export const ClosePositionsNode = memo(({ data, selected }: ClosePositionsNodeProps) => {
   // Keyed on symbol, because that is what makes the executor scope the close.
-  // exchange and product ship pre-filled (NSE / MIS), so this was always true
-  // and every node advertised a scoped square-off it did not perform.
+  // exchange ships pre-filled (NSE), so keying on it made this always true and
+  // every node advertised a scoped square-off it did not perform.
   const hasFilter = Boolean(data.symbol)
 
   return (

--- a/frontend/src/components/flow/nodes/OpenPositionNode.tsx
+++ b/frontend/src/components/flow/nodes/OpenPositionNode.tsx
@@ -6,6 +6,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { Briefcase } from 'lucide-react'
 import { memo } from 'react'
+import { defaultProductForExchange } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import type { OpenPositionNodeData } from '@/types/flow'
 
@@ -34,7 +35,7 @@ export const OpenPositionNode = memo(({ data, selected }: OpenPositionNodeProps)
             <span className="mono-data text-[10px] font-medium">{data.symbol || '-'}</span>
           </div>
           <div className="text-center text-[9px] text-muted-foreground">
-            {data.product || 'MIS'}
+            {data.product || defaultProductForExchange(data.exchange)}
           </div>
         </div>
       </div>

--- a/frontend/src/components/flow/nodes/OptionsMultiOrderNode.tsx
+++ b/frontend/src/components/flow/nodes/OptionsMultiOrderNode.tsx
@@ -6,6 +6,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { Layers } from 'lucide-react'
 import { memo } from 'react'
+import { OPTION_NODE_PRODUCT } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import type { OptionsMultiOrderNodeData } from '@/types/flow'
 
@@ -88,7 +89,7 @@ export const OptionsMultiOrderNode = memo(({ data, selected }: OptionsMultiOrder
             >
               {(nodeData.action as string) || 'SELL'}
             </span>
-            <span>{data.product || 'MIS'}</span>
+            <span>{data.product || OPTION_NODE_PRODUCT}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/flow/nodes/OptionsOrderNode.tsx
+++ b/frontend/src/components/flow/nodes/OptionsOrderNode.tsx
@@ -6,6 +6,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { TrendingUp } from 'lucide-react'
 import { memo } from 'react'
+import { OPTION_NODE_PRODUCT } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import type { OptionsOrderNodeData } from '@/types/flow'
 
@@ -66,7 +67,7 @@ export const OptionsOrderNode = memo(({ data, selected }: OptionsOrderNodeProps)
             </div>
           </div>
           <div className="flex items-center justify-between text-[9px] text-muted-foreground">
-            <span>{data.product || 'MIS'}</span>
+            <span>{data.product || OPTION_NODE_PRODUCT}</span>
             <span>{data.priceType || 'MARKET'}</span>
           </div>
           {data.ltp !== undefined && (

--- a/frontend/src/components/flow/nodes/PlaceOrderNode.tsx
+++ b/frontend/src/components/flow/nodes/PlaceOrderNode.tsx
@@ -1,6 +1,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { ShoppingCart } from 'lucide-react'
 import { memo } from 'react'
+import { defaultProductForExchange } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import type { PlaceOrderNodeData } from '@/types/flow'
 
@@ -44,7 +45,7 @@ export const PlaceOrderNode = memo(({ data, selected }: PlaceOrderNodeProps) => 
           </div>
           <div className="flex items-center justify-between text-[9px] text-muted-foreground">
             <span>{data.priceType || 'MARKET'}</span>
-            <span>{data.product || 'MIS'}</span>
+            <span>{data.product || defaultProductForExchange(data.exchange)}</span>
           </div>
           {data.ltp !== undefined && (
             <div className="mt-0.5 flex items-center justify-between rounded border border-border/50 bg-surface-2 px-1.5 py-0.5">

--- a/frontend/src/components/flow/nodes/SmartOrderNode.tsx
+++ b/frontend/src/components/flow/nodes/SmartOrderNode.tsx
@@ -6,6 +6,7 @@
 import { Handle, Position } from '@xyflow/react'
 import { Zap } from 'lucide-react'
 import { memo } from 'react'
+import { defaultProductForExchange } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import type { SmartOrderNodeData } from '@/types/flow'
 
@@ -53,7 +54,7 @@ export const SmartOrderNode = memo(({ data, selected }: SmartOrderNodeProps) => 
           </div>
           <div className="flex items-center justify-between text-[9px] text-muted-foreground">
             <span>{data.priceType || 'MARKET'}</span>
-            <span>{data.product || 'MIS'}</span>
+            <span>{data.product || defaultProductForExchange(data.exchange)}</span>
           </div>
         </div>
       </div>

--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -28,6 +28,7 @@ import {
   INDICATOR_CATALOG,
   INDICATOR_PARAMS,
   NODE_DEFINITIONS,
+  OPTION_NODE_PRODUCT,
   OPTION_STRATEGIES,
   OPTION_TYPES,
   ORDER_ACTIONS,
@@ -35,12 +36,19 @@ import {
   PRODUCT_TYPES,
   SCHEDULE_TYPES,
   STRIKE_OFFSETS,
+  defaultProductForExchange,
 } from '@/lib/flow/constants'
 import type { PriceType } from '@/lib/flow/constants'
 import { cn } from '@/lib/utils'
 import { useFlowWorkflowStore } from '@/stores/flowWorkflowStore'
 import type { BasketOrderItem } from '@/types/flow'
 import { showToast } from '@/utils/toast'
+
+/**
+ * The Basket node's "no blanket product" choice. Radix needs a non-empty item
+ * value, and the node stores the absence of a product rather than this string.
+ */
+const BASKET_PRODUCT_AUTO = 'AUTO'
 import { IndicatorParamsFields } from './IndicatorParamsFields'
 import { MarginPositionsFields } from './MarginPositionsFields'
 import { CustomLegsFields } from './CustomLegsFields'
@@ -307,6 +315,15 @@ export function ConfigPanel() {
   const nodeData = selectedNode.data as Record<string, unknown>
   const nodeType = selectedNode.type || 'unknown'
   const orderPriceType = (nodeData.priceType as PriceType | undefined) || 'MARKET'
+  // What the Product control shows. A product the author picked is stored on
+  // the node and always wins; with none stored the node follows its exchange,
+  // so a derivative segment reads NRML and cash reads MIS. Options nodes trade
+  // a derivative whatever their underlying's exchange field happens to be.
+  const nodeProduct =
+    (nodeData.product as string) ||
+    (nodeType === 'optionsOrder' || nodeType === 'optionsMultiOrder'
+      ? OPTION_NODE_PRODUCT
+      : defaultProductForExchange(nodeData.exchange as string | undefined))
   const basketOrders = nodeData.orders as string | BasketOrderItem[] | undefined
   const nodeTitle = NODE_TITLES[nodeType] || nodeInfo?.label || nodeType
 
@@ -872,7 +889,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -1010,7 +1027,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -1197,7 +1214,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -1355,7 +1372,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -1518,7 +1535,7 @@ export function ConfigPanel() {
                     value={nodeData.legs}
                     onChange={(legs) => handleDataChange('legs', legs)}
                     commonPriceType={orderPriceType}
-                    commonProduct={(nodeData.product as string) || 'MIS'}
+                    commonProduct={nodeProduct}
                     commonExpiryType={(nodeData.expiryType as string) || 'current_week'}
                     commonAction={(nodeData.action as string) || 'SELL'}
                     commonQuantity={(nodeData.quantity as number) || 1}
@@ -1583,14 +1600,21 @@ export function ConfigPanel() {
                 </div>
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
+                  {/* One basket can mix segments, so the default is decided per
+                      row rather than blanket: an NFO row goes NRML while an NSE
+                      row goes MIS. Choosing a product here overrides all of
+                      them. */}
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
-                    onValueChange={(v) => handleDataChange('product', v)}
+                    value={(nodeData.product as string) || BASKET_PRODUCT_AUTO}
+                    onValueChange={(v) =>
+                      handleDataChange('product', v === BASKET_PRODUCT_AUTO ? undefined : v)
+                    }
                   >
                     <SelectTrigger className="h-8">
                       <SelectValue />
                     </SelectTrigger>
                     <SelectContent>
+                      <SelectItem value={BASKET_PRODUCT_AUTO}>By row exchange</SelectItem>
                       {PRODUCT_TYPES.map((t) => (
                         <SelectItem key={t.value} value={t.value}>
                           {t.label}
@@ -1718,7 +1742,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -1842,7 +1866,7 @@ export function ConfigPanel() {
                     <div className="space-y-2">
                       <Label className="text-xs">Product</Label>
                       <Select
-                        value={(nodeData.product as string) || 'MIS'}
+                        value={nodeProduct}
                         onValueChange={(v) => handleDataChange('product', v)}
                       >
                         <SelectTrigger className="h-8">
@@ -2054,7 +2078,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">
@@ -3817,7 +3841,7 @@ export function ConfigPanel() {
                 <div className="space-y-2">
                   <Label className="text-xs">Product</Label>
                   <Select
-                    value={(nodeData.product as string) || 'MIS'}
+                    value={nodeProduct}
                     onValueChange={(v) => handleDataChange('product', v)}
                   >
                     <SelectTrigger className="h-8">

--- a/frontend/src/components/flow/panels/DefaultProduct.test.tsx
+++ b/frontend/src/components/flow/panels/DefaultProduct.test.tsx
@@ -1,0 +1,156 @@
+/**
+ * What the config panel's Product control shows, and when it writes.
+ *
+ * The control read `nodeData.product || 'MIS'` on every node, so a node placed
+ * on NFO or MCX said MIS - and, because the node also shipped a stored MIS,
+ * meant it. The segment was invisible: the author had to notice and fix each
+ * node by hand, and the ones they missed auto-squared-off at the close.
+ *
+ * The control now shows what the run will send: the node's own product if it
+ * has one, otherwise the default its exchange implies. It still writes nothing
+ * until the author actually picks, which is what lets changing the exchange
+ * move the default with it - and what stops a shown value from being mistaken
+ * for a chosen one.
+ */
+
+import { QueryClient, QueryClientProvider } from '@tanstack/react-query'
+import { fireEvent, render, screen, within } from '@testing-library/react'
+import { MemoryRouter } from 'react-router'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useFlowWorkflowStore } from '@/stores/flowWorkflowStore'
+
+vi.mock('@/api/flow', async (importOriginal) => {
+  const actual = await importOriginal<typeof import('@/api/flow')>()
+  return {
+    ...actual,
+    getIndexSymbolsLotSizes: vi.fn(async () => []),
+    getWebhookInfo: vi.fn(async () => null),
+    getOptionStrikes: vi.fn(async () => {
+      throw new Error('not needed here')
+    }),
+  }
+})
+
+const { ConfigPanel } = await import('./ConfigPanel')
+
+function mount(type: string, data: Record<string, unknown>) {
+  useFlowWorkflowStore.setState({
+    nodes: [{ id: 'n1', type, position: { x: 0, y: 0 }, data }],
+    selectedNodeId: 'n1',
+  })
+  const queryClient = new QueryClient({ defaultOptions: { queries: { retry: false, gcTime: 0 } } })
+  render(
+    <MemoryRouter>
+      <QueryClientProvider client={queryClient}>
+        <ConfigPanel />
+      </QueryClientProvider>
+    </MemoryRouter>
+  )
+}
+
+/** The Product select's trigger, read the way a user reads it. */
+function productControl(): HTMLElement {
+  const label = screen.getByText('Product')
+  const trigger = label.parentElement?.querySelector('button')
+  if (!trigger) throw new Error('Product control was not rendered')
+  return trigger
+}
+
+const storedProduct = () => useFlowWorkflowStore.getState().nodes[0].data.product
+
+/** Change the node's exchange the way the panel offers it. */
+function chooseExchange(value: string) {
+  const trigger = screen.getByText('Exchange').parentElement?.querySelector('button')
+  if (!trigger) throw new Error('Exchange control was not rendered')
+  fireEvent.click(trigger)
+  fireEvent.click(within(screen.getByRole('listbox')).getByText(value))
+}
+
+beforeEach(() => useFlowWorkflowStore.getState().resetWorkflow())
+
+describe('a node that names a symbol', () => {
+  it.each([
+    ['NSE', 'MIS'],
+    ['BSE', 'MIS'],
+    ['NFO', 'NRML'],
+    ['BFO', 'NRML'],
+    ['MCX', 'NRML'],
+    ['CDS', 'NRML'],
+  ])('shows %s orders as %s', (exchange, expected) => {
+    mount('placeOrder', { symbol: 'X', exchange, quantity: 1 })
+
+    expect(productControl().textContent).toBe(expected)
+  })
+
+  it('shows the product the author chose, whatever the segment implies', () => {
+    /** Intraday on a derivative is a legitimate thing to ask for. */
+    mount('placeOrder', { symbol: 'X', exchange: 'NFO', quantity: 1, product: 'MIS' })
+
+    expect(productControl().textContent).toBe('MIS')
+  })
+
+  it('leaves an untouched node storing nothing, so its exchange still decides', () => {
+    mount('placeOrder', { symbol: 'X', exchange: 'NSE', quantity: 1 })
+
+    expect(storedProduct()).toBeUndefined()
+  })
+
+  it('follows the exchange when the author changes the exchange', () => {
+    /** The point of storing nothing: moving a half-built node to NFO moves its
+     * product too, rather than leaving intraday behind to be noticed later. */
+    mount('placeOrder', { symbol: 'X', exchange: 'NSE', quantity: 1 })
+    expect(productControl().textContent).toBe('MIS')
+
+    chooseExchange('NFO')
+
+    expect(productControl().textContent).toBe('NRML')
+    expect(storedProduct()).toBeUndefined()
+  })
+
+  it('stops following once the author picks', () => {
+    mount('placeOrder', { symbol: 'X', exchange: 'NSE', quantity: 1, product: 'CNC' })
+
+    chooseExchange('NFO')
+
+    expect(productControl().textContent).toBe('CNC')
+  })
+})
+
+describe('an options node', () => {
+  it.each(['optionsOrder', 'optionsMultiOrder'])('carries, whatever %s quotes on', (type) => {
+    /** `exchange` on these names where the *underlying* is quoted - NSE_INDEX -
+     * so following it would default every index option to intraday. */
+    mount(type, { underlying: 'NIFTY', exchange: 'NSE_INDEX', quantity: 1, strategy: 'straddle' })
+
+    expect(productControl().textContent).toBe('NRML')
+  })
+})
+
+describe('a basket', () => {
+  it('decides per row rather than blanket', () => {
+    /** One basket can hold an NSE row and an MCX row; a single product would be
+     * wrong for at least one of them. */
+    mount('basketOrder', { orders: 'SBIN,NSE,BUY,1\nGOLDM,MCX,BUY,1' })
+
+    expect(productControl().textContent).toBe('By row exchange')
+    expect(storedProduct()).toBeUndefined()
+  })
+
+  it('shows a blanket product once one is chosen', () => {
+    mount('basketOrder', { orders: 'SBIN,NSE,BUY,1', product: 'NRML' })
+
+    expect(productControl().textContent).toBe('NRML')
+  })
+
+  it('clears the node product when the author goes back to per row', () => {
+    /** Writing an empty string instead would reach the executor as a product
+     * that failed to resolve, which it refuses rather than guesses. */
+    mount('basketOrder', { orders: 'SBIN,NSE,BUY,1', product: 'NRML' })
+
+    fireEvent.click(productControl())
+    fireEvent.click(screen.getByText('By row exchange'))
+
+    expect(storedProduct()).toBeUndefined()
+    expect(JSON.parse(JSON.stringify({ data: { product: storedProduct() } }))).toEqual({ data: {} })
+  })
+})

--- a/frontend/src/components/flow/panels/MarginPositionsFields.test.tsx
+++ b/frontend/src/components/flow/panels/MarginPositionsFields.test.tsx
@@ -357,3 +357,45 @@ describe('accessibility', () => {
     expect(screen.getByRole('button', { name: 'SELL' })).toHaveAttribute('aria-pressed', 'false')
   })
 })
+
+describe('a leg follows its segment', () => {
+  /**
+   * margin_service requires a product on every leg, so unlike a node this row
+   * cannot store "not chosen yet" and let the exchange decide at run time. The
+   * default is carried across on an exchange change instead - but only while
+   * the leg is still sitting on the one its old exchange implied, so a product
+   * the author actually picked survives the move.
+   */
+  async function moveExchange(user: ReturnType<typeof userEvent.setup>, to: string) {
+    await user.click(screen.getByLabelText('Exchange'))
+    await user.click(await screen.findByRole('option', { name: to }))
+  }
+
+  it('prices an untouched cash leg moved to NFO as a carry position', async () => {
+    const user = userEvent.setup()
+    renderControlled(NSE_LEG)
+
+    await moveExchange(user, 'NFO')
+
+    await waitFor(() => expect(screen.getByLabelText('Product').textContent).toBe('NRML'))
+  })
+
+  it('takes a derivative leg moved to cash back to intraday', async () => {
+    const user = userEvent.setup()
+    renderControlled(CLEAN_NFO_LEG)
+
+    await moveExchange(user, 'NSE')
+
+    await waitFor(() => expect(screen.getByLabelText('Product').textContent).toBe('MIS'))
+  })
+
+  it('leaves a product the author chose alone', async () => {
+    const user = userEvent.setup()
+    renderControlled(NSE_LEG.replace('"MIS"', '"CNC"'))
+
+    await moveExchange(user, 'NFO')
+
+    await waitFor(() => expect(screen.getByLabelText('Exchange').textContent).toBe('NFO'))
+    expect(screen.getByLabelText('Product').textContent).toBe('CNC')
+  })
+})

--- a/frontend/src/components/flow/panels/MarginPositionsFields.tsx
+++ b/frontend/src/components/flow/panels/MarginPositionsFields.tsx
@@ -24,7 +24,13 @@ import {
   SelectValue,
 } from '@/components/ui/select'
 import { Textarea } from '@/components/ui/textarea'
-import { EXCHANGES, ORDER_ACTIONS, PRICE_TYPES, PRODUCT_TYPES } from '@/lib/flow/constants'
+import {
+  EXCHANGES,
+  ORDER_ACTIONS,
+  PRICE_TYPES,
+  PRODUCT_TYPES,
+  defaultProductForExchange,
+} from '@/lib/flow/constants'
 import {
   EMPTY_LEG,
   hasVariableReference,
@@ -291,6 +297,22 @@ interface LegRowProps {
   onRemove: () => void
 }
 
+/**
+ * The product patch that goes with a leg's new exchange.
+ *
+ * margin_service requires a product on every leg, so unlike a node this row
+ * cannot store "no choice yet" and let the exchange decide at run time. The
+ * next best thing: carry the default across when the leg is still sitting on
+ * the one its old exchange implied, and leave a product the author actually
+ * changed alone. Moving an untouched NSE leg to NFO therefore prices it NRML,
+ * while a leg deliberately set to MIS stays intraday wherever it goes.
+ */
+function productForExchange(leg: MarginLeg, exchange: string): Partial<MarginLeg> {
+  if (leg.product !== defaultProductForExchange(leg.exchange)) return {}
+  const next = defaultProductForExchange(exchange)
+  return next === leg.product ? {} : { product: next }
+}
+
 function LegRow({ leg, index, lot, onRetryLookup, onUpdate, onRemove }: LegRowProps) {
   const problems: LegProblems = validateLeg(leg)
   const units = Number.parseInt(leg.quantity, 10) || 0
@@ -356,7 +378,10 @@ function LegRow({ leg, index, lot, onRetryLookup, onUpdate, onRemove }: LegRowPr
           <Label htmlFor={id('exchange')} className="text-[10px] text-muted-foreground">
             Exchange
           </Label>
-          <Select value={leg.exchange} onValueChange={(v) => onUpdate({ exchange: v })}>
+          <Select
+            value={leg.exchange}
+            onValueChange={(v) => onUpdate({ exchange: v, ...productForExchange(leg, v) })}
+          >
             <SelectTrigger id={id('exchange')} className="h-8" aria-label="Exchange">
               <SelectValue />
             </SelectTrigger>

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -39,6 +39,38 @@ export const PRODUCT_TYPES = [
   { value: 'NRML', label: 'NRML', description: 'Normal for futures and options' },
 ] as const
 
+/**
+ * Segments that trade contracts carried on margin rather than cash-settled
+ * holdings. A position in one of these is normally taken NRML, so that is what
+ * a node defaults to when its author never picked a product. Index
+ * pseudo-exchanges are absent because no order is ever placed on them.
+ *
+ * The backend keeps the same rule in services/flow_node_contracts.py; both
+ * sides must agree or the panel would promise a product the run does not send.
+ */
+export const DERIVATIVE_EXCHANGES = new Set<string>([
+  'NFO',
+  'BFO',
+  'CDS',
+  'BCD',
+  'MCX',
+  'NCDEX',
+  'NCO',
+])
+
+/**
+ * The product a node on `exchange` uses when its author picked none.
+ *
+ * A *default*, never an override: once a product is chosen it is stored on the
+ * node and wins, so a deliberately intraday NFO order stays MIS.
+ */
+export function defaultProductForExchange(exchange: string | undefined | null): 'MIS' | 'NRML' {
+  return DERIVATIVE_EXCHANGES.has((exchange || '').trim().toUpperCase()) ? 'NRML' : 'MIS'
+}
+
+/** Options nodes trade an option whatever their underlying's exchange reads. */
+export const OPTION_NODE_PRODUCT = 'NRML' as const
+
 export const PRICE_TYPES = [
   { value: 'MARKET', label: 'Market', description: 'Execute at current market price' },
   { value: 'LIMIT', label: 'Limit', description: 'Execute at specified price or better' },
@@ -1162,7 +1194,9 @@ export const DEFAULT_NODE_DATA = {
     action: 'BUY' as const,
     quantity: 1,
     priceType: 'MARKET' as const,
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     price: 0,
     triggerPrice: 0,
   },
@@ -1173,7 +1207,9 @@ export const DEFAULT_NODE_DATA = {
     quantity: 1,
     positionSize: 0,
     priceType: 'MARKET' as const,
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     price: 0,
     triggerPrice: 0,
   },
@@ -1211,7 +1247,9 @@ export const DEFAULT_NODE_DATA = {
     action: 'BUY' as const,
     quantity: 1,
     priceType: 'MARKET' as const,
-    product: 'MIS' as const,
+    // An option is a derivative contract whatever its underlying's exchange
+    // reads, so this defaults to NRML rather than following that field.
+    product: 'NRML' as const,
     price: 0,
     triggerPrice: 0,
   },
@@ -1227,7 +1265,9 @@ export const DEFAULT_NODE_DATA = {
     strangleWidth: 'OTM2' as const,
     priceType: 'MARKET' as const,
     price: 0,
-    product: 'MIS' as const,
+    // An option is a derivative contract whatever its underlying's exchange
+    // reads, so this defaults to NRML rather than following that field.
+    product: 'NRML' as const,
   },
   cancelOrder: {
     orderId: '',
@@ -1236,7 +1276,9 @@ export const DEFAULT_NODE_DATA = {
   closePositions: {
     symbol: '',
     exchange: 'NSE',
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
   },
   modifyOrder: {
     // Only the order id. symbol/exchange/action/product/priceType are read back
@@ -1249,7 +1291,9 @@ export const DEFAULT_NODE_DATA = {
   },
   basketOrder: {
     orders: '',
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     priceType: 'MARKET' as const,
     price: 0,
     triggerPrice: 0,
@@ -1261,14 +1305,18 @@ export const DEFAULT_NODE_DATA = {
     quantity: 100,
     splitSize: 50,
     priceType: 'MARKET' as const,
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     price: 0,
     triggerPrice: 0,
   },
   positionCheck: {
     symbol: '',
     exchange: 'NSE',
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     condition: 'exists' as const,
     threshold: 0,
   },
@@ -1361,7 +1409,9 @@ export const DEFAULT_NODE_DATA = {
   openPosition: {
     symbol: '',
     exchange: 'NSE',
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     outputVariable: '',
   },
   // The config panel renders this name as its input's fallback value, so the
@@ -1500,7 +1550,9 @@ export const DEFAULT_NODE_DATA = {
     exchange: 'NSE',
     quantity: 1,
     price: 0,
-    product: 'MIS' as const,
+    // No product: an untouched node follows its exchange, so switching it to a
+    // derivative segment shows -- and sends -- NRML while cash stays MIS. A
+    // product the author actually picks is stored and wins.
     action: 'BUY' as const,
     priceType: 'MARKET' as const,
     outputVariable: 'marginResult',

--- a/frontend/src/lib/flow/defaultProduct.test.ts
+++ b/frontend/src/lib/flow/defaultProduct.test.ts
@@ -1,0 +1,86 @@
+/**
+ * Which product a node uses when nobody picked one.
+ *
+ * MIS squares off at the close; NRML carries. On a cash segment MIS is right -
+ * a Flow order on NSE is nearly always intraday. On a derivative it is not: an
+ * NFO or MCX position is ordinarily carried, and MIS there is an auto
+ * square-off the author never asked for. Every node shipped MIS regardless of
+ * segment, so an F&O workflow had to be corrected node by node and any node
+ * missed traded intraday without saying so.
+ *
+ * What follows is a default and not an override. A product the author picked is
+ * stored on the node and wins, which is what leaves a deliberately intraday NFO
+ * order alone - and what leaves every already-saved workflow sending exactly
+ * what it sent before, since the old editor wrote an explicit product onto
+ * every node it created.
+ */
+
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_NODE_DATA,
+  DERIVATIVE_EXCHANGES,
+  EXCHANGES,
+  OPTION_NODE_PRODUCT,
+  defaultProductForExchange,
+} from './constants'
+
+const CASH_AND_INDEX = ['NSE', 'BSE', 'NSE_INDEX', 'BSE_INDEX', 'MCX_INDEX', 'GLOBAL_INDEX', 'CRYPTO']
+
+describe('the rule', () => {
+  it.each([...DERIVATIVE_EXCHANGES])('carries a position on %s', (exchange) => {
+    expect(defaultProductForExchange(exchange)).toBe('NRML')
+  })
+
+  it.each(CASH_AND_INDEX)('stays intraday on %s', (exchange) => {
+    expect(defaultProductForExchange(exchange)).toBe('MIS')
+  })
+
+  it.each(['nfo', ' NFO ', 'NfO'])('reads %s the way the exchange list spells it', (value) => {
+    expect(defaultProductForExchange(value)).toBe('NRML')
+  })
+
+  it.each(['', '   ', undefined, null])('falls back to intraday for %s', (value) => {
+    /** Carrying a position the author expected squared off is the costlier
+     * mistake, so a value that names no segment never guesses NRML. */
+    expect(defaultProductForExchange(value)).toBe('MIS')
+  })
+
+  it('names only exchanges the editor actually offers', () => {
+    const offered = new Set(EXCHANGES.map((e) => e.value))
+    for (const exchange of DERIVATIVE_EXCHANGES) expect(offered.has(exchange)).toBe(true)
+  })
+
+  it('leaves index pseudo-exchanges out', () => {
+    /** No order is ever placed on one. Listing them would only make the options
+     * nodes look as though they followed their `exchange` field. */
+    for (const pseudo of ['NSE_INDEX', 'BSE_INDEX', 'MCX_INDEX', 'GLOBAL_INDEX']) {
+      expect(DERIVATIVE_EXCHANGES.has(pseudo)).toBe(false)
+    }
+  })
+})
+
+describe('what a new node ships with', () => {
+  it.each([
+    'placeOrder',
+    'smartOrder',
+    'splitOrder',
+    'closePositions',
+    'positionCheck',
+    'openPosition',
+    'basketOrder',
+    'margin',
+  ] as const)('stores no product on %s, so the exchange decides', (node) => {
+    /** A stored MIS is indistinguishable from a chosen one, so shipping it
+     * would pin every node to intraday before its exchange was even picked. */
+    expect(DEFAULT_NODE_DATA[node]).not.toHaveProperty('product')
+  })
+
+  it.each(['optionsOrder', 'optionsMultiOrder'] as const)('carries on %s', (node) => {
+    /** An option is a derivative whatever the node's `exchange` says - that
+     * field names where the underlying is quoted (NSE_INDEX), not where the
+     * option trades. */
+    expect(DEFAULT_NODE_DATA[node].product).toBe(OPTION_NODE_PRODUCT)
+    expect(OPTION_NODE_PRODUCT).toBe('NRML')
+    expect(defaultProductForExchange(DEFAULT_NODE_DATA[node].exchange)).toBe('MIS')
+  })
+})

--- a/frontend/src/lib/flow/marginPositions.ts
+++ b/frontend/src/lib/flow/marginPositions.ts
@@ -11,7 +11,13 @@
 // MarginPositionSchema declares quantity and price as fields.Str, so numbers
 // are rejected outright on the REST path.
 
-import { EXCHANGES, ORDER_ACTIONS, PRICE_TYPES, PRODUCT_TYPES } from '@/lib/flow/constants'
+import {
+  EXCHANGES,
+  ORDER_ACTIONS,
+  PRICE_TYPES,
+  PRODUCT_TYPES,
+  defaultProductForExchange,
+} from '@/lib/flow/constants'
 
 export interface MarginLeg {
   symbol: string
@@ -35,7 +41,7 @@ export const EMPTY_LEG: MarginLeg = {
   exchange: 'NSE',
   action: 'BUY',
   quantity: '1',
-  product: 'MIS',
+  product: defaultProductForExchange('NSE'),
   pricetype: 'MARKET',
   price: '0',
   trigger_price: '0',
@@ -77,12 +83,15 @@ function toLeg(entry: Record<string, unknown>): MarginLeg {
   for (const [key, val] of Object.entries(entry)) {
     if (!MODELLED_KEYS.has(key)) extra[key] = val
   }
+  const exchange = str('exchange', 'NSE')
   return {
     symbol: str('symbol', ''),
-    exchange: str('exchange', 'NSE'),
+    exchange,
     action: str('action', 'BUY').toUpperCase(),
     quantity: str('quantity', '1'),
-    product: str('product', 'MIS'),
+    // A leg that names no product follows its own exchange, so an NFO leg is
+    // priced as the NRML carry position it is rather than as intraday margin.
+    product: str('product', defaultProductForExchange(exchange)),
     pricetype: str('pricetype', 'MARKET'),
     price: str('price', '0'),
     trigger_price: str('trigger_price', '0'),

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -32,6 +32,7 @@ from services.flow_node_contracts import (
 from services.flow_node_contracts import (
     VALID_EXPIRY_TYPES,
     VALID_LEG_STRIKE_MODES,
+    default_product_for_exchange,
     select_expiry,
 )
 from services.flow_openalgo_client import FlowOpenAlgoClient, get_flow_client
@@ -669,13 +670,22 @@ class NodeExecutor:
         """Resolve the fields shared by regular, smart, and split orders."""
         values = RuntimeOrderResolver(self.context, node_data, label)
         quantity_minimum = 0 if allow_zero_quantity else 1
+        # The exchange decides the product default, so it is read out before the
+        # dict is built -- a node whose author never touched Product sends NRML
+        # on a derivative segment and MIS on cash. Symbol is still resolved
+        # first, so a node with several problems reports the same one it always
+        # did.
+        symbol = values.text("symbol")
+        exchange = values.enum("exchange", VALID_EXCHANGES, default="NSE")
         resolved = {
-            "symbol": values.text("symbol"),
-            "exchange": values.enum("exchange", VALID_EXCHANGES, default="NSE"),
+            "symbol": symbol,
+            "exchange": exchange,
             "action": values.enum("action", VALID_ACTIONS, default="BUY"),
             "quantity": values.integer("quantity", default=1, minimum=quantity_minimum),
             "price_type": values.enum("priceType", VALID_PRICE_TYPES, default="MARKET"),
-            "product": values.enum("product", VALID_PRODUCT_TYPES, default="MIS"),
+            "product": values.enum(
+                "product", VALID_PRODUCT_TYPES, default=default_product_for_exchange(exchange)
+            ),
             "price": values.number("price", default=0.0),
             "trigger_price": values.number("triggerPrice", default=0.0),
         }
@@ -964,7 +974,7 @@ class NodeExecutor:
             ).lower()
             action = values.enum("action", VALID_ACTIONS, default="SELL")
             quantity_lots = values.integer("quantity", default=1, minimum=1)
-            product = values.enum("product", VALID_PRODUCT_TYPES, default="MIS")
+            product = values.enum("product", VALID_PRODUCT_TYPES, default="NRML")
             strangle_width = values.text("strangleWidth", default="OTM2").upper()
             if not _OPTION_OFFSET_PATTERN.fullmatch(strangle_width):
                 raise ValueError(
@@ -1515,7 +1525,7 @@ class NodeExecutor:
             return result
 
         exchange = self._supplied(node_data, "exchange") or "NSE"
-        product = self._supplied(node_data, "product") or "MIS"
+        product = self._supplied(node_data, "product") or default_product_for_exchange(exchange)
         self.log(f"Closing position: {symbol}@{exchange} ({product})")
         result = self.client.close_position(
             symbol=symbol,
@@ -1578,11 +1588,21 @@ class NodeExecutor:
             return {"status": "error", "message": message}
 
         try:
-            common_product = required_text(common_value("product", "MIS"), "product").upper()
+            # One basket can mix segments, so a node that names no product lets
+            # every row fall back to its own exchange's default -- NSE rows MIS,
+            # NFO rows NRML -- instead of one blanket choice. A product that is
+            # present but blank stays an error, as before.
+            unset = object()
+            common_product_raw = common_value("product", unset)
+            common_product = (
+                ""
+                if common_product_raw is unset
+                else required_text(common_product_raw, "product").upper()
+            )
             common_price_type = required_text(
                 common_value("priceType", "MARKET"), "priceType"
             ).upper()
-            if common_product not in VALID_PRODUCT_TYPES:
+            if common_product and common_product not in VALID_PRODUCT_TYPES:
                 raise ValueError(f"invalid product {common_product!r}")
             if common_price_type not in VALID_PRICE_TYPES:
                 raise ValueError(f"invalid pricetype {common_price_type!r}")
@@ -1650,7 +1670,8 @@ class NodeExecutor:
                     raise ValueError(f"quantity must be positive, got {quantity}")
 
                 product = required_text(
-                    row_value("product", common_product), "product"
+                    row_value("product", common_product or default_product_for_exchange(exchange)),
+                    "product",
                 ).upper()
                 price_type = required_text(
                     row_value("pricetype", common_price_type, "priceType"), "pricetype"
@@ -1766,7 +1787,7 @@ class NodeExecutor:
         """Execute Open Position node"""
         symbol = self.get_str(node_data, "symbol", "")
         exchange = self.get_str(node_data, "exchange", "NSE")
-        product = self.get_str(node_data, "product", "MIS")
+        product = self.get_str(node_data, "product", default_product_for_exchange(exchange))
         self.log(f"Getting open position for: {symbol}")
         result = self.client.get_open_position(
             symbol=symbol, exchange=exchange, product_type=product
@@ -2455,7 +2476,7 @@ class NodeExecutor:
         exchange = self.get_str(node_data, "exchange", "NSE")
         quantity = self.get_int(node_data, "quantity", 1)
         price = self.get_float(node_data, "price", 0)
-        product_type = self.get_str(node_data, "product", "MIS")
+        product_type = self.get_str(node_data, "product", default_product_for_exchange(exchange))
         action = self.get_str(node_data, "action", "BUY")
         price_type = self.get_str(node_data, "priceType", "MARKET")
         if positions:
@@ -2981,7 +3002,7 @@ class NodeExecutor:
         """
         symbol = self.get_str(node_data, "symbol", "")
         exchange = self.get_str(node_data, "exchange", "NSE")
-        product = self.get_str(node_data, "product", "MIS")
+        product = self.get_str(node_data, "product", default_product_for_exchange(exchange))
         condition = self.get_str(node_data, "condition", "exists")
         threshold = self.get_float(node_data, "threshold", 0.0)
 

--- a/services/flow_node_contracts.py
+++ b/services/flow_node_contracts.py
@@ -23,6 +23,24 @@ VALID_LEG_STRIKE_MODES = frozenset({"OFFSET", "STRIKE"})
 VALID_EXPIRY_TYPES = frozenset({"current_week", "next_week", "current_month", "next_month"})
 
 
+#: Segments that trade contracts carried on margin rather than cash-settled
+#: holdings. A position in one of these is normally taken NRML, so that is what
+#: a node defaults to when its author never picked a product; MIS is the
+#: default everywhere else. Index pseudo-exchanges are absent because no order
+#: is ever placed on them.
+DERIVATIVE_EXCHANGES = frozenset({"NFO", "BFO", "CDS", "BCD", "MCX", "NCDEX", "NCO"})
+
+
+def default_product_for_exchange(exchange: str | None) -> str:
+    """The product a node on ``exchange`` uses when its author picked none.
+
+    This is a *default*, never an override: a product the author actually chose
+    is stored on the node and wins, so an intraday NFO order stays MIS. The
+    editor resolves the same rule so the panel shows what the run will send.
+    """
+    return "NRML" if (exchange or "").strip().upper() in DERIVATIVE_EXCHANGES else "MIS"
+
+
 #: Expiry strings arrive from the master contract in a few shapes depending on
 #: the broker; all of them are accepted and normalized to DDMMMYY.
 _EXPIRY_INPUT_FORMATS = ("%d-%b-%y", "%d%b%y", "%d-%B-%Y", "%d%B%Y")

--- a/services/options_multiorder_service.py
+++ b/services/options_multiorder_service.py
@@ -417,7 +417,7 @@ def resolve_and_place_leg(
                 "symbol": resolved_symbol,
                 "action": leg_data.get("action"),
                 "pricetype": leg_data.get("pricetype", "MARKET"),
-                "product": leg_data.get("product", "MIS"),
+                "product": leg_data.get("product", "NRML"),
                 "price": leg_data.get("price", 0.0),
                 "trigger_price": leg_data.get("trigger_price", 0.0),
                 "disclosed_quantity": leg_data.get("disclosed_quantity", 0),
@@ -466,7 +466,7 @@ def resolve_and_place_leg(
                 # The split path reports one aggregated leg. Without product,
                 # subscribers keying on (symbol, exchange, product) cannot match
                 # it, unlike the non-split path below.
-                "product": leg_data.get("product", "MIS"),
+                "product": leg_data.get("product", "NRML"),
                 "offset": leg_data.get("offset"),
                 "strike": leg_data.get("strike"),
                 "option_type": leg_data.get("option_type", "").upper(),
@@ -487,7 +487,7 @@ def resolve_and_place_leg(
             "action": leg_data.get("action"),
             "quantity": leg_data.get("quantity"),
             "pricetype": leg_data.get("pricetype", "MARKET"),
-            "product": leg_data.get("product", "MIS"),
+            "product": leg_data.get("product", "NRML"),
             "price": leg_data.get("price", 0.0),
             "trigger_price": leg_data.get("trigger_price", 0.0),
             "disclosed_quantity": leg_data.get("disclosed_quantity", 0),

--- a/test/test_flow_default_product.py
+++ b/test/test_flow_default_product.py
@@ -1,0 +1,327 @@
+"""Which product a Flow node sends when its author never picked one.
+
+MIS squares a position off at the end of the session; NRML carries it. For a
+cash segment MIS is the sane default -- a Flow order on NSE is almost always
+intraday. For a derivative it is not: an NFO or MCX position taken NRML is the
+ordinary case, and MIS on the same contract is an auto-square-off the author
+never asked for. Every order node shipped MIS regardless of segment, so a
+workflow built on NFO had to be corrected by hand node by node, and any node
+missed silently traded intraday.
+
+The fix is a *default*, not an override. A product the author actually chose is
+stored on the node and always wins, which is what keeps a deliberately intraday
+NFO order intraday and, more importantly, keeps every already-saved workflow
+sending exactly what it sent before -- those nodes all carry an explicit
+product from the editor that wrote them.
+
+Two rules, one copy of each:
+
+* the exchange decides, for anything that names a symbol; and
+* an option is a derivative whatever its underlying's exchange field reads,
+  because that field names where the *underlying* is quoted (NSE_INDEX), not
+  where the option trades.
+"""
+
+import os
+import re
+import sys
+
+import pytest
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+import services.flow_executor_service as fes  # noqa: E402
+from services.flow_node_contracts import (  # noqa: E402
+    DERIVATIVE_EXCHANGES,
+    default_product_for_exchange,
+)
+
+REPO_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+CASH_AND_INDEX = ("NSE", "BSE", "NSE_INDEX", "BSE_INDEX", "MCX_INDEX", "GLOBAL_INDEX", "CRYPTO")
+
+
+def read(*parts):
+    with open(os.path.join(REPO_ROOT, *parts), encoding="utf-8") as handle:
+        return handle.read()
+
+
+class _RecordingClient:
+    """Captures what would have reached the broker."""
+
+    def __init__(self):
+        self.orders = []
+        self.smart_orders = []
+        self.split_orders = []
+        self.baskets = []
+        self.closed = []
+        self.positions = []
+        self.margins = []
+
+    def place_order(self, **kwargs):
+        self.orders.append(kwargs)
+        return {"status": "success", "orderid": "X1"}
+
+    def place_smart_order(self, **kwargs):
+        self.smart_orders.append(kwargs)
+        return {"status": "success", "orderid": "S1"}
+
+    def split_order(self, **kwargs):
+        self.split_orders.append(kwargs)
+        return {"status": "success", "orderid": "SP1"}
+
+    def basket_order(self, **kwargs):
+        self.baskets.append(kwargs)
+        return {"status": "success", "orderids": ["B1"]}
+
+    def close_position(self, **kwargs):
+        self.closed.append(kwargs)
+        return {"status": "success"}
+
+    def get_open_position(self, **kwargs):
+        self.positions.append(kwargs)
+        return {"status": "success", "quantity": 0}
+
+    def margin(self, **kwargs):
+        self.margins.append(kwargs)
+        return {"status": "success", "data": {}}
+
+
+@pytest.fixture
+def executor():
+    client = _RecordingClient()
+    return fes.NodeExecutor(client, fes.WorkflowContext(), [])
+
+
+class TestTheRuleItself:
+    @pytest.mark.parametrize("exchange", sorted(DERIVATIVE_EXCHANGES))
+    def test_a_derivative_segment_carries(self, exchange):
+        assert default_product_for_exchange(exchange) == "NRML"
+
+    @pytest.mark.parametrize("exchange", CASH_AND_INDEX)
+    def test_cash_and_index_stay_intraday(self, exchange):
+        assert default_product_for_exchange(exchange) == "MIS"
+
+    def test_every_segment_that_trades_options_is_covered(self):
+        """The MCX/CDS underlyings the options nodes accept trade on segments
+        that must be in the set, or an options basket routed there would default
+        to intraday."""
+        for _underlying, (_quote, option_exchange) in fes.OPTION_UNDERLYING_EXCHANGES.items():
+            assert option_exchange in DERIVATIVE_EXCHANGES
+
+    @pytest.mark.parametrize("value", ["nfo", " NFO ", "NfO"])
+    def test_the_exchange_is_read_case_and_space_insensitively(self, value):
+        assert default_product_for_exchange(value) == "NRML"
+
+    @pytest.mark.parametrize("value", ["", None, "   ", "NOTANEXCHANGE"])
+    def test_an_unusable_exchange_falls_back_to_intraday(self, value):
+        """Never guess NRML from a value that names no segment: carrying a
+        position the author expected squared off is the costlier mistake."""
+        assert default_product_for_exchange(value) == "MIS"
+
+    def test_index_pseudo_exchanges_are_absent(self):
+        """No order is ever placed on one, so listing them would only make the
+        options nodes look as if they followed their `exchange` field."""
+        assert not DERIVATIVE_EXCHANGES & {
+            "NSE_INDEX",
+            "BSE_INDEX",
+            "MCX_INDEX",
+            "GLOBAL_INDEX",
+        }
+
+
+class TestOneCopyOfTheRule:
+    """A second copy would drift, and the editor's Product box would then
+    promise a product the run does not send."""
+
+    def test_the_editor_imports_the_rule_rather_than_restating_it(self):
+        panel = read("frontend", "src", "components", "flow", "panels", "ConfigPanel.tsx")
+        assert "defaultProductForExchange" in panel
+        assert not re.search(r"nodeData\.product as string\) \|\| 'MIS'", panel)
+
+    def test_the_editor_and_the_executor_agree_on_the_segment_list(self):
+        """The two homes of the set are in different languages, which is exactly
+        where a drift would hide: the panel would show NRML on a segment the run
+        sends MIS for, or the reverse."""
+        constants = read("frontend", "src", "lib", "flow", "constants.ts")
+        block = constants.split("export const DERIVATIVE_EXCHANGES = new Set<string>([", 1)[1]
+        block = block.split("])", 1)[0]
+        listed = set(re.findall(r"'([A-Z_]+)'", block))
+
+        assert listed == set(DERIVATIVE_EXCHANGES)
+
+    def test_the_editor_derives_the_product_rather_than_hardcoding_one(self):
+        """Every Product control read `nodeData.product || 'MIS'`, which is the
+        shape that made the segment invisible in the first place."""
+        for parts in (
+            ("frontend", "src", "components", "flow", "panels", "ConfigPanel.tsx"),
+            ("frontend", "src", "components", "flow", "nodes", "PlaceOrderNode.tsx"),
+            ("frontend", "src", "components", "flow", "nodes", "SmartOrderNode.tsx"),
+            ("frontend", "src", "components", "flow", "nodes", "OpenPositionNode.tsx"),
+        ):
+            body = read(*parts)
+            assert "product || 'MIS'" not in body, parts[-1]
+            assert "defaultProductForExchange" in body, parts[-1]
+
+
+class TestAnOrderNodeFollowsItsExchange:
+    @pytest.mark.parametrize(
+        ("exchange", "expected"),
+        [("NSE", "MIS"), ("BSE", "MIS"), ("NFO", "NRML"), ("MCX", "NRML"), ("CDS", "NRML")],
+    )
+    def test_place_order(self, executor, exchange, expected):
+        executor.execute_place_order({"symbol": "X", "exchange": exchange, "quantity": 1})
+
+        assert executor.client.orders[0]["product_type"] == expected
+
+    def test_smart_order(self, executor):
+        executor.execute_smart_order(
+            {"symbol": "NIFTY28AUG2624000CE", "exchange": "NFO", "quantity": 1, "positionSize": 1}
+        )
+
+        assert executor.client.smart_orders[0]["product_type"] == "NRML"
+
+    def test_split_order(self, executor):
+        executor.execute_split_order(
+            {"symbol": "CRUDEOIL", "exchange": "MCX", "quantity": 2, "splitSize": 1}
+        )
+
+        assert executor.client.split_orders[0]["product_type"] == "NRML"
+
+    @pytest.mark.parametrize("method", ["execute_place_order", "execute_smart_order"])
+    def test_a_chosen_product_is_never_overridden(self, executor, method):
+        """Intraday on a derivative is a legitimate thing to ask for, and the
+        editor stores it the moment it is picked."""
+        getattr(executor, method)(
+            {"symbol": "X", "exchange": "NFO", "quantity": 1, "positionSize": 1, "product": "MIS"}
+        )
+
+        sent = executor.client.orders or executor.client.smart_orders
+        assert sent[0]["product_type"] == "MIS"
+
+    def test_an_already_saved_workflow_sends_what_it_always_sent(self, executor):
+        """Every node the old editor wrote carries an explicit product, so this
+        change cannot move a live workflow onto a different one."""
+        executor.execute_place_order(
+            {"symbol": "NIFTY28AUG2624000CE", "exchange": "NFO", "quantity": 1, "product": "MIS"}
+        )
+
+        assert executor.client.orders[0]["product_type"] == "MIS"
+
+    def test_a_templated_exchange_is_resolved_before_the_product_is_decided(self, executor):
+        """The default is read off the exchange the run actually uses, not off
+        the `{{...}}` text sitting in the node."""
+        executor.context.set_variable("webhook", {"exchange": "NFO"})
+
+        executor.execute_place_order(
+            {"symbol": "X", "exchange": "{{webhook.exchange}}", "quantity": 1}
+        )
+
+        assert executor.client.orders[0]["product_type"] == "NRML"
+
+
+class TestPositionNodesFollowTheirExchange:
+    def test_close_positions(self, executor):
+        executor.execute_close_positions({"symbol": "GOLDM", "exchange": "MCX"})
+
+        assert executor.client.closed[0]["product_type"] == "NRML"
+
+    def test_close_positions_on_cash(self, executor):
+        executor.execute_close_positions({"symbol": "SBIN", "exchange": "NSE"})
+
+        assert executor.client.closed[0]["product_type"] == "MIS"
+
+    def test_open_position(self, executor):
+        executor.execute_open_position({"symbol": "GOLDM", "exchange": "MCX"})
+
+        assert executor.client.positions[0]["product_type"] == "NRML"
+
+    def test_position_check_reads_the_position_it_is_guarding(self, executor):
+        """A guard that looked up MIS while the order below it took NRML would
+        never see the position it was meant to gate on."""
+        executor.execute_position_check(
+            {"symbol": "NIFTY28AUG2624000CE", "exchange": "NFO", "condition": "exists"}
+        )
+
+        assert executor.client.positions[0]["product_type"] == "NRML"
+
+    def test_margin(self, executor):
+        executor.execute_margin({"symbol": "NIFTY28AUG26FUT", "exchange": "NFO", "quantity": 1})
+
+        assert executor.client.margins[0]["product_type"] == "NRML"
+
+
+class TestABasketDecidesPerRow:
+    """One basket can hold rows from several segments, so a single blanket
+    product would be wrong for at least one of them."""
+
+    def test_each_row_follows_its_own_exchange(self, executor):
+        executor.execute_basket_order({"orders": "SBIN,NSE,BUY,1\nGOLDM,MCX,BUY,1"})
+
+        sent = executor.client.baskets[0]["orders"]
+        assert [row["product"] for row in sent] == ["MIS", "NRML"]
+
+    def test_a_product_on_the_node_still_covers_every_row(self, executor):
+        executor.execute_basket_order(
+            {"orders": "SBIN,NSE,BUY,1\nGOLDM,MCX,BUY,1", "product": "NRML"}
+        )
+
+        sent = executor.client.baskets[0]["orders"]
+        assert [row["product"] for row in sent] == ["NRML", "NRML"]
+
+    def test_a_row_that_names_its_own_product_wins(self, executor):
+        executor.execute_basket_order(
+            {
+                "orders": [
+                    {"symbol": "X", "exchange": "NFO", "action": "BUY", "quantity": 1},
+                    {
+                        "symbol": "Y",
+                        "exchange": "NFO",
+                        "action": "BUY",
+                        "quantity": 1,
+                        "product": "MIS",
+                    },
+                ]
+            }
+        )
+
+        sent = executor.client.baskets[0]["orders"]
+        assert [row["product"] for row in sent] == ["NRML", "MIS"]
+
+    def test_a_blank_product_on_the_node_is_still_refused(self, executor):
+        """Absent means "let each row decide"; present-but-empty is a template
+        that resolved to nothing, and guessing there would place the order the
+        author's data failed to describe."""
+        result = executor.execute_basket_order({"orders": "SBIN,NSE,BUY,1", "product": ""})
+
+        assert result["status"] == "error"
+        assert executor.client.baskets == []
+
+
+class TestOptionsAreAlwaysADerivative:
+    def test_the_editor_defaults_both_options_nodes_to_nrml(self):
+        constants = read("frontend", "src", "lib", "flow", "constants.ts")
+        for node in ("optionsOrder", "optionsMultiOrder"):
+            block = constants.split(f"\n  {node}: {{\n", 1)[1].split("\n  },\n", 1)[0]
+            assert "product: 'NRML'" in block, node
+
+    def test_the_underlying_exchange_field_does_not_decide_the_product(self):
+        """`exchange` on an options node names where the *underlying* is quoted
+        -- NSE_INDEX -- so following it would default every index option to
+        intraday."""
+        assert default_product_for_exchange("NSE_INDEX") == "MIS"
+        source = read("services", "flow_executor_service.py")
+        options_order = source.split("def execute_options_order", 1)[1].split("\n    def ", 1)[0]
+        assert 'default="NRML"' in options_order
+
+    def test_a_multi_leg_basket_carries(self):
+        source = read("services", "flow_executor_service.py")
+        multi = source.split("def execute_options_multi_order", 1)[1].split("\n    def ", 1)[0]
+        assert 'values.enum("product", VALID_PRODUCT_TYPES, default="NRML")' in multi
+
+    def test_a_leg_the_service_receives_without_a_product_carries(self):
+        """The legs reaching options_multiorder_service are option contracts on
+        NFO/BFO/MCX; nothing cash-settled ever arrives there."""
+        source = read("services", "options_multiorder_service.py")
+        assert 'leg_data.get("product", "MIS")' not in source
+        assert source.count('leg_data.get("product", "NRML")') == 3


### PR DESCRIPTION
Every Flow node shipped a stored MIS regardless of segment, so an F&O workflow had to be corrected node by node and any node missed traded intraday without saying so - the broker squared it off at the close.

Nodes now store no product until the author picks one, and both the editor and the executor resolve `product || defaultProductForExchange( exchange)`: NRML on NFO, BFO, CDS, BCD, MCX, NCDEX and NCO, MIS everywhere else. Options nodes always carry, since their `exchange` field names where the underlying is quoted rather than where the option trades. A basket with no blanket product decides per row, offered in the panel as "By row exchange".

This is a default and never an override: a product the author actually chose is stored and wins, so a deliberately intraday NFO order is left alone. Already-saved workflows send exactly what they sent before, since the old editor wrote an explicit product onto every node it created.

The rule has one copy per language, with a test that parses both and asserts they agree.