### PR TITLE
fix(upstox): send price/trigger_price only where the order type allows

### DIFF
--- a/broker/upstox/api/order_api.py
+++ b/broker/upstox/api/order_api.py
@@ -173,6 +173,38 @@ def get_open_position(tradingsymbol, exchange, product, auth):
         return "0"
 
 
+class _ErrorResponse:
+    """Minimal stand-in so callers can rely on the .status contract."""
+
+    def __init__(self, status):
+        self.status = status
+        self.status_code = status
+
+
+def _extract_error(response):
+    """Flatten an Upstox error body into OpenAlgo's {status, message} shape.
+
+    Upstox returns errors as {"status": "error", "errors": [{"errorCode": ..,
+    "message": ..}]} with no top-level message, which the service layer expects.
+    """
+    try:
+        body = response.json()
+    except Exception:
+        return {"status": "error", "message": response.text or "Failed to place order."}
+
+    errors = body.get("errors") or []
+    if errors:
+        parts = []
+        for err in errors:
+            code = err.get("errorCode") or err.get("error_code")
+            msg = err.get("message", "Unknown error")
+            parts.append(f"{code}: {msg}" if code else msg)
+        body["message"] = " | ".join(parts)
+    elif "message" not in body:
+        body["message"] = "Failed to place order."
+    return body
+
+
 def place_order_api(data, auth):
     """
     Places an order using the Upstox API.
@@ -236,11 +268,13 @@ def place_order_api(data, auth):
             return response, response_data, None
 
     except httpx.HTTPStatusError as e:
-        logger.exception(f"HTTP error placing order: {e.response.text}")
-        return e.response, e.response.json(), None
+        logger.error(f"HTTP error placing order: {e.response.text}")
+        # Preserve the .status contract expected by place_order_service.py
+        e.response.status = e.response.status_code
+        return e.response, _extract_error(e.response), None
     except Exception as e:
         logger.exception("Unexpected error in place_order_api")
-        return None, {"status": "error", "message": str(e)}, None
+        return _ErrorResponse(500), {"status": "error", "message": str(e)}, None
 
 
 def place_smartorder_api(data, auth):

--- a/broker/upstox/mapping/transform_data.py
+++ b/broker/upstox/mapping/transform_data.py
@@ -10,24 +10,28 @@ def transform_data(data, token):
     """
     Transforms the new API request structure to the current expected structure.
     """
+    order_type = map_order_type(data["pricetype"])
+
+    # Upstox rejects a non-zero price on MARKET/SL-M (UDAPI1040 "Price not
+    # required") and a non-zero trigger_price on MARKET/LIMIT, so zero out the
+    # field that does not apply to the order type instead of passing it through.
+    price = data.get("price", "0") if order_type in ("LIMIT", "SL") else "0"
+    trigger_price = data.get("trigger_price", "0") if order_type in ("SL", "SL-M") else "0"
+
     # Basic mapping
     transformed = {
         "quantity": data["quantity"],
         "product": map_product_type(data["product"]),
         "validity": "DAY",
-        "price": data.get("price", "0"),
-        "tag": "string",
+        "price": price,
+        "tag": "openalgo",
         "instrument_token": token,
-        "order_type": map_order_type(data["pricetype"]),
+        "order_type": order_type,
         "transaction_type": data["action"].upper(),
         "disclosed_quantity": data.get("disclosed_quantity", "0"),
-        "trigger_price": data.get("trigger_price", "0"),
+        "trigger_price": trigger_price,
         "is_amo": "false",  # Assuming false as default; you might need logic to handle this if it can vary
     }
-
-    # Extended mapping for fields that might need conditional logic or additional processing
-    transformed["disclosed_quantity"] = data.get("disclosed_quantity", "0")
-    transformed["trigger_price"] = data.get("trigger_price", "0")
 
     return transformed
 


### PR DESCRIPTION
Upstox rejects a MARKET order carrying a non-zero price with UDAPI1040 "Price not required", so market orders placed with a price failed at the exchange. Zero out price for MARKET/SL-M and trigger_price for MARKET/LIMIT rather than passing the request values through unchanged.

The failure surfaced as a generic 500 "An unexpected error occurred in the API endpoint" because place_order_api returned a bare httpx response from its HTTPStatusError branch, while place_order_service reads res.status outside its try block -> AttributeError. Preserve .status on both error paths and flatten the Upstox errors[] body into the {status, message} shape the service layer expects, so the broker message reaches the caller.

Also drop the placeholder "string" order tag in favour of "openalgo".


Claude-Session: https://claude.ai/code/session_01EjvHqWXis2u278RgwkaPzG

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Upstox order placement by zeroing `price` and `trigger_price` values that the order type doesn't accept, so orders no longer fail at the exchange with UDAPI1040. Also fixes the error path so callers get the real Upstox error instead of a generic 500.

- Zeroes `price` for MARKET/SL-M orders and `trigger_price` for MARKET/LIMIT orders.
- Preserves `.status` on Upstox error responses and flattens the `errors[]` body into `{status, message}`.
- Switches the order tag from placeholder `"string"` to `"openalgo"`.

<sup>Written for commit 28515ed652987a6b896b2e170d2298e81bbe957f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1966?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

