### PR TITLE
docs(readme): align quick-contribution example with Conventional Commits

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,7 +374,10 @@ We welcome contributions! To contribute:
 
 1. Fork the repository
 2. Create a feature branch (`git checkout -b feature/amazing-feature`)
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
+3. Commit your changes using [Conventional Commits](CONTRIBUTING.md#commit-messages), for example:
+   ```bash
+   git commit -m "feat: add amazing feature"
+   ```
 4. Push to the branch (`git push origin feature/amazing-feature`)
 5. Open a Pull Request
 


### PR DESCRIPTION
## Problem

The README's quick-contribution flow tells new contributors:

```bash
git commit -m 'Add amazing feature'
```

That command runs `git commit -m` with a **free-form** (and non-conventional) message. CONTRIBUTING.md (`### Commit Messages`) requires Conventional Commits format (`feat:`, `fix:`, `docs:`, etc., with double-quoted message). The README example contradicts the project's own documented policy, so a contributor following the README's exact command lands a commit the project would flag.

This is exactly the kind of drift issue reported in #1845.

## Triage / Root cause

- `README.md` line 377 — the inline commit example still uses single quotes and a non-conventional subject.
- `CONTRIBUTING.md` lines 377-396 — defines Conventional Commits as the project standard, with double-quoted examples.
- No internal cross-link from the README quick-contribution steps to the CONTRIBUTING guide.

## Fix

Replace the contradictory inline example in the README with a Conventional Commits example and add a cross-link to CONTRIBUTING.md's commit guide, so contributors see the full policy without leaving the page they started on.

```diff
-3. Commit your changes (`git commit -m 'Add amazing feature'`)
+3. Commit your changes using [Conventional Commits](CONTRIBUTING.md#commit-messages), for example:
+   ```bash
+   git commit -m "feat: add amazing feature"
+   ```
```

The example keeps the `feature/amazing-feature` branch flavor so a first-time contributor still gets a memorable end-to-end walkthrough; the change only touches the commit message example and the link target.

## Verification

- `rg -n "git commit|Conventional" README.md CONTRIBUTING.md` — both files now reference Conventional Commits and the example uses the project's documented format.
- The README → CONTRIBUTING anchor is `CONTRIBUTING.md#commit-messages`, matching GitHub's auto-generated anchor for the `#### Commit Messages` heading in CONTRIBUTING.md.
- Documentation-only change, so the docs-only branch (`docs/readme-quick-contribution`) and `docs:` Conventional Commit type follow the project's own PR-template guidance in CONTRIBUTING.md §5.

## Notes / Risks

- Touches the visible contributing surface, but the new wording reads identical to a first-time contributor except where it needs to differ (commit example format).
- No code or test changes; CI's ruff/biome/secrets pre-commit hooks have no README input.
- Independent of the still-open PR #1921 (which removes the stale `:ro .env` guidance from design/docker docs); the two edits do not overlap.
- No prior PR on this repo has attempted this exact fix; searched with `gh pr list --repo marketcalls/openalgo --state all --search "1845 in:body,comments"` (0 hits) and `--search "Add amazing feature"` (0 hits).

Closes #1845

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates the README quick-contribution example to use Conventional Commits format (`git commit -m "feat: add amazing feature"`) and links to the commit message guide in `CONTRIBUTING.md`. Previously the example showed a free-form message that contradicted the project's documented commit policy, so contributors following it would create commits flagged in PR reviews. Closes #1845.

<sup>Written for commit 5f21d3a3edf28bf91072cb3a4ea65ffc250e074f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1935?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

