### PR TITLE
docs: sync remaining broker plugin counts to 36

### DIFF
--- a/.claude/skills/broker-integration/SKILL.md
+++ b/.claude/skills/broker-integration/SKILL.md
@@ -10,7 +10,7 @@ description: Integrate a new Indian broker into OpenAlgo, or modify an existing 
 > specific shapes into those common contracts (and back). Copy the closest
 > reference broker, then adapt the broker-specific bits.
 
-35 brokers already exist. Almost every problem you will hit has been solved in
+36 broker plugins already exist. Almost every problem you will hit has been solved in
 one of them — the skill is knowing **which one to copy**, and which details are
 genuinely broker-specific.
 
@@ -142,7 +142,7 @@ Services do `importlib.import_module(f"broker.{broker}.api.<module>")` and call
 `auth` is always the decrypted broker token string (last positional arg).
 
 There is one more optional surface: an **order-update stream** (real-time fills,
-rejections, cancellations pushed to the client). 11 of 35 brokers implement it.
+rejections, cancellations pushed to the client). 16 of 36 brokers implement it.
 It is registered separately in `services/order_update_service.py`, not in the
 table above — see `references/order-updates.md`.
 
@@ -217,22 +217,22 @@ broker/<name>/
 
 `plugin.json` fields that actually do something: `supported_exchanges` (drives
 capability checks and what you must live-test), `broker_type` (`IN_stock` for
-all 34 Indian brokers, `crypto` for deltaexchange), `leverage_config` (false for
+all 35 Indian brokers, `crypto` for deltaexchange), `leverage_config` (false for
 every Indian broker in the tree).
 
 ## Shared `utils/` a broker plugin depends on
 
 Never hand-roll these — the shared helper is the contract, and bypassing it is
 how FD leaks, unredacted secrets and rate-limit breaches get introduced. Usage
-counts across the 35 existing plugins:
+counts across the 36 existing plugins:
 
 | Module | Uses | What you must take from it |
 | --- | --- | --- |
-| `utils.logging` | ~339 | `logger = get_logger(__name__)` in every module. Its `SensitiveDataFilter` is what stops broker tokens reaching the logs — a bare `print()` or `logging.getLogger()` bypasses that redaction. Errors use `logger.exception()`. |
+| `utils.logging` | ~361 | `logger = get_logger(__name__)` in every module. Its `SensitiveDataFilter` is what stops broker tokens reaching the logs — a bare `print()` or `logging.getLogger()` bypasses that redaction. Errors use `logger.exception()`. |
 | `utils.httpx_client` | ~197 | `get_httpx_client()` — the shared pooled HTTP/2 client. Never construct a per-call client. Always pass an explicit `timeout=`. |
-| `utils.mpp_slab` | ~16 | Market Price Protection slabs for emulating MARKET/SL-M. See `references/order-type-emulation.md`. |
+| `utils.mpp_slab` | ~18 | Market Price Protection slabs for emulating MARKET/SL-M. See `references/order-type-emulation.md`. |
 | `utils.config` | ~5 | `get_broker_api_key()`, `get_broker_api_secret()`, `get_host_server()`, rate-limit getters. Prefer these over raw `os.getenv` so composite `:::` keys and defaults resolve consistently. |
-| `utils.constants` | 1 | `EXCHANGE_NSE`, `EXCHANGE_NFO`, ... — canonical exchange codes. Use them instead of string literals. |
+| `utils.constants` | 2 | `EXCHANGE_NSE`, `EXCHANGE_NFO`, ... — canonical exchange codes. Use them instead of string literals. |
 | `utils.plugin_loader` | — | Discovers `broker/*/plugin.json` at startup and requires the exact name `authenticate_broker`. You do not call it; it calls you. |
 
 `utils.event_bus` exists but is a **services-layer** concern — broker modules do

--- a/.claude/skills/broker-integration/references/cross-broker-reference.md
+++ b/.claude/skills/broker-integration/references/cross-broker-reference.md
@@ -1,4 +1,4 @@
-# Cross-broker reference — how the 35 existing plugins actually behave
+# Cross-broker reference — how the 36 existing plugins actually behave
 
 Measured from the tree, not from any broker's documentation. Use these as
 calibration when deciding what is normal, what is a broker quirk, and what a
@@ -78,7 +78,7 @@ broker module.
 ## Depth capability is loosely declared
 
 `get_supported_depth_levels()` exists in the adapter design but is implemented
-by only a couple of plugins — grepping all 35 finds `[1]` and `[5]` and little
+by only a couple of plugins — grepping all 36 finds `[1]` and `[5]` and little
 else. The mechanism that actually runs is:
 
 ```python

--- a/.claude/skills/broker-integration/references/order-updates.md
+++ b/.claude/skills/broker-integration/references/order-updates.md
@@ -9,7 +9,7 @@ much smaller. Do not confuse the two:
 | Subscription | per symbol + mode (1/2/3) | one `subscribe_orders` for the whole account |
 | Registered in | `websocket_proxy/__init__.py` (`register_adapter`) | `services/order_update_service.py` (`_BROKER_FACTORIES`) |
 | You implement | connect, subscribe, unsubscribe, disconnect, parsing | **3 methods** |
-| Optional? | effectively required | yes — 12 of 35 brokers have one |
+| Optional? | effectively required | yes — 16 of 36 brokers have one |
 
 Client-facing protocol (see `docs/prompt/websockets-format.md`): the client
 sends `{"action": "subscribe_orders"}` after authenticating and receives

--- a/DISCOVERY_MAP.md
+++ b/DISCOVERY_MAP.md
@@ -7,7 +7,7 @@ Phase 1 discovery map. This file documents behavior found in the current source 
 - Backend runtime: Flask app with Flask-RESTX, Flask-SocketIO, SQLAlchemy, APScheduler, DuckDB, ZeroMQ, and a separate asyncio WebSocket proxy. Entry point is `app.py:134`.
 - Frontend runtime: React 19, Vite 8, TypeScript 5.9, served from `frontend/dist` by `blueprints/react_app.py` when available. React routes are registered before the REST/UI blueprints at `app.py:236`.
 - API surface documented here: 57 RESTX `/api/v1` endpoints, 459 Flask blueprint routes, and 1 app-level route. Total documented HTTP endpoints: 517.
-- Broker plugins: 34 broker plugin directories with `plugin.json`, matching `VALID_BROKERS` in `.sample.env:22`.
+- Broker plugins: 36 broker plugin directories with `plugin.json`, matching `VALID_BROKERS` in `.sample.env:22`.
 - Primary data stores: main `openalgo.db`, traffic `logs.db`, latency `latency.db`, health `health.db`, sandbox `sandbox.db`, and Historify `historify.duckdb`, configured in `.sample.env:54` through `.sample.env:61`.
 - Security baseline: `APP_KEY` and `API_KEY_PEPPER` are required and placeholder-rotated, API keys are Argon2-hashed plus encrypted for retrieval, broker tokens are Fernet-encrypted, CSRF is enabled for session routes, and `/api/v1` is CSRF-exempt for external callers. Sources: `.sample.env:24`, `database/auth_db.py:36`, `database/auth_db.py:761`, `app.py:171`, `app.py:248`.
 
@@ -144,8 +144,8 @@ The RESTX API blueprint has prefix `/api/v1` at `restx_api/__init__.py:4` throug
 
 - Broker capabilities are loaded from every `broker/*/plugin.json` with `supported_exchanges`, `broker_name`, `broker_type`, and `leverage_config`. Source: `utils/plugin_loader.py:17` through `utils/plugin_loader.py:54`.
 - Broker auth modules are lazy-loaded from `broker.{broker}.api.auth_api`. Source: `utils/plugin_loader.py:65` through `utils/plugin_loader.py:128`.
-- Current broker count is 34. Current `VALID_BROKERS` is `.sample.env:22`.
-- `docs/broker-integration-guide.md:1011` gives a deliberately vague "(24+)" broker count rather than an exact figure, so it no longer numerically conflicts with the plugin count.
+- Current broker count is 36. Current `VALID_BROKERS` is `.sample.env:22`.
+- `docs/broker-integration-guide.md:1011` now states an exact count that matches the plugin inventory, and the guide carries a maintainer note with the commands to re-verify it.
 - Live GTT broker modules exist only for Dhan and Zerodha: `broker/dhan/api/gtt_api.py`, `broker/zerodha/api/gtt_api.py`.
 
 ### Broker Matrix
@@ -742,7 +742,7 @@ blueprints/whatsapp.py:388 GET /whatsapp/stats stats
 
 ## Unverified
 
-- Broker-specific response payload shape is not exhaustively verified for all 34 brokers. The services dynamically import broker modules and normalize only the wrapper-level response.
+- Broker-specific response payload shape is not exhaustively verified for all 36 brokers. The services dynamically import broker modules and normalize only the wrapper-level response.
 - The static route inventory lists all blueprint decorators in source. Runtime registration may omit Remote MCP unless enabled and may omit React routes when `frontend/dist` is absent.
 - `HISTORIFY_DATABASE_URL` in `.sample.env` and `HISTORIFY_DATABASE_PATH` in `database/historify_db.py` need review before documenting a single env var as authoritative.
 - Sandbox GTT tables exist, but all GTT services return 501 in analyzer mode. The current behavior is "not implemented" for analyzer GTT, not the sandbox table state machine.

--- a/DOCKER_README.md
+++ b/DOCKER_README.md
@@ -1,6 +1,6 @@
 # OpenAlgo - Algorithmic Trading Platform
 
-OpenAlgo is a production-ready algorithmic trading platform providing a unified API layer across 34 Indian brokers. Seamlessly integrate with TradingView, Amibroker, Excel, Python, and AI agents.
+OpenAlgo is a production-ready algorithmic trading platform providing a unified API layer across 36 broker plugins: 35 securities integrations and Delta Exchange for crypto derivatives. Seamlessly integrate with TradingView, Amibroker, Excel, Python, and AI agents.
 
 ## Quick Start
 

--- a/docs/broker-integration-guide.md
+++ b/docs/broker-integration-guide.md
@@ -1464,8 +1464,14 @@ This inventory is derived from `broker/*/plugin.json`. Authentication requiremen
 > # Count all broker plugin definitions
 > find broker -name "plugin.json" | wc -l
 >
-> # Check for hard-coded counts across documentation
-> rg -n "\b(3[0-9])\s+(plugins?|brokers?)\b" README.md CONTRIBUTING.md docs/INDEX.md docs/broker-integration-guide.md
+> # Confirm .sample.env stays in step with the directories on disk
+> grep VALID_BROKERS .sample.env | tr ',' '\n' | wc -l
+>
+> # Check for hard-coded counts across docs, skills, and shipped UI copy
+> rg -n "\b3[0-9]\+?\s*(plugins?|brokers?|Indian brokers?)\b|Inventory \(3[0-9]\)" \
+>    README.md CONTRIBUTING.md DOCKER_README.md DISCOVERY_MAP.md \
+>    docs/ .claude/skills/ frontend/src/ \
+>    --glob '!docs/audit/**' --glob '!docs/releases/**' --glob '!docs/superpowers/**'
 > ```
 
 | # | Directory | Type |

--- a/docs/design/00-directory-structure/README.md
+++ b/docs/design/00-directory-structure/README.md
@@ -8,7 +8,7 @@ openalgo/
 |-- restx_api/                 External `/api/v1` resources and schemas
 |-- blueprints/                Session UI APIs, webhooks, React route serving
 |-- services/                  Business logic and mode routing
-|-- broker/                    34 metadata-driven broker plugins
+|-- broker/                    36 metadata-driven broker plugins
 |-- websocket_proxy/           Standalone asyncio WebSocket server and adapters
 |-- database/                  SQLAlchemy/DuckDB models and persistence helpers
 |-- sandbox/                   Analyzer execution, positions, funds, settlement

--- a/docs/design/03-login-broker-flow/README.md
+++ b/docs/design/03-login-broker-flow/README.md
@@ -20,7 +20,7 @@ When login TOTP is required, the password step stores a short-lived `pending_tot
 
 `utils/plugin_loader.py` reads `broker/*/plugin.json` and lazy-loads `broker.<key>.api.auth_api`. Generic callbacks are handled by `blueprints/brlogin.py`; specialized routes support brokers that need extra OTP, TOTP, or credential steps.
 
-The current plugin inventory is 34. Authentication shape varies by broker, and capability metadata is the correct way for UI code to discover supported exchanges and features.
+The current plugin inventory is 36. Authentication shape varies by broker, and capability metadata is the correct way for UI code to discover supported exchanges and features.
 
 ## Token Storage
 

--- a/docs/design/52-broker-factory/README.md
+++ b/docs/design/52-broker-factory/README.md
@@ -44,9 +44,9 @@ Connection pools recognize common authentication failures such as 401, 403, expi
 
 ## Current Plugin Inventory
 
-There are 34 `broker/*/plugin.json` directories:
+There are 36 `broker/*/plugin.json` directories:
 
-`aliceblue`, `angel`, `arrow`, `compositedge`, `definedge`, `deltaexchange`, `dhan`, `dhan_sandbox`, `firstock`, `fivepaisa`, `fivepaisaxts`, `flattrade`, `fyers`, `groww`, `ibulls`, `iifl`, `iiflcapital`, `indmoney`, `jainamxts`, `kotak`, `motilal`, `mstock`, `nubra`, `paytm`, `pocketful`, `rmoney`, `samco`, `shoonya`, `tradejini`, `tradesmart`, `upstox`, `wisdom`, `zebu`, and `zerodha`.
+`aliceblue`, `angel`, `arrow`, `compositedge`, `definedge`, `deltaexchange`, `dhan`, `dhan_sandbox`, `firstock`, `fivepaisa`, `fivepaisaxts`, `flattrade`, `fyers`, `groww`, `hdfcsecurities`, `hdfcsky`, `ibulls`, `iifl`, `iiflcapital`, `indmoney`, `jainamxts`, `kotak`, `motilal`, `mstock`, `nubra`, `paytm`, `pocketful`, `rmoney`, `samco`, `shoonya`, `tradejini`, `tradesmart`, `upstox`, `wisdom`, `zebu`, and `zerodha`.
 
 Individual broker symbol limits and depth capabilities are adapter/upstream concerns and must not be inferred from the generic 1000-by-3 pool defaults.
 

--- a/docs/devsprint/README.md
+++ b/docs/devsprint/README.md
@@ -18,7 +18,7 @@ day cost you the morning.
 ## 1. What OpenAlgo is (3 minute read)
 
 OpenAlgo is a self-hosted algorithmic trading platform for Indian markets. It puts
-one common API in front of 35 different broker APIs, so a strategy written once
+one common API in front of 36 different broker APIs, so a strategy written once
 runs against any supported broker without change.
 
 - Backend: Python 3.12+, Flask, SQLAlchemy, Flask-SocketIO

--- a/docs/installation-guidelines/getting-started/ubuntu-server-installation.md
+++ b/docs/installation-guidelines/getting-started/ubuntu-server-installation.md
@@ -85,7 +85,7 @@ sudo ./install.sh
 The script will interactively prompt you for:
 
 * Your domain name (root domains and subdomains both supported)
-* Broker selection from the 34 installed plugins
+* Broker selection from the 36 installed plugins
 * Broker API credentials (Key + Secret)
 * For XTS-based brokers (5paisa XTS, Compositedge, IIFL, etc.): additional market-data API key/secret
 * **Enable Remote MCP?** (y/N) — opt-in to expose `/mcp` and `/oauth/*` for hosted AI clients (Claude.ai, ChatGPT) at the same domain. You can also enable this later from the admin UI

--- a/docs/prd/PRD.md
+++ b/docs/prd/PRD.md
@@ -150,7 +150,7 @@ The product purpose is to let a local trader connect a broker session, issue nor
 
 ## Broker Support
 
-Current broker count is 34. Broker support is plugin-based and loaded from `broker/*/plugin.json`. Live GTT modules were found only for Dhan and Zerodha. Trace: `DISCOVERY_MAP.md` `Broker Plugins`; BDD: `docs/bdd/broker_sessions.feature`, `docs/bdd/gtt_orders.feature`.
+Current broker count is 36. Broker support is plugin-based and loaded from `broker/*/plugin.json`. Live GTT modules were found only for Dhan and Zerodha. Trace: `DISCOVERY_MAP.md` `Broker Plugins`; BDD: `docs/bdd/broker_sessions.feature`, `docs/bdd/gtt_orders.feature`.
 
 | Broker key | Plugin name | Type | Leverage config | Exchanges |
 |---|---|---|---|---|

--- a/docs/prd/README.md
+++ b/docs/prd/README.md
@@ -14,7 +14,7 @@ Use `PRD.md` as the source for current behavior. It is grounded in `DISCOVERY_MA
 - RESTX `/api/v1` endpoints: 57
 - Flask blueprint routes: 459
 - App-level routes: 1
-- Broker plugins: 34
+- Broker plugins: 36
 - RESTX Swagger UI: deliberately disabled (`doc=False`)
 - BDD feature files: 17
 - BDD scenario definitions: 86

--- a/frontend/src/pages/Faq.tsx
+++ b/frontend/src/pages/Faq.tsx
@@ -36,12 +36,12 @@ const faqData = [
       {
         question: 'What is OpenAlgo?',
         answer:
-          'OpenAlgo is an open-source algorithmic trading platform that provides a unified API layer across 35 brokers. It enables seamless integration with TradingView, Amibroker, Excel, Python, and AI agents, allowing traders to automate their trading strategies without being locked into a single broker.',
+          'OpenAlgo is an open-source algorithmic trading platform that provides a unified API layer across 36 broker plugins: 35 securities integrations and Delta Exchange for crypto derivatives. It enables seamless integration with TradingView, Amibroker, Excel, Python, and AI agents, allowing traders to automate their trading strategies without being locked into a single broker.',
       },
       {
         question: 'Which brokers are supported?',
         answer:
-          'OpenAlgo supports 35 brokers: 5 Paisa, 5 Paisa (XTS), Alice Blue, Angel One, Arrow, CompositEdge, Definedge, Delta Exchange, Dhan, Dhan (Sandbox), Firstock, Flattrade, Fyers, Groww, HDFC Sky, Ibulls, IIFL, IIFL Capital, IndMoney, JainamXts, Kotak Securities, Motilal Oswal, mStock by Mirae Asset, Nubra, Paytm Money, Pocketful, RMoney, Samco, Shoonya (Finvasia), TradeSmart, Tradejini, Upstox, Wisdom Capital, Zebu and Zerodha. Delta Exchange is a crypto exchange; the rest are Indian brokers. New brokers are being added regularly.',
+          'OpenAlgo supports 36 broker plugins: 5 Paisa, 5 Paisa (XTS), Alice Blue, Angel One, Arrow, CompositEdge, Definedge, Delta Exchange, Dhan, Dhan (Sandbox), Firstock, Flattrade, Fyers, Groww, HDFC Securities, HDFC Sky, Ibulls, IIFL, IIFL Capital, IndMoney, JainamXts, Kotak Securities, Motilal Oswal, mStock by Mirae Asset, Nubra, Paytm Money, Pocketful, RMoney, Samco, Shoonya (Finvasia), TradeSmart, Tradejini, Upstox, Wisdom Capital, Zebu and Zerodha. Delta Exchange is a crypto exchange; the rest are Indian brokers. New brokers are being added regularly.',
       },
       {
         question: 'What are the system requirements?',


### PR DESCRIPTION
Follow-up to #1906. That PR corrected 17 files but left several live inventory claims at the old 34/35 figures, including shipped UI copy.

## What was still wrong

| Location | Was | Now |
| --- | --- | --- |
| `frontend/src/pages/Faq.tsx` | "35 brokers", list of 35 names omitting HDFC Securities | 36, list completed |
| `docs/devsprint/README.md:21` | 35, while line 396 in the same file said 36 | 36 |
| `docs/design/52-broker-factory` | 34, inline list missing `hdfcsecurities` and `hdfcsky` | 36, list completed |
| `DISCOVERY_MAP.md` (3 lines) | 34 | 36 |
| `DOCKER_README.md` | "34 Indian brokers" | 36 plugins, 35 securities plus Delta Exchange |
| `docs/prd/PRD.md`, `docs/prd/README.md` | 34 | 36 |
| `docs/design/00-directory-structure`, `docs/design/03-login-broker-flow` | 34 | 36 |
| `ubuntu-server-installation.md` | 34 | 36 |

`DISCOVERY_MAP.md` also claimed the integration guide gives a deliberately vague "(24+)" count. That stopped being true in #1906, so the line now describes the exact figure and the verification note.

## Capability ratios in the broker-integration skill

Two claims were stale on both numerator and denominator, and contradicted each other ("11 of 35" vs "12 of 35"). The authoritative registry `services/order_update_service.py:_BROKER_FACTORIES` holds 16 entries, which matches `audit/BROKER_API_COMPATIBILITY.md`. Both now read "16 of 36".

Also corrected in the same skill: `broker_type` is 35 `IN_stock` plus 1 `crypto` (was "all 34 Indian brokers"), and the shared `utils/` usage counts were re-measured from the tree.

## Verification

```
find broker -name plugin.json | wc -l                        -> 36
grep VALID_BROKERS .sample.env | tr ',' '\n' | wc -l          -> 36
_BROKER_FACTORIES entries                                    -> 16
plugin.json broker_type                                      -> 35 IN_stock, 1 crypto
```

The maintainer note added in #1906 is widened to cover `DOCKER_README`, `DISCOVERY_MAP`, `docs/`, `.claude/skills/` and `frontend/src/`, and to cross-check `VALID_BROKERS` against the directories on disk. Running it now returns only 36s.

## Deliberately not changed

`audit/`, `docs/audit/`, `docs/releases/` and `docs/superpowers/` are dated snapshots where the count of the day is the correct value. `docs/migration/flask-to-fastapi-migration-plan.md` carries related stale figures (33 broker `master_contract_db.py` modules, now 36; 44 socketio importers, now 48) but they belong to a separate coupling audit and are better corrected in their own pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)