### PR TITLE
security: Add no-store headers to API-key responses

### DIFF
--- a/blueprints/apikey.py
+++ b/blueprints/apikey.py
@@ -56,7 +56,7 @@ def manage_api_key():
 
         # Return JSON if Accept header requests it (for React frontend)
         if request.headers.get("Accept") == "application/json":
-            return jsonify(
+            resp = jsonify(
                 {
                     "login_username": login_username,
                     "has_api_key": has_api_key,
@@ -64,6 +64,9 @@ def manage_api_key():
                     "order_mode": order_mode,
                 }
             )
+            resp.headers["Cache-Control"] = "no-store, max-age=0"
+            resp.headers["Pragma"] = "no-cache"
+            return resp
 
         # Serve React app for browser navigation
         index_path = FRONTEND_DIST / "index.html"
@@ -92,9 +95,12 @@ def manage_api_key():
 
         if key_id is not None:
             logger.info(f"API key updated successfully for user: {user_id}")
-            return jsonify(
+            resp = jsonify(
                 {"message": "API key updated successfully.", "api_key": api_key, "key_id": key_id}
             )
+            resp.headers["Cache-Control"] = "no-store, max-age=0"
+            resp.headers["Pragma"] = "no-cache"
+            return resp
         else:
             logger.error(f"Failed to update API key for user: {user_id}")
             return jsonify({"error": "Failed to update API key"}), 500

--- a/blueprints/playground.py
+++ b/blueprints/playground.py
@@ -305,7 +305,10 @@ def get_api_key():
         return jsonify({"error": "Not authenticated"}), 401
 
     api_key = get_api_key_for_tradingview(login_username)
-    return jsonify({"api_key": api_key or ""})
+    resp = jsonify({"api_key": api_key or ""})
+    resp.headers["Cache-Control"] = "no-store, max-age=0"
+    resp.headers["Pragma"] = "no-cache"
+    return resp
 
 
 @playground_bp.route("/collections")

--- a/blueprints/websocket_example.py
+++ b/blueprints/websocket_example.py
@@ -180,7 +180,10 @@ def api_get_websocket_apikey():
             {"status": "error", "message": "No API key found. Please generate an API key first."}
         ), 404
 
-    return jsonify({"status": "success", "api_key": api_key}), 200
+    resp = jsonify({"status": "success", "api_key": api_key})
+    resp.headers["Cache-Control"] = "no-store, max-age=0"
+    resp.headers["Pragma"] = "no-cache"
+    return resp, 200
 
 
 @websocket_bp.route("/api/websocket/config", methods=["GET"])

--- a/test/test_api_key_cache_headers.py
+++ b/test/test_api_key_cache_headers.py
@@ -1,0 +1,115 @@
+"""Test that API key endpoints return proper cache-control headers for security."""
+
+import json
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from blueprints.apikey import api_key_bp
+from blueprints.playground import playground_bp
+from blueprints.websocket_example import websocket_bp
+
+
+@pytest.fixture
+def client(app):
+    """Create a test client with mocked session."""
+    return app.test_client()
+
+
+@pytest.fixture
+def mock_session():
+    """Mock session data."""
+    return {"user": "test-user"}
+
+
+class TestAPIKeyEndpointCacheHeaders:
+    """Test cache headers on API key endpoints."""
+
+    def test_apikey_get_has_cache_headers(self, client, mock_session):
+        """GET /apikey should return no-store and no-cache headers."""
+        with client.session_transaction() as sess:
+            sess.update(mock_session)
+
+        with patch("database.auth_db.get_api_key_for_tradingview") as mock_get_key:
+            mock_get_key.return_value = "test-token-not-real"
+            with patch("database.auth_db.get_order_mode") as mock_get_mode:
+                mock_get_mode.return_value = "auto"
+
+                response = client.get(
+                    "/apikey",
+                    headers={"Accept": "application/json"},
+                )
+
+                assert response.status_code == 200
+                assert response.headers.get("Cache-Control") == "no-store, max-age=0"
+                assert response.headers.get("Pragma") == "no-cache"
+
+    def test_apikey_post_has_cache_headers(self, client, mock_session):
+        """POST /apikey should return no-store and no-cache headers."""
+        with client.session_transaction() as sess:
+            sess.update(mock_session)
+
+        with patch("database.auth_db.upsert_api_key") as mock_upsert:
+            mock_upsert.return_value = 1  # key_id
+
+            response = client.post(
+                "/apikey",
+                json={"user_id": "test-user"},
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            assert response.headers.get("Cache-Control") == "no-store, max-age=0"
+            assert response.headers.get("Pragma") == "no-cache"
+            data = json.loads(response.data)
+            assert "api_key" in data
+            # Verify test value is used
+            assert data["api_key"].startswith("test-") or len(data["api_key"]) == 64
+
+    def test_playground_api_key_has_cache_headers(self, client, mock_session):
+        """GET /playground/api-key should return no-store and no-cache headers."""
+        with client.session_transaction() as sess:
+            sess.update(mock_session)
+
+        with patch("database.auth_db.get_api_key_for_tradingview") as mock_get_key:
+            mock_get_key.return_value = "test-token-not-real"
+
+            response = client.get("/playground/api-key")
+
+            assert response.status_code == 200
+            assert response.headers.get("Cache-Control") == "no-store, max-age=0"
+            assert response.headers.get("Pragma") == "no-cache"
+
+    def test_websocket_apikey_has_cache_headers(self, client, mock_session):
+        """GET /api/websocket/apikey should return no-store and no-cache headers."""
+        with client.session_transaction() as sess:
+            sess.update(mock_session)
+
+        with patch("database.auth_db.get_api_key_for_tradingview") as mock_get_key:
+            mock_get_key.return_value = "test-token-not-real"
+
+            response = client.get("/api/websocket/apikey")
+
+            assert response.status_code == 200
+            assert response.headers.get("Cache-Control") == "no-store, max-age=0"
+            assert response.headers.get("Pragma") == "no-cache"
+
+    def test_apikey_no_credentials_in_test(self, client, mock_session):
+        """Verify tests use only test values, never real credentials."""
+        with client.session_transaction() as sess:
+            sess.update(mock_session)
+
+        with patch("database.auth_db.upsert_api_key") as mock_upsert:
+            mock_upsert.return_value = 1
+
+            response = client.post(
+                "/apikey",
+                json={"user_id": "test-user"},
+                content_type="application/json",
+            )
+
+            assert response.status_code == 200
+            data = json.loads(response.data)
+            # Ensure no real keys are exposed in error logs or test output
+            assert "your-real-key" not in str(data)
+            assert "production-key" not in str(data)


### PR DESCRIPTION
## Summary

This PR implements the security fix for issue #1850. Credential-bearing API key endpoints now return explicit cache-control headers to prevent browser, proxy, and intermediary caching.

## Changes

Added `Cache-Control: no-store, max-age=0` and `Pragma: no-cache` headers to:
- `GET /apikey` — returns decrypted API key
- `POST /apikey` — returns newly generated API key  
- `GET /playground/api-key` — returns current API key for playground
- `GET /api/websocket/apikey` — returns API key for WebSocket auth

## Implementation

- Modified 3 blueprint files to set response headers before returning
- Follows existing pattern from `blueprints/admin.py`
- No changes to JSON response bodies
- Added comprehensive tests in `test/test_api_key_cache_headers.py`

## Testing

All endpoints verified to:
✓ Return correct cache headers
✓ Work with both GET and POST methods
✓ Use only test values (never real credentials)
✓ Pass syntax and linting checks

Run tests with:
```bash
uv run pytest test/test_api_key_cache_headers.py -v
```

## Security notes

- Credentials are returned but now explicitly marked as non-cacheable
- `Pragma: no-cache` added for legacy proxy compatibility
- Tests use obvious test values like `test-token-not-real`
- No broker credentials required for testing

Fixes #1850

🤖 Generated with Claude Code

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1850 by preventing browsers, proxies, and intermediaries from caching responses that return API keys.

- Adds `Cache-Control: no-store, max-age=0` and `Pragma: no-cache` headers to all four API key endpoints.
- Covers GET/POST `/apikey`, GET `/playground/api-key`, and GET `/api/websocket/apikey`.
- Response bodies and status codes are unchanged.
- Adds tests verifying cache headers and that only test values are used.

<sup>Written for commit 7d839be78acf8740139b5f0dffc8528146672f55. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1941?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

