### PR TITLE
fix(positions): stop overwriting broker-supplied P&L with the sandbox model

### DIFF
--- a/frontend/src/hooks/useLivePrice.ts
+++ b/frontend/src/hooks/useLivePrice.ts
@@ -34,6 +34,14 @@ export interface UseLivePriceOptions {
   multiQuotesRefreshInterval?: number
   /** Pause WebSocket and polling when tab is hidden (default: true) */
   pauseWhenHidden?: boolean
+  /**
+   * Recompute P&L from the live tick instead of using the source's value.
+   * Only correct when the caller's P&L model matches this hook's, i.e.
+   * unrealized = (ltp - avg) * qty * lot_size. A live broker's P&L comes
+   * from the exchange and may use entirely different accounting, so this
+   * defaults to false. See the note at the recomputation below.
+   */
+  recalculatePnl?: boolean
   /** Time in ms to wait before pausing when hidden (default: 5000) */
   pauseDelay?: number
 }
@@ -86,6 +94,7 @@ export function useLivePrice<T extends PriceableItem>(
     useMultiQuotesFallback = true,
     multiQuotesRefreshInterval = 30000,
     pauseWhenHidden = true,
+    recalculatePnl = false,
   } = options
 
   const { apiKey } = useAuthStore()
@@ -259,13 +268,34 @@ export function useLivePrice<T extends PriceableItem>(
       // For open positions: recalculate P&L and P&L% using live LTP
       // This ensures real-time updates as LTP changes
       let calculatedPnl = item.pnl || 0
-      let calculatedPnlPercent = item.pnlpercent || 0
+      // Left undefined when the source omits it. Synthesizing 0 makes a missing
+      // value look authoritative, so callers that would derive a percentage
+      // from the preserved P&L render +0.00% instead.
+      let calculatedPnlPercent = item.pnlpercent
 
       // Get today's realized P&L if available (from sandbox mode)
       // This ensures cumulative P&L (realized + unrealized) is shown correctly
       const todayRealizedPnl = item.today_realized_pnl || 0
 
-      if (currentLtp && avgPrice > 0) {
+      // Recompute only when the caller owns the same P&L model this hook does.
+      //
+      // The sandbox does: it reports today_realized + unrealized computed as
+      // (ltp - avg) * qty * contract_value, exactly what is recomputed below,
+      // so refreshing it per tick is faithful.
+      //
+      // A live broker does not. Its P&L comes from the exchange and can follow
+      // completely different accounting. Delta Exchange reports option
+      // unrealized P&L as the current buyback cost, tracking
+      // -(mark * contract_value) and ignoring entry price entirely, so no
+      // (ltp - avg) formula reproduces it in magnitude OR SIGN. Measured on a
+      // live account, contract_value 0.001: a BTC call bought at 1104.00 and
+      // marked at 1211.79 shows -1.21 on the exchange, while this formula
+      // gives +0.11 -- a loss rendered as a gain.
+      //
+      // Callers that pass recalculatePnl must either own the model (sandbox)
+      // or be reading a source that returns a placeholder (several holdings
+      // adapters hard-code pnl to 0 and rely on the browser to fill it in).
+      if (recalculatePnl && currentLtp && avgPrice > 0) {
         // Contract multiplier: e.g. 0.01 for Delta Exchange ETHUSD.P (1 lot = 0.01 ETH)
         // Defaults to 1 for all standard brokers where qty is already in underlying units
         const lotSize = item.lot_size ?? 1
@@ -288,15 +318,20 @@ export function useLivePrice<T extends PriceableItem>(
         calculatedPnlPercent = investment > 0 ? (calculatedPnl / investment) * 100 : 0
       }
 
-      return {
+      const enhancedItem = {
         ...item,
         ltp: currentLtp,
         pnl: calculatedPnl,
-        pnlpercent: calculatedPnlPercent,
         _dataSource: dataSource,
       } as T & { _dataSource: string }
+
+      if (calculatedPnlPercent !== undefined && calculatedPnlPercent !== null) {
+        enhancedItem.pnlpercent = calculatedPnlPercent
+      }
+
+      return enhancedItem
     })
-  }, [items, marketData, multiQuotes, isMarketOpen, staleThreshold])
+  }, [items, marketData, multiQuotes, isMarketOpen, staleThreshold, recalculatePnl])
 
   return {
     data: enhancedData,

--- a/frontend/src/pages/Holdings.tsx
+++ b/frontend/src/pages/Holdings.tsx
@@ -30,6 +30,7 @@ import { useOrderEventRefresh } from '@/hooks/useOrderEventRefresh'
 import { usePageVisibility } from '@/hooks/usePageVisibility'
 import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
+import { useThemeStore } from '@/stores/themeStore'
 import { onModeChange } from '@/stores/themeStore'
 import type { Holding, HoldingsStats } from '@/types/trading'
 import { showToast } from '@/utils/toast'
@@ -48,8 +49,25 @@ interface HoldingOrderIntent {
   quantity: number
 }
 
+// These holdings adapters hard-code pnl/pnlpercent to 0 and rely on the browser
+// to derive them from the live LTP -- their own comments say so ("LTP is
+// missing", "Would need current price to calculate P&L", "Will be calculated
+// when market price is available"). Refetching the book cannot fix it, because
+// the zero originates in the adapter. Keep in step with the holdings blocks in
+// broker/*/mapping/order_data.py.
+const HOLDINGS_PLACEHOLDER_PNL_BROKERS = new Set([
+  'flattrade',
+  'motilal',
+  'shoonya',
+  'tradesmart',
+])
+
 export default function Holdings() {
   const { apiKey, user } = useAuthStore()
+  const { appMode } = useThemeStore()
+  const shouldRecalculatePnl =
+    appMode === 'analyzer' ||
+    HOLDINGS_PLACEHOLDER_PNL_BROKERS.has(user?.broker?.toLowerCase() ?? '')
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
   const [holdings, setHoldings] = useState<Holding[]>([])
   const [stats, setStats] = useState<HoldingsStats | null>(null)
@@ -75,6 +93,7 @@ export default function Holdings() {
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,
     pauseWhenHidden: true,
+    recalculatePnl: shouldRecalculatePnl,
   })
 
   // Calculate enhanced stats based on real-time data

--- a/frontend/src/pages/Positions.tsx
+++ b/frontend/src/pages/Positions.tsx
@@ -56,7 +56,7 @@ import { usePageVisibility } from '@/hooks/usePageVisibility'
 import { useSupportedExchanges } from '@/hooks/useSupportedExchanges'
 import { cn, makeFormatCurrency, sanitizeCSV } from '@/lib/utils'
 import { useAuthStore } from '@/stores/authStore'
-import { onModeChange } from '@/stores/themeStore'
+import { onModeChange, useThemeStore } from '@/stores/themeStore'
 import type { Position } from '@/types/trading'
 import { showToast } from '@/utils/toast'
 import { EmptyState } from '@/components/ui/empty-state'
@@ -146,6 +146,11 @@ const PRODUCT_COLORS: Record<string, string> = {
 
 export default function Positions() {
   const { apiKey, user } = useAuthStore()
+  // Recompute P&L only in analyzer mode. Every live broker adapter returns a
+  // real positions P&L, so recomputing would overwrite the exchange's figure.
+  // Holdings is deliberately different -- see the note there.
+  const { appMode } = useThemeStore()
+  const shouldRecalculatePnl = appMode === 'analyzer'
   const { isCrypto } = useSupportedExchanges()
   const formatCurrency = useMemo(() => makeFormatCurrency(user?.broker), [user?.broker])
   const [positions, setPositions] = useState<Position[]>([])
@@ -182,6 +187,7 @@ export default function Positions() {
     staleThreshold: 5000,
     multiQuotesRefreshInterval: 30000,
     pauseWhenHidden: true,
+    recalculatePnl: shouldRecalculatePnl,
   })
 
   // Load preferences from localStorage


### PR DESCRIPTION
`useLivePrice` recomputes P&L on every tick as `(ltp - avg) * qty * lot_size`. That is the **sandbox's** model, and it is applied to live broker positions too.

A live broker's P&L comes from the exchange and can use entirely different accounting. Delta Exchange reports option unrealized P&L as the current *buyback cost* — it tracks `-(mark * contract_value)` and ignores entry price completely, so no `(ltp - avg)` formula reproduces it in magnitude **or in sign**.

## Measured on a live account

`contract_value = 0.001`:

| position | avg | mark | exchange reports | `-(mark × cv)` | `(ltp − avg) × qty × cv` |
| --- | --- | --- | --- | --- | --- |
| BTC call | 1104.00 | 1211.79 | **−1.21** | **−1.2118** ✓ | **+0.11** ✗ |
| BTC put | 1072.00 | 517.22 | −0.51 | −0.5172 ✓ | −0.55 |

The call is the clear case: **a losing position is rendered as a gain.** On the page this showed as −0.72 against the exchange's −6.86.

The API is already correct — `broker/deltaexchange/mapping/order_data.py` reads `realized_pnl` and `unrealized_pnl` verbatim. This is purely the display layer overwriting a good number.

## The fix

Make the recomputation opt-in via `recalculatePnl`, defaulting to `false`.

**Positions** passes analyzer mode only. Every broker adapter returns a real positions P&L (`flattrade`/`tradesmart` `round(total_pnl, 2)`, `motilal` `marktomarket`, `shoonya` `pnl`), so recomputing there overwrites the exchange's figure.

**Holdings is deliberately different**, and this is the part worth reviewing closely. Four adapters hard-code holdings `pnl`/`pnlpercent` to `0` and rely on the browser to fill them in — their own comments say so:

```
flattrade   0.0  # LTP is missing, so P&L is effectively 0 for now
motilal     0.0  # Would need current price to calculate P&L
shoonya     0.0  # Will be calculated when market price is available
tradesmart  0.0
```

Disabling recalculation for all live holdings would show `0.00` on every holding for those brokers, and refetching cannot fix it because the zero originates in the adapter. So Holdings also opts in for those, via a named set kept next to a comment pointing back at the mappings.

The same broker therefore recalculates on Holdings and not on Positions. That looks inconsistent and is not — the two books carry different data quality from the same adapter, and a later "consistency" cleanup would reintroduce the bug.

## Also

Stop synthesizing `pnlpercent = 0` when a source omits the field. `Positions.calculatePnlPercent` is designed to derive a percentage when it is absent, but a synthesized zero makes the placeholder look API-provided, so every nonzero Delta position rendered `+0.00%`. The field is now left undefined and only emitted when present.

## Verification

- `tsc --noEmit` clean.
- Frontend suite unchanged by this PR: **19 failing / 1044 passing on `main`, and the same 19 / 1044 with the change applied.** Those failures are pre-existing (`IndicatorPickerDialog` and three others) and unrelated.
- Behaviour verified against a live Delta account, numbers above.

## Note on history

This supersedes #1712, which I closed myself while reworking it — it was never reviewed. This version differs in two substantive ways that came out of downstream review: the placeholder-adapter handling for Holdings (without which four brokers regress), and a periodic broker-book refresh so a preserved broker P&L does not sit frozen while the page is open.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the display layer from overwriting broker-supplied P&L with the sandbox's `(ltp – avg) * qty * lot_size` formula, which can show a losing position as a gain (measured: a Delta BTC call rendered +0.11 against the exchange's –1.21). Recalculation is now opt-in via `recalculatePnl`, defaulting to `false`.

**Migration / Behavior**
- Positions recalculate only in analyzer mode; every live broker adapter returns a real P&L, so the exchange's figure is now preserved.
- Holdings still recalculate for `flattrade`, `motilal`, `shoonya`, and `tradesmart`, whose holdings adapters hard-code pnl to 0 and rely on the browser to derive it.
- `pnlpercent` is no longer synthesized as `0` when the source omits it, so missing values are not shown as authoritative `+0.00%`.

<sup>Written for commit 27f13fc2b5d452403fdc60ac22bbe57b57b2f366. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1931?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

