### PR TITLE
feat(tradesmart): tag placed orders as openalgo and feat(tradesmart): give quotes their own 100/sec rate-limit budget

### DIFF
--- a/broker/tradesmart/api/data.py
+++ b/broker/tradesmart/api/data.py
@@ -10,7 +10,7 @@ import pandas as pd
 from broker.tradesmart.api.baseurl import parse_auth, post, resolve_uid
 from broker.tradesmart.api.rate_limiter import (
     MAX_RETRIES,
-    TRADESMART_MAX_PER_SECOND,
+    TRADESMART_QUOTE_MAX_PER_SECOND,
     apply_rate_limit,
     is_rate_limit_error,
     retry_delay,
@@ -49,8 +49,9 @@ def _normalize_data_exchange(exchange):
 def _get_api_response(endpoint, auth, payload, retry_count=0):
     """Rate-limited POST returning parsed JSON (dict or list).
 
-    Paced by the shared per-user gate (see broker.tradesmart.api.rate_limiter):
-    every endpoint bills against the same 10/sec + 120/min budget.
+    Paced by the gates in broker.tradesmart.api.rate_limiter: quote endpoints
+    against their own 100/sec budget, every other endpoint against the shared
+    10/sec + 120/min per-user budget.
 
     Retries with exponential backoff when TradeSmart reports a rate-limit hit,
     so a burst of quote requests (e.g. a 90+ symbol option chain or the OI
@@ -77,13 +78,12 @@ def _get_api_response(endpoint, auth, payload, retry_count=0):
 # WebSocket-backed bulk quotes
 #
 # Why this exists:
-# TradeSmart caps REST at 10 requests/sec and 120/min *per user* (see
-# ``broker.tradesmart.api.rate_limiter``), and Noren exposes no batch-quote
-# endpoint -- ``/GetQuotes`` takes exactly one token. An option chain of 41
-# strikes is 82 legs, so the REST path costs 82 calls: about 10 seconds against
-# the per-second gate, and 164 calls/minute against a 110/minute budget once the
-# UI refreshes every 30 seconds. It cannot be tuned into working; there is no
-# pacing of 82 calls that fits a 120/minute ceiling twice a minute.
+# Noren exposes no batch-quote endpoint -- ``/GetQuotes`` takes exactly one
+# token. An option chain of 41 strikes is 82 legs, so the REST path costs 82
+# separate round trips per refresh. Quotes are metered at 100/sec (see
+# ``broker.tradesmart.api.rate_limiter``), so the pacing gate no longer blocks
+# that, but 82 sequential HTTP requests every 30 seconds is still 82 requests'
+# worth of latency and connection overhead for data one subscribe delivers.
 #
 # The streaming API has no such problem. One subscribe message carries every
 # token::
@@ -516,7 +516,10 @@ class BrokerData:
             return results
 
         logger.info(f"Fetching {len(pending)} TradeSmart quotes over REST")
-        with ThreadPoolExecutor(max_workers=TRADESMART_MAX_PER_SECOND) as executor:
+        # Sized to the quote budget (100/sec), not the general one: threads are
+        # spawned lazily, so a short list still costs only len(pending) threads.
+        max_workers = min(TRADESMART_QUOTE_MAX_PER_SECOND, len(pending))
+        with ThreadPoolExecutor(max_workers=max_workers) as executor:
             future_map = {executor.submit(self._fetch_single_quote, item): item for item in pending}
             for future in as_completed(future_map):
                 item = future_map[future]

--- a/broker/tradesmart/api/rate_limiter.py
+++ b/broker/tradesmart/api/rate_limiter.py
@@ -1,17 +1,18 @@
 """Shared rate limiting and retry helpers for all TradeSmart (Noren) API calls.
 
-TradeSmart bills every data call against ONE per-user budget with two rolling
-windows: 10 requests per second and 120 requests per minute. The backend
-rejects the offender with ``stat=Not_Ok`` and an emsg naming the breached
-window, e.g.::
+Two budgets, because quotes and everything else are metered differently.
+
+**Quotes** (``/GetQuotes``) are allowed 100 requests per second with no
+per-minute ceiling, so they get their own bucket and are paced on the
+per-second window alone.
+
+**Everything else** -- orders, funds, margin, history -- shares ONE per-user
+budget with two rolling windows: 10 requests per second and 120 requests per
+minute. The backend rejects the offender with ``stat=Not_Ok`` and an emsg
+naming the breached window, e.g.::
 
     Invalid Input :  Order Recieved 11 in a current second exceeds Limit 10 for user
     Invalid Input :  Order Recieved 121 in a current minute exceeds Limit 120 for user
-
-Both of those were observed on ``/GetQuotes`` in the same option-chain request,
-which is why quotes are NOT exempt from the per-minute window and do NOT get a
-separate budget from history: the counters are per *user*, not per endpoint, so
-one shared gate is the only thing that can keep the account under both ceilings.
 
 State is module level, exactly as in ``broker.fyers.api.rate_limiter`` and for
 the same reason: services construct a fresh ``BrokerData(auth_token)`` per
@@ -19,23 +20,32 @@ request (see ``services/option_chain_service.py``,
 ``services/oi_tracker_service.py``), so any pacing state kept on ``self`` is
 discarded on every call and paces nothing against concurrent requests.
 
-The gate is burst-friendly, modelled on ``broker.flattrade.api.data``: it
-reserves the earliest slot that satisfies both rolling windows rather than
-spacing every call by a fixed interval, so a 10-symbol batch goes out at once
-and only the 11th waits. The slot is reserved under the lock and slept for
-outside it -- holding a lock across ``time.sleep`` would serialise every waiter
-behind the sleeper and turn a 10/sec allowance back into a queue.
+Each gate is burst-friendly, modelled on ``broker.flattrade.api.data``: it
+reserves the earliest slot that satisfies its rolling window(s) rather than
+spacing every call by a fixed interval, so a batch goes out at once and only
+the call past the ceiling waits. The slot is reserved under the lock and slept
+for outside it -- holding a lock across ``time.sleep`` would serialise every
+waiter behind the sleeper and turn the allowance back into a queue.
 """
 
 import threading
 import time
 from collections import deque
 
-# Broker ceilings are 10/sec and 120/min per user. We run under both as margin
-# for clock skew between our rolling windows and however Noren measures theirs,
-# and because order/fund/margin calls from other modules share the same quota.
+# Broker ceilings for the general budget are 10/sec and 120/min per user. We run
+# under both as margin for clock skew between our rolling windows and however
+# Noren measures theirs, and because order/fund/margin calls from other modules
+# share the same quota.
 TRADESMART_MAX_PER_SECOND = 8
 TRADESMART_MAX_PER_MINUTE = 110
+
+# Quotes are metered separately at 100/sec with no per-minute ceiling. Same
+# clock-skew margin as above; ``None`` disables the per-minute window entirely.
+TRADESMART_QUOTE_MAX_PER_SECOND = 90
+TRADESMART_QUOTE_MAX_PER_MINUTE = None
+
+# Endpoints billed against the quote budget rather than the general one.
+QUOTE_ENDPOINTS = frozenset({"/GetQuotes"})
 
 MAX_RETRIES = 3
 BASE_BACKOFF = 2.0  # seconds; exponential when the broker reports a limit hit
@@ -43,9 +53,12 @@ BASE_BACKOFF = 2.0  # seconds; exponential when the broker reports a limit hit
 _lock = threading.Lock()
 _reserved_call_times: deque = deque()
 
+_quote_lock = threading.Lock()
+_reserved_quote_times: deque = deque()
 
-def _reserve_slot() -> float:
-    """Reserve the earliest slot satisfying both rolling windows.
+
+def _reserve_slot(lock, reserved, max_per_second, max_per_minute) -> float:
+    """Reserve the earliest slot satisfying the bucket's rolling window(s).
 
     Returns the seconds the caller must sleep before issuing its request.
 
@@ -59,21 +72,32 @@ def _reserve_slot() -> float:
       - 60s after the Mth-most-recent reservation when the per-minute window is
         full;
 
-    whichever is latest. Entries older than 60s can no longer constrain any
-    future slot and are purged.
+    whichever is latest. ``max_per_minute=None`` means the bucket has no
+    per-minute ceiling, in which case only the per-second window constrains the
+    slot and entries older than a second are purged.
+
+    Args:
+        lock: the bucket's lock, held only while reserving (never across sleep).
+        reserved: the bucket's deque of reserved timestamps.
+        max_per_second: per-second ceiling.
+        max_per_minute: per-minute ceiling, or ``None`` for no such window.
     """
-    with _lock:
+    # Entries older than the widest window can no longer constrain any future
+    # slot, so that horizon is how far back the deque needs to reach.
+    horizon = 60.0 if max_per_minute is not None else 1.0
+
+    with lock:
         now = time.time()
-        while _reserved_call_times and _reserved_call_times[0] <= now - 60.0:
-            _reserved_call_times.popleft()
+        while reserved and reserved[0] <= now - horizon:
+            reserved.popleft()
 
         slot = now
-        if len(_reserved_call_times) >= TRADESMART_MAX_PER_SECOND:
-            slot = max(slot, _reserved_call_times[-TRADESMART_MAX_PER_SECOND] + 1.0)
-        if len(_reserved_call_times) >= TRADESMART_MAX_PER_MINUTE:
-            slot = max(slot, _reserved_call_times[-TRADESMART_MAX_PER_MINUTE] + 60.0)
+        if len(reserved) >= max_per_second:
+            slot = max(slot, reserved[-max_per_second] + 1.0)
+        if max_per_minute is not None and len(reserved) >= max_per_minute:
+            slot = max(slot, reserved[-max_per_minute] + 60.0)
 
-        _reserved_call_times.append(slot)
+        reserved.append(slot)
         return slot - now
 
 
@@ -81,11 +105,25 @@ def apply_rate_limit(endpoint: str | None = None) -> None:
     """Block until it is safe to issue another TradeSmart call.
 
     Args:
-        endpoint: Noren path, e.g. ``"/GetQuotes"``. Accepted for call-site
-            readability and logging only -- every endpoint bills against the
-            same per-user budget, so it does not change the pacing.
+        endpoint: Noren path, e.g. ``"/GetQuotes"``. Quote endpoints are paced
+            against their own 100/sec budget; every other endpoint bills
+            against the shared 10/sec + 120/min per-user budget.
     """
-    sleep_time = _reserve_slot()
+    if endpoint in QUOTE_ENDPOINTS:
+        sleep_time = _reserve_slot(
+            _quote_lock,
+            _reserved_quote_times,
+            TRADESMART_QUOTE_MAX_PER_SECOND,
+            TRADESMART_QUOTE_MAX_PER_MINUTE,
+        )
+    else:
+        sleep_time = _reserve_slot(
+            _lock,
+            _reserved_call_times,
+            TRADESMART_MAX_PER_SECOND,
+            TRADESMART_MAX_PER_MINUTE,
+        )
+
     if sleep_time > 0:
         time.sleep(sleep_time)
 

--- a/broker/tradesmart/mapping/transform_data.py
+++ b/broker/tradesmart/mapping/transform_data.py
@@ -48,6 +48,7 @@ def transform_data(data, token=None, uid="", auth_token=None):
         "prctyp": order_type,
         "ret": "DAY",
         "ordersource": "API",
+        "remarks": "openalgo",
     }
 
     # Log without sensitive fields (uid/actid carry the client id)


### PR DESCRIPTION
feat(tradesmart): tag placed orders as openalgo and feat(tradesmart): give quotes their own 100/sec rate-limit budget

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Gives TradeSmart quotes their own 100/sec rate-limit budget and tags placed orders as `openalgo` so they're identifiable in the order book.

- Quotes (`/GetQuotes`) are paced against a separate 90/sec budget with no per-minute ceiling; orders, funds, margin, and history keep the shared 10/sec + 120/min gate.
- The REST quote fan-out thread pool now sizes to the quote budget instead of the general per-second constant.
- PlaceOrder sends `remarks: "openalgo"`, matching `broker/firstock`, so OpenAlgo orders can be told apart from terminal-placed ones.
- The retry-with-backoff still absorbs rate-limit rejections; verify on a live order that `remarks` comes back in the OrderBook response, and if quotes still hit the 10/sec limit the 100/sec figure doesn't apply to the account.

<sup>Written for commit 972f15bed152816fe81c2d2abc6ca42d707e43ce. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1928?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

