### PR TITLE
fix(dhan): stop symbol mapping from routing orders to the wrong instrument (#1929, #1930) and fix(dhan): correct master contract mapping and symbol construction (#1929, #1930)

### DIFF
--- a/broker/dhan/api/data.py
+++ b/broker/dhan/api/data.py
@@ -27,6 +27,11 @@ _last_api_call_time = {"data": 0.0, "quote": 0.0}
 DHAN_DATA_INTERVAL = 0.2  # seconds between /v2/charts/* requests (5 req/s)
 DHAN_QUOTE_INTERVAL = 1.1  # seconds between /v2/marketfeed/* requests (1 req/s)
 
+# MCX index derivatives. Dhan classifies these as FUTIDX / OPTIDX, not the
+# FUTCOM / OPTFUT used by the commodity contracts, so the history API needs the
+# index instrument type for them.
+MCX_INDEX_UNDERLYINGS = ("MCXBULLDEX", "MCXMETLDEX", "MCXENRGDEX")
+
 
 def _apply_rate_limit(category="data"):
     """Apply per-category rate limiting to avoid Dhan API error 805 (too many requests)"""
@@ -289,13 +294,21 @@ class BrokerData:
                 # For stock futures
                 return "FUTSTK"
 
-        # For commodity market (MCX)
-        elif exchange == "MCX":
-            # For commodity options on futures
+        # NSE commodity derivatives. Dhan lists these as OPTFUT, the same
+        # instrument name it uses for MCX commodity options.
+        elif exchange == "NCO":
             if symbol.endswith("CE") or symbol.endswith("PE"):
                 return "OPTFUT"
-            # For commodity futures
             return "FUTCOM"
+
+        # For commodity market (MCX)
+        elif exchange == "MCX":
+            is_index = symbol.startswith(MCX_INDEX_UNDERLYINGS)
+            # For commodity options on futures, or options on an MCX index
+            if symbol.endswith("CE") or symbol.endswith("PE"):
+                return "OPTIDX" if is_index else "OPTFUT"
+            # For commodity futures, or an MCX index future
+            return "FUTIDX" if is_index else "FUTCOM"
 
         # For currency market (CDS, BCD)
         elif exchange in ["CDS", "BCD"]:

--- a/broker/dhan/api/data.py
+++ b/broker/dhan/api/data.py
@@ -235,6 +235,7 @@ class BrokerData:
             "NFO": "NSE_FNO",  # NSE F&O
             "BFO": "BSE_FNO",  # BSE F&O
             "MCX": "MCX_COMM",  # MCX Commodity
+            "NCO": "NSE_COMM",  # NSE Commodity
             "CDS": "NSE_CURRENCY",  # NSE Currency
             "BCD": "BSE_CURRENCY",  # BSE Currency
             "NSE_INDEX": "IDX_I",  # NSE Index
@@ -294,8 +295,7 @@ class BrokerData:
                 # For stock futures
                 return "FUTSTK"
 
-        # NSE commodity derivatives. Dhan lists these as OPTFUT, the same
-        # instrument name it uses for MCX commodity options.
+        # NSE commodity derivatives, listed by Dhan as OPTFUT like MCX.
         elif exchange == "NCO":
             if symbol.endswith("CE") or symbol.endswith("PE"):
                 return "OPTFUT"

--- a/broker/dhan/api/order_api.py
+++ b/broker/dhan/api/order_api.py
@@ -143,6 +143,11 @@ def _invalidate_position_cache(auth):
 
 def get_open_position(tradingsymbol, exchange, product, auth):
     # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
+    # securityId is the authoritative match: tradingSymbol is identical across
+    # NSE series, so matching on it alone could read a warrant's position for
+    # an equity order (#1930). Keep the symbol as a fallback for when the
+    # master contract has no token for the symbol.
+    security_id = get_token(tradingsymbol, exchange)
     tradingsymbol = get_br_symbol(tradingsymbol, exchange)
     positions_data = _get_cached_positions(auth)
     net_qty = "0"
@@ -162,10 +167,15 @@ def get_open_position(tradingsymbol, exchange, product, auth):
     if positions_data and isinstance(positions_data, list):
         for position in positions_data:
             if (
-                position.get("tradingSymbol") == tradingsymbol
-                and position.get("exchangeSegment") == map_exchange_type(exchange)
-                and position.get("productType") == product
+                position.get("exchangeSegment") != map_exchange_type(exchange)
+                or position.get("productType") != product
             ):
+                continue
+            if security_id is not None:
+                matched = str(position.get("securityId", "")) == str(security_id)
+            else:
+                matched = position.get("tradingSymbol") == tradingsymbol
+            if matched:
                 net_qty = position.get("netQty", "0")
                 break  # Assuming you need the first match
 

--- a/broker/dhan/api/order_api.py
+++ b/broker/dhan/api/order_api.py
@@ -37,6 +37,8 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
     url = get_url(endpoint)
 
+    logger.debug(f"{method} {endpoint} request payload: {payload if payload else '<none>'}")
+
     try:
         if method == "GET":
             response = client.get(url, headers=headers)
@@ -50,6 +52,11 @@ def get_api_response(endpoint, auth, method="GET", payload=""):
 
         # Parse the response JSON
         response_data = json.loads(response.text)
+
+        # Covers the orderbook, tradebook, positions and holdings readers,
+        # which all funnel through here and previously logged nothing at all
+        # on the success path.
+        logger.debug(f"{method} {endpoint} response ({response.status_code}): {response_data}")
 
         # Check for API errors in the response
         if isinstance(response_data, dict):
@@ -216,7 +223,12 @@ def place_order_api(data, auth):
     payload = json.dumps(newdata)
 
     logger.debug(f"Placing order with client_id: {client_id}")
-    logger.debug(f"Placing order with headers: {headers}")
+    # Never log the raw headers - they carry the broker access-token, and
+    # LOG_LEVEL=DEBUG would write it to log/*.log in plain text.
+    logger.debug(
+        "Placing order with headers: "
+        f"{ {k: ('[REDACTED]' if k == 'access-token' else v) for k, v in headers.items()} }"
+    )
     logger.debug(f"Placing order with payload: {payload}")
 
     # Get the shared httpx client with connection pooling

--- a/broker/dhan/database/master_contract_db.py
+++ b/broker/dhan/database/master_contract_db.py
@@ -144,66 +144,76 @@ def reformat_symbol(row):
     return symbol
 
 
+# Dhan segment codes. A Dhan security id is unique per SEM_SEGMENT, not per
+# SEM_EXM_EXCH_ID, so the segment is the only safe key to map on.
+SEGMENT_EQUITY = "E"
+SEGMENT_INDEX = "I"
+SEGMENT_EQUITY_DERIVATIVE = "D"
+SEGMENT_CURRENCY = "C"
+SEGMENT_COMMODITY = "M"
+
+# Instrument names valid within each segment.
+EQUITY_FNO_INSTRUMENTS = {"FUTIDX", "FUTSTK", "OPTIDX", "OPTSTK", "OPTFUT"}
+CURRENCY_INSTRUMENTS = {"FUTCUR", "OPTCUR"}
+COMMODITY_INSTRUMENTS = {"FUTCOM", "FUTIDX", "OPTFUT", "OPTIDX"}
+
+
 # Define the function to apply conditions
 def assign_values(row):
-    if row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] == "EQUITY":
-        return "NSE", "NSE_EQ", "EQ"
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] == "EQUITY":
-        return "BSE", "BSE_EQ", "EQ"
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] == "INDEX":
-        return "NSE_INDEX", "IDX_I", "INDEX"
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] == "INDEX":
-        return "BSE_INDEX", "IDX_I", "INDEX"
-    elif row["SEM_EXM_EXCH_ID"] == "MCX" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTCOM",
-        "OPTFUT",
-    ]:
-        return (
-            "MCX",
-            "MCX_COMM",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    """Map a Dhan scrip master row onto an OpenAlgo (exchange, brexchange, instrumenttype).
 
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTSTK",
-        "OPTIDX",
-        "OPTSTK",
-        "OPTFUT",
-    ]:
-        return (
-            "NFO",
-            "NSE_FNO",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] in ["FUTCUR", "OPTCUR"]:
-        return (
-            "CDS",
-            "NSE_CURRENCY",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    Gating on SEM_SEGMENT is mandatory, not defensive. Dhan scopes
+    SEM_SMST_SECURITY_ID per segment, and NSE carries two derivative segments
+    under the same SEM_EXM_EXCH_ID of "NSE": segment D (equity F&O) and segment
+    M (NSE's own commodity book, all OPTFUT). Matching on SEM_INSTRUMENT_NAME
+    alone put both under NFO, so 8,642 security ids resolved to two different
+    contracts - a TCS option and a SILVERM option shared token 153964. The
+    reverse lookup in get_symbol() takes the first match, so a live equity
+    option position could be reported under a commodity symbol, the position
+    book lookup would miss it, and a strategy would skip the exit. See #1929.
+    """
+    exchange_id = row["SEM_EXM_EXCH_ID"]
+    segment = row["SEM_SEGMENT"]
+    instrument = str(row["SEM_INSTRUMENT_NAME"])
 
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTSTK",
-        "OPTIDX",
-        "OPTSTK",
-    ]:
-        return (
-            "BFO",
-            "BSE_FNO",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] in ["FUTCUR", "OPTCUR"]:
-        return (
-            "BCD",
-            "BSE_CURRENCY",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    # CE / PE for options, FUT for futures.
+    derivative_type = row["SEM_OPTION_TYPE"] if "OPT" in instrument else "FUT"
 
-    else:
-        return "Unknown", "Unknown", "Unknown"
+    if segment == SEGMENT_EQUITY and instrument == "EQUITY":
+        if exchange_id == "NSE":
+            return "NSE", "NSE_EQ", "EQ"
+        if exchange_id == "BSE":
+            return "BSE", "BSE_EQ", "EQ"
+
+    elif segment == SEGMENT_INDEX and instrument == "INDEX":
+        if exchange_id == "NSE":
+            return "NSE_INDEX", "IDX_I", "INDEX"
+        if exchange_id == "BSE":
+            return "BSE_INDEX", "IDX_I", "INDEX"
+
+    elif segment == SEGMENT_EQUITY_DERIVATIVE and instrument in EQUITY_FNO_INSTRUMENTS:
+        if exchange_id == "NSE":
+            return "NFO", "NSE_FNO", derivative_type
+        if exchange_id == "BSE":
+            return "BFO", "BSE_FNO", derivative_type
+
+    elif segment == SEGMENT_CURRENCY and instrument in CURRENCY_INSTRUMENTS:
+        if exchange_id == "NSE":
+            return "CDS", "NSE_CURRENCY", derivative_type
+        if exchange_id == "BSE":
+            return "BCD", "BSE_CURRENCY", derivative_type
+
+    elif segment == SEGMENT_COMMODITY and instrument in COMMODITY_INSTRUMENTS:
+        if exchange_id == "MCX":
+            return "MCX", "MCX_COMM", derivative_type
+        # NSE segment M is NSE's commodity derivatives book - OpenAlgo's NCO
+        # exchange. It is a security id space of its own (121601-171512), fully
+        # disjoint from MCX (471725-584158) and overlapping NSE segment D,
+        # which is exactly why it must never be folded into NFO.
+        if exchange_id == "NSE":
+            return "NCO", "NSE_COMM", derivative_type
+
+    return "Unknown", "Unknown", "Unknown"
 
 
 def process_dhan_csv(path):
@@ -241,6 +251,27 @@ def process_dhan_csv(path):
     df[["exchange", "brexchange", "instrumenttype"]] = df.apply(
         assign_values, axis=1, result_type="expand"
     )
+
+    # Drop rows no OpenAlgo exchange covers. Every segment Dhan currently ships
+    # is mapped, so this is normally a no-op; it exists so that a segment or
+    # instrument Dhan adds later cannot silently reach the symbol table. Such a
+    # row would keep its raw SEM_CUSTOM_SYMBOL (reformat_symbol only normalizes
+    # known instrument types) and still surface in symbol search, which filters
+    # by exchange only when the caller passes one. Log the breakdown so the
+    # addition is visible and can be mapped properly.
+    unmapped = df["exchange"] == "Unknown"
+    if unmapped.any():
+        breakdown = (
+            df.loc[unmapped]
+            .groupby(["SEM_EXM_EXCH_ID", "SEM_SEGMENT", "SEM_INSTRUMENT_NAME"])
+            .size()
+            .to_dict()
+        )
+        logger.info(
+            f"Dhan master contract: dropping {int(unmapped.sum())} rows with no "
+            f"OpenAlgo exchange (exchange/segment/instrument: {breakdown})"
+        )
+        df = df[~unmapped].copy()
 
     df["symbol"] = df.apply(reformat_symbol, axis=1)
 
@@ -391,6 +422,25 @@ def process_dhan_csv(path):
             f"(by exchange: {df.loc[missing, 'exchange'].value_counts().to_dict()})"
         )
 
+    # A (exchange, token) pair is what get_symbol() reverse-looks-up a live
+    # position with, so it has to be unique. Two rows sharing one pair means a
+    # position can resolve to the wrong contract silently (#1929). Log loudly
+    # rather than raise - a broken master contract is worse than a duplicated
+    # one, and the operator needs the detail to report it.
+    collisions = df[df.duplicated(subset=["exchange", "token"], keep=False)]
+    if not collisions.empty:
+        samples = [
+            f"{r.exchange}/{r.token}: {r.brsymbol}"
+            for r in collisions.sort_values(["exchange", "token"]).head(6).itertuples()
+        ]
+        logger.error(
+            f"Dhan master contract: {len(collisions)} rows share a duplicate "
+            f"(exchange, token) across "
+            f"{collisions.groupby(['exchange', 'token']).ngroups} pairs "
+            f"(by exchange: {collisions['exchange'].value_counts().to_dict()}). "
+            f"Position reverse-lookup is ambiguous for these. Samples: {samples}"
+        )
+
     # List of columns to remove
     columns_to_remove = [
         "SEM_EXM_EXCH_ID",
@@ -411,8 +461,9 @@ def process_dhan_csv(path):
         "SM_SYMBOL_NAME",
     ]
 
-    # Removing the specified columns
-    token_df = df.drop(columns=columns_to_remove)
+    # Removing the specified columns. errors="ignore" so a column Dhan drops
+    # from a future master file does not break the whole download.
+    token_df = df.drop(columns=columns_to_remove, errors="ignore")
 
     return token_df
 

--- a/broker/dhan/database/master_contract_db.py
+++ b/broker/dhan/database/master_contract_db.py
@@ -112,6 +112,37 @@ def download_csv_dhan_data(output_path):
             )
 
 
+def format_strike(strike):
+    """Render a strike in OpenAlgo format: exact value, no trailing zeros.
+
+    SEM_CUSTOM_SYMBOL renders strikes at two decimals, which both misformats
+    (87.5 shown as "87.50") and, in currency, loses precision outright - EURUSD
+    1.010 and 1.015 both display as "1.01". Building the strike from the
+    authoritative SEM_STRIKE_PRICE avoids both. See #1930.
+    """
+    if pd.isna(strike):
+        return ""
+    # Format with decimals first so rstrip cannot eat significant zeros: "100"
+    # would strip to "1", whereas "100.000000" stops at the decimal point.
+    return f"{float(strike):.6f}".rstrip("0").rstrip(".") or "0"
+
+
+def qualify_equity_symbol(trading_symbol, series):
+    """Suffix a non-EQ NSE series onto the symbol, matching Zerodha's convention.
+
+    Several NSE securities share a SEM_TRADING_SYMBOL across series - ELECTCAST
+    is both the equity (EQ) and its warrant (W1), and IMC1 is three different
+    bond tranches (N1/N2/N3). Without the series in the symbol, get_token()
+    takes the first match and an order can reach the warrant. See #1930.
+    """
+    if pd.isna(series):
+        return trading_symbol
+    series = str(series).strip()
+    if not series or series == "EQ":
+        return trading_symbol
+    return f"{trading_symbol}-{series}"
+
+
 def reformat_symbol(row):
     symbol = row["SEM_CUSTOM_SYMBOL"]
     instrument_type = row["instrumenttype"]
@@ -119,7 +150,11 @@ def reformat_symbol(row):
     expiry = row["expiry"].replace("-", "")
 
     if equity == "EQUITY":
-        symbol = row["SEM_TRADING_SYMBOL"]
+        # NSE qualifies by series; BSE ships one row per symbol and has none.
+        if row["SEM_EXM_EXCH_ID"] == "NSE":
+            symbol = qualify_equity_symbol(row["SEM_TRADING_SYMBOL"], row["SEM_SERIES"])
+        else:
+            symbol = row["SEM_TRADING_SYMBOL"]
     elif equity == "INDEX":
         symbol = row["SEM_TRADING_SYMBOL"]
 
@@ -131,12 +166,11 @@ def reformat_symbol(row):
         if len(parts) == 4:  # Make sure the symbol has the correct format
             symbol = f"{parts[0]}{expiry}{instrument_type}"
     elif instrument_type in ["CE", "PE"]:
-        # For CE/PE, rearrange the parts and remove spaces
+        # For CE/PE take the underlying from the display string but the strike
+        # from SEM_STRIKE_PRICE, which is exact.
         parts = symbol.split(" ")
-        if len(parts) == 4:  # Make sure the symbol has the correct format
-            symbol = f"{parts[0]}{expiry}{parts[2]}{instrument_type}"
-        if len(parts) == 5:  # Make sure the symbol has the correct format
-            symbol = f"{parts[0]}{expiry}{parts[3]}{instrument_type}"
+        if len(parts) in (4, 5):
+            symbol = f"{parts[0]}{expiry}{format_strike(row['SEM_STRIKE_PRICE'])}{instrument_type}"
 
     else:
         symbol = symbol  # No change for other instrument types
@@ -439,6 +473,25 @@ def process_dhan_csv(path):
             f"{collisions.groupby(['exchange', 'token']).ngroups} pairs "
             f"(by exchange: {collisions['exchange'].value_counts().to_dict()}). "
             f"Position reverse-lookup is ambiguous for these. Samples: {samples}"
+        )
+
+    # The mirror of the check above: (symbol, exchange) is what get_token()
+    # forward-looks-up before placing an order, so it has to be unique too. Two
+    # rows sharing one pair means an order can reach the wrong instrument -
+    # historically a warrant instead of the equity, or a neighbouring strike
+    # (#1930). Logged, not raised, for the same reason as above.
+    sym_collisions = df[df.duplicated(subset=["symbol", "exchange"], keep=False)]
+    if not sym_collisions.empty:
+        samples = [
+            f"{r.exchange}/{r.symbol} -> {r.brsymbol} (token {r.token})"
+            for r in sym_collisions.sort_values(["exchange", "symbol"]).head(6).itertuples()
+        ]
+        logger.error(
+            f"Dhan master contract: {len(sym_collisions)} rows share a duplicate "
+            f"(symbol, exchange) across "
+            f"{sym_collisions.groupby(['symbol', 'exchange']).ngroups} pairs "
+            f"(by exchange: {sym_collisions['exchange'].value_counts().to_dict()}). "
+            f"Order forward-lookup is ambiguous for these. Samples: {samples}"
         )
 
     # List of columns to remove

--- a/broker/dhan/database/master_contract_db.py
+++ b/broker/dhan/database/master_contract_db.py
@@ -241,9 +241,13 @@ def assign_values(row):
         if exchange_id == "MCX":
             return "MCX", "MCX_COMM", derivative_type
         # NSE segment M is NSE's commodity derivatives book - OpenAlgo's NCO
-        # exchange. It is a security id space of its own (121601-171512), fully
-        # disjoint from MCX (471725-584158) and overlapping NSE segment D,
-        # which is exactly why it must never be folded into NFO.
+        # exchange, which Dhan addresses as NSE_COMM. That segment string is
+        # absent from Dhan's published annexure but is accepted by the API:
+        # /v2/margincalculator returns a real margin and the live account
+        # balance for NSE_COMM + securityId 153964, while NSE_COMMODITY and
+        # NSE_FNO are both rejected with DH-905. It must never be folded into
+        # NFO - its id space (121601-171512) overlaps NSE segment D, which is
+        # the #1929 collision.
         if exchange_id == "NSE":
             return "NCO", "NSE_COMM", derivative_type
 
@@ -287,12 +291,12 @@ def process_dhan_csv(path):
     )
 
     # Drop rows no OpenAlgo exchange covers. Every segment Dhan currently ships
-    # is mapped, so this is normally a no-op; it exists so that a segment or
-    # instrument Dhan adds later cannot silently reach the symbol table. Such a
-    # row would keep its raw SEM_CUSTOM_SYMBOL (reformat_symbol only normalizes
-    # known instrument types) and still surface in symbol search, which filters
-    # by exchange only when the caller passes one. Log the breakdown so the
-    # addition is visible and can be mapped properly.
+    # is mapped, so this is a no-op today; it exists so a segment or instrument
+    # Dhan adds later cannot silently reach the symbol table. Such a row would
+    # keep its raw SEM_CUSTOM_SYMBOL (reformat_symbol only normalizes known
+    # instrument types) and still surface in symbol search, which filters by
+    # exchange only when the caller passes one - so it would look tradable and
+    # then fail downstream. Log the breakdown so the addition is visible.
     unmapped = df["exchange"] == "Unknown"
     if unmapped.any():
         breakdown = (

--- a/broker/dhan/mapping/order_data.py
+++ b/broker/dhan/mapping/order_data.py
@@ -49,7 +49,7 @@ def map_order_data(order_data):
                     order["productType"] = "MIS"
 
                 elif (
-                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS", "NCO"]
+                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS", "BCD", "NCO"]
                     and order["productType"] == "MARGIN"
                 ):
                     order["productType"] = "NRML"

--- a/broker/dhan/mapping/order_data.py
+++ b/broker/dhan/mapping/order_data.py
@@ -49,7 +49,7 @@ def map_order_data(order_data):
                     order["productType"] = "MIS"
 
                 elif (
-                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS"]
+                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS", "NCO"]
                     and order["productType"] == "MARGIN"
                 ):
                     order["productType"] = "NRML"

--- a/broker/dhan/mapping/transform_data.py
+++ b/broker/dhan/mapping/transform_data.py
@@ -278,7 +278,10 @@ def reverse_map_product_type(product):
     """
     Reverse maps the broker product type to the OpenAlgo product type, considering the exchange.
     """
-    # Exchange to OpenAlgo product type mapping for 'D'
-    product_mapping = {"CNC": "CNC", "MARGIN": "NRML", "MIS": "INTRADAY"}
+    # Keys are Dhan's productType values, values are OpenAlgo's. The INTRADAY
+    # pair used to be written the wrong way round as "MIS": "INTRADAY", so
+    # every intraday position reverse-mapped to None. See map_product_type
+    # above for the forward direction.
+    product_mapping = {"CNC": "CNC", "MARGIN": "NRML", "INTRADAY": "MIS"}
 
     return product_mapping.get(product)  # Removed default; will return None if not found

--- a/broker/dhan/mapping/transform_data.py
+++ b/broker/dhan/mapping/transform_data.py
@@ -237,6 +237,7 @@ def map_exchange_type(exchange):
         "BFO": "BSE_FNO",
         "BCD": "BSE_CURRENCY",
         "MCX": "MCX_COMM",
+        "NCO": "NSE_COMM",
     }
     return exchange_mapping.get(exchange)  # Default to MARKET if not found
 
@@ -253,6 +254,7 @@ def map_exchange(brexchange):
         "BSE_FNO": "BFO",
         "BSE_CURRENCY": "BCD",
         "MCX_COMM": "MCX",
+        "NSE_COMM": "NCO",
     }
     # Fall back to the raw broker segment instead of None so an unmapped
     # segment degrades to a visible label rather than propagating null

--- a/broker/dhan/streaming/dhan_mapping.py
+++ b/broker/dhan/streaming/dhan_mapping.py
@@ -15,6 +15,7 @@ class DhanExchangeMapper:
         "NFO": "NSE_FNO",
         "BFO": "BSE_FNO",
         "MCX": "MCX_COMM",  # Corrected from MCX_COM to MCX_COMM
+        "NCO": "NSE_COMM",  # NSE Commodity (undocumented but API-accepted)
         "CDS": "NSE_CURRENCY",
         "BCD": "BSE_CURRENCY",  # Added BSE Currency
         "NSE_INDEX": "IDX_I",  # Added NSE Index
@@ -24,6 +25,17 @@ class DhanExchangeMapper:
     # Dhan exchange segment codes (numeric) to OpenAlgo exchange mapping
     # Based on official Dhan documentation
     # Note: Both NSE_INDEX and BSE_INDEX use segment 0 (IDX_I), defaulting to NSE_INDEX
+    #
+    # 6 (NCO) is INFERRED, not observed. Dhan's published annexure lists
+    # 0-5, 7 and 8, leaving exactly one gap at 6, and NSE_COMM is the only
+    # segment the API accepts that the annexure omits. It could not be
+    # confirmed from the feed because Dhan does not stream this segment at
+    # all: subscribing to NSE_COMM/143318 (the one leg in that chain carrying
+    # a price) yields no packets, while an MCX control on the same socket
+    # streams normally as segment 5. Quotes are equally unavailable over REST
+    # - /v2/marketfeed does not even echo the NSE_COMM key back. NCO orders
+    # and margin do work, so the entry is here for the day Dhan starts
+    # feeding it; replace it with the observed value if a packet ever arrives.
     SEGMENT_TO_EXCHANGE = {
         0: "NSE_INDEX",  # IDX_I (Index) - Both NSE_INDEX and BSE_INDEX use this
         1: "NSE",  # NSE_EQ (NSE Equity Cash)
@@ -31,6 +43,7 @@ class DhanExchangeMapper:
         3: "CDS",  # NSE_CURRENCY (NSE Currency)
         4: "BSE",  # BSE_EQ (BSE Equity Cash)
         5: "MCX",  # MCX_COMM (MCX Commodity)
+        6: "NCO",  # NSE_COMM (NSE Commodity) - inferred, see note above
         7: "BCD",  # BSE_CURRENCY (BSE Currency)
         8: "BFO",  # BSE_FNO (BSE Futures & Options)
     }

--- a/broker/dhan_sandbox/api/data.py
+++ b/broker/dhan_sandbox/api/data.py
@@ -18,6 +18,11 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+# MCX index derivatives. Dhan classifies these as FUTIDX / OPTIDX, not the
+# FUTCOM / OPTFUT used by the commodity contracts, so the history API needs the
+# index instrument type for them.
+MCX_INDEX_UNDERLYINGS = ("MCXBULLDEX", "MCXMETLDEX", "MCXENRGDEX")
+
 
 def _get_dhan_client_id() -> str | None:
     """Extract Dhan client-id from BROKER_API_KEY env value."""
@@ -211,6 +216,7 @@ class BrokerData:
             "NFO": "NSE_FNO",  # NSE F&O
             "BFO": "BSE_FNO",  # BSE F&O
             "MCX": "MCX_COMM",  # MCX Commodity
+            "NCO": "NSE_COMM",  # NSE Commodity
             "CDS": "NSE_CURRENCY",  # NSE Currency
             "BCD": "BSE_CURRENCY",  # BSE Currency
             "NSE_INDEX": "IDX_I",  # NSE Index
@@ -270,13 +276,20 @@ class BrokerData:
                 # For stock futures
                 return "FUTSTK"
 
-        # For commodity market (MCX)
-        elif exchange == "MCX":
-            # For commodity options on futures
+        # NSE commodity derivatives, listed by Dhan as OPTFUT like MCX.
+        elif exchange == "NCO":
             if symbol.endswith("CE") or symbol.endswith("PE"):
                 return "OPTFUT"
-            # For commodity futures
             return "FUTCOM"
+
+        # For commodity market (MCX)
+        elif exchange == "MCX":
+            is_index = symbol.startswith(MCX_INDEX_UNDERLYINGS)
+            # For commodity options on futures, or options on an MCX index
+            if symbol.endswith("CE") or symbol.endswith("PE"):
+                return "OPTIDX" if is_index else "OPTFUT"
+            # For commodity futures, or an MCX index future
+            return "FUTIDX" if is_index else "FUTCOM"
 
         # For currency market (CDS, BCD)
         elif exchange in ["CDS", "BCD"]:

--- a/broker/dhan_sandbox/api/order_api.py
+++ b/broker/dhan_sandbox/api/order_api.py
@@ -166,6 +166,11 @@ def _invalidate_position_cache(auth):
 
 def get_open_position(tradingsymbol, exchange, product, auth):
     # Convert Trading Symbol from OpenAlgo Format to Broker Format Before Search in OpenPosition
+    # securityId is the authoritative match: tradingSymbol is identical across
+    # NSE series, so matching on it alone could read a warrant's position for
+    # an equity order (#1930). Keep the symbol as a fallback for when the
+    # master contract has no token for the symbol.
+    security_id = get_token(tradingsymbol, exchange)
     tradingsymbol = get_br_symbol(tradingsymbol, exchange)
     positions_data = _get_cached_positions(auth)
     net_qty = "0"
@@ -185,10 +190,15 @@ def get_open_position(tradingsymbol, exchange, product, auth):
     if positions_data and isinstance(positions_data, list):
         for position in positions_data:
             if (
-                position.get("tradingSymbol") == tradingsymbol
-                and position.get("exchangeSegment") == map_exchange_type(exchange)
-                and position.get("productType") == product
+                position.get("exchangeSegment") != map_exchange_type(exchange)
+                or position.get("productType") != product
             ):
+                continue
+            if security_id is not None:
+                matched = str(position.get("securityId", "")) == str(security_id)
+            else:
+                matched = position.get("tradingSymbol") == tradingsymbol
+            if matched:
                 net_qty = position.get("netQty", "0")
                 break  # Assuming you need the first match
 

--- a/broker/dhan_sandbox/database/master_contract_db.py
+++ b/broker/dhan_sandbox/database/master_contract_db.py
@@ -112,6 +112,37 @@ def download_csv_dhan_data(output_path):
             )
 
 
+def format_strike(strike):
+    """Render a strike in OpenAlgo format: exact value, no trailing zeros.
+
+    SEM_CUSTOM_SYMBOL renders strikes at two decimals, which both misformats
+    (87.5 shown as "87.50") and, in currency, loses precision outright - EURUSD
+    1.010 and 1.015 both display as "1.01". Building the strike from the
+    authoritative SEM_STRIKE_PRICE avoids both. See #1930.
+    """
+    if pd.isna(strike):
+        return ""
+    # Format with decimals first so rstrip cannot eat significant zeros: "100"
+    # would strip to "1", whereas "100.000000" stops at the decimal point.
+    return f"{float(strike):.6f}".rstrip("0").rstrip(".") or "0"
+
+
+def qualify_equity_symbol(trading_symbol, series):
+    """Suffix a non-EQ NSE series onto the symbol, matching Zerodha's convention.
+
+    Several NSE securities share a SEM_TRADING_SYMBOL across series - ELECTCAST
+    is both the equity (EQ) and its warrant (W1), and IMC1 is three different
+    bond tranches (N1/N2/N3). Without the series in the symbol, get_token()
+    takes the first match and an order can reach the warrant. See #1930.
+    """
+    if pd.isna(series):
+        return trading_symbol
+    series = str(series).strip()
+    if not series or series == "EQ":
+        return trading_symbol
+    return f"{trading_symbol}-{series}"
+
+
 def reformat_symbol(row):
     symbol = row["SEM_CUSTOM_SYMBOL"]
     instrument_type = row["instrumenttype"]
@@ -119,7 +150,11 @@ def reformat_symbol(row):
     expiry = row["expiry"].replace("-", "")
 
     if equity == "EQUITY":
-        symbol = row["SEM_TRADING_SYMBOL"]
+        # NSE qualifies by series; BSE ships one row per symbol and has none.
+        if row["SEM_EXM_EXCH_ID"] == "NSE":
+            symbol = qualify_equity_symbol(row["SEM_TRADING_SYMBOL"], row["SEM_SERIES"])
+        else:
+            symbol = row["SEM_TRADING_SYMBOL"]
     elif equity == "INDEX":
         symbol = row["SEM_TRADING_SYMBOL"]
 
@@ -131,12 +166,11 @@ def reformat_symbol(row):
         if len(parts) == 4:  # Make sure the symbol has the correct format
             symbol = f"{parts[0]}{expiry}{instrument_type}"
     elif instrument_type in ["CE", "PE"]:
-        # For CE/PE, rearrange the parts and remove spaces
+        # For CE/PE take the underlying from the display string but the strike
+        # from SEM_STRIKE_PRICE, which is exact.
         parts = symbol.split(" ")
-        if len(parts) == 4:  # Make sure the symbol has the correct format
-            symbol = f"{parts[0]}{expiry}{parts[2]}{instrument_type}"
-        if len(parts) == 5:  # Make sure the symbol has the correct format
-            symbol = f"{parts[0]}{expiry}{parts[3]}{instrument_type}"
+        if len(parts) in (4, 5):
+            symbol = f"{parts[0]}{expiry}{format_strike(row['SEM_STRIKE_PRICE'])}{instrument_type}"
 
     else:
         symbol = symbol  # No change for other instrument types
@@ -144,66 +178,80 @@ def reformat_symbol(row):
     return symbol
 
 
+# Dhan segment codes. A Dhan security id is unique per SEM_SEGMENT, not per
+# SEM_EXM_EXCH_ID, so the segment is the only safe key to map on.
+SEGMENT_EQUITY = "E"
+SEGMENT_INDEX = "I"
+SEGMENT_EQUITY_DERIVATIVE = "D"
+SEGMENT_CURRENCY = "C"
+SEGMENT_COMMODITY = "M"
+
+# Instrument names valid within each segment.
+EQUITY_FNO_INSTRUMENTS = {"FUTIDX", "FUTSTK", "OPTIDX", "OPTSTK", "OPTFUT"}
+CURRENCY_INSTRUMENTS = {"FUTCUR", "OPTCUR"}
+COMMODITY_INSTRUMENTS = {"FUTCOM", "FUTIDX", "OPTFUT", "OPTIDX"}
+
+
 # Define the function to apply conditions
 def assign_values(row):
-    if row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] == "EQUITY":
-        return "NSE", "NSE_EQ", "EQ"
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] == "EQUITY":
-        return "BSE", "BSE_EQ", "EQ"
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] == "INDEX":
-        return "NSE_INDEX", "IDX_I", "INDEX"
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] == "INDEX":
-        return "BSE_INDEX", "IDX_I", "INDEX"
-    elif row["SEM_EXM_EXCH_ID"] == "MCX" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTCOM",
-        "OPTFUT",
-    ]:
-        return (
-            "MCX",
-            "MCX_COMM",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    """Map a Dhan scrip master row onto an OpenAlgo (exchange, brexchange, instrumenttype).
 
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTSTK",
-        "OPTIDX",
-        "OPTSTK",
-        "OPTFUT",
-    ]:
-        return (
-            "NFO",
-            "NSE_FNO",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
-    elif row["SEM_EXM_EXCH_ID"] == "NSE" and row["SEM_INSTRUMENT_NAME"] in ["FUTCUR", "OPTCUR"]:
-        return (
-            "CDS",
-            "NSE_CURRENCY",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    Gating on SEM_SEGMENT is mandatory, not defensive. Dhan scopes
+    SEM_SMST_SECURITY_ID per segment, and NSE carries two derivative segments
+    under the same SEM_EXM_EXCH_ID of "NSE": segment D (equity F&O) and segment
+    M (NSE's own commodity book, all OPTFUT). Matching on SEM_INSTRUMENT_NAME
+    alone put both under NFO, so 8,642 security ids resolved to two different
+    contracts - a TCS option and a SILVERM option shared token 153964. The
+    reverse lookup in get_symbol() takes the first match, so a live equity
+    option position could be reported under a commodity symbol, the position
+    book lookup would miss it, and a strategy would skip the exit. See #1929.
+    """
+    exchange_id = row["SEM_EXM_EXCH_ID"]
+    segment = row["SEM_SEGMENT"]
+    instrument = str(row["SEM_INSTRUMENT_NAME"])
 
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] in [
-        "FUTIDX",
-        "FUTSTK",
-        "OPTIDX",
-        "OPTSTK",
-    ]:
-        return (
-            "BFO",
-            "BSE_FNO",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
-    elif row["SEM_EXM_EXCH_ID"] == "BSE" and row["SEM_INSTRUMENT_NAME"] in ["FUTCUR", "OPTCUR"]:
-        return (
-            "BCD",
-            "BSE_CURRENCY",
-            row["SEM_OPTION_TYPE"] if "OPT" in row["SEM_INSTRUMENT_NAME"] else "FUT",
-        )
+    # CE / PE for options, FUT for futures.
+    derivative_type = row["SEM_OPTION_TYPE"] if "OPT" in instrument else "FUT"
 
-    else:
-        return "Unknown", "Unknown", "Unknown"
+    if segment == SEGMENT_EQUITY and instrument == "EQUITY":
+        if exchange_id == "NSE":
+            return "NSE", "NSE_EQ", "EQ"
+        if exchange_id == "BSE":
+            return "BSE", "BSE_EQ", "EQ"
+
+    elif segment == SEGMENT_INDEX and instrument == "INDEX":
+        if exchange_id == "NSE":
+            return "NSE_INDEX", "IDX_I", "INDEX"
+        if exchange_id == "BSE":
+            return "BSE_INDEX", "IDX_I", "INDEX"
+
+    elif segment == SEGMENT_EQUITY_DERIVATIVE and instrument in EQUITY_FNO_INSTRUMENTS:
+        if exchange_id == "NSE":
+            return "NFO", "NSE_FNO", derivative_type
+        if exchange_id == "BSE":
+            return "BFO", "BSE_FNO", derivative_type
+
+    elif segment == SEGMENT_CURRENCY and instrument in CURRENCY_INSTRUMENTS:
+        if exchange_id == "NSE":
+            return "CDS", "NSE_CURRENCY", derivative_type
+        if exchange_id == "BSE":
+            return "BCD", "BSE_CURRENCY", derivative_type
+
+    elif segment == SEGMENT_COMMODITY and instrument in COMMODITY_INSTRUMENTS:
+        if exchange_id == "MCX":
+            return "MCX", "MCX_COMM", derivative_type
+        # NSE segment M is NSE's commodity derivatives book - OpenAlgo's NCO
+        # exchange, which Dhan addresses as NSE_COMM. That segment string is
+        # absent from Dhan's published annexure but is accepted by the API:
+        # /v2/margincalculator returns a real margin and the live account
+        # balance for NSE_COMM + securityId 153964, while NSE_COMMODITY and
+        # NSE_FNO are both rejected with DH-905. It must never be folded into
+        # NFO - its id space (121601-171512) overlaps NSE segment D, which is
+        # the #1929 collision.
+        if exchange_id == "NSE":
+            return "NCO", "NSE_COMM", derivative_type
+
+    return "Unknown", "Unknown", "Unknown"
 
 
 def process_dhan_csv(path):
@@ -241,6 +289,27 @@ def process_dhan_csv(path):
     df[["exchange", "brexchange", "instrumenttype"]] = df.apply(
         assign_values, axis=1, result_type="expand"
     )
+
+    # Drop rows no OpenAlgo exchange covers. Today that is NSE segment M, whose
+    # security ids Dhan does not serve on any exchangeSegment (see
+    # assign_values). A row kept here would keep its raw SEM_CUSTOM_SYMBOL
+    # (reformat_symbol only normalizes known instrument types) and still
+    # surface in symbol search, which filters by exchange only when the caller
+    # passes one - so it would look tradable and then fail at the quote step.
+    # Log the breakdown so a segment Dhan adds later is visible, not silent.
+    unmapped = df["exchange"] == "Unknown"
+    if unmapped.any():
+        breakdown = (
+            df.loc[unmapped]
+            .groupby(["SEM_EXM_EXCH_ID", "SEM_SEGMENT", "SEM_INSTRUMENT_NAME"])
+            .size()
+            .to_dict()
+        )
+        logger.info(
+            f"Dhan master contract: dropping {int(unmapped.sum())} rows with no "
+            f"OpenAlgo exchange (exchange/segment/instrument: {breakdown})"
+        )
+        df = df[~unmapped].copy()
 
     df["symbol"] = df.apply(reformat_symbol, axis=1)
 
@@ -332,6 +401,44 @@ def process_dhan_csv(path):
     }
     df.loc[bse_idx_mask, "symbol"] = df.loc[bse_idx_mask, "symbol"].replace(bse_index_map)
 
+    # A (exchange, token) pair is what get_symbol() reverse-looks-up a live
+    # position with, so it has to be unique. Two rows sharing one pair means a
+    # position can resolve to the wrong contract silently (#1929). Log loudly
+    # rather than raise - a broken master contract is worse than a duplicated
+    # one, and the operator needs the detail to report it.
+    collisions = df[df.duplicated(subset=["exchange", "token"], keep=False)]
+    if not collisions.empty:
+        samples = [
+            f"{r.exchange}/{r.token}: {r.brsymbol}"
+            for r in collisions.sort_values(["exchange", "token"]).head(6).itertuples()
+        ]
+        logger.error(
+            f"Dhan master contract: {len(collisions)} rows share a duplicate "
+            f"(exchange, token) across "
+            f"{collisions.groupby(['exchange', 'token']).ngroups} pairs "
+            f"(by exchange: {collisions['exchange'].value_counts().to_dict()}). "
+            f"Position reverse-lookup is ambiguous for these. Samples: {samples}"
+        )
+
+    # The mirror of the check above: (symbol, exchange) is what get_token()
+    # forward-looks-up before placing an order, so it has to be unique too. Two
+    # rows sharing one pair means an order can reach the wrong instrument -
+    # historically a warrant instead of the equity, or a neighbouring strike
+    # (#1930). Logged, not raised, for the same reason as above.
+    sym_collisions = df[df.duplicated(subset=["symbol", "exchange"], keep=False)]
+    if not sym_collisions.empty:
+        samples = [
+            f"{r.exchange}/{r.symbol} -> {r.brsymbol} (token {r.token})"
+            for r in sym_collisions.sort_values(["exchange", "symbol"]).head(6).itertuples()
+        ]
+        logger.error(
+            f"Dhan master contract: {len(sym_collisions)} rows share a duplicate "
+            f"(symbol, exchange) across "
+            f"{sym_collisions.groupby(['symbol', 'exchange']).ngroups} pairs "
+            f"(by exchange: {sym_collisions['exchange'].value_counts().to_dict()}). "
+            f"Order forward-lookup is ambiguous for these. Samples: {samples}"
+        )
+
     # List of columns to remove
     columns_to_remove = [
         "SEM_EXM_EXCH_ID",
@@ -352,8 +459,9 @@ def process_dhan_csv(path):
         "SM_SYMBOL_NAME",
     ]
 
-    # Removing the specified columns
-    token_df = df.drop(columns=columns_to_remove)
+    # Removing the specified columns. errors="ignore" so a column Dhan drops
+    # from a future master file does not break the whole download.
+    token_df = df.drop(columns=columns_to_remove, errors="ignore")
 
     return token_df
 

--- a/broker/dhan_sandbox/mapping/order_data.py
+++ b/broker/dhan_sandbox/mapping/order_data.py
@@ -78,7 +78,7 @@ def map_order_data(order_data):
                     order["productType"] = "MIS"
 
                 elif (
-                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS"]
+                    order["exchangeSegment"] in ["NFO", "MCX", "BFO", "CDS", "BCD", "NCO"]
                     and order["productType"] == "MARGIN"
                 ):
                     order["productType"] = "NRML"

--- a/broker/dhan_sandbox/mapping/transform_data.py
+++ b/broker/dhan_sandbox/mapping/transform_data.py
@@ -133,6 +133,7 @@ def map_exchange_type(exchange):
         "BFO": "BSE_FNO",
         "BCD": "BSE_CURRENCY",
         "MCX": "MCX_COMM",
+        "NCO": "NSE_COMM",
     }
     return exchange_mapping.get(exchange)  # Default to MARKET if not found
 
@@ -149,6 +150,7 @@ def map_exchange(brexchange):
         "BSE_FNO": "BFO",
         "BSE_CURRENCY": "BCD",
         "MCX_COMM": "MCX",
+        "NSE_COMM": "NCO",
     }
     return exchange_mapping.get(brexchange)  # Default to MARKET if not found
 

--- a/broker/dhan_sandbox/mapping/transform_data.py
+++ b/broker/dhan_sandbox/mapping/transform_data.py
@@ -171,7 +171,10 @@ def reverse_map_product_type(product):
     """
     Reverse maps the broker product type to the OpenAlgo product type, considering the exchange.
     """
-    # Exchange to OpenAlgo product type mapping for 'D'
-    product_mapping = {"CNC": "CNC", "MARGIN": "NRML", "MIS": "INTRADAY"}
+    # Keys are Dhan's productType values, values are OpenAlgo's. The INTRADAY
+    # pair used to be written the wrong way round as "MIS": "INTRADAY", so
+    # every intraday position reverse-mapped to None. See map_product_type
+    # above for the forward direction.
+    product_mapping = {"CNC": "CNC", "MARGIN": "NRML", "INTRADAY": "MIS"}
 
     return product_mapping.get(product)  # Removed default; will return None if not found

--- a/broker/dhan_sandbox/streaming/dhan_mapping.py
+++ b/broker/dhan_sandbox/streaming/dhan_mapping.py
@@ -15,6 +15,7 @@ OPENALGO_TO_DHAN_EXCHANGE = {
     "CDS": "NSE_CURRENCY",
     "BCD": "BSE_CURRENCY",
     "MCX": "MCX_COMM",
+    "NCO": "NSE_COMM",  # NSE Commodity (undocumented but API-accepted)
     "NSE_INDEX": "IDX_I",
     "BSE_INDEX": "IDX_I",
 }


### PR DESCRIPTION
fix(dhan): stop symbol mapping from routing orders to the wrong instrument (#1929, #1930) and fix(dhan): correct master contract mapping and symbol construction (#1929, #1930)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops Dhan orders and position lookups from routing to the wrong instrument. Master contract rows now map by segment, symbols are built from exact source columns, and open positions match on security ID instead of trading symbol, which is identical across NSE series.

- NSE commodity derivatives now trade on NCO instead of sharing tokens with NFO equity options, which previously made 8,642 contracts resolve two ways.
- Equity symbols carry a non-EQ series suffix and option strikes come from `SEM_STRIKE_PRICE`, fixing warrant and EURUSD strike-collapse cases.
- The INTRADAY product mapping is corrected, and debug logs no longer write the access token.
- `dhan_sandbox` gets the same fixes.

**Migration**
- 7,190 NSE equity symbols gain a series suffix; strategies using a bare symbol must reference the suffixed form. No database migration is needed because the master contract table is rebuilt on every download.

<sup>Written for commit 2479b3a5ba169769ca30f3168ce2112950a10e38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1932?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

