### PR TITLE
fix(fyers): remove Authorization header from HSM WebSocket connection

### DIFF
--- a/broker/fyers/streaming/fyers_hsm_websocket.py
+++ b/broker/fyers/streaming/fyers_hsm_websocket.py
@@ -896,7 +896,7 @@ class FyersHSMWebSocket:
                     on_close=self._on_ws_close,
                     on_ping=self._on_ws_ping,
                     on_pong=self._on_ws_pong,
-                    header={"Authorization": self.access_token, "User-Agent": f"{self.source}/1.0"},
+                    header={"User-Agent": f"{self.source}/1.0"},
                 )
 
                 # Run until disconnection. Enable protocol ping/pong keepalive so


### PR DESCRIPTION


<!-- This is an auto-generated description by cubic. -->
## Summary by cubic
Removes the `Authorization` header from the Fyers HSM WebSocket connection. The header previously sent the access token on every request; now only the `User-Agent` header is sent, so the token is no longer transmitted during the WebSocket handshake.

<sup>Written for commit a0c5bf1f127c2ce3cb7362e5ed4cd3d8c49fe931. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1951?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

