### PR TITLE
feat(kotak): backfill LTP for positions via batched multiquotes

### DIFF
--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -60,8 +60,75 @@ def get_trade_book(auth_token):
     return get_api_response("/quick/user/trades", auth_token)
 
 
+def _backfill_ltp(response, auth_token):
+    """Kotak's positions payload never includes a live price field at all,
+    for an open position or a closed one - confirmed against the raw
+    endpoint response and against Kotak's own SDK docs, whose "Profit N
+    Loss" formula treats LTP as an external input the caller must supply,
+    not something this endpoint returns. Zerodha's equivalent positions API
+    does return one (`last_price`, straight from Kite) - transform_positions_data
+    just reads it - so this is a Kotak-specific gap, not a display bug in
+    any consumer.
+
+    Batch-fetches one quote per distinct position via the same multiquotes
+    endpoint the option chain/quotes routes already use, and stamps each
+    raw row with an "_ltp" scratch field for transform_positions_data to
+    pick up. Deliberately not the final "ltp" key: this runs before
+    map_position_data's exchange/symbol resolution, so trdSym/exSeg here
+    are still Kotak's raw broker-native values, not OpenAlgo's - resolving
+    them again independently (not mutating the row) keeps get_positions()'s
+    contract of returning raw, unmapped data intact for its other caller
+    (map_position_data itself, called right after this by
+    services/positionbook_service.py).
+
+    Best-effort and non-fatal: any failure here (a bad auth token, the
+    quotes endpoint being down, a symbol that can't be resolved) just
+    leaves positions without a price, exactly as before this function
+    existed - it must never break the positions endpoint itself.
+    """
+    positions = response.get("data")
+    if not positions:
+        return
+    try:
+        from broker.kotak.api.data import BrokerData
+        from broker.kotak.mapping.order_data import _openalgo_symbol
+
+        resolved = []
+        for position in positions:
+            oa_exchange = map_exchange(position.get("exSeg", ""))
+            oa_symbol = _openalgo_symbol(position, oa_exchange) or position.get("trdSym", "")
+            if oa_symbol:
+                resolved.append((position, oa_symbol, oa_exchange))
+        if not resolved:
+            return
+
+        broker_data = BrokerData(auth_token)
+        symbols = [{"symbol": s, "exchange": e} for _, s, e in resolved]
+        # One batched call for every position (get_multiquotes already
+        # handles Kotak's own <50-symbol batch cap internally) - not one
+        # call per position, which is the per-symbol-latency concern that
+        # stalled an earlier, unrelated Kotak P&L PR (#1224).
+        quotes = broker_data.get_multiquotes(symbols)
+
+        ltp_by_key = {}
+        for item in quotes or []:
+            data = item.get("data") or {}
+            ltp = data.get("ltp")
+            if ltp:
+                ltp_by_key[(item.get("symbol"), item.get("exchange"))] = float(ltp)
+
+        for position, oa_symbol, oa_exchange in resolved:
+            ltp = ltp_by_key.get((oa_symbol, oa_exchange))
+            if ltp:
+                position["_ltp"] = ltp
+    except Exception as e:
+        logger.warning(f"Could not backfill LTP for positions: {e}")
+
+
 def get_positions(auth_token):
-    return get_api_response("/quick/user/positions", auth_token)
+    response = get_api_response("/quick/user/positions", auth_token)
+    _backfill_ltp(response, auth_token)
+    return response
 
 
 def get_holdings(auth_token):

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -246,6 +246,15 @@ def transform_positions_data(positions_data):
             "quantity": (int(position.get("flBuyQty", 0)) - int(position.get("flSellQty", 0)))
             + (int(position.get("cfBuyQty", 0)) - int(position.get("cfSellQty", 0))),
             "average_price": position.get("avgnetprice", 0.0),
+            # "_ltp" is a scratch field get_positions() stamps on before this
+            # function runs (see order_api.py's _backfill_ltp) - Kotak's own
+            # positions endpoint never returns a live price at all, open or
+            # closed, unlike Zerodha's (which reads "last_price" directly
+            # from Kite here). Matches Zerodha's "ltp" key/shape exactly so
+            # every consumer of transform_positions_data can treat brokers
+            # uniformly - always present, defaults to 0.0 if the backfill
+            # couldn't resolve a quote for this symbol.
+            "ltp": round(position.get("_ltp", 0.0), 2),
         }
         buy_qty = float(position.get("flBuyQty", 0))
         sell_qty = float(position.get("flSellQty", 0))


### PR DESCRIPTION
Fixes #1972

## Problem

Kotak's positions endpoint never returns a live price field at all — open or closed — confirmed against the raw response and against Kotak's own SDK docs ([`Kotak-Neo/kotak-neo-api-v2` `docs/Positions.md`](https://github.com/Kotak-Neo/Kotak-neo-api-v2/blob/main/docs/Positions.md)), whose "Profit N Loss" formula treats LTP as an external input the caller must supply, not something the endpoint returns. Zerodha's equivalent `transform_positions_data` already reads `last_price` straight from Kite — this is a Kotak-specific gap, and it shows up in OpenAlgo's own Positions page too, not just downstream consumers.

## Fix

Added `_backfill_ltp(response, auth_token)` in `order_api.py`'s `get_positions()`:

1. Resolve each raw position's OpenAlgo symbol/exchange using the same `_openalgo_symbol()` helper `map_position_data` already uses for orders/trades (read-only — doesn't mutate `trdSym`/`exSeg` on the raw row, keeping `get_positions()`'s contract of returning genuinely raw data intact).
2. One **batched** `BrokerData(auth_token).get_multiquotes()` call for every position needing a price — not one call per position, which is the per-symbol-latency concern that stalled an earlier, unrelated Kotak P&L PR (#1224). `get_multiquotes` already handles Kotak's own <50-symbol batch cap internally.
3. Stamp a `_ltp` scratch field onto each raw position (not the final `ltp` key, since this runs before `map_position_data`'s exchange/symbol resolution).
4. `transform_positions_data()` reads `_ltp` into `ltp`, matching Zerodha's key/shape exactly.

## Verification

Verified end-to-end against a live account today:

| Leg (raw → OpenAlgo symbol) | LTP resolved |
|---|---|
| SENSEX2690376900CE → SENSEX03SEP2676900CE | **60.6** |
| SENSEX2690376300CE → SENSEX03SEP2676300CE | **313.6** |
| SENSEX2690375700PE → SENSEX03SEP2675700PE | **27.9** |
| SENSEX2690376300PE → SENSEX03SEP2676300PE | **131.75** |

All previously showed no price at all. One batched `get_multiquotes` call resolved all 4. Also confirmed through the actual `services/positionbook_service.get_positionbook()` pipeline (not just an isolated test), and that `get_positions()`'s raw output is otherwise unchanged.

## Scope / risk

Best-effort and non-fatal by design — any failure (bad auth, quotes endpoint down, unresolvable symbol) just leaves positions without a price, exactly as before this function existed. Deliberately a single batched call rather than per-position, avoiding the exact objection that stalled #1224.

## Regression coverage

Happy to add tests covering: a resolvable symbol gets `ltp` populated from a mocked `get_multiquotes` response; an unresolvable symbol or quotes failure leaves `ltp` at `0.0` without raising; `get_positions()`'s raw `trdSym`/`exSeg` output is unchanged by this function.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes #1972 by backfilling live prices on Kotak positions. Kotak's positions endpoint never returns an LTP field — open or closed — so position rows previously showed no price. This resolves each raw position to its OpenAlgo symbol and fetches all prices in one batched `get_multiquotes()` call, then surfaces them as `ltp` via `transform_positions_data()`.

**Behavior**
- `_backfill_ltp()` in `order_api.py` stamps a `_ltp` scratch field on raw positions; `transform_positions_data()` reads it into `ltp`, matching Zerodha's key and shape.
- Best-effort and non-fatal: any failure (bad auth, quotes endpoint down, unresolvable symbol) leaves positions without a price, exactly as before.
- Uses one batched call for all positions, not one per symbol, avoiding per-symbol latency.

<sup>Written for commit e5b3fe40167dc46dbed89c594a2d70827d3fd368. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1973?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

