### PR TITLE
fix: apply central CORS policy to blueprint decorators

### DIFF
--- a/cors.py
+++ b/cors.py
@@ -52,12 +52,17 @@ def get_cors_config():
 
 
 def init_cors(app):
-    """Initialize Flask-CORS when it has been explicitly enabled."""
-    if not is_cors_enabled():
+    """Apply one CORS policy to the API extension and blueprint decorators."""
+    enabled = is_cors_enabled()
+    cors_config = get_cors_config() if enabled else {"origins": []}
+    # @cross_origin() reads app.config independently of the API extension.
+    # An empty origin list also keeps its automatic OPTIONS handling fail-closed.
+    app.config.update({f"CORS_{key.upper()}": value for key, value in cors_config.items()})
+
+    if not enabled:
         logger.debug("CORS is disabled")
         return
 
-    cors_config = get_cors_config()
     if cors_config["origins"]:
         logger.debug("CORS enabled for origins: %s", ", ".join(cors_config["origins"]))
     else:

--- a/test/test_cors_config.py
+++ b/test/test_cors_config.py
@@ -1,6 +1,27 @@
-from flask import Flask
+import importlib.util
+import sys
+from pathlib import Path
+from types import ModuleType
+
+import pytest
+from flask import Blueprint, Flask
+from flask_cors import cross_origin
 
 from cors import init_cors
+
+
+@pytest.fixture(autouse=True)
+def clear_cors_environment(monkeypatch):
+    for name in (
+        "CORS_ENABLED",
+        "CORS_ALLOWED_ORIGINS",
+        "CORS_ALLOWED_METHODS",
+        "CORS_ALLOWED_HEADERS",
+        "CORS_EXPOSED_HEADERS",
+        "CORS_ALLOW_CREDENTIALS",
+        "CORS_MAX_AGE",
+    ):
+        monkeypatch.delenv(name, raising=False)
 
 
 def create_test_app():
@@ -102,3 +123,190 @@ def test_enabled_cors_rejects_unlisted_origin(monkeypatch):
     )
 
     assert "Access-Control-Allow-Origin" not in response.headers
+
+
+def create_decorated_blueprint():
+    blueprint = Blueprint("tools", __name__)
+
+    @blueprint.post("/tools/api/test")
+    @cross_origin()
+    def tool_test():
+        # Like the production blueprints, authentication belongs to the view,
+        # while Flask-CORS handles OPTIONS without entering the view.
+        return {"status": "error", "message": "Authentication required"}, 401
+
+    return blueprint
+
+
+def create_decorated_app(blueprint=None):
+    app = create_test_app()
+    app.register_blueprint(blueprint or create_decorated_blueprint())
+    return app
+
+
+def request_tool(app, method, origin="https://allowed.example"):
+    return app.test_client().open(
+        "/tools/api/test",
+        method=method,
+        headers={
+            "Origin": origin,
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": "X-API-KEY, X-Unlisted",
+        },
+    )
+
+
+def cors_headers(response):
+    return {
+        name: value
+        for name, value in response.headers
+        if name.lower().startswith("access-control-")
+    }
+
+
+@pytest.mark.parametrize("enabled", [None, "FALSE", "false", "", "1", "invalid"])
+@pytest.mark.parametrize("method", ["POST", "OPTIONS"])
+def test_decorated_route_denies_cors_unless_explicitly_enabled(monkeypatch, enabled, method):
+    if enabled is not None:
+        monkeypatch.setenv("CORS_ENABLED", enabled)
+    # Keep a matching origin and credentials configured so neither can mask a
+    # missing enable gate.
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://allowed.example")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "TRUE")
+
+    response = request_tool(create_decorated_app(), method)
+
+    assert response.status_code == (200 if method == "OPTIONS" else 401)
+    assert not cors_headers(response)
+    if method == "POST":
+        assert response.json["message"] == "Authentication required"
+
+
+@pytest.mark.parametrize("origins", [None, "", "   ", " , , "])
+@pytest.mark.parametrize("method", ["POST", "OPTIONS"])
+def test_decorated_route_without_origins_fails_closed(monkeypatch, origins, method):
+    monkeypatch.setenv("CORS_ENABLED", "TRUE")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "TRUE")
+    if origins is not None:
+        monkeypatch.setenv("CORS_ALLOWED_ORIGINS", origins)
+
+    response = request_tool(create_decorated_app(), method)
+
+    assert response.status_code == (200 if method == "OPTIONS" else 401)
+    assert not cors_headers(response)
+
+
+@pytest.mark.parametrize("method", ["POST", "OPTIONS"])
+def test_decorated_route_rejects_unlisted_origin(monkeypatch, method):
+    monkeypatch.setenv("CORS_ENABLED", "TRUE")
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://allowed.example")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", "TRUE")
+
+    response = request_tool(create_decorated_app(), method, "https://unlisted.example")
+
+    assert response.status_code == (200 if method == "OPTIONS" else 401)
+    assert not cors_headers(response)
+
+
+@pytest.mark.parametrize("credentials", ["TRUE", "FALSE"])
+@pytest.mark.parametrize("method", ["POST", "OPTIONS"])
+def test_decorated_route_uses_all_central_options(monkeypatch, credentials, method):
+    monkeypatch.setenv("CORS_ENABLED", "true")
+    monkeypatch.setenv(
+        "CORS_ALLOWED_ORIGINS", " , https://allowed.example, https://other.example, "
+    )
+    monkeypatch.setenv("CORS_ALLOWED_METHODS", "GET, POST")
+    monkeypatch.setenv("CORS_ALLOWED_HEADERS", "Content-Type, X-API-KEY")
+    monkeypatch.setenv("CORS_EXPOSED_HEADERS", "X-Result")
+    monkeypatch.setenv("CORS_ALLOW_CREDENTIALS", credentials)
+    monkeypatch.setenv("CORS_MAX_AGE", "600")
+    app = create_decorated_app()
+
+    response = request_tool(app, method)
+
+    assert response.status_code == (200 if method == "OPTIONS" else 401)
+    assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
+    assert response.headers["Access-Control-Expose-Headers"] == "X-Result"
+    assert response.headers.get("Access-Control-Allow-Credentials") == (
+        "true" if credentials == "TRUE" else None
+    )
+    assert "Origin" in response.vary
+    if method == "OPTIONS":
+        assert response.headers["Access-Control-Allow-Methods"] == "GET, POST"
+        assert response.headers["Access-Control-Allow-Headers"] == "X-API-KEY"
+        assert response.headers["Access-Control-Max-Age"] == "600"
+        assert "POST" in response.allow
+        assert "OPTIONS" in response.allow
+
+        central_response = app.test_client().options(
+            "/api/test",
+            headers={
+                "Origin": "https://allowed.example",
+                "Access-Control-Request-Method": "POST",
+                "Access-Control-Request-Headers": "X-API-KEY, X-Unlisted",
+            },
+        )
+        assert cors_headers(response) == cors_headers(central_response)
+
+
+def test_decorated_blueprint_uses_each_apps_policy(monkeypatch):
+    # Blueprints are imported once, before app creation. Reusing one must not
+    # capture the first app's settings or leak an enabled app's policy to another.
+    blueprint = create_decorated_blueprint()
+    monkeypatch.setenv("CORS_ENABLED", "TRUE")
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://allowed.example")
+    allowed_app = create_decorated_app(blueprint)
+    monkeypatch.setenv("CORS_ENABLED", "FALSE")
+    denied_app = create_decorated_app(blueprint)
+
+    assert not cors_headers(request_tool(denied_app, "POST"))
+    assert request_tool(allowed_app, "POST").headers["Access-Control-Allow-Origin"] == (
+        "https://allowed.example"
+    )
+
+
+@pytest.mark.parametrize("enabled", ["FALSE", "TRUE"])
+@pytest.mark.parametrize("method", ["POST", "OPTIONS"])
+def test_oitracker_blueprint_respects_policy_without_bypassing_auth(monkeypatch, enabled, method):
+    # Import the real blueprint and session decorator, isolating only database
+    # and broker services. Neither OPTIONS nor unauthenticated POST may use them.
+    def unexpected_service_call(*args, **kwargs):
+        pytest.fail(
+            "Preflight and unauthenticated requests must not reach broker/database services"
+        )
+
+    auth_db = ModuleType("database.auth_db")
+    auth_db.get_api_key_for_tradingview = unexpected_service_call
+    service = ModuleType("services.oi_tracker_service")
+    service.calculate_max_pain = unexpected_service_call
+    service.get_oi_data = unexpected_service_call
+    monkeypatch.setitem(sys.modules, "database.auth_db", auth_db)
+    monkeypatch.setitem(sys.modules, "services.oi_tracker_service", service)
+    path = Path(__file__).resolve().parents[1] / "blueprints" / "oitracker.py"
+    spec = importlib.util.spec_from_file_location("cors_test_oitracker", path)
+    module = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(module)
+
+    monkeypatch.setenv("CORS_ENABLED", enabled)
+    monkeypatch.setenv("CORS_ALLOWED_ORIGINS", "https://allowed.example")
+    app = create_test_app()
+    app.config["SECRET_KEY"] = "test-only-cors-key"
+    app.register_blueprint(module.oitracker_bp)
+
+    for endpoint in ("/oitracker/api/oi-data", "/oitracker/api/maxpain"):
+        response = app.test_client().open(
+            endpoint,
+            method=method,
+            json={},
+            headers={
+                "Origin": "https://allowed.example",
+                "Access-Control-Request-Method": "POST",
+            },
+        )
+        assert response.status_code == (200 if method == "OPTIONS" else 401)
+        if method == "POST":
+            assert response.json["error"] == "session_expired"
+        if enabled == "TRUE":
+            assert response.headers["Access-Control-Allow-Origin"] == "https://allowed.example"
+        else:
+            assert not cors_headers(response)


### PR DESCRIPTION
## Summary

Closes #1891.

- Publish the environment-backed CORS options to Flask's application config during `init_cors()`. The existing zero-argument `@cross_origin()` decorators read those options at request time, so the 21 decorated handlers across 12 blueprints now follow the same policy as the central `/api/*` extension.
- Set an empty application-level origin list when CORS is disabled, including when `CORS_ENABLED` is absent. Enabled with missing, empty or whitespace-only origins also fails closed.
- Preserve Flask-CORS automatic OPTIONS handling, existing route/authentication behavior and the central resource scope. No custom decorator, broker changes, dependency changes or workflow changes.

## Regression coverage

`test/test_cors_config.py` is already in the maintained CI-safe test list. It now has 38 cases, including the original seven:

- POST and OPTIONS with unset, false, empty and invalid enable values, while a matching origin and credential support remain configured.
- Missing/blank origins and unlisted origins, including credentialed configuration.
- Lowercase `true`, trimmed origin lists, allowed methods/headers, exposed headers, credentials and preflight max-age. The decorated and central preflight CORS headers are compared directly.
- One blueprint reused by enabled and disabled Flask apps, ensuring policy is application-specific rather than captured at import time.
- The real OI Tracker blueprint and session decorator on both endpoints: preflight stays 200, unauthenticated JSON POST stays 401, and disabled responses carry no CORS headers. Only its database and market-data services are replaced with fail-if-called stubs; neither path should reach those services.

## Upgrade behavior

Previously these blueprint decorators reflected arbitrary origins regardless of the environment policy. Cross-origin clients of these endpoints now need `CORS_ENABLED=TRUE` and an entry in `CORS_ALLOWED_ORIGINS`; credentialed browser clients also need `CORS_ALLOW_CREDENTIALS=TRUE`. Requested methods and headers must be allowed by the existing settings. Same-origin access and server-to-server calls do not require CORS. CORS is not a replacement for authentication or CSRF protection, which this patch does not change.

## Validation

- All 38 focused tests pass on Python 3.12.12, 3.13.15 and 3.14.7 with the repository's Flask 3.1.3 and Flask-Cors 6.0.5 versions.
- Before the production fix, the initial 27 added cases fail and the original seven pass. Re-running the final test file with the base `cors.py` loaded in memory gives 29 failures and nine passes, including failures on both real OI Tracker disabled paths. No baseline file or assertion was modified for that check.
- Ruff check and format check pass on both changed files; `git diff --check` passes. Whole-repository Ruff reports 1,242 findings, all outside the two changed files; no unrelated cleanup was applied.
- Local testing uses a minimal uv-managed environment because available disk space is insufficient for a full application dependency install. The full CI-safe backend selection and application startup have not been run locally. No frontend code changed, so no local frontend build/test is claimed.

Reproduce the local focused run (replace `3.12` with `3.13` or `3.14`):

```sh
env -u LOG_FORMAT uv run --no-project --python 3.12 \
  --with Flask==3.1.3 --with Flask-Cors==6.0.5 \
  --with pytest==9.1.1 --with pytest-timeout==2.4.0 \
  --with ruff --with pytz==2026.2 \
  python -m pytest test/test_cors_config.py -q
```

`LOG_FORMAT` is unset here because this shell exports `json`, which is not a valid Python logging format for the application's console formatter. The test configuration directs logs to `log/test`; no production database or broker credentials are used.


## Hosted CI

[CI run 33137730828](https://github.com/marketcalls/openalgo/actions/runs/33137730828), head `0b802e3918908630473d0055a25ee910c11ad4b7`:

- Backend CI-safe selection: 274 passed on each of Python 3.12, 3.13 and 3.14. Logs confirm the actual OI Tracker regression cases execute.
- Frontend: build and test jobs pass on Node 20, 22 and 24. Both ordinary and coverage runs pass all 1,114 tests (57 files) on each version. Frontend lint and all 16 Chromium end-to-end tests pass.
- Security scan remains in progress as of 03:06 UTC. No completed security pass is claimed.
- Backend lint job is non-blocking by existing workflow policy: its steps report the same 1,242 whole-repository lint findings and 510 files needing formatting. Both modified files pass local lint/format checks; this PR does not change or suppress those gates.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Applies the central environment-backed CORS policy to all `@cross_origin()`-decorated handlers across 12 blueprints. Those handlers previously reflected arbitrary origins regardless of the environment policy; they now honor `CORS_ENABLED`, `CORS_ALLOWED_ORIGINS`, and the rest of the central options, and fail closed when CORS is disabled.

- `init_cors()` now writes the resolved CORS options into Flask's app config, which the zero-argument decorators read at request time.
- When CORS is disabled, or when no origins are configured, responses carry no CORS headers, including when `CORS_ENABLED` is missing or blank.
- Cross-origin clients now need `CORS_ENABLED=TRUE` and an entry in `CORS_ALLOWED_ORIGINS`; credentialed browser clients also need `CORS_ALLOW_CREDENTIALS=TRUE`.
- Same-origin access and server-to-server calls are unaffected, and Flask-CORS automatic OPTIONS handling and the central resource scope are preserved.
- Test coverage expanded to 38 cases covering disabled, blank, and unlisted origins, trimmed origin lists, lowercase enable values, allowed methods/headers, credentials, max-age, blueprint reuse across apps, and the real OI Tracker blueprint with its database and broker services stubbed.

<sup>Written for commit 0b802e3918908630473d0055a25ee910c11ad4b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1927?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->
