### PR TITLE
fix(kotak): report availablecash as cash only (CollateralValue)

### DIFF
--- a/broker/kotak/api/funds.py
+++ b/broker/kotak/api/funds.py
@@ -69,16 +69,26 @@ def get_margin_data(auth_token):
             logger.error(f"Kotak Limits API error: {error_msg}")
             return {}
 
-        # Process and return the margin data
-        # Note: Based on the API docs, the response fields are at root level
-        # Available Balance = CollateralValue + RmsPayInAmt - RmsPayOutAmt + Collateral
-        collateral_value = float(margin_data.get("CollateralValue", 0))
-        pay_in = float(margin_data.get("RmsPayInAmt", 0))
-        pay_out = float(margin_data.get("RmsPayOutAmt", 0))
+        # Process and return the margin data.
+        #
+        # "availablecash" is cash only. Collateral is reported as its own field,
+        # so folding it into availablecash double-counts (issue #1582 -- same bug
+        # class fixed for other brokers there, never touched here).
+        #
+        # Kotak's cash-balance field in /quick/user/limits is "CollateralValue"
+        # -- misleadingly named: it does NOT track pledged collateral. Verified on
+        # a real account before and after pledging two holdings: CollateralValue
+        # stayed on cash (179542.8 both times), "Collateral" carried the
+        # pledged-shares margin (0 -> 222565.5), and "Net" == CollateralValue +
+        # Collateral - MarginUsed (179542.8 + 222565.5 - 0.2 = 402108.1, matching
+        # the Kotak app's "Available margin"). "RmsPayInAmt - RmsPayOutAmt" is
+        # only the current day's fund pay-in/pay-out delta -- 0 unless the account
+        # was funded that same day -- so it is not a cash source either.
+        cash = float(margin_data.get("CollateralValue", 0))
         collateral = float(margin_data.get("Collateral", 0))
 
         processed_margin_data = {
-            "availablecash": f"{collateral_value + pay_in - pay_out + collateral:.2f}",
+            "availablecash": f"{cash:.2f}",
             "collateral": f"{collateral:.2f}",
             "m2munrealized": f"{float(margin_data.get('UnrealizedMtomPrsnt', 0)):.2f}",
             "m2mrealized": f"{float(margin_data.get('RealizedMtomPrsnt', 0)):.2f}",


### PR DESCRIPTION
## Problem

`broker/kotak/api/funds.py` computes:

```python
"availablecash": f"{collateral_value + pay_in - pay_out + collateral:.2f}",
"collateral":    f"{collateral:.2f}",
```

`CollateralValue + RmsPayInAmt - RmsPayOutAmt + Collateral` equals Kotak's `Net`
(cash + collateral). Since `collateral` is also returned as its own field, any
consumer doing `availablecash + collateral` (Telegram `/funds`, the dashboard
Total) double-counts collateral. Same bug class as #1582, which fixed
Zerodha/Upstox/Fyers/Dhan but explicitly never touched Kotak (reported there by
@sbt987).

## Field mapping (verified on a real account)

Kotak's field names are counterintuitive. Comparing the raw `/quick/user/limits`
response to the Kotak Neo app's Funds screen, on the same account, before and
after pledging two holdings:

| Kotak app | Value | Raw field | Pre-pledge | Post-pledge |
|---|---|---|---|---|
| Cash balance | 1,79,543 | `CollateralValue` | 179542.8 | 179542.8 |
| Margin from shares | 2,22,566 | `Collateral` | 0 | 222565.5 |
| Available margin | 4,02,108 | `Net` | 179542.8 | 402108.1 |
| Used margin | 0 | `MarginUsed` | 0 | 0.2 |

- `CollateralValue` tracks **cash** (unchanged by pledging).
- `Collateral` is the **pledged-shares margin**.
- `Net = CollateralValue + Collateral - MarginUsed` exactly.

`RmsPayInAmt - RmsPayOutAmt` is only the current day's fund pay-in/pay-out delta
- `0` for any account not funded that same day - so it is not a cash source.

## Fix

```python
"availablecash": f"{cash:.2f}",         # cash = CollateralValue
"collateral":    f"{collateral:.2f}",   # unchanged
```

Result: `availablecash = 1,79,543`, `collateral = 2,22,566`,
`availablecash + collateral = Net = 4,02,108` - matching the Kotak app's own
Cash + Margin-from-shares breakdown.

Refs #1582


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotak's `availablecash` so it reports cash only, eliminating double-counting for consumers who add `availablecash + collateral` (Telegram `/funds`, dashboard total). Old behavior returned `CollateralValue + RmsPayInAmt - RmsPayOutAmt + Collateral`; new behavior returns `CollateralValue` alone, with `collateral` unchanged.

**Bug Fixes**
- `RmsPayInAmt - RmsPayOutAmt` is only the same-day fund delta, zero unless the account was funded that day, so it is not a cash source.
- Verified against the Kotak app: `CollateralValue` tracks cash, `Collateral` tracks pledged-shares margin, and `Net = CollateralValue + Collateral - MarginUsed`.

<sup>Written for commit af6bbbfd4306fd73f1301518f014a58d4f1ae1fc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1955?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

