### PR TITLE
fix: apply supported date range to holiday checks

### DIFF
--- a/services/market_calendar_service.py
+++ b/services/market_calendar_service.py
@@ -17,6 +17,13 @@ from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
+MIN_SUPPORTED_DATE = date(2020, 1, 1)
+MAX_SUPPORTED_DATE = date(2050, 12, 31)
+
+
+def _is_supported_date(query_date: date) -> bool:
+    return MIN_SUPPORTED_DATE <= query_date <= MAX_SUPPORTED_DATE
+
 
 def get_holidays(year: int | None = None) -> tuple[bool, dict[str, Any], int]:
     """
@@ -73,11 +80,7 @@ def get_timings(date_str: str) -> tuple[bool, dict[str, Any], int]:
         except (TypeError, ValueError):
             return False, {"status": "error", "message": "Invalid date format. Use YYYY-MM-DD"}, 400
 
-        # Validate date range (not too far in past or future)
-        min_date = date(2020, 1, 1)
-        max_date = date(2050, 12, 31)
-
-        if query_date < min_date or query_date > max_date:
+        if not _is_supported_date(query_date):
             return (
                 False,
                 {"status": "error", "message": "Date must be between 2020-01-01 and 2050-12-31"},
@@ -116,6 +119,13 @@ def check_holiday(date_str: str, exchange: str | None = None) -> tuple[bool, dic
             query_date = datetime.strptime(date_str, "%Y-%m-%d").date()
         except (TypeError, ValueError):
             return False, {"status": "error", "message": "Invalid date format. Use YYYY-MM-DD"}, 400
+
+        if not _is_supported_date(query_date):
+            return (
+                False,
+                {"status": "error", "message": "Date must be between 2020-01-01 and 2050-12-31"},
+                400,
+            )
 
         # Validate exchange if provided
         if exchange and exchange.upper() not in SUPPORTED_EXCHANGES:

--- a/test/test_market_calendar_validation.py
+++ b/test/test_market_calendar_validation.py
@@ -17,6 +17,27 @@ def test_calendar_service_rejects_invalid_date_values(service, invalid_date):
     assert response == {"status": "error", "message": "Invalid date format. Use YYYY-MM-DD"}
 
 
+@pytest.mark.parametrize(
+    ("date_value", "expected_success"),
+    [("2019-12-31", False), ("2020-01-01", True), ("2050-12-31", True), ("2051-01-01", False)],
+)
+@pytest.mark.parametrize(
+    "service", [market_calendar_service.get_timings, market_calendar_service.check_holiday]
+)
+def test_calendar_services_apply_supported_date_range(
+    monkeypatch, service, date_value, expected_success
+):
+    monkeypatch.setattr(market_calendar_service, "get_market_timings_for_date", lambda _date: [])
+    monkeypatch.setattr(market_calendar_service, "is_market_holiday", lambda *_args: False)
+
+    success, response, status_code = service(date_value)
+
+    assert success is expected_success
+    assert status_code == (200 if expected_success else 400)
+    if not expected_success:
+        assert response["message"] == "Date must be between 2020-01-01 and 2050-12-31"
+
+
 def test_get_timings_accepts_valid_iso_date(monkeypatch):
     monkeypatch.setattr(market_calendar_service, "get_market_timings_for_date", lambda _date: [])
 


### PR DESCRIPTION
Fixes #1825

## Summary
- centralize the supported 2020-2050 calendar bounds
- apply the same validation to timing and holiday checks
- cover both boundaries and immediately adjacent invalid dates

## Tests
- uv run ruff check services/market_calendar_service.py test/test_market_calendar_validation.py
- uv run ruff format --check services/market_calendar_service.py test/test_market_calendar_validation.py
- uv run pytest test/test_market_calendar_validation.py -v: 18 passed

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1825 by applying the supported 2020-2050 date bounds to `check_holiday`, which previously accepted out-of-range dates; both calendar services now reject them with the same 400 response.

- Centralizes the bounds into `MIN_SUPPORTED_DATE`, `MAX_SUPPORTED_DATE`, and `_is_supported_date()`.
- Adds parameterized tests covering both boundaries and immediately adjacent invalid dates for `get_timings` and `check_holiday`.

<sup>Written for commit 1f795c8b323b374588e4b39d8535642a3d1679eb. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1938?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

