### PR TITLE
security: add no-store headers to API-key responses

### DIFF
--- a/blueprints/apikey.py
+++ b/blueprints/apikey.py
@@ -1,5 +1,6 @@
 import os
 import secrets
+from functools import wraps
 from pathlib import Path
 
 from argon2 import PasswordHasher
@@ -42,8 +43,26 @@ def generate_api_key():
     return secrets.token_hex(32)
 
 
+def no_store_headers(f):
+    """Add no-store cache headers to credential-bearing responses.
+
+    Prevents browser history, shared proxies, and debugging caches from
+    retaining decrypted/newly generated API keys.
+    """
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        resp = f(*args, **kwargs)
+        resp.headers["Cache-Control"] = "no-store, max-age=0"
+        resp.headers["Pragma"] = "no-cache"
+        return resp
+
+    return wrapper
+
+
 @api_key_bp.route("/apikey", methods=["GET", "POST"])
 @check_session_validity
+@no_store_headers
 def manage_api_key():
     if request.method == "GET":
         login_username = session["user"]

--- a/blueprints/playground.py
+++ b/blueprints/playground.py
@@ -3,6 +3,7 @@ import json
 import os
 import re
 from collections import OrderedDict
+from functools import wraps
 
 from flask import Blueprint, current_app, jsonify, redirect, session, url_for
 
@@ -11,6 +12,19 @@ from utils.logging import get_logger
 from utils.session import check_session_validity
 
 logger = get_logger(__name__)
+
+
+def no_store_headers(f):
+    """Add no-store cache headers to credential-bearing responses."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        resp = f(*args, **kwargs)
+        resp.headers["Cache-Control"] = "no-store, max-age=0"
+        resp.headers["Pragma"] = "no-cache"
+        return resp
+
+    return wrapper
 
 
 def parse_bru_file(filepath):
@@ -298,6 +312,7 @@ def index():
 
 @playground_bp.route("/api-key")
 @check_session_validity
+@no_store_headers
 def get_api_key():
     """Get the current user's API key"""
     login_username = session.get("user")

--- a/blueprints/websocket_example.py
+++ b/blueprints/websocket_example.py
@@ -3,6 +3,8 @@ Example blueprint showing how to use the WebSocket service layer
 for internal UI components without authentication overhead.
 """
 
+from functools import wraps
+
 from flask import Blueprint, current_app, jsonify, render_template, request, session
 from flask_socketio import emit, join_room, leave_room
 
@@ -26,6 +28,20 @@ from services.websocket_service import (
 )
 from utils.logging import get_logger
 from utils.session import check_session_validity
+
+
+def no_store_headers(f):
+    """Add no-store cache headers to credential-bearing responses."""
+
+    @wraps(f)
+    def wrapper(*args, **kwargs):
+        resp = f(*args, **kwargs)
+        resp.headers["Cache-Control"] = "no-store, max-age=0"
+        resp.headers["Pragma"] = "no-cache"
+        return resp
+
+    return wrapper
+
 
 # Initialize logger
 logger = get_logger(__name__)
@@ -163,6 +179,7 @@ def api_websocket_market_data():
 
 
 @websocket_bp.route("/api/websocket/apikey", methods=["GET"])
+@no_store_headers
 def api_get_websocket_apikey():
     """Get API key for WebSocket authentication"""
     username = get_username_from_session()


### PR DESCRIPTION
## Summary

Authenticated endpoints return decrypted or newly generated API keys without explicit no-store cache headers, so the credentials can linger in browser history, shared proxies, and debugging caches.

## Fix

Added a reusable `no_store_headers` decorator (matching the `Cache-Control: no-store, max-age=0` pattern already used by admin endpoints) and applied it to every credential-returning route:

- `blueprints/apikey.py` — `GET/POST /apikey` (`manage_api_key`)
- `blueprints/playground.py` — `GET /api-key` (`get_api_key`)
- `blueprints/websocket_example.py` — `GET /api/websocket/apikey` (`api_get_websocket_apikey`)

Each response now carries `Cache-Control: no-store, max-age=0` and the legacy `Pragma: no-cache` header. JSON bodies are unchanged; non-sensitive endpoints are untouched.

## Acceptance criteria

- [x] Every endpoint that returns a decrypted/new API key sends no-store headers
- [x] Non-sensitive endpoints are not accidentally changed
- [x] GET and POST paths in `/apikey` are covered
- [x] Local syntax verification passed for all three modified files

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Endpoints that return decrypted or newly generated API keys previously went out without no-store cache headers, letting credentials linger in browser history, shared proxies, and debugging caches. They now send `Cache-Control: no-store, max-age=0` and `Pragma: no-cache`.

- Adds a `no_store_headers` decorator to `blueprints/apikey.py`, `blueprints/playground.py`, and `blueprints/websocket_example.py`.
- Applies it to `GET/POST /apikey`, `GET /api-key`, and `GET /api/websocket/apikey`.
- JSON response bodies and all other routes are unchanged.
- The decorator is duplicated in each blueprint instead of a shared helper.

<sup>Written for commit 050df2d8cc475edb7092f68d05e5a5584c54c8b1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1920?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

