### PR TITLE
fix: remove credentials from broker logs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             test/test_multi_option_greeks_regression.py \
             test/test_history_format.py \
             test/test_precompress_assets.py \
+            test/test_broker_credential_logging.py \
             -v --timeout=60
 
   # Frontend linting

--- a/broker/dhan/api/auth_api.py
+++ b/broker/dhan/api/auth_api.py
@@ -37,11 +37,9 @@ def generate_consent(dhan_client_id):
         # Build URL with client_id parameter - REQUIRED by Dhan API
         url = f"{AUTH_BASE_URL}/app/generate-consent"
 
-        logger.info(f"Generating consent for Dhan Client ID: {dhan_client_id}")
+        logger.info("Generating consent for configured Dhan client")
         logger.info("Using configured broker API key")
-        logger.info(
-            f"Using API Secret: {BROKER_API_SECRET[:8] if BROKER_API_SECRET else 'None'}..."
-        )
+        logger.info("Using configured Dhan API secret")
 
         # Make the POST request with the client_id as a query parameter
         # The client_id parameter is REQUIRED for generate-consent
@@ -55,19 +53,25 @@ def generate_consent(dhan_client_id):
             data = response.json()
             if data.get("status") == "success":
                 consent_app_id = data.get("consentAppId")
-                logger.info(f"Consent generated successfully: {consent_app_id}")
+                logger.info(
+                    "Consent generated successfully; consent_id_present=%s",
+                    bool(consent_app_id),
+                )
                 return consent_app_id, None
             else:
                 error_msg = f"Failed to generate consent: {data}"
-                logger.error(error_msg)
+                logger.error(
+                    "Failed to generate consent; status=%s",
+                    data.get("status", "unknown"),
+                )
                 return None, error_msg
         else:
             error_msg = f"Failed to generate consent: HTTP {response.status_code} - {response.text}"
-            logger.error(error_msg)
+            logger.error("Failed to generate consent; HTTP status=%s", response.status_code)
             return None, error_msg
 
     except Exception as e:
-        logger.error(f"Exception in generate_consent: {str(e)}")
+        logger.error("Exception in generate_consent; type=%s", type(e).__name__)
         return None, f"An exception occurred: {str(e)}"
 
 
@@ -116,7 +120,10 @@ def consume_consent(token_id):
                     "token_expiry": data.get("expiryTime"),
                 }
                 logger.debug("Access token obtained")
-                logger.debug(f"Additional Data: {additional_data}")
+                logger.debug(
+                    "Additional authentication data fields: %s",
+                    list(additional_data.keys()),
+                )
                 return access_token, additional_data
             else:
                 return None, "Access token not found in response"
@@ -124,7 +131,7 @@ def consume_consent(token_id):
             return None, f"Failed to consume consent: {response.status_code}"
 
     except Exception as e:
-        logger.error(f"Exception in consume_consent: {str(e)}")
+        logger.error("Exception in consume_consent; type=%s", type(e).__name__)
         return None, f"An exception occurred: {str(e)}"
 
 
@@ -138,7 +145,7 @@ def get_direct_access_token(access_token):
         logger.info("Using direct access token from Dhan web")
         return access_token, None
     except Exception as e:
-        logger.error(f"Exception in get_direct_access_token: {str(e)}")
+        logger.error("Exception in get_direct_access_token; type=%s", type(e).__name__)
         return None, f"An exception occurred: {str(e)}"
 
 
@@ -157,7 +164,10 @@ def authenticate_broker(code):
             if access_token and isinstance(additional_data, dict):
                 # Extract the dhanClientId to return as user_id
                 dhan_client_id = additional_data.get("dhan_client_id")
-                logger.debug(f"Dhan authentication successful, client_id: {dhan_client_id}")
+                logger.debug(
+                    "Dhan authentication successful; client_id_present=%s",
+                    bool(dhan_client_id),
+                )
                 # Return access_token, user_id (dhanClientId), error_message format
                 # This matches the format expected by brlogin.py for brokers with user_id
                 return access_token, dhan_client_id, None
@@ -168,5 +178,5 @@ def authenticate_broker(code):
             return None, None, "No token ID provided for authentication"
 
     except Exception as e:
-        logger.error(f"Exception in authenticate_broker: {str(e)}")
+        logger.error("Exception in authenticate_broker; type=%s", type(e).__name__)
         return None, None, f"An exception occurred: {str(e)}"

--- a/broker/fivepaisa/api/auth_api.py
+++ b/broker/fivepaisa/api/auth_api.py
@@ -1,6 +1,5 @@
 import json
 import os
-from typing import Optional, Tuple
 
 import httpx
 
@@ -60,9 +59,11 @@ def authenticate_broker(
         totp_response.raise_for_status()
         totp_data = totp_response.json()
 
-        logger.debug(f"The Request Token response is :{totp_data}")
-
         request_token = totp_data.get("body", {}).get("RequestToken")
+        logger.debug(
+            "TOTP login response received; request_token_present=%s",
+            bool(request_token),
+        )
         logger.debug("Request token received")
 
         if not request_token:
@@ -87,7 +88,10 @@ def authenticate_broker(
         token_response.raise_for_status()
         token_data = token_response.json()
 
-        logger.debug(f"The Access Token response is :{token_data}")
+        logger.debug(
+            "Access-token response received; access_token_present=%s",
+            bool(token_data.get("body", {}).get("AccessToken")),
+        )
 
         if "body" in token_data and "AccessToken" in token_data["body"]:
             return token_data["body"]["AccessToken"], None

--- a/broker/flattrade/api/auth_api.py
+++ b/broker/flattrade/api/auth_api.py
@@ -39,15 +39,14 @@ def authenticate_broker(code, password=None, totp_code=None):
         url = "https://authapi.flattrade.in/trade/apitoken"
         data = {"api_key": BROKER_API_KEY, "request_code": code, "api_secret": security_hash}
 
-        logger.debug(f"Request Data: {data}")  # Debug print
+        logger.debug("Request data prepared; fields=%s", list(data.keys()))
 
         # Get the shared httpx client
         client = get_httpx_client()
 
         response = client.post(url, json=data)
 
-        logger.debug(f"Response Status: {response.status_code}")  # Debug print
-        logger.debug(f"Response Content: {response.text}")  # Debug print
+        logger.debug("Response status: %s", response.status_code)
 
         if response.status_code == 200:
             response_data = response.json()
@@ -65,11 +64,11 @@ def authenticate_broker(code, password=None, totp_code=None):
                 error_msg = f"API error: {error_detail.get('emsg', 'Unknown error')}"
             except Exception:
                 error_msg = f"API error: Status {response.status_code}, Response: {response.text}"
-            logger.error(f"Request Error: {error_msg}")  # Debug print
+            logger.error("Authentication request failed; status=%s", response.status_code)
             return None, error_msg
 
     except Exception as e:
-        logger.debug(f"Exception: {e}")  # Debug print
+        logger.debug("Authentication exception; type=%s", type(e).__name__)
         return None, f"An exception occurred: {str(e)}"
 
 

--- a/broker/groww/api/funds.py
+++ b/broker/groww/api/funds.py
@@ -13,7 +13,7 @@ logger = get_logger(__name__)
 
 def get_margin_data(auth_token):
     """Fetch margin data directly from Groww API using the provided auth token."""
-    logger.info(f"Getting margin data with token: {auth_token}...")
+    logger.info("Getting margin data; auth_token_present=%s", bool(auth_token))
 
     try:
         # Define the API endpoint for user margin details
@@ -30,14 +30,12 @@ def get_margin_data(auth_token):
 
         # Check if the request was successful
         if response.status_code != 200:
-            logger.error(
-                f"Error fetching margin data: HTTP {{response.status_code}} - {response.text}"
-            )
+            logger.error(f"Error fetching margin data: HTTP {response.status_code}")
             return {}
 
         # Parse the JSON response
         response_data = response.json()
-        logger.info(f"Funds Details: {response_data}")
+        logger.info("Funds response received; status=%s", response_data.get("status"))
 
         # Check if the response was successful according to Groww's status field
         if response_data.get("status") != "SUCCESS":

--- a/broker/kotak/database/master_contract_db.py
+++ b/broker/kotak/database/master_contract_db.py
@@ -314,7 +314,7 @@ def get_kotak_master_filepaths():
             # Construct full URL
             url = f"{base_url_attempt}{endpoint}"
 
-            logger.info(f"SCRIPMASTER API - Using access_token: {access_token[:10]}...")
+            logger.info("SCRIPMASTER API - Using configured access token")
             logger.info(f"Making request to: {url}")
 
             response = client.get(url, headers=headers, timeout=30)
@@ -322,14 +322,12 @@ def get_kotak_master_filepaths():
             logger.info(f"Response status: {response.status_code} from {base_url_attempt}")
 
             if response.status_code != 200:
-                logger.warning(
-                    f"HTTP {response.status_code} from {base_url_attempt}: {response.text}"
-                )
+                logger.warning(f"HTTP {response.status_code} from {base_url_attempt}")
 
             if response.status_code == 200:
                 try:
                     data_dict = json.loads(response.text)
-                    logger.debug(f"Response data: {data_dict}")
+                    logger.debug("Scripmaster response fields: %s", list(data_dict.keys()))
 
                     # Check for the expected response structure
                     if "data" in data_dict and "filesPaths" in data_dict["data"]:
@@ -363,19 +361,17 @@ def get_kotak_master_filepaths():
                         logger.info(f"Available files: {list(file_dict.keys())}")
                         return file_dict
                     else:
-                        logger.warning(
-                            f"Unexpected response structure from {base_url_attempt}: {data_dict}"
-                        )
+                        logger.warning(f"Unexpected response structure from {base_url_attempt}")
 
                 except json.JSONDecodeError as e:
                     logger.error(f"Failed to parse JSON from {base_url_attempt}: {e}")
-                    logger.debug(f"Raw response: {response.text}")
+                    logger.debug("Scripmaster response was not valid JSON")
 
         except httpx.HTTPError as e:
-            logger.error(f"HTTP error with {base_url_attempt}: {e}")
+            logger.error("HTTP error with %s; type=%s", base_url_attempt, type(e).__name__)
             continue
         except Exception as e:
-            logger.error(f"Error with {base_url_attempt}: {e}")
+            logger.error("Error with %s; type=%s", base_url_attempt, type(e).__name__)
             continue
 
     logger.error("All baseUrl attempts failed for scripmaster API")

--- a/broker/mstock/api/auth_api.py
+++ b/broker/mstock/api/auth_api.py
@@ -32,7 +32,7 @@ def authenticate_with_totp(password, totp_code):
     if not totp_code:
         return None, None, "TOTP code is required."
 
-    logger.info(f"Using clientcode: {clientcode}")
+    logger.info("Using configured mStock clientcode")
 
     try:
         client = get_httpx_client()
@@ -65,7 +65,7 @@ def authenticate_with_totp(password, totp_code):
         status = login_result.get("status")
         if status not in [True, "true"] or "data" not in login_result:
             error_message = login_result.get("message", "Authentication failed.")
-            logger.error(f"Authentication failed: {error_message}")
+            logger.error("Authentication failed; status=%s", status)
             return None, None, error_message
 
         # Get refresh token from response (not the final auth token)
@@ -74,7 +74,7 @@ def authenticate_with_totp(password, totp_code):
 
         if not refresh_token:
             logger.error("No refreshToken in login response")
-            logger.info(f"Available fields in data: {data}")
+            logger.info("Login response data fields: %s", list(data.keys()))
             return None, None, "Failed to get refresh token from response."
 
         logger.info("Login with TOTP successful, now verifying TOTP to get final token")
@@ -106,7 +106,7 @@ def authenticate_with_totp(password, totp_code):
         status = verify_result.get("status")
         if status not in [True, "true"] or "data" not in verify_result:
             error_message = verify_result.get("message", "TOTP verification failed.")
-            logger.error(f"TOTP verification failed: {error_message}")
+            logger.error("TOTP verification failed; status=%s", status)
             return None, None, error_message
 
         # Get final authentication tokens
@@ -117,7 +117,7 @@ def authenticate_with_totp(password, totp_code):
 
         if not auth_token:
             logger.error("No jwtToken in verification response")
-            logger.debug(f"Available fields in data: {final_data}")
+            logger.debug("Verification response fields: %s", list(final_data.keys()))
             return None, None, "Failed to get authentication token from verification response."
 
         logger.info("TOTP authentication successful, got final jwtToken")
@@ -128,10 +128,10 @@ def authenticate_with_totp(password, totp_code):
         try:
             error_detail = e.response.json()
             error_msg += f" - {error_detail.get('message', e.response.text)}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Details: {error_detail}")
+            logger.error("mStock authentication HTTP error; status=%s", e.response.status_code)
         except Exception:
             error_msg += f" - {e.response.text}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Raw: {e.response.text}")
+            logger.error("mStock authentication HTTP error; status=%s", e.response.status_code)
         return None, None, error_msg
     except Exception as e:
         logger.exception("Unexpected error during TOTP authentication")
@@ -158,7 +158,7 @@ def send_otp(password):
     if not password:
         return None, None, "Password is required."
 
-    logger.debug(f"Using clientcode: {clientcode}")
+    logger.debug("Using configured mStock clientcode")
 
     try:
         client = get_httpx_client()
@@ -185,7 +185,7 @@ def send_otp(password):
         status = login_result.get("status")
         if status not in [True, "true"] or "data" not in login_result:
             error_message = login_result.get("message", "Login failed.")
-            logger.error(f"Login failed: {error_message}")
+            logger.error("Login failed; status=%s", status)
             return None, None, error_message
 
         # Check if refreshToken field exists first, otherwise use jwtToken
@@ -194,12 +194,10 @@ def send_otp(password):
 
         if not refresh_token:
             logger.error("No refreshToken or jwtToken in login response")
-            logger.debug(f"Available fields in data: {data}")
+            logger.debug("Login response data fields: %s", list(data.keys()))
             return None, None, "Failed to get refreshToken from login response."
 
-        logger.debug(
-            f"Using token as refreshToken: {refresh_token[:30]}... (length: {len(refresh_token)})"
-        )
+        logger.debug("Refresh token received; length=%s", len(refresh_token))
 
         success_message = login_result.get("message", "OTP sent successfully")
         logger.debug(f"Login successful, OTP sent. Message: {success_message}")
@@ -211,10 +209,10 @@ def send_otp(password):
         try:
             error_detail = e.response.json()
             error_msg += f" - {error_detail.get('message', e.response.text)}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Details: {error_detail}")
+            logger.error("mStock OTP HTTP error; status=%s", e.response.status_code)
         except Exception:
             error_msg += f" - {e.response.text}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Raw: {e.response.text}")
+            logger.error("mStock OTP HTTP error; status=%s", e.response.status_code)
         return None, None, error_msg
     except Exception as e:
         logger.exception("Unexpected error during OTP send")
@@ -268,8 +266,11 @@ def verify_otp(otp_code, refresh_token):
         )
 
         logger.debug(f"OTP verification HTTP status: {token_response.status_code}")
-        logger.debug(f"OTP verification response headers: {dict(token_response.headers)}")
-        logger.debug(f"OTP verification raw response text: [{token_response.text}]")
+        logger.debug(
+            "OTP verification response received; status=%s, content_type=%s",
+            token_response.status_code,
+            token_response.headers.get("content-type"),
+        )
 
         token_response.raise_for_status()
         token_result = token_response.json()
@@ -286,7 +287,7 @@ def verify_otp(otp_code, refresh_token):
             return auth_token, feed_token, None
         else:
             error_message = token_result.get("message", "Token generation failed.")
-            logger.error(f"OTP verification failed: {error_message}")
+            logger.error("OTP verification failed; status=%s", status)
             return None, None, error_message
 
     except httpx.HTTPStatusError as e:
@@ -294,10 +295,10 @@ def verify_otp(otp_code, refresh_token):
         try:
             error_detail = e.response.json()
             error_msg += f" - {error_detail.get('message', e.response.text)}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Details: {error_detail}")
+            logger.error("mStock token HTTP error; status=%s", e.response.status_code)
         except Exception:
             error_msg += f" - {e.response.text}"
-            logger.error(f"HTTP Error: {e.response.status_code}, Raw: {e.response.text}")
+            logger.error("mStock token HTTP error; status=%s", e.response.status_code)
         return None, None, error_msg
     except Exception as e:
         logger.exception("Unexpected error during OTP verification")

--- a/broker/mstock/api/funds.py
+++ b/broker/mstock/api/funds.py
@@ -43,8 +43,7 @@ def get_margin_data(auth_token):
         logger.debug(
             f"Fund summary response: status={margin_data.get('status')}, has_data={bool(margin_data.get('data'))}"
         )
-        logger.debug(f"Full margin data response: {margin_data}")
-        if margin_data.get("status") == True and margin_data.get("data"):
+        if margin_data.get("status") == True and margin_data.get("data"):  # noqa: E712
             data = margin_data["data"][0]
             key_mapping = {
                 "AVAILABLE_BALANCE": "availablecash",
@@ -65,19 +64,17 @@ def get_margin_data(auth_token):
                     formatted_value = "0.00"
                 filtered_data[openalgo_key] = formatted_value
 
-            logger.debug(f"filteredMargin Data: {filtered_data}")
+            logger.debug("Margin data processed; fields=%s", list(filtered_data.keys()))
             return filtered_data
 
         logger.error(f"Margin API failed: {margin_data.get('message', 'No data')}")
         return {}
 
     except httpx.HTTPStatusError as e:
-        logger.error(f"HTTP Error while fetching margin data: {e}")
-        logger.error(f"Response status code: {e.response.status_code}")
-        logger.error(f"Response body: {e.response.text}")
+        logger.error("HTTP error while fetching margin data; status=%s", e.response.status_code)
         try:
             error_detail = e.response.json()
-            logger.error(f"Error details: {error_detail}")
+            logger.error("Margin API error fields: %s", list(error_detail.keys()))
         except Exception:
             pass
         return {}

--- a/broker/paytm/api/auth_api.py
+++ b/broker/paytm/api/auth_api.py
@@ -40,7 +40,7 @@ def authenticate_broker(request_token):
 
         if response.status_code == 200:
             response_data = response.json()
-            logger.debug(f"Token: {response_data}")
+            logger.debug("Token response received; fields=%s", list(response_data.keys()))
 
             # Paytm returns multiple tokens:
             # - access_token: For REST API calls
@@ -64,7 +64,7 @@ def authenticate_broker(request_token):
             else:
                 error_msg = "Authentication succeeded but no access token was returned."
                 logger.error(error_msg)
-                logger.debug(f"Full response: {response_data}")
+                logger.debug("Token response did not contain an access token")
                 return None, None, error_msg
         else:
             # Parsing the error message from the API response
@@ -80,9 +80,7 @@ def authenticate_broker(request_token):
             except Exception:
                 error_msg = f"Authentication failed with status code {response.status_code} and non-JSON response: {response.text}"
 
-            logger.error(
-                f"Authentication failed with status code {response.status_code}. Error: {error_msg}"
-            )
+            logger.error("Authentication failed; status=%s", response.status_code)
             return None, None, error_msg
     except Exception:
         logger.exception("An exception occurred during authentication.")

--- a/test/test_broker_credential_logging.py
+++ b/test/test_broker_credential_logging.py
@@ -1,0 +1,67 @@
+"""Static regression tests for credential-bearing broker log statements."""
+
+from pathlib import Path
+
+PROJECT_ROOT = Path(__file__).resolve().parents[1]
+
+FORBIDDEN_LOG_PATTERNS = {
+    "broker/fivepaisa/api/auth_api.py": (
+        'f"The Request Token response is :{totp_data}"',
+        'f"The Access Token response is :{token_data}"',
+    ),
+    "broker/mstock/api/auth_api.py": (
+        'f"Using clientcode: {clientcode}"',
+        'f"Available fields in data: {data}"',
+        'f"Available fields in data: {final_data}"',
+        "refresh_token[:30]",
+        "dict(token_response.headers)",
+        "token_response.text",
+        'f"HTTP Error: {e.response.status_code}, Details: {error_detail}"',
+        'f"HTTP Error: {e.response.status_code}, Raw: {e.response.text}"',
+    ),
+    "broker/mstock/api/funds.py": (
+        'f"Full margin data response: {margin_data}"',
+        'f"Response body: {e.response.text}"',
+        'f"Error details: {error_detail}"',
+    ),
+    "broker/groww/api/funds.py": (
+        'f"Getting margin data with token: {auth_token}..."',
+        'f"Funds Details: {response_data}"',
+    ),
+    "broker/flattrade/api/auth_api.py": (
+        'f"Request Data: {data}"',
+        'f"Response Content: {response.text}"',
+        'f"Exception: {e}"',
+    ),
+    "broker/dhan/api/auth_api.py": (
+        'f"Generating consent for Dhan Client ID: {dhan_client_id}"',
+        "BROKER_API_SECRET[:8]",
+        'f"Consent generated successfully: {consent_app_id}"',
+        'f"Additional Data: {additional_data}"',
+        'f"Exception in generate_consent: {str(e)}"',
+        'f"Exception in consume_consent: {str(e)}"',
+        'f"Dhan authentication successful, client_id: {dhan_client_id}"',
+        'f"Exception in authenticate_broker: {str(e)}"',
+    ),
+    "broker/paytm/api/auth_api.py": (
+        'f"Token: {response_data}"',
+        'f"Full response: {response_data}"',
+    ),
+    "broker/kotak/database/master_contract_db.py": (
+        "access_token[:10]",
+        'f"HTTP {response.status_code} from {base_url_attempt}: {response.text}"',
+        'f"Response data: {data_dict}"',
+        'f"Unexpected response structure from {base_url_attempt}: {data_dict}"',
+        'f"Raw response: {response.text}"',
+        'f"HTTP error with {base_url_attempt}: {e}"',
+        'f"Error with {base_url_attempt}: {e}"',
+    ),
+}
+
+
+def test_listed_broker_logs_do_not_include_credentials():
+    """The issue's listed files must not reintroduce known secret dumps."""
+    for relative_path, forbidden_patterns in FORBIDDEN_LOG_PATTERNS.items():
+        source = (PROJECT_ROOT / relative_path).read_text(encoding="utf-8")
+        for pattern in forbidden_patterns:
+            assert pattern not in source, f"{relative_path} contains {pattern!r}"


### PR DESCRIPTION
## Summary

Remove credential material from authentication and funds-related logs in the broker modules identified by #1854.

## Changes

- Removed full authentication response logging from 5paisa and Paytm.
- Removed mStock client-code, token-prefix, response-body, response-header, and raw error logging.
- Removed mStock and Groww funds payload/token logging.
- Removed Flattrade request-payload, response-body, and exception-value logging.
- Removed Dhan client ID, API-secret prefix, consent ID, and additional authentication-data logging.
- Removed Kotak access-token prefix and raw scripmaster response logging.
- Replaced sensitive values with safe status, presence, length, field-name, content-type, and exception-type metadata where useful.
- Preserved authentication request/response handling and caller-visible error values.
- Added a static regression test covering all eight files listed in the issue.
- Added the regression test to the CI-safe backend test selection.

## Security Coverage

The updated log statements no longer emit:

- Access tokens, refresh tokens, or token prefixes
- API keys, API-secret fragments, or client-code values
- OTP-related credential material
- Authentication request payloads or response payloads
- Response headers that may contain session credentials
- Raw credential-bearing HTTP error responses

## Issue

Closes #1854

## Verification

- `uv run pytest test/test_broker_credential_logging.py -v --timeout=60`: 1 passed
- Maintained CI-safe backend selection including the new test: 95 passed
- `uv run ruff check` on all changed files: passed
- `uv run ruff format --check` on all changed files: passed
- `git diff --check`: passed
- FD audit completed; no new resource-management concerns introduced

No real broker credentials, tokens, OTPs, or network calls were used.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes credential material from broker authentication and funds-related logs to close #1854.

**Bug Fixes**
- Authentication responses, tokens, secrets, OTP material, and response headers are no longer logged across the affected broker modules.
- Sensitive values are replaced with safe metadata such as presence flags, field names, response status, and exception type.
- Caller-visible error values and request/response handling are unchanged.
- Adds a static regression test that blocks reintroduction of the removed log patterns and runs in the CI-safe backend test selection.

<sup>Written for commit 7b73ca15cfb8d3aa4b95326b77114cfaee95ed5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1916?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

