### PR TITLE
fix(kotak): report realized pnl for fully-closed positions

### DIFF
--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -249,6 +249,7 @@ def transform_positions_data(positions_data):
         }
         buy_qty = float(position.get("flBuyQty", 0))
         sell_qty = float(position.get("flSellQty", 0))
+        cf_buy_qty = float(position.get("cfBuyQty", 0))
 
         if transformed_position["quantity"] > 0 and buy_qty > 0:
             transformed_position["average_price"] = round(
@@ -260,6 +261,18 @@ def transform_positions_data(positions_data):
             )
         elif transformed_position["quantity"] != 0:
             transformed_position["average_price"] = 0.0
+        elif buy_qty + cf_buy_qty > 0:
+            # Fully closed (net quantity 0, but there was a real round trip
+            # today or carried forward) - Kotak never returns a pnl field
+            # for positions at all (transform_holdings_data two functions
+            # below does; this function didn't). Kotak's own Positions.md
+            # ("Profit N Loss" formula) reduces to sellAmt - buyAmt once Net
+            # Qty is 0; cfBuyAmt/cfSellAmt are included so a leg carried
+            # forward and closed today still gets its full realized P&L,
+            # not just today's fresh-leg portion. See openalgo issue #1970.
+            total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
+            total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
+            transformed_position["pnl"] = round(total_sell_amt - total_buy_amt, 2)
 
         transformed_data.append(transformed_position)
 


### PR DESCRIPTION
Fixes #1970

## Problem

`transform_positions_data()` never emits a `pnl` key for positions at all (`transform_holdings_data()`, two functions below in the same file, already does this for holdings — this function just never got the same treatment). For a fully-closed leg it also falls through every `average_price` branch, landing on Kotak's raw `avgnetprice` (0.0 once flat) — which per Kotak's own docs is the *correct* documented value for that case, so only the missing `pnl` is a bug.

## Fix

Kotak's own SDK docs ([`Kotak-Neo/kotak-neo-api-v2` `docs/Positions.md`](https://github.com/Kotak-Neo/Kotak-neo-api-v2/blob/main/docs/Positions.md), "Profit N Loss" section) document:

```
PnL = (Total Sell Amt - Total Buy Amt) + Net Qty * LTP * multiplier * (genNum/genDen) * (prcNum/prcDen)
Total Buy Amt = cfBuyAmt + buyAmt, Total Sell Amt = cfSellAmt + sellAmt
```

For a fully-closed leg (Net Qty = 0) this reduces to `sellAmt - buyAmt`, generalized with `cfBuyAmt`/`cfSellAmt` so a position carried forward and closed today still gets its full realized P&L, not just today's fresh-leg slice. Added as a fourth branch — only reachable when `quantity == 0`, since the existing three branches already exhaust every non-zero case:

```python
elif buy_qty + cf_buy_qty > 0:
    total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
    total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
    transformed_position["pnl"] = round(total_sell_amt - total_buy_amt, 2)
```

## Scope

Deliberately scoped to the closed-position case only — open positions are left for callers to derive from LTP themselves (OpenAlgo consumers like AlgoMirror already do this). Two earlier PRs (#1220, #1224) attempting a broader Kotak P&L fix in `api/funds.py` were closed unmerged after a maintainer flagged unhandled carry-forward math and per-position LTP-call performance concerns. This fix avoids both: zero new network calls, and carry-forward is handled via the same `cfBuyAmt`/`cfSellAmt` fields Kotak's own docs specify, not a reconstruction.

## Verification

Verified against a live account's real closed SENSEX option legs (2026-09-02):

| Leg | Before (this PR) | After |
|---|---|---|
| 76900 CE | no `pnl` key | **+169.00** |
| 76300 CE | no `pnl` key | **−783.00** |
| 75700 PE | no `pnl` key | **−860.00** |
| 76300 PE | no `pnl` key | **+2462.00** |
| **Total** | **shown as ₹0 everywhere** | **+988.00** |

Also verified:
- Open position (unaffected — no `pnl` key added, `average_price` unchanged)
- Synthetic carry-forward-closed-today case (10 carried forward @ `cfBuyAmt=450`, 10 sold fresh @ `sellAmt=500` → `pnl = 50.0`, confirming `cfBuyAmt`/`cfSellAmt` are actually included — the exact case that stalled #1224)
- `python -m py_compile broker/kotak/mapping/order_data.py` — clean
- Deployed to a live account and re-verified the same real numbers appear through the actual running service (not just the isolated unit test)

## Regression coverage

Happy to add a parameterized test on `transform_positions_data()` covering the three cases above if that's wanted before merge.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1970 so fully-closed Kotak positions now report their realized P&L instead of showing ₹0.

Previously `transform_positions_data()` never emitted a `pnl` key for positions, so closed legs displayed ₹0. Now, for a fully-closed leg (net quantity 0 with a real round trip), it computes realized P&L using Kotak's documented formula: `(cfSellAmt + sellAmt) - (cfBuyAmt + buyAmt)`. Carry-forward amounts are included, so a leg carried forward and closed today gets its full realized P&L.

**Verification**
- Verified against a live account's closed SENSEX option legs: all four legs now report correct P&L (combined +988.00).
- Open positions are unaffected (no `pnl` key added, `average_price` unchanged).
- No new network calls.

<sup>Written for commit ca1fd18e28605ea13f96cf59134f180f387e4d9b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1971?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

