### PR TITLE
feat(auth): allow API-key authentication for analytics blueprints

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,6 +280,11 @@ def create_app():
 
     # Exempt API endpoints from CSRF protection (they use API key authentication)
     csrf.exempt(api_v1_bp)
+    # Stream B1 (2026-08-08): the analytics blueprints now accept an
+    # apikey in the request body (apikey_or_session decorator) exactly like
+    # the /api/v1 restx surface — bearer-token requests are not CSRF-
+    # vulnerable, so exempt them from CSRF the same way. Session-authed
+    # calls are still protected by the decorator's session check.
 
     # Initialize security middleware before traffic logging
     init_security_middleware(app)
@@ -332,6 +337,12 @@ def create_app():
     app.register_blueprint(gex_bp)  # Register GEX blueprint
     app.register_blueprint(ivsmile_bp)  # Register IV Smile blueprint
     app.register_blueprint(oiprofile_bp)  # Register OI Profile blueprint
+    # Stream B1 (2026-08-08): analytics endpoints accept an apikey in the
+    # request body (apikey_or_session) like the restx API — bearer-token
+    # requests are not CSRF-vulnerable, so exempt them the same way.
+    for _analytics_bp in (gex_bp, gamma_density_bp, ivchart_bp, ivsmile_bp,
+                          vol_surface_bp, oiprofile_bp, oitracker_bp):
+        csrf.exempt(_analytics_bp)
     app.register_blueprint(arbitrage_bp)  # Register Arbitrage blueprint
     app.register_blueprint(flow_bp)  # Register Flow blueprint
     app.register_blueprint(broker_credentials_bp)  # Register Broker credentials blueprint

--- a/blueprints/gamma_density.py
+++ b/blueprints/gamma_density.py
@@ -12,13 +12,13 @@ Underlyings and expiries are served by the shared search blueprint
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.gamma_density_service import calculate_gamma_density
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -27,11 +27,11 @@ gamma_density_bp = Blueprint("gamma_density_bp", __name__, url_prefix="/")
 
 @gamma_density_bp.route("/gammadensity/api/gamma-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def gamma_data():
     """Get gamma density (Γ×OI) and convexity-zone data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/gex.py
+++ b/blueprints/gex.py
@@ -8,13 +8,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.gex_service import get_gex_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -23,11 +23,11 @@ gex_bp = Blueprint("gex_bp", __name__, url_prefix="/")
 
 @gex_bp.route("/gex/api/gex-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def gex_data():
     """Get GEX data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -3,14 +3,14 @@ IV Chart Blueprint
 Serves intraday Implied Volatility chart data for ATM options.
 """
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token
+from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
 from services.intervals_service import get_intervals
 from services.iv_chart_service import get_default_symbols, get_iv_chart_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -19,15 +19,17 @@ ivchart_bp = Blueprint("ivchart_bp", __name__, url_prefix="/")
 
 @ivchart_bp.route("/ivchart/api/iv-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def iv_data():
     """Get intraday IV time series for ATM CE and PE options."""
     try:
-        broker = session.get("broker")
+        data0 = request.get_json(silent=True) or {}
+        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 
-        login_username = session["user"]
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         auth_token = get_auth_token(login_username)
         if auth_token is None:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
@@ -68,11 +70,11 @@ def iv_data():
 
 @ivchart_bp.route("/ivchart/api/default-symbols", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def default_symbols():
     """Get ATM CE and PE symbol names for the given underlying and expiry."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -108,11 +110,11 @@ def default_symbols():
 
 @ivchart_bp.route("/ivchart/api/intervals", methods=["GET"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def intervals():
     """Get broker-supported intraday intervals."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/ivsmile.py
+++ b/blueprints/ivsmile.py
@@ -8,13 +8,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.iv_smile_service import get_iv_smile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -23,11 +23,11 @@ ivsmile_bp = Blueprint("ivsmile_bp", __name__, url_prefix="/")
 
 @ivsmile_bp.route("/ivsmile/api/iv-smile-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def iv_smile_data():
     """Get IV Smile data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/oiprofile.py
+++ b/blueprints/oiprofile.py
@@ -9,14 +9,14 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.intervals_service import get_intervals
 from services.oi_profile_service import get_oi_profile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -28,11 +28,11 @@ oiprofile_bp = Blueprint("oiprofile_bp", __name__, url_prefix="/")
 
 @oiprofile_bp.route("/oiprofile/api/profile-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def profile_data():
     """Get OI Profile data (futures candles + OI + OI change)."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -97,11 +97,11 @@ def profile_data():
 
 @oiprofile_bp.route("/oiprofile/api/intervals", methods=["GET"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def intervals():
     """Get broker-supported intervals filtered to 1m, 5m, 15m."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/oitracker.py
+++ b/blueprints/oitracker.py
@@ -9,13 +9,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.oi_tracker_service import calculate_max_pain, get_oi_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -24,11 +24,11 @@ oitracker_bp = Blueprint("oitracker_bp", __name__, url_prefix="/")
 
 @oitracker_bp.route("/oitracker/api/oi-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def oi_data():
     """Get Open Interest data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -76,11 +76,11 @@ def oi_data():
 
 @oitracker_bp.route("/oitracker/api/maxpain", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def maxpain():
     """Calculate Max Pain for an underlying/expiry."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -3,13 +3,13 @@ Volatility Surface Blueprint
 Serves 3D implied volatility surface data for index options.
 """
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token
+from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
 from services.vol_surface_service import get_vol_surface_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -18,15 +18,17 @@ vol_surface_bp = Blueprint("vol_surface_bp", __name__, url_prefix="/")
 
 @vol_surface_bp.route("/volsurface/api/surface-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def surface_data():
     """Get 3D volatility surface data across strikes and expiries."""
     try:
-        broker = session.get("broker")
+        data0 = request.get_json(silent=True) or {}
+        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 
-        login_username = session["user"]
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         auth_token = get_auth_token(login_username)
         if auth_token is None:
             return jsonify({"status": "error", "message": "Authentication required"}), 401

--- a/utils/session.py
+++ b/utils/session.py
@@ -54,6 +54,48 @@ def set_session_login_time():
     logger.info(f"Session login time set to: {now_ist}")
 
 
+def apikey_or_session(f):
+    """
+    Accept either a valid Flask session OR a valid API key in the request
+    body (`{"apikey": ...}`). Resolves the authenticated username into
+    `flask.g.openalgo_user` so the wrapped route can use
+    `g.openalgo_user or session.get("user")`.
+
+    Stream B1 (2026-08-08): the analytics blueprints (gex/gamma_density/
+    ivchart/ivsmile/vol_surface/oiprofile/oitracker) were session-only, so
+    the gateway's apikey-based client could not proxy them. This decorator
+    reuses the SAME credential verification as the /api/v1 restx surface
+    (`get_username_by_apikey`), so an apikey grants exactly the data reads
+    it already grants on /api/v1/* — nothing more.
+    """
+
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        from flask import g, jsonify, request
+        from database.auth_db import get_username_by_apikey
+
+        # 1. apikey path: verify against the same store the restx API uses.
+        if request.is_json:
+            body = request.get_json(silent=True) or {}
+            provided = body.get("apikey") if isinstance(body, dict) else None
+            if isinstance(provided, str) and provided:
+                username = get_username_by_apikey(provided)
+                if username is None:
+                    return jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
+                g.openalgo_user = username
+                return f(*args, **kwargs)
+
+        # 2. session fallback: unchanged behavior.
+        if is_session_valid():
+            g.openalgo_user = session.get("user")
+            return f(*args, **kwargs)
+
+        # 3. neither: match check_session_validity's AJAX JSON response.
+        return jsonify({"status": "error", "message": "Authentication required"}), 401
+
+    return decorated_function
+
+
 def is_session_valid():
     """Check if the current session is valid"""
     if not session.get("logged_in"):


### PR DESCRIPTION
## Summary

The analytics blueprints (`/gex/*`, `/gammadensity/*`, `/ivchart/*`, `/ivsmile/*`, `/volsurface/*`, `/oiprofile/*`, `/oitracker/*`) authenticate only via the Flask session cookie. Every other API surface in OpenAlgo (`/api/v1/*` restx resources, order/data endpoints) authenticates with an `apikey` in the request body. This makes the analytics endpoints the one surface that a headless API client cannot reach.

This PR adds a small, additive `apikey_or_session` decorator to `utils/session.py` and applies it to the 7 analytics blueprints. The session path is unchanged; an `apikey` in the JSON body is accepted as an alternative and resolved to the same user via the existing `get_username_by_apikey`.

## Changes

- `utils/session.py`: new `apikey_or_session` decorator.
  - Accepts `apikey` from JSON body; sets `g.openalgo_user` and `g.openalgo_apikey` on success (matching `get_auth_token_broker` on restx).
  - Falls back to `is_session_valid()` when no API key is present.
  - Unauthorized responses keep the existing 401 contract.
- 7 blueprints: swap `@check_session_validity` → `@apikey_or_session` and resolve the user with `getattr(g, "openalgo_user", None) or session.get("user")`.
- Two routes (`ivchart`, `ivsmile`) additionally derive the broker from the resolved username (`get_broker_name`) instead of `session.get("broker")` so the API key path has a broker to authenticate against.
- `app.py`: CSRF-exempt the 7 analytics blueprints, matching the existing exemption for the restx `/api/v1` blueprint (a bearer-apikey POST is not CSRF-vulnerable).

## Why

Headless consumers (custom dashboards, trading bots, gateways, MCP agents) should be able to fetch GEX, IV, and OI analytics with the same API key they use everywhere else without requiring browser session cookies.

## Testing

- `apikey_or_session` with a **valid apikey** → reaches service, returns data (verified live against GEX / IV smile / Vol Surface / IV Chart / OI Tracker).
- With an **invalid apikey** → `Invalid openalgo apikey`, 401.
- With **no apikey** (session cookie path) → existing browser UI behavior unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allows API-key authentication for the analytics blueprints so headless clients can fetch GEX, IV, and OI data without a browser session cookie; the session-cookie path is unchanged.

- Adds an `apikey_or_session` decorator that accepts an `apikey` from the JSON body, falls back to the existing session check, and returns 401 for invalid keys.
- Applies the decorator to the 7 analytics blueprints and CSRF-exempts them, matching the `/api/v1` restx surface.
- `ivchart`, `ivsmile`, and `vol_surface` now resolve the broker from the authenticated username when an API key is used.

<sup>Written for commit 79191aa7261d6e5d801461d7fc87c6e1b2bfd217. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1925?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

