### PR TITLE
fix(fyers): drop Authorization header on HSM websocket upgrade

### DIFF
--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -896,7 +896,10 @@ class FyersHSMWebSocket:
                     on_close=self._on_ws_close,
                     on_ping=self._on_ws_ping,
                     on_pong=self._on_ws_pong,
-                    header={"Authorization": self.access_token, "User-Agent": f"{self.source}/1.0"},
+                    # Fyers HSM endpoint ignores the binary auth frame if the WS upgrade
+                    # request carries an Authorization header, causing connect() to time out
+                    # after 15s. The official fyers-apiv3 SDK sends no upgrade headers; auth
+                    # is carried in the binary auth frame's hsm_key field.
                 )
 
                 # Run until disconnection. Enable protocol ping/pong keepalive so


### PR DESCRIPTION
## Summary

Fyers' HSM endpoint (`wss://socket.fyers.in/hsm/v1-5/prod`) ignores the application-level binary auth frame when the WebSocket HTTP upgrade request carries an `Authorization` header. As a result, no acknowledgment arrives and `connect()` times out after 15 seconds (`Failed to authenticate with Fyers HSM WebSocket (timeout)`), preventing live ticks from streaming.

## Root Cause

The official `fyers-apiv3` SDK (`FyersWebsocket/data_ws.py`) sends no HTTP headers on the HSM endpoint upgrade. Auth is completely carried in the binary auth frame's `hsm_key` field, making the upgrade HTTP `Authorization` header redundant and causing the Fyers HSM server to ignore the subsequent binary auth frame.

## Changes

- `broker/fyers/streaming/fyers_hsm_websocket.py`: Remove `header={"Authorization": ...}` argument when constructing `websocket.WebSocketApp`.

## Verification

Verified live:
- With HTTP Authorization header: 15s timeout / no auth ack.
- Without HTTP Authorization header: Immediate authentication and continuous live tick feed.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fyers HSM WebSocket connections timing out after 15 seconds by removing the `Authorization` header from the WebSocket upgrade request. The HSM endpoint ignores the binary auth frame when the upgrade request carries the header, so authentication never completes and live ticks don't stream; without the header, auth succeeds immediately and ticks flow normally.

<sup>Written for commit 6a473cbc775bc913d1331b6de6a0e83ab05520c6. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1926?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

