### PR TITLE
feat(trading): user custom chart indicators, loaded at runtime

### DIFF
--- a/.claude/skills/chart-indicator/SKILL.md
+++ b/.claude/skills/chart-indicator/SKILL.md
@@ -1,0 +1,129 @@
+---
+name: chart-indicator
+description: Build a custom indicator for the OpenAlgo /trading charting terminal (openalgo-charts). Use when asked to create, port, or debug a chart indicator, overlay, oscillator, band, or on-chart signal, including porting a Pine Script / TradingView study to the chart. Writes a plain-JS descriptor into strategies/indicators/, but only after it validates against the real library. Not for openalgo.ta Python indicators, which is the custom-indicator skill.
+argument-hint: "[indicator name or Pine script]"
+allowed-tools: Read, Write, Edit, Bash, Glob, Grep
+---
+
+# Custom chart indicators for `/trading`
+
+Build an indicator for the charting terminal. It becomes a picker entry with a
+generated settings dialog, a legend row and saved-layout persistence, with no
+build step and no restart.
+
+**This is the chart (JavaScript) path.** For a Python `openalgo.ta` indicator
+used from a strategy or scanner, use the **`custom-indicator`** skill instead.
+The two share nothing.
+
+## The one rule
+
+**Never write a file into `strategies/indicators/` directly.** That folder is
+imported by the live chart, and the runtime fails silently in the ways that
+matter most: a column that is one element short, or a plot key that does not
+match what `calc` returns, draws nothing at all and raises nothing anywhere.
+
+Always: write to a scratch path, validate, install on a pass.
+
+```bash
+# 1. draft to a scratch file (never the indicators folder)
+#    e.g. <scratchpad>/my_indicator.js
+
+# 2. validate against the real openalgo-charts build
+node .claude/skills/chart-indicator/validate.mjs <scratch>/my_indicator.js
+
+# 3. only on PASSED, install it
+node .claude/skills/chart-indicator/validate.mjs <scratch>/my_indicator.js --install
+```
+
+`--install` copies into `strategies/indicators/` **only** when there are zero
+errors, and exits 1 otherwise. If validation fails, fix the draft and re-run.
+Do not install a failing indicator, and do not weaken the validator to get a
+pass. Report warnings to the user rather than silently accepting them.
+
+The validator needs `frontend/node_modules/openalgo-charts`. If it is missing,
+run `cd frontend && npm install` first.
+
+## Workflow
+
+1. **Read the request.** If it is a Pine script, read it fully and identify:
+   what is plotted, what is a signal, what state carries across bars, and what
+   resets per day or per session.
+2. **Load the context you need.** `reference/contract.md` for the descriptor
+   shape and the runtime's exact behaviour, `reference/api.md` for what is
+   available inside the module, `reference/pitfalls.md` for the traps. Read
+   `reference/pitfalls.md` before writing anything; most first drafts fail on
+   something in it.
+3. **Pick the closest example** in `examples/` and work from it:
+   - `simple_zscore.js` — one pane, one plot, rolling window, levels, range
+   - `intermediate_keltner_squeeze.js` — several plots, `fills`, `colorBy`, a
+     second price scale, a boolean that hides part of the drawing
+   - `complex_session_vwap.js` — per-session state, `markers` with a signal
+     latch, `table`, `calcTail`, zone-aware day boundaries
+4. **Draft to scratch. Validate. Iterate until it passes.**
+5. **Install**, then tell the user to hard-refresh `/trading`.
+
+## What the file has to look like
+
+Plain JavaScript. Nothing compiles it: no TypeScript, no JSX, no imports. The
+module default-exports one function and is handed the whole charting API.
+
+```js
+export default function ({ registerIndicator, sourceValues, sma, nulls }) {
+  registerIndicator({
+    id: 'my-thing',        // unique slug; prefix your own to avoid overriding a built-in
+    name: 'My Thing',      // picker and legend
+    category: 'Custom',    // groups it in the picker rail
+    placement: 'onchart',  // 'onchart' overlays price, 'pane' gets its own pane
+    inputs: [ ... ],       // becomes the settings dialog
+    plots: [ ... ],        // each key must appear in what calc returns
+    calc(bars, settings, store) {
+      return { /* one array per plot key, exactly bars.length long */ }
+    },
+  })
+}
+```
+
+A `bar` is `{ time, open, high, low, close, volume }` with `time` in **UTC
+seconds**.
+
+## The four things that go wrong most
+
+Full list in `reference/pitfalls.md`. These four account for most failures:
+
+1. **Column length.** Every array must be exactly `bars.length`. Short arrays do
+   not error, they just stop drawing partway.
+2. **Warmup.** Use `null` (or `nulls(...)` on a helper's NaN output). A `0` puts
+   a spike at the bottom of the pane and wrecks autoscale.
+3. **`na` semantics.** In Pine every comparison against `na` is false. In
+   JavaScript `5 > null` is **true**. Guard with `x != null` or signals fire
+   through the warmup gap.
+4. **Marker anchoring.** `aboveBar` / `belowBar` anchor to *this indicator's own
+   plot line*, not to the candle. To place a label relative to a bar, use
+   `position: 'atPrice'` with an explicit price.
+
+## Do not
+
+- Add colour or line-width inputs. The chart generates colour, opacity,
+  thickness, line style and plot style per plot automatically, seeded from each
+  plot's `style`. Your own width input becomes a second control that disagrees.
+- Reuse a built-in id unless overriding it is the actual intent. Custom modules
+  register last, so they win. The validator warns on this.
+- Assume the browser's local time. Use `zonedDayIndex` /
+  `utcSecondsToZonedParts` with a zone, defaulting to `DEFAULT_TIMEZONE`.
+
+## Where things live
+
+| Path | |
+| --- | --- |
+| `strategies/indicators/*.js` | installed indicators, gitignored, never pushed |
+| `.claude/skills/chart-indicator/validate.mjs` | the gate |
+| `.claude/skills/chart-indicator/examples/` | three validated worked examples |
+| `.claude/skills/chart-indicator/reference/` | contract, API surface, pitfalls |
+| `docs/custom-indicators.md` | the user-facing guide |
+| `blueprints/custom_indicators.py` | serves the folder to the chart |
+| `frontend/src/lib/trading/customIndicators.ts` | the loader |
+
+Indicators are loaded over HTTP at runtime, not bundled, so they survive
+`git pull` and need no rebuild. They run with full access to the logged-in
+session: treat an indicator file from an untrusted source as you would any
+script you are about to run.

--- a/.claude/skills/chart-indicator/examples/complex_session_vwap.js
+++ b/.claude/skills/chart-indicator/examples/complex_session_vwap.js
@@ -1,0 +1,254 @@
+/**
+ * COMPLEX example: Session VWAP with deviation bands and cross signals.
+ *
+ * Everything the descriptor contract offers, in one indicator:
+ *
+ *   - per-session state that resets on a calendar boundary, using the zone
+ *     helpers rather than the browser's local time
+ *   - a text input parsed defensively, and a select input
+ *   - bands built from a running variance, not a second pass
+ *   - `markers` anchored with `atPrice` so labels sit off the candle
+ *   - a signal latch so the same side does not fire twice in a row
+ *   - `table` for a per-session summary the plots cannot express
+ *   - `calcTail` for the live path, kept consistent with `calc`
+ *
+ * VWAP resets each session. The bands are standard deviations of price around
+ * that running VWAP, so they widen with dispersion rather than with time.
+ */
+
+const BUY_COLOR = '#4caf50'
+const SELL_COLOR = '#ef5350'
+
+export default function ({
+  registerIndicator,
+  sourceValues,
+  zonedDayIndex,
+  isValidTimezone,
+  DEFAULT_TIMEZONE,
+}) {
+  /** The zone the session boundary is read in. Bar times are UTC seconds. */
+  function zoneOf(settings) {
+    const raw = typeof settings.timezone === 'string' ? settings.timezone.trim() : ''
+    return raw && isValidTimezone(raw) ? raw : DEFAULT_TIMEZONE
+  }
+
+  /**
+   * The whole computation in one pass.
+   *
+   * Kept as a standalone function because `calc`, `markers` and `calcTail` all
+   * need it and none of them can see the others' work.
+   */
+  function compute(bars, settings) {
+    const zone = zoneOf(settings)
+    const mult = Number(settings.bandMult) || 2
+    const src = sourceValues(bars, settings.source ?? 'hlc3')
+    const n = bars.length
+
+    const vwap = new Array(n).fill(null)
+    const upper = new Array(n).fill(null)
+    const lower = new Array(n).fill(null)
+    const sessionBar = new Array(n).fill(0)
+
+    let day = null
+    let sumPV = 0
+    let sumV = 0
+    let sumP2V = 0
+    let barsThisSession = 0
+
+    for (let i = 0; i < n; i++) {
+      const d = zonedDayIndex(bars[i].time, zone)
+      if (d !== day) {
+        day = d
+        sumPV = 0
+        sumV = 0
+        sumP2V = 0
+        barsThisSession = 0
+      }
+      barsThisSession++
+      sessionBar[i] = barsThisSession
+
+      // Volume can be absent on index series. Falling back to 1 makes this a
+      // plain average rather than dividing by zero and blanking the plot.
+      const v = Number.isFinite(bars[i].volume) && bars[i].volume > 0 ? bars[i].volume : 1
+      const p = src[i]
+      if (!Number.isFinite(p)) continue
+
+      sumPV += p * v
+      sumV += v
+      sumP2V += p * p * v
+
+      const mean = sumPV / sumV
+      vwap[i] = mean
+      // Variance of a weighted mean, accumulated rather than re-walked. Clamp at
+      // zero: floating point can drift a hair negative on a flat session.
+      const variance = Math.max(sumP2V / sumV - mean * mean, 0)
+      const sd = Math.sqrt(variance)
+      upper[i] = mean + mult * sd
+      lower[i] = mean - mult * sd
+    }
+
+    return { vwap, upper, lower, sessionBar }
+  }
+
+  /** Crosses of price through VWAP, one signal per side until the other fires. */
+  function signals(bars, values, settings) {
+    if (settings.showSignals === false) return []
+    const vwap = values.vwap ?? []
+    const out = []
+    let isLong = false
+    let isShort = false
+
+    for (let i = 1; i < bars.length; i++) {
+      const prev = vwap[i - 1]
+      const cur = vwap[i]
+      // Both ends must exist. In JavaScript `5 > null` is true, so an unguarded
+      // comparison fires signals through the warmup gap.
+      if (prev == null || cur == null) continue
+
+      const crossUp = bars[i - 1].close <= prev && bars[i].close > cur
+      const crossDown = bars[i - 1].close >= prev && bars[i].close < cur
+
+      if (crossUp && !isLong) {
+        isLong = true
+        isShort = false
+        out.push({ index: i, side: 'buy' })
+      } else if (crossDown && !isShort) {
+        isLong = false
+        isShort = true
+        out.push({ index: i, side: 'sell' })
+      }
+    }
+    return out
+  }
+
+  /**
+   * Label offset in price. `aboveBar` / `belowBar` anchor to this indicator's
+   * own plot line, not to the candle, so a label placed relative to a bar has to
+   * use `atPrice` and bring its own gap.
+   */
+  function markerPad(bars) {
+    let sum = 0
+    let count = 0
+    for (const bar of bars) {
+      const range = bar.high - bar.low
+      if (Number.isFinite(range) && range > 0) {
+        sum += range
+        count++
+      }
+    }
+    const mean = count > 0 ? sum / count : 0
+    const last = bars.length > 0 ? Math.abs(bars[bars.length - 1].close) : 0
+    return Math.max(mean * 0.5, last * 0.0005)
+  }
+
+  registerIndicator({
+    id: 'ex-session-vwap',
+    name: 'Session VWAP Bands',
+    category: 'Custom',
+    placement: 'onchart',
+
+    inputs: [
+      { key: 'source', type: 'source', label: 'Source', default: 'hlc3' },
+      { key: 'bandMult', type: 'number', label: 'Band Multiplier', default: 2, min: 0.5, max: 5, step: 0.1 },
+      { key: 'timezone', type: 'text', label: 'Session Timezone', default: DEFAULT_TIMEZONE },
+      { key: 'showSignals', type: 'boolean', label: 'Show Cross Signals', default: true },
+      { key: 'showTable', type: 'boolean', label: 'Show Session Summary', default: true },
+      {
+        key: 'bandStyle',
+        type: 'select',
+        label: 'Bands',
+        default: 'both',
+        options: [
+          { label: 'Both', value: 'both' },
+          { label: 'Upper only', value: 'upper' },
+          { label: 'Hidden', value: 'none' },
+        ],
+      },
+    ],
+
+    plots: [
+      { key: 'vwap', type: 'line', title: 'VWAP', style: { color: '#ffa726', lineWidth: 2 } },
+      { key: 'upper', type: 'line', title: 'Upper', style: { color: '#4f8cff', lineWidth: 1, lineStyle: 'dashed' } },
+      { key: 'lower', type: 'line', title: 'Lower', style: { color: '#4f8cff', lineWidth: 1, lineStyle: 'dashed' } },
+    ],
+
+    fills: [{ between: ['upper', 'lower'], colorUp: '#4f8cff', colorDown: '#4f8cff', opacity: 0.06 }],
+
+    calc(bars, settings) {
+      const { vwap, upper, lower } = compute(bars, settings)
+      const style = settings.bandStyle ?? 'both'
+      const blank = new Array(bars.length).fill(null)
+      return {
+        vwap,
+        upper: style === 'none' ? blank : upper,
+        lower: style === 'both' ? lower : blank,
+      }
+    },
+
+    markers({ bars, values, settings }) {
+      const pad = markerPad(bars)
+      return signals(bars, values, settings).map((sig) => {
+        const bar = bars[sig.index]
+        return sig.side === 'buy'
+          ? {
+              time: bar.time,
+              position: 'atPrice',
+              price: bar.low - pad,
+              shape: 'labelUp',
+              size: 'small',
+              color: BUY_COLOR,
+              text: 'Buy',
+            }
+          : {
+              time: bar.time,
+              position: 'atPrice',
+              price: bar.high + pad,
+              shape: 'labelDown',
+              size: 'small',
+              color: SELL_COLOR,
+              text: 'Sell',
+            }
+      })
+    },
+
+    /**
+     * A per-session scoreboard. This is not a value per bar, so it has no place
+     * in `calc`, whose contract is one column per plot aligned to the bars.
+     */
+    table({ bars, values, settings }) {
+      if (settings.showTable === false || bars.length === 0) return null
+      const last = bars.length - 1
+      const vwap = values.vwap?.[last]
+      if (vwap == null) return null
+
+      const close = bars[last].close
+      const diff = close - vwap
+      const pct = vwap !== 0 ? (diff / vwap) * 100 : 0
+      return {
+        rows: [
+          ['VWAP', vwap.toFixed(2)],
+          ['Close', close.toFixed(2)],
+          ['Diff', `${diff >= 0 ? '+' : ''}${diff.toFixed(2)} (${pct.toFixed(2)}%)`],
+          ['Side', diff >= 0 ? 'Above' : 'Below'],
+        ],
+      }
+    },
+
+    /**
+     * Live path. The runtime calls this when only the tail changed, for indices
+     * [fromIndex, bars.length). Recomputing the whole series and slicing keeps it
+     * exactly consistent with `calc`, which is the property that matters: a
+     * calcTail that drifts makes the live chart disagree with a reload.
+     *
+     * For a session-anchored accumulator this is honest rather than lazy. The
+     * running sums cannot be resumed from the previous output, and `markers`
+     * re-runs in full after every recompute anyway.
+     */
+    calcTail(bars, settings, fromIndex) {
+      const full = this.calc(bars, settings)
+      const out = {}
+      for (const key of Object.keys(full)) out[key] = full[key].slice(fromIndex)
+      return out
+    },
+  })
+}

--- a/.claude/skills/chart-indicator/examples/intermediate_keltner_squeeze.js
+++ b/.claude/skills/chart-indicator/examples/intermediate_keltner_squeeze.js
@@ -1,0 +1,105 @@
+/**
+ * INTERMEDIATE example: Keltner Squeeze.
+ *
+ * Adds everything a multi-plot overlay needs: several plots on one descriptor,
+ * a shaded band between two of them (`fills`), a per-bar colour on a histogram
+ * (`colorBy`), a boolean input that switches part of the drawing off, and a
+ * second price scale so the squeeze histogram does not fight the price axis.
+ *
+ * Bollinger Bands inside Keltner Channels means volatility has compressed and a
+ * range is coiling. The histogram is the width of the Bollinger band relative to
+ * the Keltner channel: below 1 the bands are inside the channel, which is the
+ * squeeze.
+ */
+
+export default function ({ registerIndicator, sourceValues, sma, stdev, atr, nulls }) {
+  registerIndicator({
+    id: 'ex-keltner-squeeze',
+    name: 'Keltner Squeeze',
+    category: 'Custom',
+    placement: 'onchart',
+
+    inputs: [
+      { key: 'length', type: 'number', label: 'Length', default: 20, min: 2, max: 200, step: 1 },
+      { key: 'bbMult', type: 'number', label: 'Bollinger Mult', default: 2, min: 0.5, max: 5, step: 0.1 },
+      { key: 'kcMult', type: 'number', label: 'Keltner Mult', default: 1.5, min: 0.5, max: 5, step: 0.1 },
+      { key: 'source', type: 'source', label: 'Source', default: 'close' },
+      { key: 'showSqueeze', type: 'boolean', label: 'Show Squeeze Histogram', default: true },
+    ],
+
+    plots: [
+      { key: 'basis', type: 'line', title: 'Basis', style: { color: '#8892a6', lineWidth: 1 } },
+      { key: 'bbUpper', type: 'line', title: 'BB Upper', style: { color: '#4f8cff', lineWidth: 1.5 } },
+      { key: 'bbLower', type: 'line', title: 'BB Lower', style: { color: '#4f8cff', lineWidth: 1.5 } },
+      { key: 'kcUpper', type: 'line', title: 'KC Upper', style: { color: '#ffa726', lineWidth: 1, lineStyle: 'dashed' } },
+      { key: 'kcLower', type: 'line', title: 'KC Lower', style: { color: '#ffa726', lineWidth: 1, lineStyle: 'dashed' } },
+      {
+        key: 'squeeze',
+        type: 'histogram',
+        title: 'Squeeze',
+        // Its own axis: a ratio near 1 has nothing to do with the price range,
+        // and sharing the right scale would flatten the price series.
+        priceScaleId: 'squeeze',
+        style: { color: '#26a69a', base: 0 },
+        // Red while the bands sit inside the channel, which is the signal.
+        colorBy: ({ value }) => (value < 1 ? '#ef5350' : '#26a69a'),
+      },
+    ],
+
+    // The band between the two Bollinger lines. A pair of lines and a filled
+    // region are not the same picture: the fill is what makes the compression
+    // readable at a glance.
+    fills: [{ between: ['bbUpper', 'bbLower'], colorUp: '#4f8cff', colorDown: '#4f8cff', opacity: 0.08 }],
+
+    calc(bars, settings) {
+      const length = Math.max(2, Math.floor(Number(settings.length) || 20))
+      const bbMult = Number(settings.bbMult) || 2
+      const kcMult = Number(settings.kcMult) || 1.5
+      const src = sourceValues(bars, settings.source ?? 'close')
+
+      const basis = sma(src, length)
+      const dev = stdev(src, length)
+      // `atr` and `trueRange` take three separate price arrays, NOT a bars
+      // array. Passing bars is the single easiest mistake to make here.
+      const range = atr(
+        bars.map((b) => b.high),
+        bars.map((b) => b.low),
+        bars.map((b) => b.close),
+        length
+      )
+
+      const n = bars.length
+      const bbUpper = new Array(n).fill(NaN)
+      const bbLower = new Array(n).fill(NaN)
+      const kcUpper = new Array(n).fill(NaN)
+      const kcLower = new Array(n).fill(NaN)
+      const squeeze = new Array(n).fill(NaN)
+
+      for (let i = 0; i < n; i++) {
+        if (!Number.isFinite(basis[i])) continue
+        if (Number.isFinite(dev[i])) {
+          bbUpper[i] = basis[i] + bbMult * dev[i]
+          bbLower[i] = basis[i] - bbMult * dev[i]
+        }
+        if (Number.isFinite(range[i])) {
+          kcUpper[i] = basis[i] + kcMult * range[i]
+          kcLower[i] = basis[i] - kcMult * range[i]
+        }
+        // Guard the divide: a flat series gives a zero-width channel.
+        const kcWidth = kcUpper[i] - kcLower[i]
+        if (settings.showSqueeze !== false && Number.isFinite(kcWidth) && kcWidth > 0) {
+          squeeze[i] = (bbUpper[i] - bbLower[i]) / kcWidth
+        }
+      }
+
+      return {
+        basis: nulls(basis),
+        bbUpper: nulls(bbUpper),
+        bbLower: nulls(bbLower),
+        kcUpper: nulls(kcUpper),
+        kcLower: nulls(kcLower),
+        squeeze: nulls(squeeze),
+      }
+    },
+  })
+}

--- a/.claude/skills/chart-indicator/examples/simple_zscore.js
+++ b/.claude/skills/chart-indicator/examples/simple_zscore.js
@@ -1,0 +1,54 @@
+/**
+ * SIMPLE example: Price Z-Score.
+ *
+ * One pane, one plot, one rolling window. Shows the minimum shape of a working
+ * indicator: inputs, a plot, a calc that fills every bar, plus `levels` and
+ * `range` to make the pane readable.
+ *
+ * How many standard deviations the source sits from its own rolling mean. Above
+ * +2 is stretched, below -2 is stretched the other way.
+ */
+
+export default function ({ registerIndicator, sourceValues, sma, stdev, nulls }) {
+  registerIndicator({
+    id: 'ex-zscore',
+    name: 'Z-Score',
+    category: 'Custom',
+    placement: 'pane',
+
+    inputs: [
+      { key: 'length', type: 'number', label: 'Length', default: 20, min: 2, max: 500, step: 1 },
+      { key: 'source', type: 'source', label: 'Source', default: 'close' },
+    ],
+
+    plots: [{ key: 'z', type: 'line', title: 'Z', style: { color: '#4f8cff', lineWidth: 2 } }],
+
+    // Reference lines and a fixed pane range, so the scale does not rescale
+    // itself every time the series drifts.
+    levels: () => [
+      { price: 2, title: '+2', color: '#ef5350' },
+      { price: 0, title: '0', color: '#8892a6' },
+      { price: -2, title: '-2', color: '#26a69a' },
+    ],
+    range: () => ({ min: -4, max: 4 }),
+
+    calc(bars, settings) {
+      // Always coerce: a cleared number field arrives as '' and Number('') is 0,
+      // which would make the window length zero.
+      const length = Math.max(2, Math.floor(Number(settings.length) || 20))
+      const src = sourceValues(bars, settings.source ?? 'close')
+
+      // The shipped helpers return NaN during warmup; `nulls` converts that to
+      // the explicit gaps a plot column wants.
+      const mean = sma(src, length)
+      const sd = stdev(src, length)
+
+      const z = new Array(bars.length).fill(NaN)
+      for (let i = 0; i < bars.length; i++) {
+        if (!Number.isFinite(mean[i]) || !Number.isFinite(sd[i]) || sd[i] === 0) continue
+        z[i] = (src[i] - mean[i]) / sd[i]
+      }
+      return { z: nulls(z) }
+    },
+  })
+}

--- a/.claude/skills/chart-indicator/reference/api.md
+++ b/.claude/skills/chart-indicator/reference/api.md
@@ -1,0 +1,178 @@
+# The API handed to your module
+
+Your default export receives one object carrying the whole of `openalgo-charts`
+(core) plus its `indicators` tier, merged. Destructure what you need:
+
+```js
+export default function ({ registerIndicator, sourceValues, sma, nulls }) { ... }
+```
+
+There is nothing to import. A runtime module cannot resolve the bare
+`openalgo-charts` specifier, which is why the API arrives as an argument.
+
+## Registration
+
+| | |
+| --- | --- |
+| `registerIndicator(descriptor)` | the one call that matters |
+| `createTier2Indicator(d)` | wrap an external-data descriptor as a normal one |
+| `registeredIndicators()` | every registered descriptor |
+| `getIndicator(id)`, `hasIndicator(id)` | look one up |
+| `indicatorDefaults(descriptor)` | its declared defaults as a settings object |
+| `indicatorStyleInputs(descriptor)` | the generated style fields |
+| `registeredChartTypes()` | valid `plot.type` values |
+
+## Reading bars
+
+| | |
+| --- | --- |
+| `sourceValues(bars, source)` | whole bar array as one price column |
+| `sourceValue(bar, source)` | one bar's value |
+| `INDICATOR_SOURCES` | the canonical source list for a select |
+
+Sources: `open`, `high`, `low`, `close`, `hl2`, `hlc3`, `ohlc4`, `volume`.
+
+## Moving averages and statistics
+
+All take a **numeric array** and return an array the same length, with `NaN`
+during warmup.
+
+| | |
+| --- | --- |
+| `sma(values, period)` | simple |
+| `wma(values, period)` | linearly weighted |
+| `rma(values, period)` | Wilder smoothing, the basis of RSI/ATR/ADX |
+| `ema(values, period)` | seeds from `values[0]`, emits from index 0 |
+| `stdev(values, period)` | rolling population standard deviation |
+| `highest(values, period)`, `lowest(values, period)` | rolling extremes |
+| `connorsStreak(values)` | consecutive up/down streak length per bar |
+| `nulls(values)` | NaN to null, for a plot column |
+
+`ema` seeds from `values[0]` and emits a value from index 0, matching
+`openalgo.ta`. TradingView's `ta.ema` seeds from the SMA of the first `period`
+values and is NaN before that, so the two disagree for roughly the first
+`period` bars and converge after. The library has an SMA-seeded variant
+internally but **does not export it**: when reproducing a reference platform
+plot exactly, seed it yourself.
+
+```js
+const seeded = new Array(src.length).fill(NaN)
+const base = sma(src, period)
+let prev = base[period - 1]
+seeded[period - 1] = prev
+const k = 2 / (period + 1)
+for (let i = period; i < src.length; i++) {
+  prev = src[i] * k + prev * (1 - k)
+  seeded[i] = prev
+}
+```
+
+`sma` is NaN-safe: it counts non-finite inputs rather than poisoning its running
+sum, so chaining it onto another indicator's warmup gap works.
+
+## OHLC-based studies
+
+**These take three separate arrays, not a bars array.** Getting this wrong is the
+easiest mistake in the whole API.
+
+| | |
+| --- | --- |
+| `trueRange(high, low, close)` | `tr[0] = high[0] - low[0]`, then the 3-way max |
+| `atr(high, low, close, period?)` | Wilder ATR, first value at `period - 1` |
+| `rsi(values, period?)` | takes a **single** numeric array |
+| `supertrend(bars, period?, multiplier?)` | takes **bars**, returns `{ value, direction }[]` |
+
+```js
+const range = atr(bars.map(b => b.high), bars.map(b => b.low), bars.map(b => b.close), 14)
+```
+
+`supertrend`'s `direction` is `-1` for uptrend and `+1` for downtrend.
+
+## Time and calendar
+
+Bar times are UTC seconds. A session is exchange wall clock. They only meet
+through a zone, so never use the browser's local time.
+
+| | |
+| --- | --- |
+| `DEFAULT_TIMEZONE` | `'Asia/Kolkata'` |
+| `isValidTimezone(zone)` | guard a user-supplied zone |
+| `utcSecondsToZonedParts(t, zone?)` | `{ year, month, day, hour, minute, second, weekday }` |
+| `zonedDayIndex(t, zone?)` | days since epoch in that zone, for per-day buckets |
+| `zonedWeekIndex(t, zone?)` | Monday-start week bucket |
+| `isNewZonedDay(prev, t, zone?)` | boundary test; also Week/Month/Quarter/Year |
+| `isNewZonedPeriod(prev, t, period, zone?)` | the same carried as data |
+| `startOfZonedDay / Week / Month` | period start |
+| `zoneOffsetSeconds(t, zone?)` | DST-correct offset |
+| `sessionStartFlags(times, zone?)` | per-bar first-bar-of-session flags |
+| `sessionStartIndices(times, zone?)` | the same as indices |
+| `calendarPeriodFlags(times, isNew)` | first bar of each period, session-aware |
+| `formatIstTime`, `formatZonedTime`, `formatZonedDate` | labels |
+
+Prefer `calendarPeriodFlags` / `sessionStartFlags` over comparing bar to bar: a
+session that straddles a calendar boundary is not cut in half by them.
+
+## Numbers and drawing
+
+| | |
+| --- | --- |
+| `clamp(v, min, max)`, `lerp(a, b, t)` | |
+| `roundToTick(price, tick)` | |
+| `precisionForStep(step)` | decimals for a tick size |
+| `compactVolume(n)` | `1.2M` style |
+| `niceTicks(...)` | axis-style tick selection |
+| `INDICATOR_LINE_STYLES`, `INDICATOR_PLOT_STYLES` | option lists for selects |
+
+## Constants
+
+| | |
+| --- | --- |
+| `IST_OFFSET_SECONDS` | 19800 |
+| `DEFAULT_THEME`, `darkTheme`, `lightTheme` | theme palettes |
+| `VERSION` | library version |
+
+## Complete export index
+
+Every one of the 303 names on the API object, so nothing is a surprise.
+Generated from the installed `openalgo-charts` build.
+
+**Registration and introspection** (14)
+
+`registerIndicator`, `createTier2Indicator`, `registeredIndicators`, `getIndicator`, `hasIndicator`, `indicatorDefaults`, `indicatorStyleInputs`, `plotStyleKeys`, `registeredChartTypes`, `getChartType`, `registerChartType`, `registerBuiltinIndicators`, `BUILTIN_INDICATORS`, `INDICATORS_TIER`
+
+**Reading bars** (10)
+
+`sourceValues`, `sourceValue`, `INDICATOR_SOURCES`, `toBar`, `mergeBars`, `conflateBars`, `conflateItems`, `isWhitespace`, `generateBars`, `FakeDataFeed`
+
+**Moving averages and statistics** (9)
+
+`sma`, `wma`, `rma`, `ema`, `stdev`, `highest`, `lowest`, `nulls`, `connorsStreak`
+
+**OHLC studies** (7)
+
+`trueRange`, `atr`, `rsi`, `supertrend`, `emaSeries`, `rsiSeries`, `supertrendSeries`
+
+**Time, calendar and sessions** (40)
+
+`DEFAULT_TIMEZONE`, `IST_OFFSET_SECONDS`, `isValidTimezone`, `utcSecondsToZonedParts`, `utcSecondsToIstParts`, `zonedDayIndex`, `zonedWeekIndex`, `zoneOffsetSeconds`, `isNewZonedDay`, `isNewZonedWeek`, `isNewZonedMonth`, `isNewZonedQuarter`, `isNewZonedYear`, `isNewZonedPeriod`, `isNewIstDay`, `startOfZonedDay`, `startOfZonedWeek`, `startOfZonedMonth`, `sessionStartFlags`, `sessionStartIndices`, `calendarPeriodFlags`, `epochMsToUtcSeconds`, `istStringToUtcSeconds`, `zonedStringToUtcSeconds`, `zonedWallClockToUtcSeconds`, `utcSecondsToIstDateString`, `utcSecondsToZonedDateString`, `rowTimeToUtcSeconds`, `barCloseSec`, `bucketStartOf`, `nextBucketStart`, `isTimeBucketed`, `intervalToSeconds`, `isKnownInterval`, `resolveInterval`, `tryResolveInterval`, `registeredIntervals`, `registerInterval`, `unregisterInterval`, `UnknownIntervalError`
+
+**Formatting labels** (10)
+
+`formatIstTime`, `formatIstTimeSeconds`, `formatIstDate`, `formatIstCrosshairLabel`, `formatZonedTime`, `formatZonedTimeSeconds`, `formatZonedDate`, `formatZonedCrosshairLabel`, `compactVolume`, `precisionForStep`
+
+**Numbers and geometry** (18)
+
+`clamp`, `lerp`, `roundToTick`, `niceTicks`, `autoscaleRange`, `optimalBarWidth`, `snapToDevicePixel`, `bitmapSize`, `dashPattern`, `verticalGradient`, `markerSizePx`, `effectiveMarkerPx`, `drawShape`, `drawLabel`, `bestHit`, `tableOrigin`, `watermarkRect`, `resolvePlotMargins`
+
+**Style and option lists** (19)
+
+`INDICATOR_LINE_STYLES`, `INDICATOR_PLOT_STYLES`, `PRICE_SCALE_MODES`, `PRICE_LEVEL_KINDS`, `DEFAULT_THEME`, `darkTheme`, `lightTheme`, `ALT_PRESET`, `VERSION`, `version`, `CHART_STATE_VERSION`, `DEFAULT_CANDLE_STYLE`, `DEFAULT_HISTOGRAM_STYLE`, `DEFAULT_TRADING_COLORS`, `resolveCrosshairStyle`, `resolveGridStyle`, `resolveScaleStyle`, `seriesStyleForLastPriceLevel`, `lastPriceLevelFromSeriesStyle`
+
+**Chart infrastructure, not for indicators** (176)
+
+These build and drive a chart: panes, scales, feeds, drawing primitives,
+trading controllers, link groups, replay. An indicator describes what to
+compute and what to plot; the chart owns all of this. Listed for completeness.
+
+`ADAPTIVE_INDICATORS`, `ADL`, `ADX`, `ALLIGATOR`, `ALMA`, `ALPHATREND`, `AROON`, `AROON_OSCILLATOR`, `ATR`, `AVERAGE_DAILY_RANGE`, `AVERAGE_INDICATORS`, `AWESOME_OSCILLATOR`, `BALANCE_OF_POWER`, `BB_TREND`, `BOLLINGER`, `BOLLINGER_BANDWIDTH`, `BOLLINGER_PERCENT_B`, `BUILTIN_COMMANDS`, `BarCache`, `BuySellButtons`, `CCI`, `CHAIKIN_MONEY_FLOW`, `CHAIKIN_OSCILLATOR`, `CHANDELIER_EXIT`, `CHANDE_KROLL_STOP`, `CHANDE_MOMENTUM`, `CHOPPINESS_INDEX`, `CHOP_ZONE`, `CONNORS_RSI`, `COPPOCK_CURVE`, `CPR`, `CandleBuilder`, `Chart`, `ChartTable`, `ComparisonController`, `DEFAULT_CANDLE_BUILDER_OPTIONS`, `DEFAULT_CHART_TABLE_OPTIONS`, `DEFAULT_KEYMAP`, `DEFAULT_PRICE_SCALE_OPTIONS`, `DEFAULT_TIME_NAVIGATOR_OPTIONS`, `DEFAULT_TIME_SCALE_OPTIONS`, `DEMA`, `DONCHIAN`, `DPO`, `EASE_OF_MOVEMENT`, `ELDER_FORCE_INDEX`, `EMA`, `ENVELOPE`, `EventMarkers`, `FISHER_TRANSFORM`, `FLOW_INDICATORS`, `HALFTREND`, `HISTORICAL_VOLATILITY`, `HMA`, `ICHIMOKU`, `INDEX_INDICATORS`, `IndicatorFill`, `InvalidationLevel`, `KAMA`, `KELTNER_CHANNEL`, `KLINGER_OSCILLATOR`, `KNOW_SURE_THING`, `LINK_CROSSHAIR_ALPHA`, `LSMA`, `LinkCrosshair`, `LinkGroup`, `LogoWatermark`, `MACD`, `MASS_INDEX`, `MA_CROSS`, `MA_RIBBON`, `MCGINLEY_DYNAMIC`, `MEDIAN`, `MFI`, `MOMENTUM`, `NVI`, `OBV`, `OSCILLATOR_INDICATORS`, `OVERLAY_INDICATORS`, `OpenAlgoDataFeed`, `OpenAlgoLiveDataFeed`, `OpenAlgoTradeFeed`, `OpenAlgoWsFeed`, `PARABOLIC_SAR`, `PPO`, `PVI`, `PVO`, `PVT`, `Pane`, `PaneLegend`, `PriceLevels`, `PriceLine`, `PriceScale`, `RANGE_ANALYSIS`, `RANGE_INDICATORS`, `RELATIVE_VIGOR_INDEX`, `RELATIVE_VOLATILITY_INDEX`, `ROC`, `RSI`, `RSI_DIVERGENCE`, `ReplayController`, `SCALE_FONT_MAX`, `SCALE_FONT_MIN`, `SEASONALITY`, `SEASONALITY_INDICATORS`, `SIGNAL_INDICATORS`, `SMA`, `SMI`, `SMI_ERGODIC_INDICATOR`, `SMI_ERGODIC_OSCILLATOR`, `SPECIAL_K`, `STOCHASTIC`, `STOCHASTIC_RSI`, `STRENGTH_INDICATORS`, `STUDY_INDICATORS`, `SUPERTREND`, `SeriesMarkers`, `ShortcutManager`, `TEMA`, `TREND_STRENGTH_INDEX`, `TRIX`, `TSI`, `TWAP`, `TickBarAggregator`, `TimeNavigator`, `TimeScale`, `TradeMarkersPrimitive`, `TradingController`, `ULCER_INDEX`, `ULTIMATE_OSCILLATOR`, `VOLATILITY_INDICATORS`, `VOLATILITY_STOP`, `VOLUME`, `VORTEX`, `VWAP`, `VWMA`, `WAVETREND`, `WAVETREND_INDICATORS`, `WILLIAMS_FRACTALS`, `WILLIAMS_PERCENT_R`, `WILLIAMS_VIX_FIX`, `WMA`, `WOODIES_CCI`, `addComparison`, `alignToPrimary`, `applyChartSettings`, `backoffDelayMs`, `barCacheKey`, `chartSettingsSchema`, `classifyAuthAck`, `comparisonController`, `computePriceLevels`, `conflationGroupSize`, `createChart`, `createLinkGroup`, `decodeOrder`, `eventToCombo`, `followerIndex`, `followerRange`, `formatCombo`, `formatSubscribe`, `formatUnsubscribe`, `isRebasing`, `isReservedCombo`, `isValidCombo`, `mapHistoryResponse`, `mapOrder`, `mapOrderStatus`, `mapPosition`, `normalizeCombo`, `parseCombo`, `parseMessage`, `parseTopic`, `readChartSettings`, `readSequence`, `withBarCache`
+

--- a/.claude/skills/chart-indicator/reference/contract.md
+++ b/.claude/skills/chart-indicator/reference/contract.md
@@ -1,0 +1,197 @@
+# The descriptor contract
+
+What `registerIndicator` accepts, and what the runtime actually does with it.
+Behaviour here is read from `openalgo-charts` `src/model/indicator-instance.ts`,
+not inferred from the type declarations.
+
+## Shape
+
+```js
+{
+  id: string,                    // required, unique registry key
+  name: string,                  // required, picker + legend
+  category?: string,             // picker rail grouping; 'Custom' by convention
+  placement: 'onchart' | 'pane', // required
+  inputs: IndicatorInput[],      // required (use [] for none)
+  plots: IndicatorPlot[],        // required, at least one
+  fills?: IndicatorFillSpec[],
+  calc(bars, settings, store): IndicatorValues,   // required
+  calcTail?(bars, settings, fromIndex, previous, store),
+  markers?({ bars, values, settings }),
+  levels?(settings),
+  range?(settings),
+  table?({ bars, values, settings }),
+  attach?(ctx),
+}
+```
+
+## Bars
+
+```js
+{ time: number,   // UTC SECONDS, not milliseconds
+  open: number, high: number, low: number, close: number,
+  volume?: number }
+```
+
+`volume` is genuinely optional. Index series carry none, so guard any divide by
+it.
+
+## `calc` and how its output is consumed
+
+The runtime does this, per plot, every recompute:
+
+```js
+const col = values[plot.key]
+if (col === undefined) { series.setData([]); continue }   // plot draws NOTHING
+for (let i = 0; i < bars.length; i++) {
+  const v = col[i]
+  const value = (v === null || v === undefined) ? NaN : v
+  ...
+}
+```
+
+Three consequences that matter:
+
+- **A missing plot key is silent.** The series is emptied, no error.
+- **Length is not checked.** Iteration is over `bars.length`, so a short column
+  reads `undefined` past its end (drawn as a gap) and a long one has its tail
+  ignored. Neither raises.
+- **`null`, `undefined` and `NaN` are equivalent** and all become gaps. The
+  declared type is `number | null`; the shipped helpers emit `NaN` and `nulls()`
+  converts. Either is safe. `0` is not a gap and will distort autoscale.
+
+Non-finite points break the line renderer cleanly and are skipped by autoscale,
+which is exactly what a warmup gap should do.
+
+## Inputs
+
+| type | Renders as | Extra |
+| --- | --- | --- |
+| `number` | number box with steppers | `min`, `max`, `step` |
+| `boolean` | tick box | |
+| `color` | colour swatch | |
+| `text` | text box | |
+| `select` | dropdown | `options: [{ label, value }]` |
+| `source` | price-source dropdown | default must be a valid source |
+
+Every input needs `key`, `type`, `label`, `default`. Valid sources: `open`,
+`high`, `low`, `close`, `hl2`, `hlc3`, `ohlc4`, `volume`.
+
+A cleared text or number field arrives as `''`, not as the default. Always
+coerce: `Math.max(2, Math.floor(Number(settings.length) || 20))`.
+
+`group` buckets inputs in the dialog.
+
+## Plots
+
+```js
+{ key: 'ma',                 // must match a calc output key
+  type: 'line',              // registered chart type
+  title: 'MA',               // legend label
+  style: { color: '#4f8cff', lineWidth: 2, lineStyle: 'dashed' },
+  priceScaleId: 'right',     // own axis if you name a different one
+  colorKey: 'lineColor',     // optional: an input key holding the colour
+  colorBy({ value, index, values, settings }) { return '#ef5350' } }
+```
+
+Single-column plot types: `line`, `line-markers`, `step`, `area`, `histogram`,
+`column`. The full registry also has `candlestick`, `hollow-candle`,
+`volume-candle`, `bar`, `high-low`, `hlc-area`, `baseline`, which expect richer
+data and are rarely right for an indicator.
+
+`colorBy` is honoured by `histogram` and `column`. It is skipped for non-finite
+values.
+
+**Style controls are generated for you.** `indicatorStyleInputs` derives colour,
+opacity, thickness, line style and plot style per plot, defaulting from
+`plot.style.color` (or the input named by `colorKey`) and `plot.style.lineWidth`.
+Do not hand-roll them.
+
+## Fills
+
+```js
+fills: [{ between: ['upper', 'lower'], colorUp: '#4f8cff', colorDown: '#4f8cff', opacity: 0.08 }]
+```
+
+Both keys must name real plots. `colorUp` applies where the first is above the
+second.
+
+## Markers
+
+```js
+{ time,                    // must equal a bar's time exactly
+  position,                // 'aboveBar' | 'belowBar' | 'inBar' | 'atPrice'
+  price,                   // required for 'atPrice'
+  shape,                   // arrowUp arrowDown circle square triangleUp
+                           // triangleDown diamond flag text labelUp labelDown
+  size,                    // 'tiny' | 'small' | 'medium' | 'big'
+  color, text }
+```
+
+Runs after every `calc` and is handed the values it just produced. Returning
+`[]` clears the layer, which is how a `showSignals` toggle should work.
+
+**Anchoring.** The renderer resolves `aboveBar` from `a.high` and `belowBar`
+from `a.low`, where `a` is a point of **the series the markers are attached to**.
+For an indicator that is its own plot, so on an overlay both resolve against your
+line, not the candle. `atPrice` uses `price` directly and adds no padding, so
+compute the gap yourself and scale it to the instrument.
+
+`labelUp` puts the plate below the anchor with the tail pointing up; `labelDown`
+puts it above with the tail pointing down. Plate text colour is automatic.
+
+## Levels, range, table
+
+```js
+levels: (settings) => [{ price: 70, title: '70', color: '#ef5350', dashed: true }]
+range:  (settings) => ({ min: 0, max: 100 })     // or null
+table:  (ctx) => ({ rows: [['VWAP', '123.45'], ['Side', 'Above']] })   // or null
+```
+
+`range` applies only when the indicator created its own pane; two indicators
+sharing a pane would otherwise fight over it. `table` is for things that are not
+a value per bar, such as a scoreboard or a seasonality matrix.
+
+## calcTail
+
+```js
+calcTail(bars, settings, fromIndex, previous, store) -> values | null
+```
+
+Called **instead of** `calc` when only the tail changed. The runtime uses it when
+`bars.length === previousCount` or `previousCount + 1`, passing
+`fromIndex = previousCount - 1` (the previously-last bar may have been replaced
+by a tick). Return values for `[fromIndex, bars.length)`, which the runtime
+splices onto the previous result, or `null` to fall back to a full `calc`.
+
+Without it every tick costs a full recompute: a few hundred microseconds over
+50k bars, so it only matters in a busy live pane. **If you also implement
+`markers`, skip `calcTail`** — markers re-run in full after every recompute, so
+it saves nothing.
+
+A `calcTail` that disagrees with `calc` makes the live chart differ from what a
+reload shows. The validator checks the two agree at the boundary index.
+
+## attach (Tier 2)
+
+For data the chart does not have. Prefer `createTier2Indicator`, which wraps
+`fetch` / `subscribe` into an ordinary descriptor:
+
+```js
+createTier2Indicator({
+  id, name, placement, inputs, plots,
+  refetchOn: ['symbol'],
+  async fetch({ settings, bars, from, to }) {
+    return [{ time: 1700000000, values: { oi: 12345 } }]
+  },
+  subscribe({ settings }, push) { return () => {} },
+})
+```
+
+Each bar takes the most recent external point **at or before** its time. Never
+interpolated, never forward-looking; bars before the first point are `null`.
+
+## Registration order
+
+The chart imports the built-in tier first, then user modules, so a custom
+indicator with a built-in id **overrides** it. Prefix your ids.

--- a/.claude/skills/chart-indicator/reference/pitfalls.md
+++ b/.claude/skills/chart-indicator/reference/pitfalls.md
@@ -1,0 +1,232 @@
+# Pitfalls
+
+Read this before writing an indicator. Most first drafts fail on something here.
+Each entry says what happens, why, and what the validator does about it.
+
+---
+
+## 1. Column length must equal `bars.length`
+
+```js
+calc(bars) { return { x: bars.slice(1).map(b => b.close) } }   // WRONG: one short
+```
+
+The runtime iterates `0 .. bars.length` and reads `col[i]`. Past the end it gets
+`undefined`, drawn as a gap. Nothing raises. A short column looks like an
+indicator that "stops working" partway across the chart.
+
+*Validator: ERROR.*
+
+---
+
+## 2. Every plot key must appear in what `calc` returns
+
+```js
+plots: [{ key: 'value', ... }]
+calc() { return { val: [...] } }        // WRONG: 'value' vs 'val'
+```
+
+A missing key makes the runtime call `series.setData([])`. The plot silently
+draws nothing.
+
+*Validator: ERROR.*
+
+---
+
+## 3. Warmup is `null`, never `0`
+
+`0` is a real value. It lands at the bottom of the pane, drags autoscale down and
+draws a line from zero to the first real value. Use `null`, or `nulls(x)` on a
+helper's NaN output. `null`, `undefined` and `NaN` are all treated as gaps.
+
+*Validator: cannot tell 0 from a real value. Yours to get right.*
+
+---
+
+## 4. `na` semantics are inverted in JavaScript
+
+In Pine, every comparison against `na` is false, so nothing fires during warmup.
+In JavaScript:
+
+```js
+5 > null        // true
+null >= 0       // true
+```
+
+An unguarded crossover test therefore fires a signal on the first bar where the
+level appears, and often on every warmup bar before it.
+
+```js
+if (prev == null || cur == null) continue      // do this first, always
+```
+
+*Validator: cannot detect. This is the most common logic bug.*
+
+---
+
+## 5. Marker positions do not mean what they say
+
+`aboveBar` and `belowBar` resolve against **the series the markers are attached
+to**, which for an indicator is its own plot. On an overlay, both pin the label
+to your line and ignore the candle entirely.
+
+```js
+{ position: 'atPrice', price: bar.low - pad, shape: 'labelUp' }    // relative to the candle
+```
+
+`atPrice` adds no padding, so bring your own, and scale it to the instrument:
+
+```js
+const pad = Math.max(meanBarRange * 0.5, Math.abs(lastClose) * 0.0005)
+```
+
+A fixed number of points looks right on one symbol and wrong on every other.
+
+*Validator: WARNING on `aboveBar`/`belowBar` for an `onchart` indicator.*
+
+---
+
+## 6. A cleared input arrives as `''`
+
+The settings dialog hands back `''` when a user empties a field, not the default.
+
+```js
+Number('')          // 0     -> a zero-length window
+''.split('-')[1]    // undefined -> TypeError on the next call
+```
+
+Always coerce with a floor:
+
+```js
+const length = Math.max(2, Math.floor(Number(settings.length) || 20))
+```
+
+*Validator: ERROR. It runs every calc with all text and number inputs cleared.*
+
+---
+
+## 7. `atr` and `trueRange` take three arrays, not bars
+
+```js
+atr(bars, 14)                                                        // WRONG
+atr(bars.map(b=>b.high), bars.map(b=>b.low), bars.map(b=>b.close), 14) // right
+```
+
+`rsi` takes a single numeric array. `supertrend` takes bars. There is no
+consistent rule, so check `reference/api.md`.
+
+*Validator: ERROR, as a thrown exception.*
+
+---
+
+## 8. Do not declare colour or width inputs
+
+The chart generates colour, opacity, thickness, line style and plot style for
+every plot, seeded from `plot.style`. A hand-rolled `lineWidth` input gives the
+user two width fields that disagree, and only one of them works.
+
+Set defaults on the plot instead:
+
+```js
+{ key: 'ma', type: 'line', title: 'MA', style: { color: '#4f8cff', lineWidth: 2 } }
+```
+
+*Validator: no check. Style.*
+
+---
+
+## 9. Volume can be missing
+
+Index series carry no volume. `bars[i].volume` is `undefined`, so any VWAP-style
+weight divides by zero and the whole plot blanks.
+
+```js
+const v = Number.isFinite(bar.volume) && bar.volume > 0 ? bar.volume : 1
+```
+
+*Validator: partial. The fixtures all carry volume; the flat fixture catches the
+related zero-range divide.*
+
+---
+
+## 10. Guard every divide
+
+A flat series makes `high - low` zero, a doji run makes a mean range zero, and a
+zero standard deviation is normal on a halted instrument. Division yields
+`Infinity` or `NaN`, which draws as a gap at best and destroys autoscale at
+worst.
+
+*Validator: ERROR via the flat-series fixture.*
+
+---
+
+## 11. Never use the browser's local time
+
+Bar times are UTC seconds; sessions are exchange wall clock. `new Date(t*1000)
+.getHours()` gives the viewer's timezone, so the same chart computes differently
+in Mumbai and London.
+
+```js
+const parts = utcSecondsToZonedParts(bars[i].time, zone)
+const minuteOfDay = parts.hour * 60 + parts.minute
+```
+
+Default the zone to `DEFAULT_TIMEZONE` and validate a user-supplied one with
+`isValidTimezone`.
+
+*Validator: no check. The fixtures are IST.*
+
+---
+
+## 12. `time` is seconds, not milliseconds
+
+`Date.now()` is milliseconds. A marker at `bar.time * 1000` matches no bar and
+never draws.
+
+*Validator: ERROR for markers whose time matches no bar.*
+
+---
+
+## 13. Reusing a built-in id overrides it
+
+Custom modules register after the built-in tier, so a duplicate id replaces the
+built-in for the whole app. There are 91 of them; `sma`, `rsi`, `macd`,
+`supertrend`, `vwap`, `range-analysis` are all taken.
+
+*Validator: WARNING.*
+
+---
+
+## 14. `calcTail` must agree with `calc`
+
+If it drifts, the live chart shows different values from what a reload shows, and
+the bug only appears after a session of ticking. Note the runtime passes
+`fromIndex = previousCount - 1`, because the previously-last bar may have been
+replaced by a tick, so the tail always **re-computes at least one existing bar**.
+
+Skip `calcTail` entirely if you implement `markers`: markers re-run in full after
+every recompute, so there is nothing left to save.
+
+*Validator: ERROR if the boundary value disagrees with `calc`.*
+
+---
+
+## 15. `range` only applies to an indicator's own pane
+
+Two indicators sharing a pane would fight over the scale, so the runtime applies
+`range` only when the indicator created the pane. On a shared pane it is ignored.
+
+*Validator: no check.*
+
+---
+
+## 16. Per-instance state belongs in `store`, not module scope
+
+A module-scope variable is shared by every instance of the indicator. Add the
+same indicator twice with different settings and they corrupt each other. `calc`
+receives a per-instance `store` object for scratch.
+
+Pure `calc` functions of `(bars, settings)` need no state at all, which is the
+better answer where possible.
+
+*Validator: no check. It validates one instance.*

--- a/.claude/skills/chart-indicator/validate.mjs
+++ b/.claude/skills/chart-indicator/validate.mjs
@@ -1,0 +1,580 @@
+#!/usr/bin/env node
+/**
+ * Validate a custom chart indicator before it is allowed anywhere near
+ * strategies/indicators/.
+ *
+ * A file in that folder is imported by the live chart. There is no compiler and
+ * no type check between writing it and running it, and the runtime is forgiving
+ * in exactly the wrong way: a column that is too short, or a plot key that does
+ * not match, draws nothing at all rather than raising. So a broken indicator
+ * looks like an indicator that "does not work" with no error anywhere.
+ *
+ * This runs the candidate against the real openalgo-charts build, exercises its
+ * calc over several bar shapes, and refuses to install anything that errors.
+ *
+ * Usage:
+ *   node validate.mjs <candidate.js>              check only
+ *   node validate.mjs <candidate.js> --install    check, then install on a pass
+ */
+
+import { mkdirSync, copyFileSync, existsSync } from 'node:fs'
+import { basename, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
+
+const REPO_ROOT = resolve(import.meta.dirname, '..', '..', '..')
+const INSTALL_DIR = join(REPO_ROOT, 'strategies', 'indicators')
+/** openalgo-charts is a frontend dependency; this script runs from the repo root. */
+const CHARTS_ROOT = join(REPO_ROOT, 'frontend', 'node_modules', 'openalgo-charts')
+
+const errors = []
+const warnings = []
+const notes = []
+
+// Every check runs against 5 fixtures x up to 3 settings variants, so one
+// structural defect would otherwise be reported 15 times. Callers pass a key
+// naming the defect (not the message, which carries the fixture it was caught
+// on) so the first occurrence is reported and the rest collapse into it.
+const seen = new Set()
+const once = (list) => (m, key) => {
+  const k = key ?? m
+  if (seen.has(k)) return
+  seen.add(k)
+  list.push(m)
+}
+const err = once(errors)
+const warn = once(warnings)
+const note = once(notes)
+
+const INPUT_TYPES = new Set(['number', 'boolean', 'color', 'text', 'select', 'source'])
+const SOURCES = new Set(['open', 'high', 'low', 'close', 'hl2', 'hlc3', 'ohlc4', 'volume'])
+const PLACEMENTS = new Set(['onchart', 'pane'])
+const MARKER_POSITIONS = new Set(['aboveBar', 'belowBar', 'inBar', 'atPrice'])
+const MARKER_SHAPES = new Set([
+  'arrowUp', 'arrowDown', 'circle', 'square', 'triangleUp', 'triangleDown',
+  'diamond', 'flag', 'text', 'labelUp', 'labelDown',
+])
+const MARKER_SIZES = new Set(['tiny', 'small', 'medium', 'big'])
+
+/* ── synthetic bars ────────────────────────────────────────────────────────
+ * Five shapes, because the failures cluster at the edges rather than in the
+ * middle: an empty series, a series shorter than any sane lookback, a flat
+ * series that makes every range zero (division traps), and a two-day series so
+ * anything doing per-session or per-day work actually crosses a boundary.
+ */
+const IST_OFFSET = 5.5 * 3600
+
+function sessionBars(days, perDay, startHour = 9, startMin = 15, stepMin = 5, flat = false) {
+  const bars = []
+  for (let d = 0; d < days; d++) {
+    for (let i = 0; i < perDay; i++) {
+      const minutes = startHour * 60 + startMin + i * stepMin
+      const t = Date.UTC(2024, 0, 2 + d, 0, minutes) / 1000 - IST_OFFSET
+      if (flat) {
+        bars.push({ time: t, open: 100, high: 100, low: 100, close: 100, volume: 1000 })
+        continue
+      }
+      // Deterministic wobble: no Math.random, so a failure reproduces exactly.
+      const drift = Math.sin((d * perDay + i) / 7) * 12
+      const base = 100 + drift + d * 3
+      const spread = 1 + Math.abs(Math.cos(i / 5)) * 2
+      bars.push({
+        time: t,
+        open: base,
+        high: base + spread,
+        low: base - spread,
+        close: base + spread / 3,
+        volume: 1000 + i * 25,
+      })
+    }
+  }
+  return bars
+}
+
+const FIXTURES = [
+  { label: 'two sessions, 78 bars each', bars: sessionBars(2, 78) },
+  { label: 'one session, 78 bars', bars: sessionBars(1, 78) },
+  { label: 'three bars', bars: sessionBars(1, 3) },
+  { label: 'flat series (zero range)', bars: sessionBars(1, 40, 9, 15, 5, true) },
+  { label: 'no bars', bars: [] },
+]
+
+/* ── helpers ─────────────────────────────────────────────────────────────── */
+
+function isPlainObject(v) {
+  return typeof v === 'object' && v !== null && !Array.isArray(v)
+}
+
+/** Settings variants a user can actually produce from the settings dialog. */
+function settingsVariants(descriptor, indicatorDefaults) {
+  const base = { ...indicatorDefaults(descriptor) }
+  const variants = [{ label: 'defaults', settings: base }]
+
+  // A cleared text or number field arrives as ''. This is the single most
+  // common runtime crash: `Number('')` is 0, but `''.trim()` on a number input
+  // or a regex against '' takes an unguarded calc down.
+  const cleared = { ...base }
+  let clearedAny = false
+  for (const input of descriptor.inputs ?? []) {
+    if (input.type === 'text' || input.type === 'number') {
+      cleared[input.key] = ''
+      clearedAny = true
+    }
+  }
+  if (clearedAny) variants.push({ label: 'cleared text/number fields', settings: cleared })
+
+  // Extremes, where an off-by-one in a lookback window shows up.
+  const extreme = { ...base }
+  let extremeAny = false
+  for (const input of descriptor.inputs ?? []) {
+    if (input.type === 'number') {
+      extreme[input.key] = input.min ?? 1
+      extremeAny = true
+    }
+    if (input.type === 'boolean') {
+      extreme[input.key] = !input.default
+      extremeAny = true
+    }
+  }
+  if (extremeAny) variants.push({ label: 'minimum / flipped inputs', settings: extreme })
+
+  return variants
+}
+
+function checkColumn(descriptor, plotKey, col, bars, ctxLabel, primary) {
+  const where = `${descriptor.id}: plot '${plotKey}' (${ctxLabel})`
+  const k = `${descriptor.id}|${plotKey}`
+  if (col === undefined) {
+    err(`${where}: calc returned no column for this plot key. The plot will draw nothing.`, `${k}|missing`)
+    return
+  }
+  if (!Array.isArray(col)) {
+    err(`${where}: expected an array, got ${typeof col}.`, `${k}|notarray`)
+    return
+  }
+  if (col.length !== bars.length) {
+    err(
+      `${where}: length ${col.length} but ${bars.length} bars. ` +
+        `The runtime indexes by bar, so a mismatch silently truncates or ignores values.`,
+      `${k}|length`
+    )
+    return
+  }
+  let allGap = true
+  for (let i = 0; i < col.length; i++) {
+    const v = col[i]
+    if (v === null || v === undefined) continue
+    if (typeof v !== 'number') {
+      err(`${where}: index ${i} is ${typeof v}, expected number | null.`, `${k}|elemtype`)
+      return
+    }
+    if (Number.isFinite(v)) allGap = false
+  }
+  // Only worth saying on the realistic fixture at default settings. A short or
+  // flat series, or a cleared input, produces an all-gap column legitimately,
+  // and warning on each combination buries the cases that matter.
+  if (allGap && primary && bars.length > 0) {
+    warn(
+      `${descriptor.id}: plot '${plotKey}' is empty across 156 ordinary bars at default ` +
+        `settings. Check the lookback, or that calc actually fills this column.`
+    )
+  }
+}
+
+function checkMarkers(descriptor, out, bars, ctxLabel) {
+  const where = `${descriptor.id}: markers (${ctxLabel})`
+  const k = `${descriptor.id}|markers`
+  if (!Array.isArray(out)) {
+    err(`${where}: expected an array, got ${typeof out}.`, `${k}|notarray`)
+    return
+  }
+  const times = new Set(bars.map((b) => b.time))
+  for (const m of out) {
+    if (!isPlainObject(m)) {
+      err(`${where}: every marker must be an object.`, `${k}|notobj`)
+      return
+    }
+    if (!times.has(m.time)) {
+      err(`${where}: marker time ${m.time} does not match any bar. Markers anchor to bar times.`, `${k}|time`)
+      return
+    }
+    if (!MARKER_POSITIONS.has(m.position)) {
+      err(`${where}: position '${m.position}' is not one of ${[...MARKER_POSITIONS].join(', ')}.`, `${k}|pos`)
+      return
+    }
+    if (!MARKER_SHAPES.has(m.shape)) {
+      err(`${where}: shape '${m.shape}' is not a known marker shape.`, `${k}|shape`)
+      return
+    }
+    if (m.size !== undefined && !MARKER_SIZES.has(m.size)) {
+      err(`${where}: size '${m.size}' is not one of ${[...MARKER_SIZES].join(', ')}.`, `${k}|size`)
+      return
+    }
+    if (typeof m.color !== 'string' || m.color === '') {
+      err(`${where}: every marker needs a colour.`, `${k}|color`)
+      return
+    }
+    if (m.position === 'atPrice' && !Number.isFinite(m.price)) {
+      err(`${where}: position 'atPrice' needs a finite numeric price.`, `${k}|price`)
+      return
+    }
+    if (m.position !== 'atPrice' && descriptor.placement === 'onchart') {
+      warn(
+        `${where}: position '${m.position}' on an 'onchart' indicator anchors to this ` +
+          `indicator's own plot line, NOT to the candle. Use 'atPrice' with an explicit ` +
+          `price to place a label relative to the bar's high or low.`,
+        `${k}|anchor`
+      )
+    }
+  }
+}
+
+/* ── the run ─────────────────────────────────────────────────────────────── */
+
+async function main() {
+  const args = process.argv.slice(2)
+  const install = args.includes('--install')
+  const candidatePath = args.find((a) => !a.startsWith('--'))
+
+  if (!candidatePath) {
+    console.error('usage: node validate.mjs <candidate.js> [--install]')
+    process.exit(2)
+  }
+  const candidate = resolve(candidatePath)
+  if (!existsSync(candidate)) {
+    console.error(`No such file: ${candidate}`)
+    process.exit(2)
+  }
+  if (!existsSync(CHARTS_ROOT)) {
+    console.error(
+      `openalgo-charts is not installed at ${CHARTS_ROOT}.\n` +
+        `Run: cd frontend && npm install`
+    )
+    process.exit(2)
+  }
+
+  // Import the real library, from the frontend's own node_modules.
+  const core = await import(pathToFileURL(join(CHARTS_ROOT, 'dist', 'openalgo-charts.mjs')).href)
+  const tier = await import(
+    pathToFileURL(join(CHARTS_ROOT, 'dist', 'openalgo-charts.indicators.mjs')).href
+  )
+
+  const builtinIds = new Set(core.registeredIndicators().map((d) => d.id))
+  const chartTypes = new Set(core.registeredChartTypes())
+
+  // Load the candidate. A syntax error surfaces here as a rejected import.
+  let mod
+  try {
+    mod = await import(`${pathToFileURL(candidate).href}?t=${Date.now()}`)
+  } catch (e) {
+    err(`Module failed to load: ${e.message}`)
+    return report(install, candidate)
+  }
+
+  if (typeof mod.default !== 'function') {
+    err(
+      'No default-exported function. A custom indicator file must be ' +
+        '`export default function ({ registerIndicator, ... }) { ... }`.'
+    )
+    return report(install, candidate)
+  }
+
+  // Capture what the module registers instead of mutating the shared registry.
+  const registered = []
+  const api = {
+    ...core,
+    ...tier,
+    registerIndicator: (d) => {
+      registered.push(d)
+    },
+  }
+
+  try {
+    await mod.default(api)
+  } catch (e) {
+    err(`The default export threw when called: ${e.message}`)
+    return report(install, candidate)
+  }
+
+  if (registered.length === 0) {
+    err('The module ran but never called registerIndicator.')
+    return report(install, candidate)
+  }
+
+  for (const d of registered) validateDescriptor(d, { builtinIds, chartTypes, core })
+
+  return report(install, candidate, registered)
+}
+
+function validateDescriptor(d, { builtinIds, chartTypes, core }) {
+  if (!isPlainObject(d)) {
+    err('registerIndicator was called with something that is not a descriptor object.')
+    return
+  }
+  const id = d.id
+  if (typeof id !== 'string' || id.trim() === '') {
+    err('descriptor.id must be a non-empty string.')
+    return
+  }
+  if (/\s/.test(id)) err(`id '${id}' contains whitespace. Use a kebab-case slug.`)
+  if (builtinIds.has(id)) {
+    warn(
+      `id '${id}' is already a built-in indicator. Custom modules register last, so this ` +
+        `OVERRIDES the built-in. Prefix your own ids unless that is deliberate.`
+    )
+  }
+  if (typeof d.name !== 'string' || d.name.trim() === '') err(`${id}: name must be a non-empty string.`)
+  if (!PLACEMENTS.has(d.placement)) {
+    err(`${id}: placement must be 'onchart' or 'pane', got ${JSON.stringify(d.placement)}.`)
+  }
+  if (typeof d.calc !== 'function') {
+    err(`${id}: calc must be a function.`)
+    return
+  }
+
+  /* inputs */
+  if (!Array.isArray(d.inputs)) {
+    err(`${id}: inputs must be an array (use [] when there is nothing to configure).`)
+    return
+  }
+  const inputKeys = new Set()
+  for (const input of d.inputs) {
+    if (!isPlainObject(input)) {
+      err(`${id}: every input must be an object.`)
+      return
+    }
+    if (typeof input.key !== 'string' || input.key === '') {
+      err(`${id}: every input needs a key.`)
+      return
+    }
+    if (inputKeys.has(input.key)) err(`${id}: duplicate input key '${input.key}'.`)
+    inputKeys.add(input.key)
+    if (!INPUT_TYPES.has(input.type)) {
+      err(
+        `${id}: input '${input.key}' has type '${input.type}', which the settings dialog ` +
+          `cannot render. Use one of ${[...INPUT_TYPES].join(', ')}.`
+      )
+      continue
+    }
+    if (input.default === undefined) {
+      err(`${id}: input '${input.key}' has no default. The Defaults button needs one.`)
+    }
+    if (typeof input.label !== 'string' || input.label === '') {
+      warn(`${id}: input '${input.key}' has no label, so the dialog falls back to the key.`)
+    }
+    if (input.type === 'number') {
+      if (typeof input.default !== 'number') {
+        err(`${id}: number input '${input.key}' has a non-numeric default.`)
+      } else {
+        if (input.min !== undefined && input.default < input.min) {
+          err(`${id}: input '${input.key}' default ${input.default} is below min ${input.min}.`)
+        }
+        if (input.max !== undefined && input.default > input.max) {
+          err(`${id}: input '${input.key}' default ${input.default} is above max ${input.max}.`)
+        }
+      }
+    }
+    if (input.type === 'boolean' && typeof input.default !== 'boolean') {
+      err(`${id}: boolean input '${input.key}' has a non-boolean default.`)
+    }
+    if (input.type === 'select') {
+      if (!Array.isArray(input.options) || input.options.length === 0) {
+        err(`${id}: select input '${input.key}' needs a non-empty options array.`)
+      } else if (!input.options.some((o) => o.value === input.default)) {
+        err(`${id}: select input '${input.key}' default is not among its options.`)
+      }
+    }
+    if (input.type === 'source' && !SOURCES.has(input.default)) {
+      err(`${id}: source input '${input.key}' default '${input.default}' is not a price source.`)
+    }
+    if (input.type === 'color' && typeof input.default !== 'string') {
+      err(`${id}: color input '${input.key}' needs a string default like '#4f8cff'.`)
+    }
+  }
+
+  /* plots */
+  if (!Array.isArray(d.plots) || d.plots.length === 0) {
+    err(`${id}: plots must be a non-empty array.`)
+    return
+  }
+  const plotKeys = new Set()
+  for (const plot of d.plots) {
+    if (!isPlainObject(plot)) {
+      err(`${id}: every plot must be an object.`)
+      return
+    }
+    if (typeof plot.key !== 'string' || plot.key === '') {
+      err(`${id}: every plot needs a key.`)
+      return
+    }
+    if (plotKeys.has(plot.key)) err(`${id}: duplicate plot key '${plot.key}'.`)
+    plotKeys.add(plot.key)
+    if (!chartTypes.has(plot.type)) {
+      err(
+        `${id}: plot '${plot.key}' has type '${plot.type}', which is not a registered chart ` +
+          `type. Single-column plots should use one of: line, line-markers, step, area, ` +
+          `histogram, column.`
+      )
+    }
+    if (typeof plot.title !== 'string' || plot.title === '') {
+      warn(`${id}: plot '${plot.key}' has no title, so the legend has nothing to show.`)
+    }
+    if (plot.colorKey !== undefined && !inputKeys.has(plot.colorKey)) {
+      err(`${id}: plot '${plot.key}' names colorKey '${plot.colorKey}' with no matching input.`)
+    }
+  }
+
+  /* fills reference real plots */
+  for (const fill of d.fills ?? []) {
+    for (const key of fill.between ?? []) {
+      if (!plotKeys.has(key)) err(`${id}: fill references plot '${key}', which does not exist.`)
+    }
+  }
+
+  /* run it */
+  const variants = settingsVariants(d, core.indicatorDefaults)
+  for (const variant of variants) {
+    for (const fixture of FIXTURES) {
+      const ctx = `${fixture.label} / ${variant.label}`
+      // The one combination an indicator is really expected to produce output
+      // for: a realistic two-day series with the settings it ships with.
+      const primary = fixture === FIXTURES[0] && variant === variants[0]
+      const store = {}
+      let values
+      try {
+        values = d.calc(fixture.bars, variant.settings, store)
+      } catch (e) {
+        err(`${id}: calc threw on ${ctx}: ${e.message}`, `${id}|calc-throw|${e.message}`)
+        continue
+      }
+      if (!isPlainObject(values)) {
+        err(`${id}: calc must return an object of columns, got ${typeof values} on ${ctx}.`, `${id}|calc-shape`)
+        continue
+      }
+      for (const plot of d.plots) {
+        checkColumn(d, plot.key, values[plot.key], fixture.bars, ctx, primary)
+      }
+
+      if (typeof d.markers === 'function') {
+        try {
+          checkMarkers(d, d.markers({ bars: fixture.bars, values, settings: variant.settings }), fixture.bars, ctx)
+        } catch (e) {
+          err(`${id}: markers threw on ${ctx}: ${e.message}`, `${id}|markers-throw|${e.message}`)
+        }
+      }
+      if (typeof d.levels === 'function') {
+        try {
+          const levels = d.levels(variant.settings)
+          if (!Array.isArray(levels)) err(`${id}: levels must return an array.`)
+          else {
+            for (const l of levels) {
+              if (!Number.isFinite(l?.price)) err(`${id}: every level needs a finite price.`)
+            }
+          }
+        } catch (e) {
+          err(`${id}: levels threw on ${ctx}: ${e.message}`)
+        }
+      }
+      if (typeof d.range === 'function') {
+        try {
+          const r = d.range(variant.settings)
+          if (r !== null && r !== undefined) {
+            if (!Number.isFinite(r.min) || !Number.isFinite(r.max)) {
+              err(`${id}: range must return null or { min, max } with finite numbers.`)
+            } else if (r.min >= r.max) {
+              err(`${id}: range min ${r.min} is not below max ${r.max}.`)
+            }
+          }
+        } catch (e) {
+          err(`${id}: range threw on ${ctx}: ${e.message}`)
+        }
+      }
+      if (typeof d.table === 'function') {
+        try {
+          const t = d.table({ bars: fixture.bars, values, settings: variant.settings })
+          if (t !== null && t !== undefined && !Array.isArray(t.rows)) {
+            err(`${id}: table must return null or { rows: [...] }.`)
+          }
+        } catch (e) {
+          err(`${id}: table threw on ${ctx}: ${e.message}`)
+        }
+      }
+    }
+  }
+
+  /* calcTail must agree with calc, or the live chart drifts from the reload */
+  if (typeof d.calcTail === 'function') {
+    const bars = FIXTURES[0].bars
+    const settings = core.indicatorDefaults(d)
+    const store = {}
+    const full = d.calc(bars, settings, store)
+    const from = bars.length - 1
+    let tail
+    try {
+      tail = d.calcTail(bars, settings, from, full, store)
+    } catch (e) {
+      err(`${id}: calcTail threw: ${e.message}`)
+      tail = null
+    }
+    if (tail !== null && tail !== undefined) {
+      for (const plot of d.plots) {
+        const col = tail[plot.key]
+        if (!Array.isArray(col)) {
+          err(`${id}: calcTail returned no array for plot '${plot.key}'.`)
+          continue
+        }
+        if (col.length !== bars.length - from) {
+          err(
+            `${id}: calcTail returned ${col.length} values for plot '${plot.key}', ` +
+              `expected ${bars.length - from} for indices [${from}, ${bars.length}).`
+          )
+          continue
+        }
+        const a = full[plot.key][from]
+        const b = col[0]
+        const same = (a === null || a === undefined) === (b === null || b === undefined)
+        if (same && typeof a === 'number' && typeof b === 'number' && Math.abs(a - b) > 1e-9) {
+          err(
+            `${id}: calcTail disagrees with calc at index ${from} for plot '${plot.key}' ` +
+              `(${a} vs ${b}). The live chart would drift from what a reload shows.`
+          )
+        }
+      }
+    }
+  }
+
+  note(`${id} (${d.name}): ${d.plots.length} plot(s), ${d.inputs.length} input(s), placement '${d.placement}'`)
+}
+
+function report(install, candidate, registered = []) {
+  const name = basename(candidate)
+  console.log(`\nValidating ${name}\n${'-'.repeat(60)}`)
+  for (const n of notes) console.log(`  registered  ${n}`)
+  if (warnings.length > 0) {
+    console.log('')
+    for (const w of warnings) console.log(`  WARNING  ${w}`)
+  }
+  if (errors.length > 0) {
+    console.log('')
+    for (const e of errors) console.log(`  ERROR    ${e}`)
+  }
+  console.log('')
+
+  if (errors.length > 0) {
+    console.log(`FAILED: ${errors.length} error(s), ${warnings.length} warning(s). Not installed.`)
+    process.exit(1)
+  }
+
+  console.log(`PASSED: ${registered.length} indicator(s), ${warnings.length} warning(s).`)
+  if (install) {
+    mkdirSync(INSTALL_DIR, { recursive: true })
+    const dest = join(INSTALL_DIR, name)
+    copyFileSync(candidate, dest)
+    console.log(`Installed to strategies/indicators/${name}`)
+    console.log('Hard-refresh /trading to pick it up.')
+  } else {
+    console.log('Re-run with --install to copy it into strategies/indicators/.')
+  }
+  process.exit(0)
+}
+
+await main()

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -44,6 +44,7 @@ Detailed procedures live in `.claude/skills/` and load on demand:
 - **`fd-audit`** — run after any change touching DB, WebSockets/streaming, threads/executors, subprocesses, files, or sockets
 - **`version-bump`** — releasing the platform, or bumping the pinned `openalgo` SDK (two unrelated version numbers)
 - **`broker-integration`** — adding or modifying a broker plugin
+- **`chart-indicator`** — building a custom indicator for the `/trading` chart (JavaScript, `openalgo-charts`). Not to be confused with **`custom-indicator`**, which is the Python `openalgo.ta` path.
 
 ## Security and Deployment Model
 
@@ -148,6 +149,19 @@ Session cleanup runs in `teardown_appcontext` after the response is sent.
 live dashboards.
 
 Ports: app 5000, WebSocket proxy 8765, ZeroMQ 5555.
+
+### Custom chart indicators are loaded at runtime, never bundled
+
+User indicators live in `strategies/indicators/*.js` (gitignored, mirroring
+`strategies/scripts/` for Python strategies, and inside the same Docker volume).
+`blueprints/custom_indicators.py` serves them; the chart fetches the index and
+`import()`s each one after the built-in tier
+(`frontend/src/lib/trading/customIndicators.ts`).
+
+- **Never bundle them.** `frontend/dist/` is built by CI from what is committed, so a bundled indicator would need committing first and the next `git pull` would erase it. Runtime loading keeps them outside the build: no Node.js, no rebuild, untouched by upgrades.
+- **They register after the built-ins**, so a custom id that collides with one of the 91 built-ins overrides it.
+- **They are not sandboxed.** An indicator runs on the app origin with the logged-in session and can reach `/api/v1/`. That matches the trust model of the Python strategy host, which already runs arbitrary user code, but it means an indicator from an untrusted source is as dangerous as any script.
+- Use the **`chart-indicator`** skill to write one. It validates against the real library and refuses to install a file that errors.
 
 Two built-in pages exercise the streaming stack end to end: **`/websocket/test`**
 (market data; `/20`, `/30`, `/50` variants request those depth levels) and

--- a/app.py
+++ b/app.py
@@ -59,6 +59,7 @@ from blueprints.broker_credentials import (
 from blueprints.chart_test import chart_test_bp  # Standalone chart test page (dev/testing only)
 from blueprints.chartink import chartink_bp  # Import the chartink blueprint
 from blueprints.core import core_bp
+from blueprints.custom_indicators import custom_indicators_bp  # User chart indicators
 from blueprints.custom_straddle import custom_straddle_bp  # Import custom straddle blueprint
 from blueprints.dashboard import dashboard_bp
 from blueprints.flow import flow_bp  # Import the flow blueprint
@@ -309,6 +310,7 @@ def create_app():
     app.register_blueprint(master_contract_status_bp)
     app.register_blueprint(websocket_bp)  # Register WebSocket example blueprint
     app.register_blueprint(chart_test_bp)  # Register standalone chart test page (dev/testing only)
+    app.register_blueprint(custom_indicators_bp)  # Register user chart indicators blueprint
     app.register_blueprint(pnltracker_bp)  # Register PnL tracker blueprint
     app.register_blueprint(python_strategy_bp)  # Register Python strategy blueprint
     app.register_blueprint(telegram_bp)  # Register Telegram blueprint

--- a/blueprints/custom_indicators.py
+++ b/blueprints/custom_indicators.py
@@ -1,0 +1,90 @@
+"""
+Custom Chart Indicators Blueprint.
+
+Serves the user's own indicator modules from ``strategies/indicators`` to the
+/trading chart, which imports each one at runtime and hands it the charting
+library's registration API.
+
+Why they are served rather than bundled: ``frontend/dist`` is built by CI from
+what is in the repository, so anything compiled into the bundle has to be
+committed first. User indicators are deliberately gitignored, which means a
+bundled one would be wiped by the next ``git pull``. Loading them over HTTP at
+runtime keeps them outside the build entirely, so they need no Node.js, no
+rebuild, and survive an upgrade untouched.
+
+The folder sits under ``strategies/`` because that is already the home for user
+authored content and is the path Docker keeps on a named volume
+(``openalgo_strategies:/app/strategies``), so indicators persist across
+container rebuilds for free.
+"""
+
+import re
+from pathlib import Path
+
+from flask import Blueprint, jsonify, send_from_directory
+
+from utils.logging import get_logger
+from utils.session import check_session_validity
+
+logger = get_logger(__name__)
+
+custom_indicators_bp = Blueprint("custom_indicators_bp", __name__, url_prefix="/custom-indicators")
+
+INDICATORS_DIR = Path("strategies") / "indicators"
+
+# A served filename must match this exactly. `send_from_directory` already
+# refuses to escape the directory, so this is the second layer: it keeps the
+# route to plain ES modules and rejects anything with a path separator, a dot
+# segment, or an extension the browser would not execute as a module.
+_SAFE_NAME = re.compile(r"^[A-Za-z0-9][A-Za-z0-9_.-]{0,63}\.js$")
+
+
+def _module_dir() -> Path:
+    """The indicators directory, resolved against the app's working directory."""
+    return INDICATORS_DIR.resolve()
+
+
+@custom_indicators_bp.route("/index.json", methods=["GET"])
+@check_session_validity
+def index():
+    """List the user's indicator modules, newest modification first.
+
+    ``mtime`` is returned so the chart can bust the browser's module cache on
+    the next load. Without it an edited indicator keeps running its previous
+    version until a hard refresh, since a dynamic import of an unchanged URL is
+    served from memory.
+    """
+    directory = _module_dir()
+    if not directory.is_dir():
+        return jsonify([])
+
+    modules = []
+    for entry in sorted(directory.iterdir()):
+        if not entry.is_file() or not _SAFE_NAME.match(entry.name):
+            continue
+        try:
+            modules.append({"file": entry.name, "mtime": int(entry.stat().st_mtime)})
+        except OSError:
+            # A file that vanished between listing and stat is not an error
+            # worth failing the whole picker over.
+            logger.exception("Could not stat custom indicator %s", entry.name)
+    return jsonify(modules)
+
+
+@custom_indicators_bp.route("/<path:filename>", methods=["GET"])
+@check_session_validity
+def module(filename: str):
+    """Serve one indicator module as an ES module.
+
+    The explicit mimetype matters: a dynamic ``import()`` refuses any response
+    that is not a JavaScript MIME type, and the default guess for an unknown
+    file would fail the import with an opaque error.
+    """
+    if not _SAFE_NAME.match(filename):
+        return jsonify({"error": "Invalid indicator filename"}), 400
+
+    directory = _module_dir()
+    if not directory.is_dir():
+        return jsonify({"error": "No indicators directory"}), 404
+
+    return send_from_directory(directory, filename, mimetype="text/javascript")

--- a/docs/INDEX.md
+++ b/docs/INDEX.md
@@ -21,6 +21,7 @@ need → drill into the specific file. Don't load everything at once.
 | WebSocket subscription & message format | [prompt/websockets-format.md](prompt/websockets-format.md) · [prompt/websockets-verbose-control.md](prompt/websockets-verbose-control.md) |
 | Service-layer functions & Flow JSON import | [prompt/services_documentation.md](prompt/services_documentation.md) · [prompt/flow-import-format.md](prompt/flow-import-format.md) |
 | Technical indicators (`ta` library) | [<prompt/indicators/openalgo indicators - introduction.md>](<prompt/indicators/openalgo indicators - introduction.md>) |
+| Writing your own chart indicators for `/trading` | [custom-indicators.md](custom-indicators.md) |
 | Step-by-step user guide (setup → first order → integrations) | [userguide/README.md](userguide/README.md) |
 | MCP tool reference (Claude Desktop / Cursor / Windsurf) | [mcp-tool-reference.md](mcp-tool-reference.md) |
 

--- a/docs/custom-indicators.md
+++ b/docs/custom-indicators.md
@@ -1,0 +1,552 @@
+# Custom Chart Indicators
+
+Write your own indicators for the `/trading` charting terminal.
+
+Drop a `.js` file into `strategies/indicators/`, refresh the chart, and it is in
+the indicator picker alongside the 91 built-ins. No build step, no Node.js, no
+restart of OpenAlgo.
+
+## Only add indicators you have read
+
+An indicator file is **not sandboxed**. It is JavaScript running on the OpenAlgo
+origin with your logged-in session, so it can call `/api/v1/` and place orders,
+read your positions, and send data anywhere. This is not Pine Script, which runs
+in a sandbox. It is closer to pasting a script into the browser console.
+
+Treat an indicator copied from a forum, a chat group or a stranger exactly as you
+would treat any script you are about to run on your trading machine: read it
+first, or do not add it. Nothing sits between dropping a file in this folder and
+it running against your live broker session.
+
+---
+
+## Contents
+
+- [How it works](#how-it-works)
+- [Your first indicator](#your-first-indicator)
+- [The descriptor](#the-descriptor)
+  - [Inputs](#inputs)
+  - [Plots](#plots)
+  - [calc](#calc)
+  - [Optional fields](#optional-fields)
+- [The API you are handed](#the-api-you-are-handed)
+- [Signal markers](#signal-markers)
+- [Indicators that need external data](#indicators-that-need-external-data)
+- [Worked example: Open Range Breakout](#worked-example-open-range-breakout)
+- [Porting from Pine Script](#porting-from-pine-script)
+- [Troubleshooting](#troubleshooting)
+
+---
+
+## How it works
+
+`strategies/indicators/` is gitignored, exactly like `strategies/scripts/` is for
+your Python strategies. What you write there stays on your machine, is never
+pushed, and survives `git pull`. On Docker the folder is already inside the
+`openalgo_strategies` named volume, so it persists across container rebuilds.
+
+The chart loads your files over HTTP at runtime rather than compiling them in:
+
+```
+/trading  ->  terminal.ts loadIndicators()
+                 1. import 'openalgo-charts/indicators'      (the 91 built-ins)
+                 2. GET /custom-indicators/index.json        (your file list)
+                 3. import each /custom-indicators/<file>.js
+                 4. call its default export with the charting API
+```
+
+Your modules register **after** the built-ins, so an indicator that reuses a
+built-in id overrides it rather than being overridden.
+
+**Why runtime and not bundled.** `frontend/dist/` is built by CI from what is
+committed to the repository. A bundled indicator would have to be committed
+first, and the next `git pull` would overwrite `dist/` with a build that does not
+contain yours. Loading over HTTP keeps your indicators outside the build
+entirely.
+
+The trade-off is that these are plain `.js` files, not TypeScript. Nothing
+compiles them, so use plain JavaScript with no types, no JSX and no imports.
+
+---
+
+## Your first indicator
+
+Save this as `strategies/indicators/my_sma.js`:
+
+```js
+export default function ({ registerIndicator, sourceValues }) {
+  registerIndicator({
+    id: 'my-sma',
+    name: 'My SMA',
+    category: 'Custom',
+    placement: 'onchart',
+    inputs: [
+      { key: 'length', type: 'number', label: 'Length', default: 20, min: 1, step: 1 },
+      { key: 'source', type: 'source', label: 'Source', default: 'close' },
+    ],
+    plots: [
+      { key: 'ma', type: 'line', title: 'MA', style: { color: '#4f8cff', lineWidth: 2 } },
+    ],
+    calc(bars, settings) {
+      const src = sourceValues(bars, settings.source)
+      const n = Number(settings.length)
+      const ma = new Array(bars.length).fill(null)
+      let sum = 0
+      for (let i = 0; i < src.length; i++) {
+        sum += src[i]
+        if (i >= n) sum -= src[i - n]
+        if (i >= n - 1) ma[i] = sum / n
+      }
+      return { ma }
+    },
+  })
+}
+```
+
+Refresh `/trading`, open the indicator picker, and **My SMA** is under a
+**Custom** category.
+
+Two rules that are easy to miss:
+
+- The module **default-exports a function**. It is called once with the charting
+  API. A file that exports nothing, or exports an object, is reported as an
+  error.
+- `calc` returns **one array per plot key, the same length as `bars`**, using
+  `null` for warmup. `null`, `undefined` and `NaN` are all treated as gaps: the
+  line renderer breaks across them and autoscale skips them. `0` is **not** a
+  gap, and putting one in a warmup slot drags the whole pane's scale down.
+
+---
+
+## The descriptor
+
+```js
+registerIndicator({
+  id: 'my-thing',        // registry key, unique
+  name: 'My Thing',      // shown in the picker and the legend
+  category: 'Custom',    // groups it in the picker rail
+  placement: 'onchart',  // 'onchart' overlays price, 'pane' gets its own pane
+  inputs: [...],
+  plots: [...],
+  calc(bars, settings, store) { ... },
+})
+```
+
+A `bar` is `{ time, open, high, low, close, volume }`, where `time` is **UTC
+seconds**, not milliseconds and not local time.
+
+### Inputs
+
+Each input becomes a field in the settings dialog. `key` is what `calc` reads
+from `settings`.
+
+| `type` | Renders as | Extra fields |
+|---|---|---|
+| `number` | Number box with steppers | `min`, `max`, `step` |
+| `boolean` | Tick box | |
+| `color` | Colour swatch | |
+| `text` | Text box | |
+| `select` | Dropdown | `options: [{ label, value }]` |
+| `source` | Price-source dropdown | |
+
+Every input needs a `default`. That default is also what the dialog's
+**Defaults** button restores.
+
+You do **not** need colour or line-width inputs. The chart generates a colour,
+opacity, thickness, line style and plot style control for every plot
+automatically and puts them on the **Style** tab, seeded from each plot's
+`style`. Declaring your own width input just gives the user two width fields
+that disagree.
+
+### Plots
+
+```js
+plots: [
+  { key: 'fast', type: 'line', title: 'Fast', style: { color: '#4f8cff', lineWidth: 2 } },
+  { key: 'hist', type: 'histogram', title: 'Histogram', style: { base: 0 } },
+]
+```
+
+`type` is any of `line`, `line-markers`, `step`, `area`, `histogram`, `column`.
+`key` must match a key in what `calc` returns.
+
+Useful extras:
+
+- `priceScaleId` puts a plot on its own axis (defaults to `'right'`).
+- `colorBy({ value, index, values, settings })` colours a plot bar by bar, for a
+  histogram that changes colour by sign. Honoured by `histogram` and `column`.
+
+### calc
+
+```js
+calc(bars, settings, store) {
+  // bars    : readonly array of { time, open, high, low, close, volume }
+  // settings: current values, keyed by your input keys
+  // store   : per-instance scratch object, for the external-data case
+  return { fast: [...], hist: [...] }   // one array per plot key, bars.length long
+}
+```
+
+`calc` runs on every data change, so keep it a single pass. Read settings
+defensively (`Number(settings.length)`): a user can clear a field, and the value
+arrives as `''`.
+
+### Optional fields
+
+| Field | What it does |
+|---|---|
+| `levels(settings)` | Horizontal reference lines in your pane, e.g. RSI 70/30 |
+| `range(settings)` | Fixes the pane's price range, e.g. `{ min: 0, max: 100 }` |
+| `markers(ctx)` | Bar-anchored signal labels, see below |
+| `fills` | Shades the band between two plots, e.g. a Bollinger channel |
+| `table(ctx)` | A summary grid pinned in the pane corner |
+| `calcTail(...)` | Incremental recompute for live ticks, see below |
+| `attach(ctx)` | Per-instance lifecycle for indicators with their own data |
+
+**On `calcTail`.** Without it every live tick costs a full `calc`. That is a few
+hundred microseconds over 50k bars, so it only matters for something running in a
+busy live pane. Note that if you also implement `markers`, those re-run in full
+after every recompute anyway, so adding `calcTail` alongside them saves nothing.
+
+---
+
+## The API you are handed
+
+The single argument to your default export carries the whole charting library,
+both the core and the indicator tier. Destructure what you need:
+
+```js
+export default function ({ registerIndicator, sourceValues, sma, rma }) { ... }
+```
+
+Commonly useful:
+
+| Function | Use |
+|---|---|
+| `registerIndicator(descriptor)` | The one call that matters |
+| `sourceValues(bars, source)` | Whole bar array as one price column |
+| `sourceValue(bar, source)` | One bar's value for a source |
+| `sma`, `wma`, `rma`, `ema`, `stdev` | Moving averages and deviation |
+| `highest(values, n)`, `lowest(values, n)` | Rolling extremes |
+| `nulls(n)` | An array of `n` nulls, for warmup |
+| `atr`, `trueRange`, `supertrend`, `rsi` | Prebuilt studies to compose with |
+| `utcSecondsToZonedParts(t, zone)` | Bar time to `{ year, month, day, hour, minute, ... }` |
+| `zonedDayIndex(t, zone)` | Day bucket, for per-day logic |
+| `isValidTimezone(zone)`, `DEFAULT_TIMEZONE` | Zone handling (`Asia/Kolkata`) |
+| `createTier2Indicator(descriptor)` | Indicators fed by an external series |
+| `indicatorDefaults`, `registeredIndicators` | Introspection |
+
+Anything the `openalgo-charts` package exports from its root or its
+`indicators` tier is on that object.
+
+---
+
+## Signal markers
+
+`markers` draws a labelled plate on a bar. It runs after every `calc` and is
+handed what `calc` just produced.
+
+```js
+markers({ bars, values, settings }) {
+  if (settings.showSignals === false) return []   // returning [] clears the layer
+  return [{
+    time: bars[i].time,
+    position: 'atPrice',
+    price: bars[i].low - pad,
+    shape: 'labelUp',      // labelUp, labelDown, arrowUp, arrowDown, circle, square, ...
+    size: 'small',         // tiny, small, medium, big
+    color: '#4caf50',
+    text: 'Buy',
+  }]
+}
+```
+
+**The one trap.** `position: 'aboveBar'` and `'belowBar'` do **not** mean above
+or below the candle. They resolve against the series the markers hang off, which
+for an indicator is its own plot line. On an overlay indicator that means your
+labels pin themselves to your line and ignore the candle entirely.
+
+To place a label relative to the candle, use `position: 'atPrice'` with an
+explicit `price`. `atPrice` adds no padding of its own, so compute the gap
+yourself, and scale it to the instrument rather than hardcoding a tick count:
+
+```js
+function markerPad(bars) {
+  let sum = 0, count = 0
+  for (const bar of bars) {
+    const range = bar.high - bar.low
+    if (Number.isFinite(range) && range > 0) { sum += range; count++ }
+  }
+  const mean = count > 0 ? sum / count : 0
+  const last = bars.length > 0 ? Math.abs(bars[bars.length - 1].close) : 0
+  return Math.max(mean * 0.5, last * 0.0005)   // floor covers a run of dojis
+}
+```
+
+Half a mean bar range reads the same on a 24000 index and a 100 rupee stock.
+
+---
+
+## Indicators that need external data
+
+If your indicator plots something that is not derived from the chart's own OHLCV
+(open interest, PCR, a series your own API computes), use `createTier2Indicator`.
+You supply `fetch`, it returns an ordinary descriptor:
+
+```js
+export default function ({ registerIndicator, createTier2Indicator }) {
+  registerIndicator(createTier2Indicator({
+    id: 'my-oi',
+    name: 'Open Interest',
+    placement: 'pane',
+    inputs: [{ key: 'symbol', type: 'text', label: 'Symbol', default: '' }],
+    plots: [{ key: 'oi', type: 'line', title: 'OI' }],
+    refetchOn: ['symbol'],                      // settings that invalidate the data
+    async fetch({ settings, from, to }) {
+      const res = await fetch(`/api/v1/...`)    // your own endpoint
+      return (await res.json()).map((row) => ({ time: row.t, values: { oi: row.oi } }))
+    },
+  }))
+}
+```
+
+Each bar takes the most recent external point **at or before** its time. Values
+are never interpolated and never forward-looking, and bars before the first point
+are `null`.
+
+---
+
+## Worked example: Open Range Breakout
+
+The opening range is the high and low of a fixed early window. Once the window
+closes both levels freeze for the rest of the day and are traded as breakout
+triggers. This example uses most of what the guide covers: a text input, per-day
+state, `atPrice` markers and an exrem-style signal latch.
+
+Save as `strategies/indicators/open_range_breakout.js`:
+
+```js
+const LEVEL_HIGH_COLOR = '#ff5252'
+const LEVEL_LOW_COLOR = '#00e676'
+const BUY_COLOR = '#4caf50'
+const SELL_COLOR = '#ff5252'
+
+export default function ({
+  registerIndicator,
+  utcSecondsToZonedParts,
+  zonedDayIndex,
+  isValidTimezone,
+  DEFAULT_TIMEZONE,
+}) {
+  /** '0915-1015' to minutes-from-midnight bounds. Null when unparseable. */
+  function parseSession(raw) {
+    const m = /^(\d{2})(\d{2})\s*-\s*(\d{2})(\d{2})$/.exec(String(raw).trim())
+    if (!m) return null
+    const [sh, sm, eh, em] = [Number(m[1]), Number(m[2]), Number(m[3]), Number(m[4])]
+    if (sh > 23 || eh > 23 || sm > 59 || em > 59) return null
+    return { start: sh * 60 + sm, end: eh * 60 + em }
+  }
+
+  // Bar times are UTC seconds and a session is wall clock at the exchange, so
+  // the two only line up through a zone.
+  function zoneOf(settings) {
+    const raw = typeof settings.timezone === 'string' ? settings.timezone.trim() : ''
+    return raw && isValidTimezone(raw) ? raw : DEFAULT_TIMEZONE
+  }
+
+  // Half-open bounds: a bar stamped exactly at the end time opens the breakout
+  // window rather than closing the range. Second branch wraps midnight.
+  function inSession(minuteOfDay, start, end) {
+    return end > start
+      ? minuteOfDay >= start && minuteOfDay < end
+      : minuteOfDay >= start || minuteOfDay < end
+  }
+
+  function computeOrb(bars, settings) {
+    const orbHigh = new Array(bars.length).fill(null)
+    const orbLow = new Array(bars.length).fill(null)
+    const win = parseSession(settings.session ?? '')
+    if (!win || bars.length === 0) return { orbHigh, orbLow }
+
+    const zone = zoneOf(settings)
+    let wasIn = false
+    let runHigh = Number.NEGATIVE_INFINITY
+    let runLow = Number.POSITIVE_INFINITY
+    let levelHigh = null
+    let levelLow = null
+
+    for (let i = 0; i < bars.length; i++) {
+      const parts = utcSecondsToZonedParts(bars[i].time, zone)
+      const isIn = inSession(parts.hour * 60 + parts.minute, win.start, win.end)
+
+      if (isIn && !wasIn) {
+        runHigh = Number.NEGATIVE_INFINITY
+        runLow = Number.POSITIVE_INFINITY
+      }
+      if (isIn) {
+        if (bars[i].high > runHigh) runHigh = bars[i].high
+        if (bars[i].low < runLow) runLow = bars[i].low
+      } else if (wasIn && Number.isFinite(runHigh)) {
+        // First bar after the window closed: latch the level.
+        levelHigh = runHigh
+        levelLow = runLow
+      }
+
+      // Hidden while the range is still forming, so the line starts at the
+      // breakout window instead of running back across its own session.
+      orbHigh[i] = isIn ? null : levelHigh
+      orbLow[i] = isIn ? null : levelLow
+      wasIn = isIn
+    }
+    return { orbHigh, orbLow }
+  }
+
+  function computeSignals(bars, values, settings) {
+    const hi = values.orbHigh ?? []
+    const lo = values.orbLow ?? []
+    const zone = zoneOf(settings)
+    const out = []
+    let isLong = false
+    let isShort = false
+    let prevWasNewDay = false
+
+    for (let i = 1; i < bars.length; i++) {
+      const newDay = zonedDayIndex(bars[i].time, zone) !== zonedDayIndex(bars[i - 1].time, zone)
+
+      // Crossover / crossunder against the plotted level. Both ends must be
+      // present, which is what keeps signals off a range that is still forming.
+      const [prevHigh, curHigh] = [hi[i - 1], hi[i]]
+      const [prevLow, curLow] = [lo[i - 1], lo[i]]
+      let buy =
+        prevHigh != null && curHigh != null && bars[i - 1].high <= prevHigh && bars[i].high > curHigh
+      let sell =
+        prevLow != null && curLow != null && bars[i - 1].low >= prevLow && bars[i].low < curLow
+
+      // exrem: one signal per direction until the other side fires.
+      buy = buy && !isLong
+      sell = sell && !isShort
+      if (buy) { isLong = true; isShort = false }
+      if (sell) { isLong = false; isShort = true }
+      if (prevWasNewDay) { isLong = false; isShort = false }
+
+      if (buy) out.push({ index: i, side: 'buy' })
+      if (sell) out.push({ index: i, side: 'sell' })
+      prevWasNewDay = newDay
+    }
+    return out
+  }
+
+  function markerPad(bars) {
+    let sum = 0
+    let count = 0
+    for (const bar of bars) {
+      const range = bar.high - bar.low
+      if (Number.isFinite(range) && range > 0) { sum += range; count++ }
+    }
+    const mean = count > 0 ? sum / count : 0
+    const last = bars.length > 0 ? Math.abs(bars[bars.length - 1].close) : 0
+    return Math.max(mean * 0.5, last * 0.0005)
+  }
+
+  registerIndicator({
+    id: 'oa-open-range-breakout',
+    name: 'Open Range Breakout',
+    category: 'Custom',
+    placement: 'onchart',
+    inputs: [
+      { key: 'session', type: 'text', label: 'Breakout Timings', default: '0915-1015' },
+      { key: 'showSignals', type: 'boolean', label: 'Show Buy/Sell Labels', default: true },
+      { key: 'timezone', type: 'text', label: 'Session Timezone', default: DEFAULT_TIMEZONE },
+    ],
+    plots: [
+      { key: 'orbHigh', type: 'line', title: 'ORB High',
+        style: { color: LEVEL_HIGH_COLOR, lineWidth: 2 } },
+      { key: 'orbLow', type: 'line', title: 'ORB Low',
+        style: { color: LEVEL_LOW_COLOR, lineWidth: 2 } },
+    ],
+    calc: (bars, settings) => computeOrb(bars, settings),
+    markers({ bars, values, settings }) {
+      if (settings.showSignals === false) return []
+      const pad = markerPad(bars)
+      const out = []
+      for (const sig of computeSignals(bars, values, settings)) {
+        const bar = bars[sig.index]
+        out.push(
+          sig.side === 'buy'
+            ? { time: bar.time, position: 'atPrice', price: bar.low - pad,
+                shape: 'labelUp', size: 'small', color: BUY_COLOR, text: 'Buy' }
+            : { time: bar.time, position: 'atPrice', price: bar.high + pad,
+                shape: 'labelDown', size: 'small', color: SELL_COLOR, text: 'Sell' }
+        )
+      }
+      return out
+    },
+  })
+}
+```
+
+---
+
+## Porting from Pine Script
+
+| Pine | Here |
+|---|---|
+| `indicator(overlay=true)` | `placement: 'onchart'` |
+| `indicator(overlay=false)` | `placement: 'pane'` |
+| `input.int` / `input.bool` / `input.string` | `type: 'number'` / `'boolean'` / `'text'` |
+| `input.session` | `type: 'text'`, parse it yourself |
+| `input.source` | `type: 'source'` + `sourceValues(bars, settings.source)` |
+| `plot(x)` | a plot key plus the matching array from `calc` |
+| `plotshape` | `markers()` |
+| `hline` | `levels(settings)` |
+| `na` | `null` |
+| `ta.sma` / `ta.rma` / `ta.stdev` | `sma` / `rma` / `stdev` from the API |
+| `ta.valuewhen` | a latch variable in your `calc` loop |
+| `var` state across bars | a variable outside the `calc` loop |
+| `alertcondition` | no equivalent, use markers |
+
+Three differences that catch people out:
+
+1. **There is no `request.security`.** `calc` gets one bar array. Either derive
+   the higher-timeframe value from the bars you have, or use
+   `createTier2Indicator` to fetch it. Deriving is often more correct anyway: a
+   `request.security` call on a 60-minute bar returns that whole bar's high, which
+   is lookahead if your window is shorter than the bar.
+2. **`na` comparisons.** In Pine every comparison against `na` is false. In
+   JavaScript `5 > null` is `true`. Guard explicitly with `x != null` or your
+   indicator will fire signals during its own warmup.
+3. **`linewidth` is not yours to set.** The Style tab already generates it.
+
+---
+
+## Troubleshooting
+
+**It does not appear in the picker.**
+Check the file is `strategies/indicators/<name>.js`. The filename must be
+`.js`, must start with a letter or digit, and cannot contain a path separator.
+Then hard-refresh the chart (Ctrl+Shift+R).
+
+**A red toast appears on the chart.**
+That is your file failing to load, and the message is the actual error. The
+other indicators keep working: one broken file never takes the picker down.
+
+**"module has no default-exported function".**
+The file parsed but does not `export default function (api) { ... }`.
+
+**Edits do not take effect.**
+The chart cache-busts on the file's modification time, so a normal refresh is
+enough. If you are behind a caching proxy, hard-refresh.
+
+**The pane is flat or the line is missing.**
+`calc` almost certainly returned `0` for warmup bars instead of `null`, or
+returned an array that is not `bars.length` long. A short array does not error,
+it just stops drawing partway across the chart.
+
+**Settings show empty boxes with steppers.**
+The input `type` is not one the dialog knows. Check it is one of `number`,
+`boolean`, `color`, `text`, `select`, `source`.
+
+**Nothing loads at all and there is no toast.**
+The chart treats a missing index as "no custom indicators", which is also what a
+logged-out session looks like. Confirm you are logged in, then check
+`GET /custom-indicators/index.json` in the browser's network tab.

--- a/frontend/src/components/trading/IndicatorSettingsDialog.tsx
+++ b/frontend/src/components/trading/IndicatorSettingsDialog.tsx
@@ -85,7 +85,15 @@ export function IndicatorSettingsDialog({ req, onApply, onDefaults, onClose }: P
             aria-label="Close"
             className="-mr-1 rounded p-1 text-muted-foreground transition-colors hover:bg-accent hover:text-foreground"
           >
-            <svg viewBox="0 0 24 24" className="h-4 w-4" fill="none" stroke="currentColor" strokeWidth={1.8} strokeLinecap="round" aria-hidden="true">
+            <svg
+              viewBox="0 0 24 24"
+              className="h-4 w-4"
+              fill="none"
+              stroke="currentColor"
+              strokeWidth={1.8}
+              strokeLinecap="round"
+              aria-hidden="true"
+            >
               <path d="M6 6l12 12M18 6L6 18" />
             </svg>
           </button>
@@ -270,10 +278,32 @@ export function SettingsField({
               </option>
             ))}
           </select>
-          <svg viewBox="0 0 10 10" className="pointer-events-none absolute right-2 top-1/2 h-2.5 w-2.5 -translate-y-1/2 text-muted-foreground" aria-hidden="true">
+          <svg
+            viewBox="0 0 10 10"
+            className="pointer-events-none absolute right-2 top-1/2 h-2.5 w-2.5 -translate-y-1/2 text-muted-foreground"
+            aria-hidden="true"
+          >
             <path d="M2 3.5 5 6.5 8 3.5" fill="none" stroke="currentColor" strokeWidth={1.5} />
           </svg>
         </div>
+      </>
+    )
+  }
+
+  // Everything below falls through to the number control, so a string-valued
+  // input needs its own branch: `<input type="number">` rejects a value like
+  // '0915-1015' outright and renders an empty box with spinner arrows.
+  if (field.type === 'text') {
+    return (
+      <>
+        {label}
+        <input
+          id={id}
+          type="text"
+          value={typeof value === 'string' ? value : ''}
+          onChange={(e) => onChange(e.target.value)}
+          className={cn(CONTROL, 'w-full')}
+        />
       </>
     )
   }
@@ -282,7 +312,10 @@ export function SettingsField({
   const nudge = (dir: 1 | -1) => {
     const cur = Number(value)
     const next = (Number.isFinite(cur) ? cur : 0) + dir * step
-    const clamped = Math.min(field.max ?? Number.POSITIVE_INFINITY, Math.max(field.min ?? -Number.POSITIVE_INFINITY, next))
+    const clamped = Math.min(
+      field.max ?? Number.POSITIVE_INFINITY,
+      Math.max(field.min ?? -Number.POSITIVE_INFINITY, next)
+    )
     // Step can be fractional (0.5 thickness); round to its precision so the
     // value never drifts into 1.4000000000000001.
     onChange(Number(clamped.toFixed(String(step).split('.')[1]?.length ?? 0)))
@@ -304,11 +337,25 @@ export function SettingsField({
           className="w-full min-w-0 bg-transparent text-[13px] outline-none [appearance:textfield] [&::-webkit-inner-spin-button]:appearance-none [&::-webkit-outer-spin-button]:appearance-none"
         />
         <span className="flex h-full flex-col justify-center border-l border-border">
-          <button type="button" aria-label="Increase" onClick={() => nudge(1)} className="flex h-3 w-5 items-center justify-center text-muted-foreground hover:text-foreground">
-            <svg viewBox="0 0 10 6" className="h-1.5 w-2.5" aria-hidden="true"><path d="M1 5 5 1.5 9 5" fill="none" stroke="currentColor" strokeWidth={1.6} /></svg>
+          <button
+            type="button"
+            aria-label="Increase"
+            onClick={() => nudge(1)}
+            className="flex h-3 w-5 items-center justify-center text-muted-foreground hover:text-foreground"
+          >
+            <svg viewBox="0 0 10 6" className="h-1.5 w-2.5" aria-hidden="true">
+              <path d="M1 5 5 1.5 9 5" fill="none" stroke="currentColor" strokeWidth={1.6} />
+            </svg>
           </button>
-          <button type="button" aria-label="Decrease" onClick={() => nudge(-1)} className="flex h-3 w-5 items-center justify-center text-muted-foreground hover:text-foreground">
-            <svg viewBox="0 0 10 6" className="h-1.5 w-2.5" aria-hidden="true"><path d="M1 1 5 4.5 9 1" fill="none" stroke="currentColor" strokeWidth={1.6} /></svg>
+          <button
+            type="button"
+            aria-label="Decrease"
+            onClick={() => nudge(-1)}
+            className="flex h-3 w-5 items-center justify-center text-muted-foreground hover:text-foreground"
+          >
+            <svg viewBox="0 0 10 6" className="h-1.5 w-2.5" aria-hidden="true">
+              <path d="M1 1 5 4.5 9 1" fill="none" stroke="currentColor" strokeWidth={1.6} />
+            </svg>
           </button>
         </span>
       </div>

--- a/frontend/src/lib/trading/customIndicators.test.ts
+++ b/frontend/src/lib/trading/customIndicators.test.ts
@@ -1,0 +1,80 @@
+/**
+ * The custom indicator loader.
+ *
+ * Everything here is about isolation. A user's indicator file is code the app
+ * has never seen, fetched from disk at runtime, and the one thing it must never
+ * do is take the other 91 indicators down with it. So the cases that matter are
+ * the failures: no route, no session, a malformed index, and a module that
+ * cannot be imported. None of them may throw, and none may leave the picker
+ * empty.
+ */
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+import { loadCustomIndicators } from './customIndicators'
+
+function mockIndex(body: unknown, ok = true) {
+  const fetchMock = vi.fn(async () => ({ ok, json: async () => body }) as unknown as Response)
+  vi.stubGlobal('fetch', fetchMock)
+  return fetchMock
+}
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  vi.restoreAllMocks()
+})
+
+describe('loadCustomIndicators', () => {
+  it('loads nothing when the index route is not there', async () => {
+    mockIndex(null, false)
+    expect(await loadCustomIndicators()).toEqual({ loaded: [], errors: [] })
+  })
+
+  it('stays quiet when the fetch itself throws', async () => {
+    // Logged out, offline, or the blueprint is not registered. Having no custom
+    // indicators is a normal state, not something to put in front of anyone.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn(async () => {
+        throw new Error('network down')
+      })
+    )
+    expect(await loadCustomIndicators()).toEqual({ loaded: [], errors: [] })
+  })
+
+  it('ignores an index that is not a list of modules', async () => {
+    mockIndex({ file: 'not-an-array.js' })
+    expect(await loadCustomIndicators()).toEqual({ loaded: [], errors: [] })
+  })
+
+  it('does not touch the chart library for an empty folder', async () => {
+    const fetchMock = mockIndex([])
+    expect(await loadCustomIndicators()).toEqual({ loaded: [], errors: [] })
+    expect(fetchMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a module it cannot import instead of throwing', async () => {
+    // Nothing resolves these URLs here, which is the same shape of failure as a
+    // syntax error in a user file: the import rejects. Both modules have to be
+    // attempted, so one bad file does not hide the next.
+    mockIndex([
+      { file: 'broken.js', mtime: 1 },
+      { file: 'alsobroken.js', mtime: 2 },
+    ])
+    const res = await loadCustomIndicators()
+    expect(res.loaded).toEqual([])
+    expect(res.errors.map((e) => e.file)).toEqual(['broken.js', 'alsobroken.js'])
+    expect(res.errors[0].message).toBeTruthy()
+  })
+
+  it('asks the server for the index with the session cookie', async () => {
+    const fetchMock = mockIndex([])
+    await loadCustomIndicators()
+    // The Accept header is what turns a logged-out request into a 401 instead
+    // of a 302 that fetch follows into the login page's HTML.
+    expect(fetchMock).toHaveBeenCalledWith('/custom-indicators/index.json', {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+  })
+})

--- a/frontend/src/lib/trading/customIndicators.ts
+++ b/frontend/src/lib/trading/customIndicators.ts
@@ -1,0 +1,105 @@
+/**
+ * Loads the user's own indicator modules from `strategies/indicators` and lets
+ * them register into the openalgo-charts catalogue.
+ *
+ * Called from `terminal.ts:loadIndicators` right after the built-in tier, so
+ * every path that can reach `chart.addIndicator` (the picker, `addIndicatorById`
+ * and `applyIndicators` restoring a saved layout) sees a custom indicator before
+ * it looks anything up. Registering after the built-ins also means a custom
+ * indicator that reuses a built-in id overrides it rather than being overridden.
+ *
+ * These modules are fetched at runtime rather than bundled. `frontend/dist` is
+ * built by CI from what is committed, and user indicators are deliberately
+ * gitignored, so a bundled one would be erased by the next `git pull`. Coming in
+ * over HTTP keeps them out of the build entirely: no Node.js, no rebuild, and an
+ * upgrade leaves them alone.
+ *
+ * A module default-exports a function and is handed the charting API, because a
+ * runtime module cannot resolve the bare `openalgo-charts` specifier the way a
+ * bundled import can. Passing the API in is what keeps the user's file free of
+ * import paths and CDN URLs.
+ */
+
+/** One module the server is offering. `mtime` busts the browser module cache. */
+interface CustomModule {
+  file: string
+  mtime: number
+}
+
+export interface CustomIndicatorLoad {
+  /** Modules that registered without throwing. */
+  loaded: string[]
+  /** Per-module failures, already formatted for a toast. */
+  errors: { file: string; message: string }[]
+}
+
+const INDEX_URL = '/custom-indicators/index.json'
+
+function isModuleList(value: unknown): value is CustomModule[] {
+  return (
+    Array.isArray(value) &&
+    value.every(
+      (m) => typeof m === 'object' && m !== null && typeof (m as CustomModule).file === 'string'
+    )
+  )
+}
+
+function messageOf(e: unknown): string {
+  return e instanceof Error ? e.message : String(e)
+}
+
+/**
+ * Fetch, import and run every user module.
+ *
+ * Never throws. A missing folder, a logged-out session and a syntax error in one
+ * user file all have to leave the other 91 indicators working, so the index is
+ * treated as optional and each module is isolated from the next.
+ */
+export async function loadCustomIndicators(): Promise<CustomIndicatorLoad> {
+  const result: CustomIndicatorLoad = { loaded: [], errors: [] }
+
+  let modules: CustomModule[]
+  try {
+    // Without the Accept header an expired session answers with a 302 to the
+    // login page, which fetch follows to a 200 of HTML. Asking for JSON gets a
+    // straight 401 instead, so a logged-out chart fails fast rather than trying
+    // to parse a login page as a module index.
+    const res = await fetch(INDEX_URL, {
+      credentials: 'same-origin',
+      headers: { Accept: 'application/json' },
+    })
+    if (!res.ok) return result
+    const body: unknown = await res.json()
+    if (!isModuleList(body)) return result
+    modules = body
+  } catch {
+    // No route, no network, no session. Nothing to load is a normal state here,
+    // not a failure worth showing anyone.
+    return result
+  }
+  if (modules.length === 0) return result
+
+  // The whole surface of both tiers, so a user module can reach `sma`, `rma`,
+  // `highest`, `sourceValues`, the timezone helpers and `createTier2Indicator`
+  // without importing anything itself.
+  const api = {
+    ...(await import('openalgo-charts')),
+    ...(await import('openalgo-charts/indicators')),
+  }
+
+  for (const mod of modules) {
+    try {
+      const url = `/custom-indicators/${encodeURIComponent(mod.file)}?v=${mod.mtime}`
+      const loaded: unknown = await import(/* @vite-ignore */ url)
+      const register = (loaded as { default?: unknown }).default
+      if (typeof register !== 'function') {
+        throw new Error('module has no default-exported function')
+      }
+      await register(api)
+      result.loaded.push(mod.file)
+    } catch (e) {
+      result.errors.push({ file: mod.file, message: messageOf(e) })
+    }
+  }
+  return result
+}

--- a/frontend/src/lib/trading/terminal.ts
+++ b/frontend/src/lib/trading/terminal.ts
@@ -1483,6 +1483,16 @@ export class TradingTerminal {
   private async loadIndicators(): Promise<void> {
     if (this.indicatorsLoaded) return
     await import('openalgo-charts/indicators')
+    // The user's own modules come after the built-in tier, so one that reuses a
+    // built-in id overrides it rather than being overridden. Loading here, not
+    // at module scope, is what guarantees they are registered before anything
+    // can call `addIndicator`.
+    const { loadCustomIndicators } = await import('./customIndicators')
+    const custom = await loadCustomIndicators()
+    // A broken user file must not take the picker down with it, but it must not
+    // fail silently either: without this the indicator is simply absent and
+    // there is nothing anywhere to say why.
+    for (const err of custom.errors) this.toast(`${err.file}: ${err.message}`, 'err')
     this.indicatorsLoaded = true
   }
 

--- a/frontend/vite.config.ts
+++ b/frontend/vite.config.ts
@@ -42,6 +42,12 @@ export default defineConfig({
         target: 'http://localhost:5000',
         changeOrigin: true,
       },
+      // User indicator modules are served by Flask from strategies/indicators,
+      // never bundled, so the dev server has to pass them through too.
+      '/custom-indicators': {
+        target: 'http://localhost:5000',
+        changeOrigin: true,
+      },
     },
   },
   build: {

--- a/strategies/.gitignore
+++ b/strategies/.gitignore
@@ -8,6 +8,9 @@ strategy_env.json
 # Uploaded strategy scripts
 scripts/*.py
 
+# Custom chart indicators written by the user (see indicators/.gitignore)
+indicators/*.js
+
 # Keep example strategies
 !examples/
 !examples/*.py

--- a/strategies/indicators/.gitignore
+++ b/strategies/indicators/.gitignore
@@ -1,0 +1,15 @@
+# Ignore all custom chart indicators added by the user
+*.js
+
+# But keep this .gitignore and the folder README
+!.gitignore
+!README.md
+
+# Ignore backup and editor files
+*.bak
+*.backup
+*~
+
+# Keep the directory but ignore its contents.
+# This ensures the indicators folder exists in git while the indicators you
+# write stay on your own machine and are never pushed.

--- a/strategies/indicators/README.md
+++ b/strategies/indicators/README.md
@@ -1,0 +1,49 @@
+# Custom Chart Indicators
+
+Drop a `.js` file in this folder and it becomes an indicator in the `/trading`
+chart's indicator picker. No build step, no Node.js, no restart of the app.
+Refresh the chart and it is there.
+
+Everything you put here is ignored by git, so your indicators stay on your own
+machine and survive `git pull`.
+
+## Only add indicators you have read
+
+A file here is not sandboxed. It runs on the OpenAlgo origin with your logged-in
+session, so it can place orders and read your account. Treat one copied from a
+forum or a chat group exactly as you would any script you are about to run on
+your trading machine: read it first, or do not add it.
+
+To have Claude Code write and check one for you, use the `chart-indicator`
+skill. It validates against the real charting library and refuses to install a
+file that errors.
+
+Minimal example, save as `my_indicator.js`:
+
+```js
+export default function ({ registerIndicator, sourceValues }) {
+  registerIndicator({
+    id: 'my-sma',
+    name: 'My SMA',
+    category: 'Custom',
+    placement: 'onchart',
+    inputs: [{ key: 'length', type: 'number', label: 'Length', default: 20, min: 1 }],
+    plots: [{ key: 'ma', type: 'line', title: 'MA', style: { color: '#4f8cff', lineWidth: 2 } }],
+    calc(bars, settings) {
+      const src = sourceValues(bars, 'close')
+      const n = Number(settings.length)
+      const ma = new Array(bars.length).fill(null)
+      let sum = 0
+      for (let i = 0; i < src.length; i++) {
+        sum += src[i]
+        if (i >= n) sum -= src[i - n]
+        if (i >= n - 1) ma[i] = sum / n
+      }
+      return { ma }
+    },
+  })
+}
+```
+
+Full guide, including a worked Open Range Breakout example with signal labels:
+[docs/custom-indicators.md](../../docs/custom-indicators.md)


### PR DESCRIPTION
Drop a .js file in strategies/indicators/ and it becomes an indicator in the /trading picker: generated settings dialog, legend row, saved-layout persistence. No build step, no Node.js, no restart.

Loaded over HTTP rather than bundled. frontend/dist/ is built by CI from what is committed, and user indicators are deliberately gitignored, so a bundled one would be erased by the next git pull. Runtime loading keeps them outside the build entirely.

The folder sits under strategies/ to mirror strategies/scripts/ for Python strategies, which also puts it inside the openalgo_strategies Docker volume, so indicators persist across container rebuilds.

- blueprints/custom_indicators.py serves the folder: session-gated, GET only, filename allowlist plus send_from_directory, text/javascript so a dynamic import accepts it.
- customIndicators.ts loads them after the built-in tier, so a custom id overrides a built-in rather than the reverse. A missing folder, a logged-out session, a malformed index and a file with a syntax error all leave the other 91 indicators working; a broken file raises a toast naming it.
- IndicatorSettingsDialog gains a text branch. The library's IndicatorInput union has always had one, but no built-in uses it, so a string input fell through to the number control and rendered as an empty box with steppers.

Also adds the chart-indicator skill. It validates a candidate against the real openalgo-charts build over five bar shapes and three settings variants, and refuses to install anything that errors, which is what keeps a silently broken indicator out of the folder: a short column or a mismatched plot key draws nothing and raises nothing at runtime. Ships three validated worked examples and reference docs covering all 303 library exports.

Docs: docs/custom-indicators.md, linked from docs/INDEX.md.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds custom chart indicators to `/trading`: drop a `.js` file into `strategies/indicators/` and it becomes a picker entry with a settings dialog, legend row, and saved-layout persistence. Indicators load at runtime over HTTP, so no build step or restart is needed and they survive `git pull` and container rebuilds.

**How it works**
- Serves the folder via a session-gated blueprint with GET only and a filename allowlist; user files are gitignored and stored on the Docker volume.
- Loads custom modules after built-ins so a custom id overrides a built-in; a missing folder, logged-out session, or broken file leaves the other indicators working and shows a toast naming the file.
- Fixes the settings dialog so text inputs render correctly instead of as an empty number box.
- Adds a `chart-indicator` skill that validates candidates against the real library and refuses to install anything that errors, with three worked examples and reference docs.

Note: indicator files run on the OpenAlgo origin with your session, so treat them like any script you'd run on your trading machine.

<sup>Written for commit 6db1374eb221b741694b9c074393469d79219edb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1923?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

