### PR TITLE
fix: pin security actions to immutable commits

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -376,7 +376,7 @@ jobs:
           docker buildx imagetools inspect ${{ secrets.DOCKERHUB_USERNAME }}/openalgo:${{ steps.meta.outputs.version }}
 
       - name: Trivy vulnerability scan
-        uses: aquasecurity/trivy-action@master
+        uses: aquasecurity/trivy-action@ed142fd0673e97e23eac54620cfb913e5ce36c25 # v0.36.0
         with:
           image-ref: ${{ secrets.DOCKERHUB_USERNAME }}/openalgo:latest
           exit-code: '0'

--- a/.github/workflows/security.yml
+++ b/.github/workflows/security.yml
@@ -11,8 +11,8 @@ jobs:
     permissions:
       security-events: write
     steps:
-      - uses: actions/checkout@v6
-      - uses: astral-sh/setup-uv@v7
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803 # v6.1.0
+      - uses: astral-sh/setup-uv@37802adc94f370d6bfd71619e3f0bf239e1f3b78 # v7.6.0
         with:
           enable-cache: true
           python-version: "3.12"
@@ -49,7 +49,7 @@ jobs:
           fi
 
       - name: Upload Bandit results
-        uses: github/codeql-action/upload-sarif@v4
+        uses: github/codeql-action/upload-sarif@cdf488f595d80d6e07e03d4674febd5ab45fa938 # v4.37.9
         with:
           sarif_file: bandit.sarif
           category: bandit
@@ -59,7 +59,7 @@ jobs:
 
       - name: Upload audit results
         if: always()
-        uses: actions/upload-artifact@v6
+        uses: actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f # v6.0.0
         with:
           name: security-reports
           path: |


### PR DESCRIPTION
## Summary

- pin all actions in the security workflow to immutable commit SHAs
- replace the mutable Trivy master reference with the v0.36.0 commit SHA
- retain exact release comments for Dependabot and reviewer context

Closes #1856

## Verification

- confirmed each SHA against the corresponding official action repository
- validated both workflow YAML files
- ran git diff --check

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Pins CI and security workflow actions to immutable commit SHAs so builds don't change when tags are moved. This replaces mutable references like `master` and `@v6` with specific commits while keeping the version tag as a comment for context.

- Pins `actions/checkout`, `astral-sh/setup-uv`, `github/codeql-action`, and `actions/upload-artifact` to SHA in `security.yml`.
- Updates the Trivy action in `ci.yml` from `aquasecurity/trivy-action@master` to the `v0.36.0` commit SHA.
- Retains the original version tags in comments so Dependabot and reviewers can see the target release.

Closes #1856.

<sup>Written for commit 5346480cfef0c1fc90837db20d594542792a7781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1913?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

