### PR TITLE
Add daily iron condor example strategy with matching bhavcopy backtest

### DIFF
--- a/strategies/.gitignore
+++ b/strategies/.gitignore
@@ -27,3 +27,8 @@ __pycache__/
 *.pyc
 *.pyo
 *.pyd
+
+# Local run artifacts from the example strategies (not source)
+examples/.bhavcopy_cache/
+examples/backtest_results.json
+examples/.iron_condor_daily_state.json

--- a/strategies/examples/backtest_iron_condor_daily.py
+++ b/strategies/examples/backtest_iron_condor_daily.py
@@ -1,0 +1,270 @@
+#!/usr/bin/env python
+"""
+EOD backtest for iron_condor_daily.py against real NSE settlement data.
+
+Pulls NSE's public daily F&O bhavcopy (one file per trading day, contains
+every strike/expiry's Open/High/Low/Close/Settlement for that day - this is
+NSE's own official record, not a broker feed) for NIFTY and BANKNIFTY index
+options over a date range, resolves the same OTM6-hedge / OTM4-short legs
+the live strategy uses, and sums up what selling that spread would have
+made or lost each day.
+
+HONESTY ABOUT WHAT THIS DOES AND DOESN'T PROVE:
+NSE's daily bhavcopy has one Open/High/Low/Close per contract per day - not
+a full intraday tick history. That means this backtest can faithfully
+answer "what if you entered at the day's open and held to the day's close"
+(no intraday exit at all), but it CANNOT faithfully simulate the live
+script's actual intraday profit-target / stop-loss logic - those trigger at
+a specific mark-to-market moment during the day, and reconstructing that
+from four independent daily High/Low ranges would silently assume all four
+legs hit their extreme at the same instant, which is not something the data
+supports. So this script reports two numbers, clearly separated:
+  1. Open-to-close P&L (the trustworthy one - directly backed by settlement
+     data)
+  2. A rough intraday sensitivity band using each day's High/Low (a loose
+     "how much did it move" indicator, NOT a stop-loss simulation)
+Treat (1) as the honest backtest and (2) as a hint, not a promise.
+
+Requires only the Python standard library (urllib, zipfile, csv) - no
+broker connection needed, this is pure historical NSE data.
+"""
+import csv
+import io
+import json
+import os
+import statistics
+import time
+import urllib.error
+import urllib.request
+import zipfile
+from datetime import date, timedelta
+
+# ---------------------------------------------------------------------------
+# Config - keep in sync with strategies/examples/iron_condor_daily.py
+# ---------------------------------------------------------------------------
+UNDERLYINGS = ["NIFTY", "BANKNIFTY"]
+HEDGE_OFFSET = 6   # strikes away from ATM for the long (insurance) legs
+SHORT_OFFSET = 4   # strikes away from ATM for the short (premium) legs
+PROFIT_TARGET_CREDIT_FRACTION = 0.5
+STOP_LOSS_CREDIT_MULTIPLE = 1.0
+
+START_DATE = date.today() - timedelta(days=90)
+END_DATE = date.today() - timedelta(days=1)
+
+CACHE_DIR = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".bhavcopy_cache")
+USER_AGENT = ("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 "
+              "(KHTML, like Gecko) Chrome/120.0 Safari/537.36")
+BHAVCOPY_URL = "https://nsearchives.nseindia.com/content/fo/BhavCopy_NSE_FO_0_0_0_{yyyymmdd}_F_0000.csv.zip"
+
+
+def fetch_bhavcopy(day):
+    """Return list of dict rows for one trading day, or None if no data (holiday/weekend)."""
+    os.makedirs(CACHE_DIR, exist_ok=True)
+    cache_path = os.path.join(CACHE_DIR, f"{day.isoformat()}.csv")
+    if os.path.exists(cache_path):
+        with open(cache_path, newline="") as f:
+            return list(csv.DictReader(f))
+
+    url = BHAVCOPY_URL.format(yyyymmdd=day.strftime("%Y%m%d"))
+    req = urllib.request.Request(url, headers={"User-Agent": USER_AGENT})
+    try:
+        with urllib.request.urlopen(req, timeout=20) as resp:
+            raw = resp.read()
+    except urllib.error.HTTPError as e:
+        if e.code == 404:
+            return None  # holiday or weekend - NSE simply has no file
+        raise
+
+    with zipfile.ZipFile(io.BytesIO(raw)) as zf:
+        inner_name = zf.namelist()[0]
+        with zf.open(inner_name) as f:
+            text = io.TextIOWrapper(f, encoding="utf-8")
+            rows = list(csv.DictReader(text))
+
+    with open(cache_path, "w", newline="") as f:
+        if rows:
+            writer = csv.DictWriter(f, fieldnames=rows[0].keys())
+            writer.writeheader()
+            writer.writerows(rows)
+    return rows
+
+
+# Exchange-fixed strike intervals. NOT auto-detected from the day's strike ladder:
+# NSE lists extra intermediate strikes near spot on high-volume days (tighter than
+# the nominal interval), which made a "most common gap" heuristic pick the wrong,
+# too-small value on some days - that silently broke the OTM-offset spacing the
+# whole strategy (and its defined max loss) depends on. These two are exchange
+# constants and haven't changed in years; update here if NSE revises them.
+STRIKE_INTERVALS = {"NIFTY": 50.0, "BANKNIFTY": 100.0}
+
+
+def strike_interval(underlying):
+    return STRIKE_INTERVALS[underlying]
+
+
+def find_leg(rows, underlying, expiry, strike, option_type):
+    for r in rows:
+        if (r["TckrSymb"] == underlying and r["XpryDt"] == expiry
+                and r["FinInstrmTp"] == "IDO" and r["OptnTp"] == option_type
+                and abs(float(r["StrkPric"]) - strike) < 0.01):
+            return r
+    return None
+
+
+def leg_prices(row):
+    """(open, high, low, close, lotsize) with a settlement-price fallback for zero-trade days."""
+    open_p = float(row["OpnPric"])
+    high_p = float(row["HghPric"])
+    low_p = float(row["LwPric"])
+    close_p = float(row["ClsPric"])
+    settle_p = float(row["SttlmPric"])
+    if open_p <= 0:
+        open_p = settle_p  # no trades at open - use theoretical settlement as an entry proxy
+    if close_p <= 0:
+        close_p = settle_p
+    if high_p <= 0:
+        high_p = max(open_p, close_p)
+    if low_p <= 0:
+        low_p = min(open_p, close_p) if min(open_p, close_p) > 0 else close_p
+    return open_p, high_p, low_p, close_p, int(float(row["NewBrdLotQty"]))
+
+
+def simulate_day(rows, underlying, trade_day):
+    candidates = [r["XpryDt"] for r in rows
+                  if r["TckrSymb"] == underlying and r["FinInstrmTp"] == "IDO"
+                  and r["XpryDt"] >= trade_day.isoformat()]
+    if not candidates:
+        return None
+    expiry = min(candidates)
+
+    underlying_rows = [r for r in rows if r["TckrSymb"] == underlying and r["XpryDt"] == expiry
+                        and r["FinInstrmTp"] == "IDO"]
+    spot = float(underlying_rows[0]["UndrlygPric"])
+    interval = strike_interval(underlying)
+    atm = round(spot / interval) * interval
+
+    legs_wanted = {
+        "hedge_ce": (atm + HEDGE_OFFSET * interval, "CE"),
+        "hedge_pe": (atm - HEDGE_OFFSET * interval, "PE"),
+        "short_ce": (atm + SHORT_OFFSET * interval, "CE"),
+        "short_pe": (atm - SHORT_OFFSET * interval, "PE"),
+    }
+
+    resolved = {}
+    for key, (strike, opt_type) in legs_wanted.items():
+        row = find_leg(rows, underlying, expiry, strike, opt_type)
+        if row is None:
+            return None  # illiquid/missing strike that day - skip rather than guess
+        resolved[key] = leg_prices(row)
+
+    lotsize = resolved["short_ce"][4]
+
+    def entry(key):
+        return resolved[key][0]
+
+    def close_exit(key):
+        return resolved[key][3]
+
+    width = (HEDGE_OFFSET - SHORT_OFFSET) * interval
+    net_credit = (entry("short_ce") + entry("short_pe")) - (entry("hedge_ce") + entry("hedge_pe"))
+    if net_credit <= 0 or net_credit > width:
+        # A real vertical spread's credit can never be <= 0 or exceed the strike
+        # width - either would be a free-money arbitrage, which no-arbitrage option
+        # pricing rules out. Seeing it here means at least one leg's "Open" price is
+        # a stale/theoretical value rather than a real simultaneous traded price -
+        # this shows up mainly on far-dated, illiquid wing strikes (BANKNIFTY's
+        # monthly-only expiry means it often has 2-4 weeks to expiry, versus
+        # NIFTY's much more liquid weekly chain). Not tradeable data - skip rather
+        # than report a number the market never actually offered.
+        return None
+    close_value = (close_exit("short_ce") + close_exit("short_pe")) - (close_exit("hedge_ce") + close_exit("hedge_pe"))
+    open_to_close_pnl = (net_credit - close_value) * lotsize
+
+    # Loose intraday sensitivity band (NOT a stop-loss simulation - see module docstring)
+    best_case_close_value = (resolved["short_ce"][2] + resolved["short_pe"][2]) - (resolved["hedge_ce"][1] + resolved["hedge_pe"][1])
+    worst_case_close_value = (resolved["short_ce"][1] + resolved["short_pe"][1]) - (resolved["hedge_ce"][2] + resolved["hedge_pe"][2])
+    best_case_pnl = (net_credit - best_case_close_value) * lotsize
+    worst_case_pnl = (net_credit - worst_case_close_value) * lotsize
+
+    max_loss_proxy = (HEDGE_OFFSET - SHORT_OFFSET) * interval * lotsize - net_credit * lotsize
+
+    return {
+        "date": trade_day.isoformat(), "underlying": underlying, "expiry": expiry,
+        "spot": spot, "atm": atm, "lotsize": lotsize,
+        "net_credit_per_lot": round(net_credit, 2),
+        "open_to_close_pnl_per_lot": round(open_to_close_pnl, 2),
+        "best_case_pnl_per_lot": round(best_case_pnl, 2),
+        "worst_case_pnl_per_lot": round(worst_case_pnl, 2),
+        "max_loss_proxy_per_lot": round(max_loss_proxy, 2),
+    }
+
+
+def trading_days(start, end):
+    d = start
+    while d <= end:
+        if d.weekday() < 5:
+            yield d
+        d += timedelta(days=1)
+
+
+def main():
+    print(f"Backtesting {UNDERLYINGS} iron condor (OTM{HEDGE_OFFSET} hedge / OTM{SHORT_OFFSET} short) "
+          f"from {START_DATE} to {END_DATE}\n")
+
+    results = []
+    skipped = 0
+    trading_day_count = 0
+    for day in trading_days(START_DATE, END_DATE):
+        try:
+            rows = fetch_bhavcopy(day)
+        except Exception as e:
+            print(f"  {day}: fetch failed ({e}), skipping")
+            continue
+        if rows is None:
+            continue  # holiday/weekend
+        trading_day_count += 1
+        for underlying in UNDERLYINGS:
+            try:
+                r = simulate_day(rows, underlying, day)
+            except Exception as e:
+                print(f"  {day} {underlying}: simulation error ({e}), skipping")
+                skipped += 1
+                continue
+            if r:
+                results.append(r)
+            else:
+                skipped += 1
+        time.sleep(0.3)  # be a considerate citizen of NSE's archive server
+
+    print(f"{trading_day_count} trading days processed, {skipped} underlying-days skipped "
+          f"(illiquid/unreliable strike data)\n")
+
+    if not results:
+        print("No results - check date range / connectivity / NSE bhavcopy availability.")
+        return
+
+    out_path = os.path.join(os.path.dirname(os.path.abspath(__file__)), "backtest_results.json")
+    with open(out_path, "w") as f:
+        json.dump(results, f, indent=2)
+
+    for underlying in UNDERLYINGS:
+        rows = [r for r in results if r["underlying"] == underlying]
+        if not rows:
+            continue
+        pnls = [r["open_to_close_pnl_per_lot"] for r in rows]
+        wins = [p for p in pnls if p > 0]
+        losses = [p for p in pnls if p <= 0]
+        total = sum(pnls)
+        print(f"=== {underlying} ({len(rows)} trading days) ===")
+        print(f"  Open-to-close total P&L per lot: Rs{total:,.0f}")
+        print(f"  Win rate: {len(wins)}/{len(rows)} ({len(wins)/len(rows):.0%})")
+        print(f"  Avg win: Rs{(sum(wins)/len(wins) if wins else 0):,.0f}  "
+              f"Avg loss: Rs{(sum(losses)/len(losses) if losses else 0):,.0f}")
+        print(f"  Best day: Rs{max(pnls):,.0f}  Worst day: Rs{min(pnls):,.0f}")
+        print(f"  Typical structural max loss per lot (proxy): Rs{statistics.median(r['max_loss_proxy_per_lot'] for r in rows):,.0f}\n")
+
+    print(f"Full daily results written to {out_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/strategies/examples/iron_condor_daily.py
+++ b/strategies/examples/iron_condor_daily.py
@@ -1,0 +1,331 @@
+#!/usr/bin/env python
+"""
+Autonomous Daily Iron Condor - NIFTY & BANKNIFTY options, 9:15am-2:45pm IST
+
+WHAT THIS IS: a fully automated, defined-risk premium-selling strategy.
+Each morning it sells a near-OTM Call+Put (the profit engine - collects
+theta/time decay) and simultaneously buys a further-OTM Call+Put as
+insurance (the "buying" leg). That combination caps the maximum possible
+loss to a known, fixed number *before the trade is even placed* - unlike a
+naked short strangle, where a gap move can produce unlimited loss. It then
+manages the position by itself for the rest of the day: no approval step,
+no manual intervention - it enters, watches, and exits on its own.
+
+WHAT THIS IS NOT: there is no options strategy - here or anywhere - that
+produces "no loss ever." Selling options trades a high win-rate (most days
+expire with a chunk of the credit in pocket) against occasional losing days
+when the underlying makes a large move. This script's job is to make those
+losing days small, bounded, and rare - not to eliminate them. Every rupee
+this deploys is capital you can lose, up to the position's structural max
+loss. Start in Analyzer (sandbox) mode and watch it for at least a couple
+of weeks before considering real money.
+
+DECISION LOOP (runs every POLL_SECONDS, logs its reasoning every time -
+watch it live from the /python Strategy Logs page):
+  09:15-10:30  Entry window. Once per instrument per day: size the position
+               against your capital (via live margin check), place the
+               4-leg spread.
+  All day      Re-check P&L. Exit early on whichever comes first:
+                 - PROFIT_TARGET_CREDIT_FRACTION of the credit received
+                   (booking ~50% of max profit early is the standard
+                   professional heuristic for defined-risk premium
+                   selling - don't get greedy waiting for the last few
+                   rupees while gamma risk builds into the close)
+                 - STOP_LOSS_CREDIT_MULTIPLE x the credit received, as a
+                   loss (bails out long before the structural max loss)
+                 - FORCE_EXIT_TIME reached (2:45pm - inside your requested
+                   2-3pm window, with a safety margin before the exchange's
+                   own auto square-off for MIS positions)
+  After exit   Done for the day. Does not re-enter (no revenge trading).
+
+LIVE P&L: OpenAlgo already ships a real-time PnL dashboard with an equity
+curve - open the OpenAlgo web app -> "PnL" in the sidebar -> filter by
+Strategy = "Intraday Iron Condor". That's the live graph; this script does
+not duplicate it, it just feeds it (every order below is tagged with
+STRATEGY_NAME so the dashboard can find it).
+"""
+import os
+import json
+import time
+from datetime import datetime, time as dtime
+
+from openalgo import api
+
+# ---------------------------------------------------------------------------
+# Connection (see strategies/README.md for the env var conventions)
+# ---------------------------------------------------------------------------
+API_KEY = os.getenv('OPENALGO_API_KEY')
+HOST = os.getenv('HOST_SERVER') or os.getenv('OPENALGO_HOST', 'http://127.0.0.1:5000')
+WS_URL = os.getenv('WEBSOCKET_URL') or (
+    f"ws://{os.getenv('WEBSOCKET_HOST', '127.0.0.1')}:{os.getenv('WEBSOCKET_PORT', '8765')}"
+)
+
+if not API_KEY:
+    print("Error: OPENALGO_API_KEY environment variable not set")
+    raise SystemExit(1)
+
+client = api(api_key=API_KEY, host=HOST, ws_url=WS_URL)
+
+# ---------------------------------------------------------------------------
+# Strategy configuration - review every value before going live
+# ---------------------------------------------------------------------------
+STRATEGY_NAME = "Intraday Iron Condor"
+PRODUCT = "MIS"  # intraday - broker auto-square-off is a backstop if this script ever fails to exit
+
+INSTRUMENTS = [
+    {"underlying": "NIFTY", "exchange": "NSE_INDEX",
+     "hedge_offset": "OTM6", "short_offset": "OTM4", "weight": 0.5},
+    {"underlying": "BANKNIFTY", "exchange": "NSE_INDEX",
+     "hedge_offset": "OTM6", "short_offset": "OTM4", "weight": 0.5},
+]
+
+# --- Capital & sizing -------------------------------------------------------
+TOTAL_CAPITAL = 1_000_000            # example: Rs 10L - set this to your own capital
+CAPITAL_ALLOCATION_FRACTION = 0.6    # deploy at most 60% of capital as margin - the
+                                      # rest is a buffer against intraday MTM swings.
+                                      # Never raise this to 1.0: a defined-risk spread
+                                      # still has margin, and running it to the edge
+                                      # of your funds turns any adverse move into a
+                                      # margin call instead of a controlled stop-loss.
+MAX_LOTS_PER_INSTRUMENT = 10          # hard ceiling regardless of what the margin math allows
+
+# --- Exits -------------------------------------------------------------------
+PROFIT_TARGET_CREDIT_FRACTION = 0.5  # book profit at 50% of credit received
+STOP_LOSS_CREDIT_MULTIPLE = 1.0      # stop out at 100% of credit received, as a loss
+ENTRY_START_TIME = dtime(9, 20)      # let opening-bell volatility settle first
+ENTRY_CUTOFF_TIME = dtime(10, 30)    # don't chase an entry deep into the day
+FORCE_EXIT_TIME = dtime(14, 45)      # square off well before the 3:30pm close
+
+POLL_SECONDS = 45
+
+# Real-money safety gate. Leave SANDBOX_MODE=True while testing - this does
+# NOT touch OpenAlgo's global Analyzer toggle (that's account-wide and would
+# affect other strategies you run), it's a local guard specific to this
+# script. To go live: set SANDBOX_MODE=False here AND switch off Analyzer
+# Mode yourself in the OpenAlgo navbar. Both must agree or nothing is sent.
+SANDBOX_MODE = True
+
+STATE_FILE = os.path.join(os.path.dirname(os.path.abspath(__file__)), ".iron_condor_daily_state.json")
+
+
+def load_state():
+    if os.path.exists(STATE_FILE):
+        with open(STATE_FILE) as f:
+            return json.load(f)
+    return {}
+
+
+def save_state(state):
+    with open(STATE_FILE, "w") as f:
+        json.dump(state, f, indent=2, default=str)
+
+
+def log(msg):
+    print(f"[{datetime.now().strftime('%Y-%m-%d %H:%M:%S')}] {msg}")
+
+
+def today_str():
+    return datetime.now().date().isoformat()
+
+
+def nearest_expiry(underlying):
+    resp = client.expiry(symbol=underlying, exchange="NFO", instrumenttype="options")
+    if resp.get("status") != "success" or not resp.get("data"):
+        raise RuntimeError(f"Could not fetch expiry list for {underlying}: {resp}")
+    return resp["data"][0].replace("-", "")  # e.g. "25-NOV-25" -> "25NOV25"
+
+
+def offset_count(offset):
+    return int("".join(ch for ch in offset if ch.isdigit()) or 0)
+
+
+def resolve_chain_legs(underlying, exchange, expiry_fmt, hedge_offset, short_offset):
+    """Look up exact option symbols + lot size for both offsets, with no order placed."""
+    strike_count = max(offset_count(hedge_offset), offset_count(short_offset))
+    chain = client.optionchain(underlying=underlying, exchange=exchange,
+                                expiry_date=expiry_fmt, strike_count=strike_count)
+    if chain.get("status") != "success":
+        raise RuntimeError(f"optionchain failed for {underlying}: {chain}")
+
+    found = {}
+    lotsize = None
+    for row in chain["chain"]:
+        for side in ("ce", "pe"):
+            leg = row[side]
+            lotsize = lotsize or leg["lotsize"]
+            if leg["label"] == hedge_offset:
+                found[f"hedge_{side}"] = leg["symbol"]
+            if leg["label"] == short_offset:
+                found[f"short_{side}"] = leg["symbol"]
+
+    missing = [k for k in ("hedge_ce", "hedge_pe", "short_ce", "short_pe") if k not in found]
+    if missing:
+        raise RuntimeError(f"Could not resolve legs {missing} for {underlying} {expiry_fmt} "
+                            f"(increase strike_count or check offsets)")
+    return found, lotsize
+
+
+def lots_affordable(legs, lotsize, budget):
+    """Ask the broker's own margin engine what 1 lot of this spread costs, then size to budget."""
+    positions = [
+        {"symbol": legs["hedge_ce"], "exchange": "NFO", "action": "BUY", "product": PRODUCT,
+         "pricetype": "MARKET", "quantity": str(lotsize)},
+        {"symbol": legs["hedge_pe"], "exchange": "NFO", "action": "BUY", "product": PRODUCT,
+         "pricetype": "MARKET", "quantity": str(lotsize)},
+        {"symbol": legs["short_ce"], "exchange": "NFO", "action": "SELL", "product": PRODUCT,
+         "pricetype": "MARKET", "quantity": str(lotsize)},
+        {"symbol": legs["short_pe"], "exchange": "NFO", "action": "SELL", "product": PRODUCT,
+         "pricetype": "MARKET", "quantity": str(lotsize)},
+    ]
+    resp = client.margin(positions=positions)
+    if resp.get("status") != "success":
+        raise RuntimeError(f"margin check failed: {resp}")
+    margin_per_lot = float(resp["data"]["total_margin_required"])
+    if margin_per_lot <= 0:
+        raise RuntimeError(f"margin API returned non-positive margin: {resp}")
+    lots = int(budget // margin_per_lot)
+    return max(0, min(lots, MAX_LOTS_PER_INSTRUMENT)), margin_per_lot
+
+
+def deployable_budget(weight):
+    funds = client.funds()
+    available_cash = float(funds.get("data", {}).get("availablecash", 0))
+    cap = min(TOTAL_CAPITAL * CAPITAL_ALLOCATION_FRACTION, available_cash)
+    return max(0.0, cap * weight)
+
+
+def enter_iron_condor(inst, expiry_fmt):
+    underlying, exchange = inst["underlying"], inst["exchange"]
+    legs, lotsize = resolve_chain_legs(underlying, exchange, expiry_fmt,
+                                        inst["hedge_offset"], inst["short_offset"])
+    budget = deployable_budget(inst["weight"])
+    lots, margin_per_lot = lots_affordable(legs, lotsize, budget)
+
+    if lots < 1:
+        log(f"{underlying}: skipping entry - budget Rs{budget:,.0f} can't cover "
+            f"1 lot (margin/lot Rs{margin_per_lot:,.0f})")
+        return None
+
+    qty = lots * lotsize
+    order_legs = [
+        {"offset": inst["hedge_offset"], "option_type": "CE", "action": "BUY", "quantity": qty},
+        {"offset": inst["hedge_offset"], "option_type": "PE", "action": "BUY", "quantity": qty},
+        {"offset": inst["short_offset"], "option_type": "CE", "action": "SELL", "quantity": qty},
+        {"offset": inst["short_offset"], "option_type": "PE", "action": "SELL", "quantity": qty},
+    ]
+    resp = client.optionsmultiorder(strategy=STRATEGY_NAME, underlying=underlying,
+                                     exchange=exchange, expiry_date=expiry_fmt, legs=order_legs)
+    if resp.get("status") != "success":
+        log(f"{underlying}: ENTRY FAILED: {resp}")
+        return None
+
+    log(f"{underlying}: entered {lots} lot(s) ({qty} qty), margin/lot Rs{margin_per_lot:,.0f}, "
+        f"budget Rs{budget:,.0f} -> {resp['results']}")
+
+    time.sleep(2)  # let the fills land in the position book
+    pb = client.positionbook().get("data", [])
+    by_symbol = {p["symbol"]: p for p in pb}
+
+    stored_legs = []
+    net_credit = 0.0
+    for leg in resp["results"]:
+        sym = leg["symbol"]
+        pos = by_symbol.get(sym)
+        avg_price = float(pos["average_price"]) if pos else 0.0
+        stored_legs.append({"symbol": sym, "exchange": "NFO", "action": leg["action"], "quantity": qty})
+        net_credit += avg_price * qty if leg["action"] == "SELL" else -avg_price * qty
+
+    return {
+        "date": today_str(), "status": "open", "legs": stored_legs,
+        "net_credit": net_credit, "lots": lots, "entered_at": datetime.now().isoformat(),
+    }
+
+
+def current_pnl(legs):
+    pb = client.positionbook().get("data", [])
+    by_symbol = {p["symbol"]: p for p in pb}
+    return sum(float(by_symbol[leg["symbol"]]["pnl"]) for leg in legs if leg["symbol"] in by_symbol)
+
+
+def exit_position(legs, reason):
+    orders = [{
+        "symbol": leg["symbol"], "exchange": leg["exchange"],
+        "action": "SELL" if leg["action"] == "BUY" else "BUY",
+        "quantity": leg["quantity"], "pricetype": "MARKET", "product": PRODUCT,
+    } for leg in legs]
+    resp = client.basketorder(strategy=STRATEGY_NAME, orders=orders)
+    log(f"EXIT ({reason}): {resp}")
+
+
+def run_instrument(inst, state):
+    key = inst["underlying"]
+    rec = state.get(key)
+    if rec and rec.get("date") != today_str():
+        rec = None  # yesterday's record - today starts fresh
+
+    now_t = datetime.now().time()
+
+    if rec is None:
+        if ENTRY_START_TIME <= now_t <= ENTRY_CUTOFF_TIME:
+            expiry_fmt = nearest_expiry(inst["underlying"])
+            new_rec = enter_iron_condor(inst, expiry_fmt)
+            if new_rec:
+                state[key] = new_rec
+                save_state(state)
+        else:
+            log(f"{key}: thinking... no position, outside entry window ({now_t.strftime('%H:%M')}), standing by")
+        return
+
+    if rec["status"] == "closed":
+        log(f"{key}: thinking... already done for today ({rec.get('reason', 'closed')})")
+        return
+
+    # status == "open": evaluate exits
+    pnl = current_pnl(rec["legs"])
+    credit = abs(rec["net_credit"])
+    target_level = credit * PROFIT_TARGET_CREDIT_FRACTION
+    stop_level = -credit * STOP_LOSS_CREDIT_MULTIPLE
+
+    log(f"{key}: thinking... lots={rec['lots']} credit=Rs{rec['net_credit']:.0f} "
+        f"pnl=Rs{pnl:.0f} target=Rs{target_level:.0f} stop=Rs{stop_level:.0f}")
+
+    if pnl >= target_level:
+        exit_position(rec["legs"], f"profit target hit ({pnl:.0f} >= {target_level:.0f})")
+        rec.update(status="closed", reason="profit target")
+    elif pnl <= stop_level:
+        exit_position(rec["legs"], f"stop-loss hit ({pnl:.0f} <= {stop_level:.0f})")
+        rec.update(status="closed", reason="stop-loss")
+    elif now_t >= FORCE_EXIT_TIME:
+        exit_position(rec["legs"], f"time-based exit at {FORCE_EXIT_TIME.strftime('%H:%M')}")
+        rec.update(status="closed", reason="time exit")
+
+    state[key] = rec
+    save_state(state)
+
+
+def main():
+    if not SANDBOX_MODE and os.getenv("LIVE_TRADING_CONFIRMED") != "YES":
+        log("SANDBOX_MODE is False but LIVE_TRADING_CONFIRMED != 'YES'. "
+            "Refusing to run against a live account. Set the env var explicitly to proceed.")
+        raise SystemExit(1)
+
+    mode = "SANDBOX (test with fake money)" if SANDBOX_MODE else "LIVE (real money)"
+    log(f"Starting {STRATEGY_NAME} - mode: {mode} - capital Rs{TOTAL_CAPITAL:,.0f} "
+        f"({CAPITAL_ALLOCATION_FRACTION:.0%} deployable)")
+    state = load_state()
+
+    while True:
+        try:
+            now = datetime.now()
+            if now.weekday() >= 5:
+                log("Weekend - market closed, sleeping")
+            else:
+                for inst in INSTRUMENTS:
+                    run_instrument(inst, state)
+        except Exception as e:
+            log(f"Error in main loop: {e}")
+        time.sleep(POLL_SECONDS)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## What this adds

Two self-contained scripts in `strategies/examples/`, following the existing
`simple_ema_strategy.py` pattern — no changes to core platform code.

### `iron_condor_daily.py`

An intraday iron condor on NIFTY / BANKNIFTY, uploadable via the Python Strategy Host (`/python`).

- Sells OTM4 CE/PE, hedges with OTM6 CE/PE (offsets configurable per instrument)
- **Sizes itself from a live `client.margin()` check** against a configurable `TOTAL_CAPITAL` / `CAPITAL_ALLOCATION_FRACTION`, rather than a hardcoded lot count — so the same file works on any account size, with `MAX_LOTS_PER_INSTRUMENT` as a hard ceiling
- Entry window 9:20–10:30; exits on profit target (50% of credit), stop loss (100% of credit), or forced square-off at 14:45
- One entry per instrument per day, with local state in `.iron_condor_daily_state.json` so a restart can't double-enter
- Uses `place_smart_order` / `quotes` / `optionchain` through the OpenAlgo SDK

**Safety gate:** defaults to `SANDBOX_MODE = True`. Going live requires *two* independent switches — flipping that flag **and** setting `LIVE_TRADING_CONFIRMED=YES` in the environment. The script refuses to start if only one is set.

No credentials are hardcoded. `OPENALGO_API_KEY`, `HOST_SERVER` and `WEBSOCKET_URL` are read from the environment, matching the convention in `simple_ema_strategy.py` and `strategies/README.md`.

### `backtest_iron_condor_daily.py`

An EOD backtest of the *same* configuration against real NSE F&O bhavcopy settlement data, downloaded from `nsearchives.nseindia.com`. Standard library only — no broker connection, no API key, no new dependencies. Results are written to `backtest_results.json`.

It deliberately models only what daily data can support: **enter at open, exit at close**. It does not synthesise intraday stop/target triggers from four independent daily H/L ranges. Days with unreliable prices (credit ≤ 0, credit > width, missing strike) are skipped and counted, never traded.

### `strategies/.gitignore`

Ignores the local run artifacts these two scripts produce (`.bhavcopy_cache/`, `backtest_results.json`, `.iron_condor_daily_state.json`) so they can't be committed as source.

## Results and caveats

Over roughly 60 trading days of bhavcopy data:

- **NIFTY** backtests reasonably — about an 81% win rate on gross open-to-close P&L
- **BANKNIFTY does not.** Since BANKNIFTY moved to monthly-only expiry, this "daily" setup usually holds options 2–4 weeks from expiry rather than near-dated ones. That produced both a net loss and a high rate (~40%) of unreliable / illiquid-strike days.

That caveat is written into the script header. This is offered as a *worked, documented* strategy to learn the Python Strategy Host and the option chain API from — **not** as a validated edge, and explicitly not validated for BANKNIFTY.

The backtest also reports **gross** P&L only; it does not model STT, brokerage, GST or slippage. For a high-win-rate options seller those are a material fraction of the gross number, so the win rate above should be read as an upper bound.

## Testing done

- Backtest run end-to-end against downloaded NSE bhavcopy for both underlyings (numbers above)
- Live script exercised in **sandbox mode only** — entry, profit-target, stop-loss and forced-exit paths all reached. Never run against real money.
- Verified the two-switch live gate blocks startup when either switch is unset
- Both files byte-compile clean; no core platform files touched

## Scope

Per the one-feature-per-PR policy in CONTRIBUTING.md, this PR is limited to the two example scripts and the `.gitignore` entries they need. Happy to adjust naming, defaults, or the docstrings to match house style.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds two self-contained example scripts — an intraday iron condor for NIFTY/BANKNIFTY and an EOD backtest against NSE bhavcopy settlement data — with no core platform changes and run artifacts excluded via `strategies/.gitignore`.

**Strategy script**
- Sells OTM4 CE/PE and hedges with OTM6 CE/PE, entering once per instrument between 9:20–10:30 IST.
- Sizes each position from a live margin check against configurable capital rather than a fixed lot count.
- Exits on a 50%-of-credit profit target, 100%-of-credit stop-loss, or forced square-off at 14:45.
- Defaults to sandbox mode; live trading requires both `SANDBOX_MODE=False` and `LIVE_TRADING_CONFIRMED=YES`, otherwise the script refuses to start.

**Backtest and results**
- Models enter-at-open/exit-at-close only and skips days with unreliable prices rather than trading them.
- Shows about an 81% win rate on NIFTY but a net loss on BANKNIFTY, whose monthly-only expiry leaves far-dated and often illiquid strikes.
- Reports gross P&L only — no STT, brokerage, or slippage — so win rates are an upper bound.
- The live script was tested in sandbox only and never run against real money.

<sup>Written for commit 91047a5065be633dec9d0116cca5b6d41a56a63e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1949?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

