### PR TITLE
fix: redact API keys from core service logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -58,6 +58,7 @@ jobs:
             test/test_telegram_api_contract.py test/test_cors_config.py \
             test/test_market_calendar_validation.py \
             test/test_admin_client_error_url.py \
+            test/test_core_credential_logging.py \
             test/test_multi_option_greeks_regression.py \
             test/test_history_format.py \
             test/test_precompress_assets.py \

--- a/restx_api/multi_option_greeks.py
+++ b/restx_api/multi_option_greeks.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from flask import jsonify, make_response, request
@@ -103,7 +104,7 @@ class MultiOptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for multi option greeks: {api_key[:10]}...")
+                logger.warning(f"Invalid API key used for multi option greeks: sha256:{hashlib.sha256(api_key.encode()).hexdigest()[:12]}")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/restx_api/option_greeks.py
+++ b/restx_api/option_greeks.py
@@ -1,3 +1,4 @@
+import hashlib
 import os
 
 from flask import jsonify, make_response, request
@@ -113,7 +114,7 @@ class OptionGreeks(Resource):
 
             # Verify API key
             if not verify_api_key(api_key):
-                logger.warning(f"Invalid API key used for option greeks: {api_key[:10]}...")
+                logger.warning(f"Invalid API key used for option greeks: sha256:{hashlib.sha256(api_key.encode()).hexdigest()[:12]}")
                 return make_response(
                     jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
                 )

--- a/services/websocket_client.py
+++ b/services/websocket_client.py
@@ -574,9 +574,9 @@ def get_websocket_client(
 def close_all_clients():
     """Close all WebSocket client connections"""
     with _client_lock:
-        for api_key, client in _client_instances.items():
+        for _api_key, client in _client_instances.items():
             try:
                 client.disconnect()
             except Exception as e:
-                logger.exception(f"Error closing client for API key {api_key}: {e}")
+                logger.exception(f"Error closing client: {e}")
         _client_instances.clear()

--- a/test/test_core_credential_logging.py
+++ b/test/test_core_credential_logging.py
@@ -54,12 +54,8 @@ class TestOptionGreeksKeyLogging:
         api = Api(app, prefix="/api/v1")
         api.add_namespace(greeks_api)
 
-        with patch(
-            "restx_api.option_greeks.verify_api_key", return_value=False
-        ):
-            with patch(
-                "restx_api.option_greeks.logger"
-            ) as mock_logger:
+        with patch("restx_api.option_greeks.verify_api_key", return_value=False):
+            with patch("restx_api.option_greeks.logger") as mock_logger:
                 with app.test_client() as client:
                     response = client.post(
                         "/api/v1/optiongreeks",
@@ -91,12 +87,8 @@ class TestMultiOptionGreeksKeyLogging:
         api = Api(app, prefix="/api/v1")
         api.add_namespace(multi_api)
 
-        with patch(
-            "restx_api.multi_option_greeks.verify_api_key", return_value=False
-        ):
-            with patch(
-                "restx_api.multi_option_greeks.logger"
-            ) as mock_logger:
+        with patch("restx_api.multi_option_greeks.verify_api_key", return_value=False):
+            with patch("restx_api.multi_option_greeks.logger") as mock_logger:
                 with app.test_client() as client:
                     response = client.post(
                         "/api/v1/multioptiongreeks",

--- a/test/test_core_credential_logging.py
+++ b/test/test_core_credential_logging.py
@@ -1,0 +1,120 @@
+"""Regression tests: no full or partial API key appears in core service logs."""
+
+import hashlib
+import logging
+import os
+import sys
+from unittest.mock import MagicMock, patch
+
+import pytest
+from flask import Flask
+
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+
+FAKE_KEY = "test-api-key-not-real-12345678"
+
+
+class TestWebsocketClientCloseLogging:
+    """close_all_clients must not log API key material."""
+
+    def test_close_error_does_not_leak_key(self, caplog):
+        from services import websocket_client as wc_mod
+
+        logger = logging.getLogger("services.websocket_client")
+        old_propagate = logger.propagate
+        logger.propagate = True
+        logger.addHandler(caplog.handler)
+        try:
+            bad_client = MagicMock()
+            bad_client.disconnect.side_effect = RuntimeError("connection reset")
+
+            with wc_mod._client_lock:
+                wc_mod._client_instances[FAKE_KEY] = bad_client
+
+            with caplog.at_level(logging.ERROR):
+                wc_mod.close_all_clients()
+
+            assert "Error closing client: connection reset" in caplog.text
+            assert FAKE_KEY not in caplog.text
+            assert "test-api" not in caplog.text
+        finally:
+            logger.removeHandler(caplog.handler)
+            logger.propagate = old_propagate
+
+
+class TestOptionGreeksKeyLogging:
+    """option_greeks must not log key prefixes on invalid key."""
+
+    def test_invalid_key_log_uses_fingerprint(self):
+        from flask_restx import Api
+
+        from restx_api.option_greeks import api as greeks_api
+
+        app = Flask(__name__)
+        api = Api(app, prefix="/api/v1")
+        api.add_namespace(greeks_api)
+
+        with patch(
+            "restx_api.option_greeks.verify_api_key", return_value=False
+        ):
+            with patch(
+                "restx_api.option_greeks.logger"
+            ) as mock_logger:
+                with app.test_client() as client:
+                    response = client.post(
+                        "/api/v1/optiongreeks",
+                        json={
+                            "apikey": FAKE_KEY,
+                            "symbol": "NIFTY28NOV2424000CE",
+                            "exchange": "NFO",
+                        },
+                    )
+
+                assert response.status_code == 401
+                mock_logger.warning.assert_called()
+                log_msg = mock_logger.warning.call_args[0][0]
+                assert FAKE_KEY not in log_msg
+                assert FAKE_KEY[:10] not in log_msg
+                expected_fingerprint = hashlib.sha256(FAKE_KEY.encode()).hexdigest()[:12]
+                assert f"sha256:{expected_fingerprint}" in log_msg
+
+
+class TestMultiOptionGreeksKeyLogging:
+    """multi_option_greeks must not log key prefixes on invalid key."""
+
+    def test_invalid_key_log_uses_fingerprint(self):
+        from flask_restx import Api
+
+        from restx_api.multi_option_greeks import api as multi_api
+
+        app = Flask(__name__)
+        api = Api(app, prefix="/api/v1")
+        api.add_namespace(multi_api)
+
+        with patch(
+            "restx_api.multi_option_greeks.verify_api_key", return_value=False
+        ):
+            with patch(
+                "restx_api.multi_option_greeks.logger"
+            ) as mock_logger:
+                with app.test_client() as client:
+                    response = client.post(
+                        "/api/v1/multioptiongreeks",
+                        json={
+                            "apikey": FAKE_KEY,
+                            "symbols": [
+                                {
+                                    "symbol": "NIFTY28NOV2424000CE",
+                                    "exchange": "NFO",
+                                }
+                            ],
+                        },
+                    )
+
+                assert response.status_code == 401
+                mock_logger.warning.assert_called()
+                log_msg = mock_logger.warning.call_args[0][0]
+                assert FAKE_KEY not in log_msg
+                assert FAKE_KEY[:10] not in log_msg
+                expected_fingerprint = hashlib.sha256(FAKE_KEY.encode()).hexdigest()[:12]
+                assert f"sha256:{expected_fingerprint}" in log_msg


### PR DESCRIPTION
## Summary

- Remove API keys from WebSocket close-failure logs.
- Replace invalid API-key prefixes in both option Greeks endpoints with short SHA-256 fingerprints.
- Add regression tests covering log capture, redaction, exact fingerprints, and preserved 401 responses.
- Run the credential-log regression in the explicit backend CI-safe test list.

Closes #1855

## Validation

- Local focused test: uv run pytest test/test_core_credential_logging.py -v, 3 passed.
- Ruff check and format check passed for test/test_core_credential_logging.py.
- git diff --check passed.
- GitHub Actions is running the updated CI-safe suite on Python 3.12, 3.13, and 3.14.

The full targeted Ruff command reports four pre-existing modernization findings in services/websocket_client.py that are outside the changed lines.