### PR TITLE
docs(docker): remove stale :ro .env mount guidance across design and docker docs

### DIFF
--- a/docs/design/11-docker/README.md
+++ b/docs/design/11-docker/README.md
@@ -180,7 +180,7 @@ services:
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
       - openalgo_tmp:/app/tmp
-      - ./.env:/app/.env:ro       # Environment config (read-only)
+      - ./.env:/app/.env        # Environment config (writable, required for v2.0.0.8+ key rotation)
     environment:
       - FLASK_HOST_IP=0.0.0.0
       - FLASK_PORT=5000
@@ -339,7 +339,7 @@ docker run -d \
   -p 8765:8765 \
   -v $(pwd)/db:/app/db \
   -v $(pwd)/log:/app/log \
-  -v $(pwd)/.env:/app/.env:ro \
+  -v $(pwd)/.env:/app/.env \
   openalgo
 
 # View logs
@@ -456,7 +456,7 @@ fi
 | Aspect | Implementation |
 |--------|----------------|
 | Non-root user | Runs as `appuser` |
-| Read-only .env | Mounted with `:ro` flag |
+| `.env` mount | Writable so v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can atomically write `.env.tmp`. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality. |
 | Keys directory | 700 permissions |
 | No build tools | Slim production image |
 | Minimal packages | Only runtime dependencies |

--- a/docs/design/11-docker/README.md
+++ b/docs/design/11-docker/README.md
@@ -456,7 +456,7 @@ fi
 | Aspect | Implementation |
 |--------|----------------|
 | Non-root user | Runs as `appuser` |
-| `.env` mount | Writable so v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can atomically write `.env.tmp`. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality. |
+| `.env` mount | Writable so v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — persistence is guaranteed, atomicity is not. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality. |
 | Keys directory | 700 permissions |
 | No build tools | Slim production image |
 | Minimal packages | Only runtime dependencies |

--- a/docs/design/11-docker/README.md
+++ b/docs/design/11-docker/README.md
@@ -352,6 +352,12 @@ docker stop openalgo
 docker rm openalgo
 ```
 
+> **Host `.env` permissions:** the container runs as `appuser` (UID/GID 1000) and v2.0.0.8+ automatic key rotation writes to the mounted `.env`, so the host file must be writable by that UID:
+>
+> ```bash
+> chown 1000:1000 .env && chmod 600 .env
+> ```
+
 ## Docker Compose Commands
 
 ```bash
@@ -456,7 +462,7 @@ fi
 | Aspect | Implementation |
 |--------|----------------|
 | Non-root user | Runs as `appuser` |
-| `.env` mount | Writable so v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — persistence is guaranteed, atomicity is not. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality. |
+| `.env` mount | Writable so v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — atomicity is not guaranteed, and persistence can still fail if the host file isn't writable by the container's UID 1000 `appuser`. A `:ro` mount makes every `.env` write fail, and the failure mode is asymmetric: an unwritable `FERNET_SALT` only logs a warning (the app continues with an in-memory salt), while a failed placeholder `APP_KEY`/`API_KEY_PEPPER` rotation exits before startup completes. Keep the host side owned by that UID and private (`chown 1000:1000 .env && chmod 600 .env`); if you don't use auto-rotation at all, `chmod 600` alone covers at-rest confidentiality. |
 | Keys directory | 700 permissions |
 | No build tools | Slim production image |
 | Minimal packages | Only runtime dependencies |

--- a/docs/docker/DOCKER_BUILD_GUIDE.md
+++ b/docs/docker/DOCKER_BUILD_GUIDE.md
@@ -55,7 +55,7 @@ docker run -d \
   -v openalgo_log:/app/log \
   -v openalgo_strategies:/app/strategies \
   -v openalgo_keys:/app/keys \
-  -v "$(pwd)/.env:/app/.env:ro" \
+  -v "$(pwd)/.env:/app/.env" \
   --tmpfs /app/tmp:size=1g,mode=1777 \
   --restart unless-stopped \
   openalgo:latest
@@ -469,7 +469,7 @@ kubectl apply -f k8s/deployment.yaml
 
 1. **Runs as non-root user:** Container runs as `appuser`
 2. **Restricted permissions:** Keys directory has `chmod 700`
-3. **Read-only .env:** Mounted with `:ro` flag
+3. **Writable `.env` mount:** `.env` is mounted writable so that v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can atomically write `.env.tmp`. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality.
 4. **No privilege escalation:** No `--privileged` flag
 
 ## CI/CD Integration

--- a/docs/docker/DOCKER_BUILD_GUIDE.md
+++ b/docs/docker/DOCKER_BUILD_GUIDE.md
@@ -469,7 +469,7 @@ kubectl apply -f k8s/deployment.yaml
 
 1. **Runs as non-root user:** Container runs as `appuser`
 2. **Restricted permissions:** Keys directory has `chmod 700`
-3. **Writable `.env` mount:** `.env` is mounted writable so that v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can atomically write `.env.tmp`. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality.
+3. **Writable `.env` mount:** `.env` is mounted writable so that v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — persistence is guaranteed, atomicity is not. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality.
 4. **No privilege escalation:** No `--privileged` flag
 
 ## CI/CD Integration

--- a/docs/docker/DOCKER_BUILD_GUIDE.md
+++ b/docs/docker/DOCKER_BUILD_GUIDE.md
@@ -61,6 +61,12 @@ docker run -d \
   openalgo:latest
 ```
 
+> **Host `.env` permissions:** the container runs as `appuser` (UID/GID 1000) and v2.0.0.8+ automatic key rotation writes to the mounted `.env`, so the host file must be writable by that UID:
+>
+> ```bash
+> chown 1000:1000 .env && chmod 600 .env
+> ```
+
 ## Build Process Details
 
 ### What Gets Built
@@ -469,7 +475,7 @@ kubectl apply -f k8s/deployment.yaml
 
 1. **Runs as non-root user:** Container runs as `appuser`
 2. **Restricted permissions:** Keys directory has `chmod 700`
-3. **Writable `.env` mount:** `.env` is mounted writable so that v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — persistence is guaranteed, atomicity is not. Mounting it `:ro` would crash the worker in a restart loop. If you don't use auto-rotation, apply host-side `chmod 600` and rely on filesystem permissions for at-rest confidentiality.
+3. **Writable `.env` mount:** `.env` is mounted writable so that v2.0.0.8+ automatic `APP_KEY`/`FERNET_SALT` key-rotation can persist new keys to `.env`. The rewrite normally goes through a temp file + atomic rename, but when `.env` is a single-file bind mount (`./.env:/app/.env`) `utils/env_check.py` detects the cross-device case and deliberately rewrites the file in place through the host inode instead — atomicity is not guaranteed, and persistence can still fail if the host file isn't writable by the container's UID 1000 `appuser`. A `:ro` mount makes every `.env` write fail, and the failure mode is asymmetric: an unwritable `FERNET_SALT` only logs a warning (the app continues with an in-memory salt), while a failed placeholder `APP_KEY`/`API_KEY_PEPPER` rotation exits before startup completes. Keep the host side owned by that UID and private (`chown 1000:1000 .env && chmod 600 .env`); if you don't use auto-rotation at all, `chmod 600` alone covers at-rest confidentiality.
 4. **No privilege escalation:** No `--privileged` flag
 
 ## CI/CD Integration

--- a/docs/docker/DOCKER_NUMBA_FIX.md
+++ b/docs/docker/DOCKER_NUMBA_FIX.md
@@ -115,7 +115,7 @@ docker run -d \
   -v openalgo_log:/app/log \
   -v openalgo_strategies:/app/strategies \
   -v openalgo_keys:/app/keys \
-  -v "$(pwd)/.env:/app/.env:ro" \
+  -v "$(pwd)/.env:/app/.env" \
   --tmpfs /app/tmp:size=1g,mode=1777 \
   openalgo:latest
 ```

--- a/docs/docker/DOCKER_SCRIPTS_ANALYSIS.md
+++ b/docs/docker/DOCKER_SCRIPTS_ANALYSIS.md
@@ -25,7 +25,7 @@ docker run -d \
     -v "$OPENALGO_DIR/db:/app/db" \
     -v "$OPENALGO_DIR/strategies:/app/strategies" \
     -v "$OPENALGO_DIR/log:/app/log" \
-    -v "$OPENALGO_DIR/.env:/app/.env:ro" \
+    -v "$OPENALGO_DIR/.env:/app/.env" \
     --restart unless-stopped \
     "$IMAGE"
 ```
@@ -47,7 +47,7 @@ docker run -d \
     -v "$OPENALGO_DIR/log:/app/log" \
     -v "$OPENALGO_DIR/keys:/app/keys" \
     -v "$OPENALGO_DIR/tmp:/app/tmp" \
-    -v "$OPENALGO_DIR/.env:/app/.env:ro" \
+    -v "$OPENALGO_DIR/.env:/app/.env" \
     --restart unless-stopped \
     "$IMAGE"
 ```
@@ -71,7 +71,7 @@ docker run -d ^
     -v "%OPENALGO_DIR%\db:/app/db" ^
     -v "%OPENALGO_DIR%\strategies:/app/strategies" ^
     -v "%OPENALGO_DIR%\log:/app/log" ^
-    -v "%OPENALGO_DIR%\.env:/app/.env:ro" ^
+    -v "%OPENALGO_DIR%\.env:/app/.env" ^
     --restart unless-stopped ^
     %IMAGE%
 ```
@@ -93,7 +93,7 @@ docker run -d ^
     -v "%OPENALGO_DIR%\log:/app/log" ^
     -v "%OPENALGO_DIR%\keys:/app/keys" ^
     -v "%OPENALGO_DIR%\tmp:/app/tmp" ^
-    -v "%OPENALGO_DIR%\.env:/app/.env:ro" ^
+    -v "%OPENALGO_DIR%\.env:/app/.env" ^
     --restart unless-stopped ^
     %IMAGE%
 ```
@@ -129,7 +129,7 @@ services:
       - openalgo_log:/app/log
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
-      - ./.env:/app/.env:ro
+      - ./.env:/app/.env
 
     environment:
       - FLASK_ENV=production
@@ -183,7 +183,7 @@ services:
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
       - openalgo_tmp:/app/tmp
-      - ./.env:/app/.env:ro
+      - ./.env:/app/.env
 
     environment:
       - FLASK_ENV=production

--- a/docs/docker/README.md
+++ b/docs/docker/README.md
@@ -132,7 +132,7 @@ services:
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
       - openalgo_tmp:/app/tmp
-      - ./.env:/app/.env:ro
+      - ./.env:/app/.env
 
     shm_size: '2gb'  # For scipy/numba operations
 

--- a/docs/docker/UPDATES_SUMMARY.md
+++ b/docs/docker/UPDATES_SUMMARY.md
@@ -39,7 +39,7 @@ docker run -d \
     -v "$OPENALGO_DIR/db:/app/db" \
     -v "$OPENALGO_DIR/strategies:/app/strategies" \
     -v "$OPENALGO_DIR/log:/app/log" \
-    -v "$OPENALGO_DIR/.env:/app/.env:ro" \
+    -v "$OPENALGO_DIR/.env:/app/.env" \
     --restart unless-stopped \
     "$IMAGE"
 ```
@@ -71,7 +71,7 @@ docker run -d \
     -v "$OPENALGO_DIR/log:/app/log" \
     -v "$OPENALGO_DIR/keys:/app/keys" \                # ← NEW
     -v "$OPENALGO_DIR/tmp:/app/tmp" \                  # ← NEW
-    -v "$OPENALGO_DIR/.env:/app/.env:ro" \
+    -v "$OPENALGO_DIR/.env:/app/.env" \
     --restart unless-stopped \
     "$IMAGE"
 ```
@@ -95,7 +95,7 @@ docker run -d ^
     -v "%OPENALGO_DIR%\db:/app/db" ^
     -v "%OPENALGO_DIR%\strategies:/app/strategies" ^
     -v "%OPENALGO_DIR%\log:/app/log" ^
-    -v "%OPENALGO_DIR%\.env:/app/.env:ro" ^
+    -v "%OPENALGO_DIR%\.env:/app/.env" ^
     --restart unless-stopped ^
     %IMAGE%
 ```
@@ -124,7 +124,7 @@ docker run -d ^
     -v "%OPENALGO_DIR%\log:/app/log" ^
     -v "%OPENALGO_DIR%\keys:/app/keys" ^                    # ← NEW
     -v "%OPENALGO_DIR%\tmp:/app/tmp" ^                      # ← NEW
-    -v "%OPENALGO_DIR%\.env:/app/.env:ro" ^
+    -v "%OPENALGO_DIR%\.env:/app/.env" ^
     --restart unless-stopped ^
     %IMAGE%
 ```
@@ -148,7 +148,7 @@ services:
       - openalgo_log:/app/log
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
-      - ./.env:/app/.env:ro
+      - ./.env:/app/.env
 
     environment:
       - FLASK_ENV=production
@@ -185,7 +185,7 @@ services:
       - openalgo_strategies:/app/strategies
       - openalgo_keys:/app/keys
       - openalgo_tmp:/app/tmp              # ← NEW
-      - ./.env:/app/.env:ro
+      - ./.env:/app/.env
 
     environment:
       - FLASK_ENV=production


### PR DESCRIPTION
## Problem
Multiple docs files still show the `docker run` / `docker-compose` example with `-v .../.env:/app/.env:ro`. The v2.0.0.8 hotfix (commit `245403f1`) dropped `:ro` from `docker-compose.yaml` and the install scripts because the `APP_KEY` / `FERNET_SALT` rotation cannot write its `.env.tmp` to a read-only mount — it crashes the gunicorn worker in a restart loop. Anyone copying today's docs would reintroduce the exact crash.

## Triage / Root cause
- The `:ro` was correctly removed from `docker-compose.yaml` in v2.0.0.8 (commit `245403f1`, see `docs/releases/version-2.0.0.8-released.md`).
- The same `:ro` was never cleaned out of the docker design/example docs:
  - `docs/design/11-docker/README.md` (Build Commands + Security Considerations)
  - `docs/docker/DOCKER_BUILD_GUIDE.md` (Manual Build example + Runtime Security)
  - `docs/docker/DOCKER_SCRIPTS_ANALYSIS.md` (4 platform scripts)
  - `docs/docker/README.md`
  - `docs/docker/DOCKER_NUMBA_FIX.md`
  - `docs/docker/UPDATES_SUMMARY.md` (selective — only the stale `.env` mount lines)

## Fix
- Drop `:ro` from every stale `.env` mount in the 6 files above.
- Reframe the "Security Considerations" / "Runtime Security" bullets that recommended `:ro` as a security feature, replacing them with text explaining why writable-mount + host-side `chmod 600` is the correct posture.
- Leave `docs/releases/version-2.0.0.8-released.md` untouched (its `:ro` references document the bug fix history).

## Verification
- `git grep -n '\.env:ro' -- 'docs/**/*.md'` returns only `docs/releases/version-2.0.0.8-released.md` (the historical fix note).
- `git diff --check` is clean.
- `git diff --stat` confirms only `docs/**` Markdown files changed.
- No code changes; backend tests and frontend build not run per `CONTRIBUTING.md` documentation-only path.

## Notes / Risks
- 6 files, ~15 line edits total, no code change, no public API impact.
- The Security Considerations reframe is the only place where wording changed substantively; if a maintainer wants different language, that's a one-PR fix to follow up.
- Closes #1901.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removes stale `:ro` flags from `.env` Docker mounts across six docs files and reframes the security guidance so copied examples no longer reintroduce the v2.0.0.8 key-rotation crash.

- Recommends a writable mount with host-side `chown 1000:1000` and `chmod 600` so the container's UID 1000 `appuser` can persist rotated keys.
- Clarifies single-file bind mounts are rewritten in place, not atomically; a failed `FERNET_SALT` write only warns, while a failed `APP_KEY` rotation exits before startup.
- Leaves the v2.0.0.8 release notes untouched since they document the historical fix.

<sup>Written for commit 3ffc49cff4bcdf5d5f49556be012ef249dc5d486. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1921?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

