### PR TITLE
fix(gex): abbreviate negative Net GEX values with K/L/Cr suffixes

### DIFF
--- a/frontend/src/pages/GEXDashboard.test.tsx
+++ b/frontend/src/pages/GEXDashboard.test.tsx
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { formatNumber } from './GEXDashboard'
+
+describe('formatNumber', () => {
+  it('abbreviates large positive values with Cr/L/K suffixes', () => {
+    expect(formatNumber(444071)).toBe('4.4L')
+    expect(formatNumber(270000)).toBe('2.7L')
+    expect(formatNumber(15000000)).toBe('1.5Cr')
+    expect(formatNumber(1500)).toBe('1.5K')
+  })
+
+  it('abbreviates large negative values the same way, keeping the sign', () => {
+    expect(formatNumber(-444071)).toBe('-4.4L')
+    expect(formatNumber(-259693)).toBe('-2.6L')
+    expect(formatNumber(-254946)).toBe('-2.5L')
+    expect(formatNumber(-15000000)).toBe('-1.5Cr')
+    expect(formatNumber(-1500)).toBe('-1.5K')
+  })
+
+  it('leaves small values (below 1000 in magnitude) as plain integers', () => {
+    expect(formatNumber(500)).toBe('500')
+    expect(formatNumber(-500)).toBe('-500')
+    expect(formatNumber(0)).toBe('0')
+  })
+})

--- a/frontend/src/pages/GEXDashboard.tsx
+++ b/frontend/src/pages/GEXDashboard.tsx
@@ -39,10 +39,12 @@ function convertExpiryForAPI(expiry: string): string {
   return expiry.replace(/-/g, '').toUpperCase()
 }
 
-function formatNumber(num: number): string {
-  if (num >= 10000000) return `${(num / 10000000).toFixed(1)}Cr`
-  if (num >= 100000) return `${(num / 100000).toFixed(1)}L`
-  if (num >= 1000) return `${(num / 1000).toFixed(1)}K`
+export function formatNumber(num: number): string {
+  const sign = num < 0 ? '-' : ''
+  const abs = Math.abs(num)
+  if (abs >= 10000000) return `${sign}${(abs / 10000000).toFixed(1)}Cr`
+  if (abs >= 100000) return `${sign}${(abs / 100000).toFixed(1)}L`
+  if (abs >= 1000) return `${sign}${(abs / 1000).toFixed(1)}K`
   return num.toFixed(0)
 }
 


### PR DESCRIPTION
## Summary

Fixes #1908. On the GEX Dashboard, negative Net GEX values were shown as raw
unabbreviated numbers while positive values were correctly abbreviated with
K/L/Cr suffixes — e.g. the "Top Net GEX Strikes" card showed `-444071`
alongside `+2.7L`.

## Root cause

`formatNumber` in `GEXDashboard.tsx` compared the raw value against positive
thresholds (`num >= 10000000`, etc.). A negative number is never `>=` a
positive threshold, so every negative value fell through to the last branch
and printed as a raw integer.

## Fix

Compare against `Math.abs(num)` and reapply the sign afterward, so negative
values get the same K/L/Cr abbreviation as positive ones.

## Test plan

- [x] Added `GEXDashboard.test.tsx` covering: positive abbreviation (K/L/Cr),
      negative abbreviation with sign preserved, and small values (<1000)
      left as plain integers
- [x] `npm run test`, `biome check`, `tsc --noEmit` all pass