### PR TITLE
fix(kotak): get_multiquotes batch size 50 -> 25 (Neo quotes endpoint rejects 50)

### DIFF
--- a/broker/kotak/api/data.py
+++ b/broker/kotak/api/data.py
@@ -393,7 +393,11 @@ class BrokerData:
                   [{'symbol': 'SBIN', 'exchange': 'NSE', 'data': {...}}, ...]
         """
         try:
-            BATCH_SIZE = 50  # Conservative limit for URL length (GET request)
+            # Kotak Neo's /quotes/neosymbol endpoint rejects a batch of 50 with
+            # HTTP 400 "Please set the Neo symbol max value to 50." -- confirmed
+            # live with a batch of exactly 50 bse_fo symbols. The real cap is
+            # below 50, so batch well under it.
+            BATCH_SIZE = 25
             RATE_LIMIT_DELAY = 0.2  # 5 requests/sec = 250 symbols/sec (under 500 limit)
 
             # If symbols exceed batch size, process in batches


### PR DESCRIPTION
## Problem

`KotakData.get_multiquotes()` batches at `BATCH_SIZE = 50` (chosen for URL
length, per the comment). Kotak Neo's
`/script-details/1.0/quotes/neosymbol/<symbols>/all` endpoint rejects a batch of
exactly 50 with:

```
HTTP 400
{"fault":{"code":"400","description":"Please set the Neo symbol max value to 50.","message":"Please set the Neo symbol max value to 50."}}
```

Reproduced live with a URL carrying exactly 50 `bse_fo|<token>` entries. The
"max value to 50" message fires *at* 50, so the effective cap is below 50.

Consequence: any `get_multiquotes` call wider than 50 symbols raises
`Exception: Error fetching multiquotes` and the caller's read fails. A full
index option chain (SENSEX especially) is always wider than 50 strike/type
entries, so the chain fetch breaks whenever it's routed through
`get_multiquotes`.

## Fix

`BATCH_SIZE = 25` — well under the cap. A ~340-entry chain becomes 14 requests
(~2.8s with the existing 0.2s inter-batch delay) instead of 7; acceptable for
a once-per-entry read, and robust rather than guessing an exact 40-something
limit.

For reference, `broker/zerodha/api/data.py` uses `BATCH_SIZE = 500` (Kite's
documented `/quote` limit) — the Neo endpoint is just far more constrained.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Lowers Kotak multiquotes batch size from 50 to 25 to avoid HTTP 400 errors from the Neo `/quotes/neosymbol` endpoint when requesting exactly 50 symbols.

- Calls wider than 50 symbols previously failed; they now succeed with more but smaller requests.
- A ~340-symbol chain now takes 14 requests instead of 7, adding ~1.4s at the existing 0.2s inter-batch delay.

<sup>Written for commit 595075300f1b2314b9fd71052c20f4c40dc6475b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1959?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

