### PR TITLE
fix(shoonya): raise on session errors in get_history instead of empty success

### DIFF
--- a/broker/shoonya/api/data.py
+++ b/broker/shoonya/api/data.py
@@ -88,6 +88,45 @@ def _quote_attempts() -> int:
 QUOTE_ATTEMPTS = _quote_attempts()
 
 
+# Shoonya reports every failure the same way - {"stat":"Not_Ok","emsg":"..."} -
+# so the emsg text is the only thing separating "your login is dead" from "this
+# scrip had no trades in that window". Matching is substring/lowercase because
+# the wording carries varying prefixes ("Session Expired : Invalid Session Key").
+SESSION_ERROR_MARKERS = (
+    "session expired",
+    "invalid session",
+    "session key",
+    "not logged in",
+    "invalid input : uid",
+)
+
+NO_DATA_MARKERS = (
+    "no data",
+    "no data available",
+)
+
+
+def is_session_error(emsg) -> bool:
+    """True when the broker's error message means the login is no longer valid.
+
+    Session death is fatal for every subsequent request, so callers raise on it
+    rather than treating it as a transient per-request hiccup.
+    """
+    text = str(emsg or "").lower()
+    return any(marker in text for marker in SESSION_ERROR_MARKERS)
+
+
+def is_no_data_error(emsg) -> bool:
+    """True when the broker is saying the window is legitimately empty.
+
+    Not a failure: illiquid contracts, ranges before a scrip was listed and
+    holiday-only windows all answer this way, and an empty frame is the correct
+    result for them.
+    """
+    text = str(emsg or "").lower()
+    return any(marker in text for marker in NO_DATA_MARKERS)
+
+
 def quote_matches_request(response: dict, exch: str, token: str) -> bool:
     """Check that a GetQuotes reply describes the instrument that was asked for.
 
@@ -830,8 +869,11 @@ class BrokerData:
 
             response_candles = []
             chunk_start = start_ts
+            attempted_chunks = 0
+            failed_chunks = 0
             while chunk_start <= end_ts:
                 chunk_end = min(chunk_start + chunk_seconds, end_ts)
+                attempted_chunks += 1
                 if interval == "D":
                     payload = {
                         "sym": f"{exchange}:{eod_symbol}",
@@ -856,6 +898,7 @@ class BrokerData:
                     logger.error(
                         f"{endpoint} chunk request failed ({chunk_start}-{chunk_end}): {e}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
@@ -865,10 +908,28 @@ class BrokerData:
                 # and crashed trying to json.loads("stat")).
                 if isinstance(chunk_response, dict):
                     emsg = chunk_response.get("emsg") or chunk_response.get("message") or "unknown"
+                    # A dead session fails every chunk identically, so tolerating
+                    # it per chunk drains the loop to zero candles and the API
+                    # layer reports {"status":"success","data":[]} - a fake gap
+                    # indistinguishable from a quiet window (#1944). Raise on it
+                    # the way get_quotes() does.
+                    if is_session_error(emsg):
+                        raise Exception(f"Error from Shoonya API: {emsg}")
+                    # "no data" is Shoonya answering, not failing: illiquid
+                    # contracts, pre-listing ranges and holiday-only windows all
+                    # come back this way. Count it as an empty success so the
+                    # all-chunks-failed guard below does not turn it into a 500.
+                    if is_no_data_error(emsg):
+                        logger.debug(
+                            f"{endpoint} reported no data for chunk {chunk_start}-{chunk_end}"
+                        )
+                        chunk_start = chunk_end + 1
+                        continue
                     logger.warning(
                         f"{endpoint} returned error for chunk {chunk_start}-{chunk_end}: "
                         f"stat={chunk_response.get('stat')} emsg={emsg}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
@@ -877,11 +938,22 @@ class BrokerData:
                         f"Unexpected {endpoint} response type {type(chunk_response).__name__}: "
                         f"{str(chunk_response)[:200]}"
                     )
+                    failed_chunks += 1
                     chunk_start = chunk_end + 1
                     continue
 
                 response_candles.extend(chunk_response)
                 chunk_start = chunk_end + 1
+
+            # A single bad chunk inside a long range stays tolerated - the rest
+            # of the series is still worth returning. Every chunk failing is a
+            # different animal: there is no series at all, so surface it as an
+            # error instead of an empty success (#1944).
+            if attempted_chunks and failed_chunks == attempted_chunks:
+                raise Exception(
+                    f"All {attempted_chunks} {endpoint} chunk request(s) failed for "
+                    f"{symbol}/{oa_exchange} between {start_date_str} and {end_date_str}"
+                )
 
             if interval == "D" and not response_candles:
                 # An unknown index name resolves to an empty list rather than


### PR DESCRIPTION
A dead Shoonya session fails every history chunk identically. The chunk loop logged each one and continued, so the loop drained to zero candles and the service layer wrapped that empty frame as {"status":"success","data":[]} with HTTP 200 - a fake gap indistinguishable from a quiet window. get_quotes() already raises on stat != Ok, so /quotes and /history disagreed about the same dead login, and downstream collectors recorded phantom holes in the series.

Raise on a session-level emsg the way get_quotes() does, and raise when every chunk fails rather than returning empty. A single bad chunk inside a long range stays tolerated - the rest of the series is still worth returning.

"no data" is exempted from the all-failed rule. Shoonya answers illiquid contracts, pre-listing ranges and holiday-only windows that way, and an empty frame is the correct result for them; counting those as failures would turn legitimate empty windows into 500s. Mirrors broker/tradesmart/api/data.py.

Verified against a mocked chart API: session error raises on the first chunk and aborts mid-range at chunk 2 of 18 rather than walking all of them; all chunks failing raises; "no data" everywhere returns an empty frame without raising; 1 bad chunk of 18 still returns the other 17; the happy path is unchanged. Ruff reports no new findings and the file is already formatted.

Closes #1944


Claude-Session: https://claude.ai/code/session_018iZxqACNeUztrfeaL5sdBc

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Shoonya `get_history` returning fake empty successes for dead sessions, so dead logins and quiet windows are no longer indistinguishable.

- A session-level error now raises immediately, matching `get_quotes`.
- When every chunk fails, the request raises instead of returning an empty frame.
- A single bad chunk still keeps the remaining data; `"no data"` responses still return empty frames as the correct result for illiquid or pre-listing ranges.
- Closes #1944.

<sup>Written for commit 6f6d789cb4010b6b5a02158fbafd5ba596ddc852. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1952?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

