### PR TITLE
Fix Fyers HSM WebSocket authentication timeout

### DIFF
--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -336,6 +336,24 @@ class FyersHSMWebSocket:
 
         return buffer_msg
 
+    @staticmethod
+    def _auth_response_ok(data: bytearray) -> bool:
+        """Return True if a request-type-1 frame reports authentication accepted.
+
+        Layout after the 2-byte length, 1-byte request type and 1-byte field
+        count: ``[field id][u16 field length][value]``. The first field carries
+        the status string, which is ``"K"`` when the hsm_key was accepted. A
+        frame too short to hold the field is treated as a failure rather than
+        silently passing.
+        """
+        try:
+            if len(data) < 8:
+                return False
+            field_length = struct.unpack("!H", data[5:7])[0]
+            return data[7 : 7 + field_length].decode("utf-8", errors="replace") == "K"
+        except (struct.error, IndexError):
+            return False
+
     def _parse_binary_message(self, data: bytearray):
         """
         Parse incoming binary message from HSM WebSocket
@@ -351,7 +369,23 @@ class FyersHSMWebSocket:
             msg_type = data[2]
 
             if msg_type == 1:
-                # Authentication response
+                # Authentication response. The verdict is a status field, not the
+                # mere arrival of the frame: byte 4 is the field ID, bytes 5-6 the
+                # field length, and the value is "K" for accepted. Treating any
+                # type-1 frame as success would report a rejected token as a
+                # healthy connection that then never delivers a tick.
+                if not self._auth_response_ok(data):
+                    self.authenticated = False
+                    self.logger.error(
+                        "HSM authentication rejected by Fyers - the access token's "
+                        "hsm_key was not accepted (re-authenticate the broker)"
+                    )
+                    if self.on_error_callback:
+                        self.on_error_callback(
+                            ConnectionError("Fyers HSM authentication failed - invalid token")
+                        )
+                    return
+
                 self.authenticated = True
                 self.logger.info("HSM authentication successful")
 
@@ -896,7 +930,21 @@ class FyersHSMWebSocket:
                     on_close=self._on_ws_close,
                     on_ping=self._on_ws_ping,
                     on_pong=self._on_ws_pong,
-                    header={"Authorization": self.access_token, "User-Agent": f"{self.source}/1.0"},
+                    # NO Authorization header. The HSM feed authenticates purely
+                    # in-band, via the binary request-type-1 frame carrying the
+                    # JWT's hsm_key (see _create_auth_message). Fyers' gateway now
+                    # *silently drops* any handshake that carries an Authorization
+                    # header: the WebSocket upgrade still succeeds, but the auth
+                    # frame is never answered and the socket sits mute until our
+                    # 15s timeout. Verified against the live endpoint — a bare
+                    # JWT, an "<appId>:<token>" pair, and even "Authorization: x"
+                    # all produce silence, while no header (or any other header,
+                    # e.g. User-Agent) returns the type-1 auth response. The
+                    # official fyers-apiv3 SDK's data_ws.py likewise passes no
+                    # headers here. The <appId>:<token> Authorization header is
+                    # still required by the *order* socket (wss://socket.fyers.in/
+                    # trade/v3) and the *TBT* socket — this applies to HSM only.
+                    header={"User-Agent": f"{self.source}/1.0"},
                 )
 
                 # Run until disconnection. Enable protocol ping/pong keepalive so

--- a/broker/fyers/streaming/fyers_order_adapter.py
+++ b/broker/fyers/streaming/fyers_order_adapter.py
@@ -7,7 +7,19 @@ Endpoint: wss://socket.fyers.in/trade/v3
 Auth header format: "<appId>:<accessToken>" — same convention already used
 for Fyers REST calls (see broker/fyers/api/order_api.py's
 Authorization: f"{api_key}:{AUTH_TOKEN}" header).
-Subscribe handshake (post-connect): {"T": "SUB_ORD", "SUB_T": 1, "action_data": ["orders"]}.
+Subscribe handshake (post-connect): {"T": "SUB_ORD", "SLIST": ["orders"], "SUB_T": 1}.
+Note "SLIST" is the wire key — the docs' prose calls the value "action_data",
+but that is only the variable name in their Python sample. Fyers acks *any*
+payload with {"code":1605,"message":"Successfully subscribed"}, including one
+with the wrong key, so the ack cannot be used to confirm the handshake.
+
+Order updates arrive wrapped in the action key, not flat:
+{"orders": {...}, "s": "ok"} — see "Response from socket on any action
+triggered" (~line 6076). The wrapped record uses the *raw* field names
+(org_ord_status, tran_side, ord_type, qty_filled, price_limit, ...), not the
+camelCase names the official SDK exposes after applying its "order_mapper"
+(~line 6108). We accept both, since only the SDK's parsed shape is documented
+in the response-attribute tables.
 
 The order-update payload shares its flat field shape with Fyers' Postback
 payload (numeric status/type/side/segment/exchange codes) — see
@@ -58,6 +70,58 @@ _EXCHANGE_SEGMENT_MAP = {
 }
 
 
+# Envelope keys an order record may arrive under. "orders" is what Fyers
+# actually sends; "d"/"data" are defensive against alternate framing.
+_ENVELOPE_KEYS = ("orders", "d", "data")
+
+# A record must carry an order id and a status under one of their names to be
+# an order update rather than a subscribe ack or heartbeat.
+_ID_KEYS = ("id",)
+# "org_ord_status" carries the documented 1-7 codes and is what the SDK maps to
+# "status". "ord_status" is a separate, differently-coded field present in the
+# same raw frame (the docs' sample shows 20); it is accepted last so a frame
+# that somehow lacks the others is still surfaced rather than silently dropped.
+_STATUS_KEYS = ("org_ord_status", "status", "ord_status")
+
+
+def _pick(data: dict, *names: str):
+    """Return the first present, non-None value among ``names``.
+
+    The raw socket payload and the official SDK's post-mapping payload use
+    different names for the same field (``tran_side`` vs ``side``), and only
+    the latter is described in the docs' response-attribute tables. Callers
+    pass the raw name first, then the parsed one.
+    """
+    for name in names:
+        value = data.get(name)
+        if value is not None:
+            return value
+    return None
+
+
+def _unwrap_order_record(message: dict) -> dict | None:
+    """Extract the order record from a socket frame, or None if it isn't one.
+
+    Fyers wraps updates in the action key — ``{"orders": {...}, "s": "ok"}`` —
+    rather than sending them flat. Subscribe acks
+    (``{"code": 1605, ...}``) and heartbeats carry no order record and are
+    filtered out here.
+    """
+    if not isinstance(message, dict):
+        return None
+
+    candidates = [message.get(key) for key in _ENVELOPE_KEYS]
+    candidates.append(message)  # flat framing, as a fallback
+    for candidate in candidates:
+        if not isinstance(candidate, dict):
+            continue
+        has_id = any(candidate.get(k) is not None for k in _ID_KEYS)
+        has_status = any(candidate.get(k) is not None for k in _STATUS_KEYS)
+        if has_id and has_status:
+            return candidate
+    return None
+
+
 def _oa_exchange(data: dict) -> str:
     mapped = _EXCHANGE_SEGMENT_MAP.get((data.get("exchange"), data.get("segment")))
     if mapped:
@@ -81,7 +145,7 @@ class FyersOrderUpdateAdapter(BaseOrderUpdateAdapter):
         return {"Authorization": f"{self.app_id}:{self.access_token}"}
 
     def on_open_extra(self, ws) -> None:
-        sub_msg = {"T": "SUB_ORD", "SUB_T": 1, "action_data": ["orders"]}
+        sub_msg = {"T": "SUB_ORD", "SLIST": ["orders"], "SUB_T": 1}
         ws.send(json.dumps(sub_msg))
         self.logger.info(f"Sent Fyers order-update subscribe for {self.app_id}")
 
@@ -91,41 +155,49 @@ class FyersOrderUpdateAdapter(BaseOrderUpdateAdapter):
         except (json.JSONDecodeError, TypeError):
             return None
 
-        # The order record may arrive flat at the top level or nested under
-        # a "d"/"data" envelope key, depending on socket framing — accept both.
-        data = message
-        if "id" not in data or "status" not in data:
-            data = message.get("d") or message.get("data") or {}
-        if "id" not in data or "status" not in data:
+        data = _unwrap_order_record(message)
+        if not data:
             return None  # not an order record (ack/heartbeat/other frame)
 
-        raw_status = data.get("status")
+        raw_status = _pick(data, *_STATUS_KEYS)
         order_status = _STATUS_MAP.get(raw_status, str(raw_status))
+        if raw_status not in _STATUS_MAP:
+            # Passed through verbatim rather than dropped. Log the field names so
+            # an unexpected wire shape is diagnosable from the logs alone.
+            self.logger.warning(
+                f"Fyers order update with unmapped status {raw_status!r}; "
+                f"record keys: {sorted(data)}"
+            )
 
-        qty = int(data.get("qty") or 0)
-        filled_qty = int(data.get("filledQty") or 0)
+        qty = int(_pick(data, "qty") or 0)
+        filled_qty = int(_pick(data, "qty_filled", "filledQty") or 0)
 
         # OpenAlgo exchange from (exchange, segment) codes; symbol via
         # get_oa_symbol on Fyers' "NSE:SBIN-EQ"-style brsymbol — the same
         # lookup the REST orderbook mapping uses.
         exchange = _oa_exchange(data)
-        symbol = to_openalgo_symbol(data.get("symbol", ""), exchange)
+        symbol = to_openalgo_symbol(_pick(data, "symbol") or "", exchange)
+
+        side = _pick(data, "tran_side", "side")
+        pricetype = _pick(data, "ord_type", "type")
 
         return {
-            "orderid": str(data.get("id", "")),
+            "orderid": str(_pick(data, "id") or ""),
             "symbol": symbol,
             "exchange": exchange,
-            "action": _ACTION_MAP.get(data.get("side"), str(data.get("side", ""))),
+            "action": _ACTION_MAP.get(side, str(side or "")),
             "quantity": qty,
-            "price": float(data.get("limitPrice") or 0),
-            "trigger_price": float(data.get("stopPrice") or 0),
-            "pricetype": _PRICETYPE_MAP.get(data.get("type"), str(data.get("type", ""))),
-            "product": data.get("productType", ""),
+            "price": float(_pick(data, "price_limit", "limitPrice") or 0),
+            "trigger_price": float(_pick(data, "price_stop", "stopPrice") or 0),
+            "pricetype": _PRICETYPE_MAP.get(pricetype, str(pricetype or "")),
+            "product": _pick(data, "product_type", "productType") or "",
             "order_status": order_status,
             "filled_quantity": filled_qty,
             "pending_quantity": max(qty - filled_qty, 0),
-            "average_price": float(data.get("tradedPrice") or 0),
-            "rejection_reason": data.get("message", "") if raw_status == 5 else "",
+            "average_price": float(_pick(data, "price_traded", "tradedPrice") or 0),
+            "rejection_reason": (
+                _pick(data, "oms_msg", "message", "status_msg") or "" if raw_status == 5 else ""
+            ),
         }
 
 


### PR DESCRIPTION
The market-data feed stopped authenticating: the socket connected, the binary auth frame was sent, and nothing came back until the 15s timeout fired with "Failed to authenticate with Fyers HSM WebSocket (timeout)".

Cause: Fyers' gateway now silently drops any HSM handshake that carries an Authorization header. The WebSocket upgrade still succeeds and on_open fires normally, but the auth frame is never answered - no error frame, no close frame, no close code - so the failure reads like a bad token.

The HSM feed authenticates purely in-band, via the request-type-1 frame carrying the JWT's hsm_key, and needs no handshake header at all. Verified against the live endpoint: a bare JWT, an "<appId>:<token>" pair and even "Authorization: x" all produce silence, while no header - or any other header, including User-Agent and an arbitrary X-Custom - returns the type-1 response. The header's value is irrelevant; its presence alone is disqualifying. The official fyers-apiv3 SDK passes no headers here either.

The endpoint and frame layout are unchanged: wss://socket.fyers.in/hsm/v1-5/prod is still the only live version (v1-4 and v1-6..v2-0 all 404), and the auth frame is byte-for-byte identical between fyers-apiv3 3.1.7 and 3.1.16.

Also verify the auth verdict properly. A type-1 frame only means "this is an auth response"; the outcome is the status string at offset 7, which is "K" when accepted. Treating any type-1 frame as success would report a rejected token as a healthy connection that never delivers a tick.

Note the <appId>:<token> Authorization header is still required by the order socket and the TBT socket - this applies to the HSM socket only.

Verified live end-to-end: connect() returns True and LTP callbacks stream for NSE equities.


Claude-Session: https://claude.ai/code/session_01Unb3RUV3GQhTHHH9ncamJR

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes both Fyers WebSocket feeds: HSM market-data authentication no longer times out, and order updates are no longer silently discarded.

**HSM market-data socket**
- Drops the `Authorization` header from the HSM handshake; Fyers silently drops any handshake that carries it.
- The `Authorization` header is still required for the order and TBT sockets.
- Rejects auth unless the type-1 response status is `"K"`, so a rejected token surfaces as an error instead of a healthy-looking connection.

**Order socket**
- Unwraps order updates from the `"orders"` envelope and accepts both raw wire names and SDK-mapped camelCase names.
- Fixes the subscribe key (`"SLIST"` instead of `"action_data"`); Fyers acks any subscribe payload, so the ack cannot confirm the handshake.
- Logs unmapped order statuses with the record's field names instead of dropping them.

<sup>Written for commit 7b58b60b2a73c40930452de5bfb12e78dce2c129. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1950?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

