### PR TITLE
fix(shoonya): raise on session errors in get_history instead of returning empty success

### DIFF
--- a/broker/shoonya/api/data.py
+++ b/broker/shoonya/api/data.py
@@ -830,8 +830,11 @@ class BrokerData:
 
             response_candles = []
             chunk_start = start_ts
+            attempted_chunks = 0
+            failed_chunks = 0
             while chunk_start <= end_ts:
                 chunk_end = min(chunk_start + chunk_seconds, end_ts)
+                attempted_chunks += 1
                 if interval == "D":
                     payload = {
                         "sym": f"{exchange}:{eod_symbol}",
@@ -856,6 +859,7 @@ class BrokerData:
                     logger.error(
                         f"{endpoint} chunk request failed ({chunk_start}-{chunk_end}): {e}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
@@ -865,10 +869,19 @@ class BrokerData:
                 # and crashed trying to json.loads("stat")).
                 if isinstance(chunk_response, dict):
                     emsg = chunk_response.get("emsg") or chunk_response.get("message") or "unknown"
+                    # A session-level failure is fatal for every chunk: raising
+                    # here (like get_quotes does) beats returning an empty
+                    # frame that the API layer would report as success (#1944).
+                    if any(
+                        marker in str(emsg).lower()
+                        for marker in ("session expired", "invalid session key", "not logged in")
+                    ):
+                        raise Exception(f"Error from Shoonya API: {emsg}")
                     logger.warning(
                         f"{endpoint} returned error for chunk {chunk_start}-{chunk_end}: "
                         f"stat={chunk_response.get('stat')} emsg={emsg}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
@@ -877,11 +890,20 @@ class BrokerData:
                         f"Unexpected {endpoint} response type {type(chunk_response).__name__}: "
                         f"{str(chunk_response)[:200]}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
                 response_candles.extend(chunk_response)
                 chunk_start = chunk_end + 1
+
+            if attempted_chunks and failed_chunks == attempted_chunks:
+                # Every chunk failed — do not let a fully failed request
+                # masquerade as an empty-but-successful response (#1944).
+                raise Exception(
+                    f"All {attempted_chunks} {endpoint} chunk requests failed for "
+                    f"{symbol}/{oa_exchange} between {start_ts} and {end_ts}"
+                )
 
             if interval == "D" and not response_candles:
                 # An unknown index name resolves to an empty list rather than


### PR DESCRIPTION
Fixes #1944.

## Problem

With an expired/invalid Shoonya session, `/api/v1/history` returns `{"status": "success", "data": []}` while `/api/v1/quotes` correctly returns the session error. Root cause: in `get_history`'s chunk loop, both the transport `except` and the `{"stat":"Not_Ok",...}` error-dict branch log and `continue`. When the session is dead, *every* chunk fails the same way, the loop completes with zero candles, and the empty DataFrame surfaces as success — indistinguishable from "no data in range", which silently corrupts downstream data pipelines (fake gaps) and leaves bots running blind.

## Change

Keeps per-chunk tolerance for transient issues, adds two guards:

1. **Session-level errors raise immediately** — if the chunk error's `emsg` contains `session expired` / `invalid session key` / `not logged in`, raise (mirroring `get_quotes`), since it is fatal for every remaining chunk anyway.
2. **All-chunks-failed raises** — if every attempted chunk failed (transport error, error dict, or unexpected type), raise instead of returning an empty frame as success.

Legitimately empty periods are unaffected: chunks that succeed with an empty *list* count as successes, so holidays/quiet ranges still return empty data with success as before. The existing outer `except` in `get_history` re-raises, so the API layer reports these as errors exactly like the quotes endpoint.

## Verification

- Reproduced the original behaviour live against a Shoonya account with an expired session: `/quotes` → HTTP 500 `Session Expired : Invalid Session Key`, `/history` → HTTP 200 success + `[]` for a liquid MCX symbol on a known trading day.
- With this patch, the same session-expired dict now raises on the first chunk and surfaces through the existing error path.
- `python -m ast` clean; change is +22 lines, `broker/shoonya/api/data.py` only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01BhoYr24dEbRAypNrgEgKXU

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1944: `get_history` now raises on expired or invalid Shoonya sessions instead of returning an empty success response, which previously masked fatal errors as quiet periods.

**Bug Fixes**
- Session-level error messages (`session expired`, `invalid session key`, `not logged in`) now raise immediately, matching the quotes endpoint.
- If every chunk attempt fails, the request raises an error instead of returning empty data, while legitimate empty periods still succeed.

<sup>Written for commit 267d266bd15a2376ab9e128651e148c126beed3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1945?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

