### PR TITLE
fix(strategy): cash and equity leg parity, and three defects that stranded runs

### DIFF
--- a/blueprints/strategy_module.py
+++ b/blueprints/strategy_module.py
@@ -867,11 +867,17 @@ def _validate_strategy_config(payload: Any) -> dict:
     raw = _mapping(payload, "The request body")
     _reject_unknown(raw, CONFIG_FIELDS, "The request")
 
+    # Legs first, because the universe tab is derived from them when the caller
+    # names none, and that derivation has to read the segment a leg will
+    # actually carry. Reading the raw payload saw no segment on a signal leg
+    # that relied on the default, derived a tab for a derivative universe, and
+    # then refused the very cash leg the default had just produced.
+    kind = _choice(raw.get("strategy_kind") or "batch", store.STRATEGY_KINDS, "strategy_kind")
+    legs = _validate_legs(_required(raw, "legs"), kind)
+
     config: dict[str, Any] = {
         "name": _text(_required(raw, "name"), "name", max_length=MAX_NAME_LENGTH),
-        "strategy_kind": _choice(
-            raw.get("strategy_kind") or "batch", store.STRATEGY_KINDS, "strategy_kind"
-        ),
+        "strategy_kind": kind,
         # Only read for signal strategies; harmless and inert on a batch one.
         "direction": _choice(raw.get("direction") or "both", store.DIRECTIONS, "direction"),
         # Derived from the legs when the caller does not say, because the tab
@@ -880,7 +886,7 @@ def _validate_strategy_config(payload: Any) -> dict:
         # cash leg underneath it would be a refusal about a field the caller
         # never set. An explicit tab is still checked, and still governs.
         "universe_tab": _choice(
-            raw.get("universe_tab") or _tab_for_legs(raw), UNIVERSE_TABS, "universe_tab"
+            raw.get("universe_tab") or _tab_for_legs(raw, legs), UNIVERSE_TABS, "universe_tab"
         ),
         "underlying": _text(
             _required(raw, "underlying"), "underlying", max_length=MAX_UNDERLYING_LENGTH
@@ -893,10 +899,7 @@ def _validate_strategy_config(payload: Any) -> dict:
         ),
         "product": _choice(raw.get("product") or "NRML", PRODUCTS, "product"),
         "pricetype": _choice(raw.get("pricetype") or "MARKET", PRICETYPES, "pricetype"),
-        "legs": _validate_legs(
-            _required(raw, "legs"),
-            _choice(raw.get("strategy_kind") or "batch", store.STRATEGY_KINDS, "strategy_kind"),
-        ),
+        "legs": legs,
         "overall_sl_mtm": _loss_amount(raw.get("overall_sl_mtm"), "overall_sl_mtm"),
         "overall_target_mtm": _gain_amount(raw.get("overall_target_mtm"), "overall_target_mtm"),
         "lock_profit": _validate_lock_profit(raw.get("lock_profit")),
@@ -936,17 +939,17 @@ _COMMODITY_EXCHANGES = frozenset({"MCX", "NCDEX", "NCO"})
 _WEEKLY_RANKS = frozenset({"weekly", "next_week"})
 
 
-def _tab_for_legs(raw: Any) -> str:
+def _tab_for_legs(raw: Any, legs: list[dict[str, Any]]) -> str:
     """The tab a configuration belongs to, read off the configuration itself.
 
-    Used only when the caller did not name one. Kept in step with the same
-    derivation in upgrade/migrate_strategy_universe_tab.py, which normalizes
-    rows written before the tab was validated.
+    Used only when the caller did not name one. Takes the *validated* legs
+    rather than the raw ones: a signal leg's segment defaults to cash, and
+    deriving from the raw payload missed that default, picked a derivative
+    universe, and then refused the cash leg validation had just produced. Kept
+    in step with the same derivation in
+    upgrade/migrate_strategy_universe_tab.py, which normalizes rows written
+    before the tab was validated.
     """
-    legs = raw.get("legs")
-    if not isinstance(legs, list):
-        return "weekly_monthly"
-
     segments = {str(leg.get("segment") or "").lower() for leg in legs if isinstance(leg, dict)}
     if "cash" in segments:
         return "stocks_fno"
@@ -1298,6 +1301,25 @@ def update_strategy(sid):
 
     if row.status == "running":
         return _error("Stop the strategy before editing it", 409)
+
+    # Refused here rather than left to the merge. strategy_kind is in
+    # CONFIG_FIELDS because the merge seeds itself from that set and a signal
+    # strategy whose kind was dropped would have its legs re-validated as batch
+    # legs, failing on its own stored configuration. But that also let a PATCH
+    # carry a kind: a changed one then failed on leg shape, naming a leg field
+    # instead of the field the caller actually tried to change, and an
+    # unchanged one was recorded as an update that changed nothing.
+    requested_kind = payload.get("strategy_kind")
+    if requested_kind is not None and requested_kind != row.strategy_kind:
+        return _error(
+            "A strategy cannot change between batch and signal. The two kinds do not "
+            "share a leg shape, so every leg would describe the wrong kind of contract. "
+            "Create a new strategy instead.",
+            400,
+        )
+    payload.pop("strategy_kind", None)
+    if not payload:
+        return _error("Nothing to update", 400)
 
     stored = store.strategy_to_dict(row)
     merged = {field: stored[field] for field in CONFIG_FIELDS if field in stored}

--- a/blueprints/strategy_module.py
+++ b/blueprints/strategy_module.py
@@ -135,7 +135,13 @@ def _rate_limited(error):
 
 #: The store's PATCH allowlist doubles as the create allowlist. Sharing it is
 #: deliberate: two lists would drift, and the second one would be the loose one.
-CONFIG_FIELDS = store.UPDATABLE_FIELDS
+#:
+#: strategy_kind is the one field that is settable at create and not updatable
+#: afterwards, so it is added here rather than to the store's list. It also has
+#: to survive the PATCH merge: the merge seeds itself from these fields, and a
+#: signal strategy whose kind was dropped on the way in would have its legs
+#: re-validated as batch legs and fail on its own stored configuration.
+CONFIG_FIELDS = store.UPDATABLE_FIELDS | {"strategy_kind"}
 
 PRODUCTS = ("CNC", "NRML", "MIS")
 # MARKET only, and deliberately so. Neither the strategy configuration nor a
@@ -164,7 +170,28 @@ UNDERLYING_EXCHANGES = (
     "BSE_INDEX",
 )
 
+#: How the wizard groups instruments, and the only thing that says which
+#: segments a leg may use. Stored on the strategy and echoed back, so it was
+#: previously validated as free text: any thirty characters were accepted and
+#: every rule hanging off the tab lived in the browser. A cash leg on an index
+#: tab therefore validated here and failed at run start with "no cash contract
+#: found for NIFTY on NSE", which is the correct refusal arriving far too late.
+UNIVERSE_TABS = ("weekly_monthly", "monthly_only", "stocks_fno", "mcx")
+
 LEG_SEGMENTS = ("options", "futures", "cash")
+
+#: Which segments each tab offers. Cash appears on one tab only, because an
+#: index has no cash instrument of its own and an MCX commodity has no spot:
+#: both resolve to a symbol the master contract does not list. This mirrors
+#: TAB_SEGMENTS in frontend/src/types/strategy_module.ts, which is where the
+#: rule used to live on its own.
+TAB_SEGMENTS = {
+    "weekly_monthly": ("futures", "options"),
+    "monthly_only": ("futures", "options"),
+    "stocks_fno": ("cash", "futures", "options"),
+    "mcx": ("futures", "options"),
+}
+
 LEG_POSITIONS = ("B", "S")
 LEG_OPTION_TYPES = ("CE", "PE")
 LEG_STRIKE_MODES = ("atm", "strike")
@@ -258,7 +285,6 @@ MAX_LOTS = 50
 # capped differently by which kind of strategy holds it.
 MAX_CASH_QUANTITY = 1_000_000
 MAX_NAME_LENGTH = 200
-MAX_UNIVERSE_TAB_LENGTH = 30
 MAX_UNDERLYING_LENGTH = 50
 MAX_IP_ALLOWLIST = 20
 
@@ -848,10 +874,13 @@ def _validate_strategy_config(payload: Any) -> dict:
         ),
         # Only read for signal strategies; harmless and inert on a batch one.
         "direction": _choice(raw.get("direction") or "both", store.DIRECTIONS, "direction"),
-        "universe_tab": _text(
-            raw.get("universe_tab") or "weekly_monthly",
-            "universe_tab",
-            max_length=MAX_UNIVERSE_TAB_LENGTH,
+        # Derived from the legs when the caller does not say, because the tab
+        # is a grouping the wizard uses and not something an API caller should
+        # have to know. Defaulting it to weekly_monthly and then refusing the
+        # cash leg underneath it would be a refusal about a field the caller
+        # never set. An explicit tab is still checked, and still governs.
+        "universe_tab": _choice(
+            raw.get("universe_tab") or _tab_for_legs(raw), UNIVERSE_TABS, "universe_tab"
         ),
         "underlying": _text(
             _required(raw, "underlying"), "underlying", max_length=MAX_UNDERLYING_LENGTH
@@ -894,7 +923,128 @@ def _validate_strategy_config(payload: Any) -> dict:
         raise ValidationError("entry_time must be earlier than exit_time")
 
     _reject_contradictory_sides(config)
+    _reject_segments_outside_tab(config)
+    _reject_cash_on_a_derivative_venue(config)
+    _reject_uncoverable_short_cash(config)
     return config
+
+
+#: Underlying exchanges whose instruments belong to the commodity tab.
+_COMMODITY_EXCHANGES = frozenset({"MCX", "NCDEX", "NCO"})
+
+#: Expiry ranks that only exist where an instrument lists weekly contracts.
+_WEEKLY_RANKS = frozenset({"weekly", "next_week"})
+
+
+def _tab_for_legs(raw: Any) -> str:
+    """The tab a configuration belongs to, read off the configuration itself.
+
+    Used only when the caller did not name one. Kept in step with the same
+    derivation in upgrade/migrate_strategy_universe_tab.py, which normalizes
+    rows written before the tab was validated.
+    """
+    legs = raw.get("legs")
+    if not isinstance(legs, list):
+        return "weekly_monthly"
+
+    segments = {str(leg.get("segment") or "").lower() for leg in legs if isinstance(leg, dict)}
+    if "cash" in segments:
+        return "stocks_fno"
+
+    if str(raw.get("underlying_exchange") or "").upper() in _COMMODITY_EXCHANGES:
+        return "mcx"
+
+    ranks = {str(leg.get("expiry") or "").lower() for leg in legs if isinstance(leg, dict)}
+    return "weekly_monthly" if ranks & _WEEKLY_RANKS else "monthly_only"
+
+
+def _reject_segments_outside_tab(config: dict[str, Any]) -> None:
+    """Refuse a leg whose segment the strategy's universe tab does not offer.
+
+    The tab decides what the underlying is, so it decides which segments can
+    resolve against it. A cash leg on an index tab names the index itself,
+    which has no cash instrument, and a cash leg on the commodity tab names a
+    spot that does not exist. Both were accepted here and refused at run start,
+    after the operator had finished the form and pressed Start.
+    """
+    tab = config.get("universe_tab", "weekly_monthly")
+    allowed = TAB_SEGMENTS.get(tab)
+    if not allowed:
+        return
+
+    for index, leg in enumerate(config.get("legs") or []):
+        segment = leg.get("segment")
+        if segment and segment not in allowed:
+            raise ValidationError(
+                f"legs[{index}].segment is {segment!r}, which the {tab!r} universe does not "
+                f"offer. That tab trades {' and '.join(allowed)}."
+            )
+
+
+def _reject_cash_on_a_derivative_venue(config: dict[str, Any]) -> None:
+    """Refuse a signal leg whose segment and exchange disagree.
+
+    A signal leg names its own venue, and nothing downstream reconciles that
+    against its segment: a leg marked cash on NFO was accepted, and the segment
+    was then simply ignored, so the leg traded whatever the symbol happened to
+    be. Batch legs take their venue from the strategy's underlying and are
+    covered by the tab rule above instead.
+    """
+    if config.get("strategy_kind") != "signal":
+        return
+
+    from services.strategy_module.symbol_resolver import DERIVATIVE_EXCHANGES
+
+    for index, leg in enumerate(config.get("legs") or []):
+        segment = leg.get("segment")
+        exchange = leg.get("exchange")
+        if not segment or not exchange:
+            continue
+        if segment == "cash" and exchange in DERIVATIVE_EXCHANGES:
+            raise ValidationError(
+                f"legs[{index}] is a cash leg on {exchange}, which lists derivatives. "
+                f"Use NSE or BSE for cash, or set the segment to 'futures'."
+            )
+        if segment == "futures" and exchange not in DERIVATIVE_EXCHANGES:
+            raise ValidationError(
+                f"legs[{index}] is a futures leg on {exchange}, which lists cash. "
+                f"Use a derivative exchange, or set the segment to 'cash'."
+            )
+
+
+def _reject_uncoverable_short_cash(config: dict[str, Any]) -> None:
+    """Refuse a short cash leg the product cannot deliver.
+
+    Indian cash equity can be sold short intraday and not carried short: a
+    delivery sell has to be covered by stock the account holds. The product is
+    read as intent, so anything that is not MIS is carry and reaches a cash
+    venue as CNC. A short cash leg under carry is therefore a naked short
+    delivery, which the broker refuses at order time and nothing refused here.
+
+    Batch legs only, and deliberately. A batch leg's position is what it will
+    be entered as the moment the run starts, so a short cash leg under carry is
+    an order that cannot be placed. A signal leg's ``side`` is only which
+    signals it accepts: a leg set to short, or to both, is an ordinary intraday
+    configuration until an alert actually asks for a short, and refusing it
+    here would block the common case to catch a rarer one. That case is caught
+    at signal time by ``signals._reject_uncarryable_short``, which knows the
+    side being opened rather than the sides being accepted.
+    """
+    if config.get("strategy_kind") == "signal":
+        return
+    product = (config.get("product") or "").upper()
+    if product == "MIS":
+        return
+
+    for index, leg in enumerate(config.get("legs") or []):
+        if leg.get("segment") != "cash":
+            continue
+        if leg.get("position") == "S":
+            raise ValidationError(
+                f"legs[{index}] sells cash short, but product {product!r} carries the position. "
+                f"Cash cannot be held short overnight. Use MIS for an intraday short, or make "
+                f"the leg long."
+            )
 
 
 #: Which leg sides a strategy-level direction can ever act on.

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -180,13 +180,16 @@ def _prune_old_tags() -> None:
         # Committed whether or not anything matched. The DELETE opens SQLite's
         # write transaction the moment it runs, and a prune that matches
         # nothing is the ordinary case, so committing only when `removed` was
-        # truthy left that transaction open on this thread's session. This runs
-        # from app startup, which has no Flask app context, so the teardown
-        # that would have released it never fires: the write lock was then held
-        # for the life of the process. Every other writer on openalgo.db backed
-        # off for its full budget and failed with "database is locked",
-        # strategy recovery among them, which is how a run that was already
-        # finished stayed open across every restart.
+        # truthy left that transaction open on this thread's session.
+        #
+        # This runs from app startup, inside the single app context that wraps
+        # the whole of `_init_databases_and_schedulers`. `teardown_appcontext`
+        # therefore does not fire until every startup step has finished, so the
+        # write lock was held straight through the ones that still had writing
+        # to do. Every other writer on openalgo.db backed off for its full
+        # budget and failed with "database is locked", strategy recovery among
+        # them, which is how a run that was already finished stayed open across
+        # every restart.
         db_session.commit()
         if removed:
             logger.info(f"Strategy book: pruned {removed} order tag(s) past retention")
@@ -194,7 +197,8 @@ def _prune_old_tags() -> None:
         db_session.rollback()
         logger.exception("Could not prune old order tags")
     finally:
-        # Startup owns no app context, so nothing else will release this.
+        # Released here rather than left to the context teardown, which does
+        # not run until the rest of startup has finished.
         db_session.remove()
 
 

--- a/database/strategy_book_db.py
+++ b/database/strategy_book_db.py
@@ -67,6 +67,7 @@ _initialized = False
 class StrategyBookUnavailable(RuntimeError):
     """The per-strategy book could not be read, so its figures are unknown."""
 
+
 engine = create_db_engine()
 
 db_session = scoped_session(sessionmaker(autocommit=False, autoflush=False, bind=engine))
@@ -176,12 +177,25 @@ def _prune_old_tags() -> None:
             .filter(StrategyOrderTag.created_at < cutoff)
             .delete(synchronize_session=False)
         )
+        # Committed whether or not anything matched. The DELETE opens SQLite's
+        # write transaction the moment it runs, and a prune that matches
+        # nothing is the ordinary case, so committing only when `removed` was
+        # truthy left that transaction open on this thread's session. This runs
+        # from app startup, which has no Flask app context, so the teardown
+        # that would have released it never fires: the write lock was then held
+        # for the life of the process. Every other writer on openalgo.db backed
+        # off for its full budget and failed with "database is locked",
+        # strategy recovery among them, which is how a run that was already
+        # finished stayed open across every restart.
+        db_session.commit()
         if removed:
-            db_session.commit()
             logger.info(f"Strategy book: pruned {removed} order tag(s) past retention")
     except Exception:
         db_session.rollback()
         logger.exception("Could not prune old order tags")
+    finally:
+        # Startup owns no app context, so nothing else will release this.
+        db_session.remove()
 
 
 def _migrate_add_columns():
@@ -347,8 +361,11 @@ def _prune_pending_fills() -> None:
             .filter(StrategyPendingFill.created_at < cutoff)
             .delete(synchronize_session=False)
         )
+        # Unconditionally, for the reason given in _prune_old_tags: the DELETE
+        # takes the write lock whether or not it matches a row, so a commit
+        # guarded on the row count leaves the transaction open.
+        db_session.commit()
         if removed:
-            db_session.commit()
             # The bulk delete bypasses the identity map; drop the stale entries
             # so a reused primary key does not warn on the next flush.
             db_session.expire_all()

--- a/database/strategy_module_db.py
+++ b/database/strategy_module_db.py
@@ -168,6 +168,7 @@ class OrderFactFold:
     def was_terminal(self) -> bool:
         return self.previous_status in _TERMINAL_ORDER_STATUSES
 
+
 EVENT_SEVERITIES = ("info", "warn", "critical")
 
 EVENT_KINDS = (
@@ -842,10 +843,17 @@ def get_strategy_unscoped(strategy_id: int) -> SmStrategy | None:
 # Fields a PATCH is allowed to touch. An allowlist, not a denylist: it is the
 # only thing standing between a mass-assignment and a caller setting
 # webhook_token_hash, user_id or current_run_id directly.
+#
+# strategy_kind is deliberately absent. The two kinds do not share a leg shape:
+# a batch leg carries a segment, a position and a lot count resolved from the
+# strategy's underlying, while a signal leg names its own instrument, side and
+# absolute quantity. Flipping the kind leaves every stored leg describing the
+# other kind's contract, and the legs are an opaque JSON column, so nothing
+# downstream notices until a run tries to resolve them. The wizard already
+# refuses to send it; this is the half that a caller cannot route around.
 UPDATABLE_FIELDS = frozenset(
     {
         "name",
-        "strategy_kind",
         "direction",
         "universe_tab",
         "underlying",
@@ -877,6 +885,17 @@ def update_strategy(
             return None, "Strategy not found"
         if row.status == "running":
             return None, "Stop the strategy before editing it"
+
+        # Said rather than silently dropped. strategy_kind is outside
+        # UPDATABLE_FIELDS, so a caller asking to change it would otherwise get
+        # a 200 and a strategy that did not change, which reads as success.
+        requested_kind = changes.get("strategy_kind")
+        if requested_kind is not None and requested_kind != row.strategy_kind:
+            return None, (
+                "A strategy cannot change between batch and signal. The two kinds do not "
+                "share a leg shape, so every leg would describe the wrong kind of contract. "
+                "Create a new strategy instead."
+            )
 
         for field, value in changes.items():
             if field in UPDATABLE_FIELDS:
@@ -1625,9 +1644,7 @@ def _pnl_fill_fact(order: SmStrategyOrder) -> _PnlFillFact | None:
     )
 
 
-def _fold_owner_pnl(
-    facts: list[_PnlFillFact], *, referenced: bool
-) -> tuple[float, int] | None:
+def _fold_owner_pnl(facts: list[_PnlFillFact], *, referenced: bool) -> tuple[float, int] | None:
     """FIFO one provable owner; ``None`` means its ownership is ambiguous."""
     # A positive but unpriced fact leaves checkpoint/live P&L authoritative for
     # this owner. Do not manufacture a partial owner valuation from later rows.

--- a/docs/api/strategy-services/README.md
+++ b/docs/api/strategy-services/README.md
@@ -118,13 +118,25 @@ neither preflight refusal writes a durable webhook audit row.
 
 ## Vocabularies
 
-These tuples live in `database/strategy_module_db.py` and are imported by the schemas, so the API and the store cannot drift apart.
+Most of these tuples live in `database/strategy_module_db.py`. The four the request schemas validate against, `RUN_MODES`, `STRATEGY_STATUSES`, `EVENT_KINDS` and `EVENT_SEVERITIES`, are imported from there by `restx_api/strategy_schema.py`, so those four cannot drift apart from the store. Products, price types, quantity modes, universe tabs and leg segments are configuration vocabularies owned by `blueprints/strategy_module.py`, because the store has no opinion on a leg's shape: legs are a JSON column.
 
 ### Strategy kinds
 
 `batch`, `signal`
 
 A batch strategy is a multi-leg spread entered and exited as a unit, driven by `start` and `stop`. A signal strategy moves one leg at a time, driven by `long_entry`, `long_exit`, `short_entry` and `short_exit`. Each kind refuses the other's vocabulary.
+
+### Universe tabs
+
+`weekly_monthly`, `monthly_only`, `stocks_fno`, `mcx`
+
+The instrument universe a strategy was built from. It is not decoration: it decides which segments a leg may use. A configuration saved without a tab has one derived from its own legs rather than defaulted, so a caller is never refused about a field it did not set.
+
+### Leg segments
+
+`options`, `futures`, `cash`
+
+A batch leg's segment must be one its universe tab offers. **Cash is offered on `stocks_fno` only**: an index has no cash instrument of its own and an MCX commodity has no spot, so a cash leg on either tab names a symbol the master contract does not list. A signal leg takes `cash` or `futures` only; there is no `options` segment in signal mode, and an exact option contract is named as a symbol instead. A signal leg's segment and its exchange must agree, so cash on a derivative venue is refused rather than ignored.
 
 ### Directions
 
@@ -183,13 +195,19 @@ important to an operator:
 
 `lots`, `units`
 
-`lots` multiplies the value by the contract's lot size from the master contract, so 5 lots of NIFTY is 5 x 65. The lot **count** is what is stored, so a strategy survives the exchange revising the lot size, as NIFTY did from 75 to 65. `units` is the number of shares or contracts outright. A derivative venue defaults to `lots` and a cash venue to `units`; an explicit value always wins. An unknown lot size in `lots` mode is an error, never a guess.
+`lots` multiplies the value by the contract's lot size from the master contract, so 5 lots of NIFTY is 5 x 65. The lot **count** is what is stored, so a strategy survives the exchange revising the lot size, as NIFTY did from 75 to 65. `units` is the number of shares or contracts outright. An unknown lot size in `lots` mode is an error, never a guess.
+
+`qty_mode` is a **signal** leg field. A derivative venue defaults to `lots` and a cash venue to `units`; `units` may be set explicitly on a derivative, but `lots` on a cash venue is refused, because a cash instrument has no lot size to multiply by.
+
+A **batch** leg has no `qty_mode` at all. Its `lots` count is multiplied by the master contract's lot size on every segment, cash included. A cash row's lot size is 1, so the count reads as a share count, but the multiplication is unconditional.
 
 ### Products
 
 `CNC`, `NRML`, `MIS`
 
 A strategy carries one product for every leg, and it is read as the **intent** rather than the literal: `MIS` is intraday everywhere, and anything else means carry the position, which is sent as `NRML` on a derivatives venue and `CNC` on cash. A basket mixing a cash leg and an option leg therefore works, and no leg is ever sent a product its venue refuses.
+
+One combination is refused rather than translated: a **short** cash leg under a carrying product. Cash cannot be held short overnight, so anything that is not `MIS` would reach the venue as a naked short delivery. A batch leg with `position: "S"` on a cash segment is refused when the product is not `MIS`; a signal leg is refused at signal time instead, when the side actually being opened is known rather than the sides it accepts.
 
 ### Price types
 

--- a/docs/api/strategy-services/events.md
+++ b/docs/api/strategy-services/events.md
@@ -176,7 +176,7 @@ the same owners and quantities.
 - **A `run_id` belonging to another strategy matches nothing.** The query is scoped to this strategy before the run filter is applied.
 - Configuration-layer events share the table with runtime ones and carry `run_id: null`. Filtering by `run_id` therefore excludes them.
 - The `close_all_manual` event written by [`/close_all`](./close_all.md) records the request before broker exits settle; use `run_stopped` as confirmed-flat evidence.
-- `payload` is free-form JSON and is `null` on most events. A scheduler-started run carries `{"trigger_source": "scheduler", "mode": "sandbox"}`; `order_ack_unrecorded` carries the exact reconciliation fields documented above. Do not assume one shape across kinds.
+- `payload` is free-form JSON and is `null` on most events, `run_started` included. A scheduled **live** start that was refused because live trading is not enabled writes a `live_disabled` event carrying `{"trigger_source": "scheduler", "mode": "live"}`; `order_ack_unrecorded` carries the exact reconciliation fields documented above. Do not assume one shape across kinds.
 
 ## Use Cases
 

--- a/docs/api/strategy-services/list.md
+++ b/docs/api/strategy-services/list.md
@@ -146,13 +146,12 @@ Each object in `data`:
 | name | string | Strategy name, unique per user |
 | strategy_kind | string | `batch` or `signal` |
 | direction | string | `both`, `long_only` or `short_only`. Signal mode only |
-| universe_tab | string | Which instrument universe the wizard built this from |
+| universe_tab | string | Which instrument universe the strategy was built from: `weekly_monthly`, `monthly_only`, `stocks_fno` or `mcx`. It decides which segments a leg may use, and cash is offered on `stocks_fno` only. A strategy saved without one has it derived from its own legs |
 | underlying | string | Underlying symbol |
 | underlying_exchange | string | Exchange the underlying is quoted on |
 | strategy_type | string | `intraday` or `positional` |
 | entry_time | string or null | IST entry time as `HH:MM` |
 | exit_time | string or null | IST square-off time as `HH:MM` |
-| risk_unit | string | `points` (default) or `percent`. Governs `sl_pts`, `target_pts` and `trail` together. A percentage is measured against the leg's own entry price, so 2 on a short filled at 2500 is a stop at 2550. Absent means points |
 | product | string | `CNC`, `NRML` or `MIS`, as configured. It is read as the intent rather than the literal when an order goes out: `MIS` is intraday everywhere, anything else means carry, which is sent as `NRML` on a derivatives venue and `CNC` on cash. See the `product` field on [`/orders`](./orders.md) for what was actually sent |
 | pricetype | string | `MARKET`. Neither the strategy nor a leg carries a price, so a LIMIT, SL or SL-M order would go out priced at zero; exits are MARKET on every path regardless |
 | overall_sl_mtm | number or null | Strategy-level stop loss in rupees of MTM |

--- a/docs/api/strategy-services/start.md
+++ b/docs/api/strategy-services/start.md
@@ -171,7 +171,7 @@ Each object in `legs`:
 - **Live is opt-in per strategy.** A strategy is created sandbox-only. Enable live trading on the strategy page at `/strategy` before asking for `mode: "live"`. This endpoint cannot enable it.
 - **Starting is idempotent by conflict, not by silence.** A second start against a running strategy answers 409, so two triggers firing at the same instant cannot both place a full set of entries.
 - A start through this API records `trigger_source: "manual"` on the run.
-- A run whose entry orders were **all** rejected is closed immediately and the call answers 400 with `Every entry order was rejected`: a running strategy holding nothing would be worse than none.
+- A run whose entry orders were **all** rejected is closed immediately and the call answers 400: a running strategy holding nothing would be worse than none. The message carries the venue's own words, so `Every entry order was rejected: MIS orders cannot be placed after square-off time (15:15 IST). Trading resumes at 09:00 AM IST.` rather than the bare sentence. When the legs were refused for different reasons each is listed against the leg it belongs to.
 - Partial success is a 200. Check `legs[].ok` rather than assuming every leg is in the market.
 - **`ok: true, acknowledged: false` is a real broker order with incomplete
   database attribution.** The intent row was durable before dispatch and the
@@ -181,7 +181,7 @@ Each object in `legs`:
   reconciliation. Conflicts remain managed and reserved rather than retrying
   the entry or asserting flatness.
 - Long legs are placed before short legs. On a spread, a short leg alone can be refused for margin the account would have had once the long leg existed.
-- This endpoint is for `batch` strategies. A `signal` strategy has no start: its first inbound signal after the platform session boundary opens the run. See the [webhook page](./webhook.md).
+- This endpoint is for `batch` strategies, and enforces it. A `signal` strategy has no start: its first inbound signal after the platform session boundary opens the run, so a start against one answers 400 with `A signal strategy has no start. Its run opens on the first long_entry or short_entry signal after the session boundary.` and nothing is claimed or resolved. See the [webhook page](./webhook.md).
 
 ## Use Cases
 

--- a/docs/api/strategy-services/status.md
+++ b/docs/api/strategy-services/status.md
@@ -146,11 +146,13 @@ The `data` object above is abridged for readability. A real response always carr
 | data | object | The strategy's full configuration, including `legs` |
 | run | object or null | The current run, or `null` when the strategy is not running |
 
-`data` carries the same fields as a [list](./list.md) row, plus:
+`data` carries the same fields as a [list](./list.md) row, with one omission and one addition. It does **not** carry `last_finalized_run`, which the list builds by joining each strategy's most recently finalised run; read the newest row from [`/runs`](./runs.md) instead. It adds:
 
 | Field | Type | Description |
 |-------|------|-------------|
 | legs | array | The leg configuration as the wizard saved it |
+
+Each leg carries `risk_unit`, `points` (the default) or `percent`, which governs that leg's `sl_pts`, `target_pts` and `trail` together. A percentage is measured against the leg's own entry price, so 2 on a short filled at 2500 is a stop at 2550. Every saved leg carries the field even when it was defaulted.
 
 `run`:
 

--- a/docs/api/strategy-services/webhook.md
+++ b/docs/api/strategy-services/webhook.md
@@ -108,7 +108,7 @@ subscribed and managed until exact exit fills confirm every owner is flat.
 
 A signal strategy moves one leg at a time. It accepts `long_entry`, `long_exit`, `short_entry` and `short_exit`, and nothing else. There is no `start` and no `mode`: the first signal after the platform session boundary opens the run, and the mode comes from the strategy's own live opt-in.
 
-The leg is named either by `leg_id` or by `symbol` plus `exchange`. `leg_id` wins when both are given.
+The leg is named either by `leg_id` or by `symbol`, optionally narrowed by `exchange`. `leg_id` wins when both are given.
 
 ### Sample API Request (By Leg Id)
 
@@ -206,7 +206,7 @@ The body must be a JSON object. A JSON array, a bare string and a number are all
 | `rejected_live_disabled` | 403 | `mode: "live"` on a strategy that has not opted into live trading |
 | `rejected_dedupe` | 200 | An identical signal was already handled within the last 60 seconds. Reported as a success |
 | `rejected_cooling_off` | 409 | The strategy stopped within the last 30 seconds, so a `start` is held off |
-| `rejected_engine_error` | 500 | The engine refused the signal or raised while acting on it |
+| `rejected_engine_error` | 500 | The engine refused a batch `start` or `stop`, or raised anywhere. A signal-mode engine refusal is reported as `rejected_invalid_action` (400) instead; only a raised exception on the signal path answers 500 |
 | `rate_limited` | 429 | The route's rate limiter refused the request |
 
 Only requests admitted to the validation pipeline are audited. Every terminal
@@ -214,7 +214,7 @@ outcome inside that pipeline, accepted or rejected, writes a row to the webhook
 audit table. The route's rate limiter and declared-size 413 run before durable
 webhook-event audit, so those preflight refusals do not create an audit row.
 The declared-size 413 response contains `status` and `message` but no `result`;
-the limiter's 429 response contains `result: "rate_limited"`.
+the limiter's 429 response contains `result: "rate_limited"`, a `retry_after` field and a `Retry-After` header.
 The session endpoint can read admitted events, but the `/strategy` page does
 not currently expose them. The page also does not provide an IP-allowlist
 editor; creation currently stores no allowlist. Configure/read these through
@@ -243,15 +243,16 @@ The kill switch outranks the allowlist, and the allowlist outranks the payload, 
 
 ## Notes
 
-- **`mode` is required on a batch `start` and is never defaulted.** A start with no mode, or with `paper`, `real`, `LIVE` or an empty string, is refused with `rejected_invalid_action` and never reaches the engine.
+- **`mode` is required on a batch `start` and is never defaulted.** A start with no mode, or with `paper`, `real` or an empty string, is refused with `rejected_invalid_action` and never reaches the engine. Case and surrounding whitespace do not matter here: `"LIVE"` and `" Sandbox "` are read as `live` and `sandbox`. This is the one place the webhook is more forgiving than [`/start`](./start.md), where `LIVE` is a 400.
 - **Live is opt-in per strategy.** A strategy is created sandbox-only. `mode: "live"` is refused with `rejected_live_disabled` until the operator enables live trading on the strategy page.
 - **An unknown token and a malformed one are indistinguishable.** Same result label, same message, same status, so the endpoint is not an oracle for which tokens exist. A malformed token is refused on its shape before any database lookup, so the two are not separable by timing either.
 - **A 404 here does not count towards an IP ban.** The endpoint answers with a controlled 404 rather than falling through to the application's handler, so a scanner walking the token space cannot get the address a real alert arrives from banned.
-- **A signal that does nothing answers 200 with a note.** A repeat `long_entry` on a leg already long, or an exit for a position that is not held, is a no-op, not a failure. This is deliberate: reporting it as a failure invites a retry, and a retry on an order path is how one alert becomes two positions. The notes are `already_long`, `already_short`, `no_matching_position`, `outside_entry_window` and `outside_trading_window`, and they appear in the message as `Signal accepted (already_long)`.
-- **Being refused is different from being a no-op.** A signal blocked by the strategy's `direction`, or by the leg's own accepted side, or naming a leg that does not exist, is a configuration mismatch the operator should see. It answers `rejected_invalid_action` with the engine's own message, for example `This strategy is long_only; a short signal is not accepted` or `No leg matches this signal`.
+- **A signal that does nothing answers 200 with a note.** A repeat `long_entry` on a leg already long, or an exit for a position that is not held, is a no-op, not a failure. This is deliberate: reporting it as a failure invites a retry, and a retry on an order path is how one alert becomes two positions. The notes are `already_long`, `already_short`, `flip_pending`, `no_matching_position`, `outside_entry_window` and `outside_trading_window`, and they appear in the message as `Signal accepted (already_long)`. One further note, `run_stopping`, is not a no-op: a signal arriving while a durable stop is in flight is refused with `rejected_invalid_action` and the generic message `The signal was refused`.
+- **Being refused is different from being a no-op.** A signal blocked by the strategy's `direction`, or by the leg's own accepted side, or naming a leg that does not exist, is a configuration mismatch the operator should see. So is a `short_entry` on a cash leg when the strategy's product is not `MIS`: cash cannot be carried short, so anything else would reach the venue as a naked short delivery. All of these answer `rejected_invalid_action` with the engine's own message, for example `This strategy is long_only; a short signal is not accepted`, `No leg matches this signal`, or `Leg 1: cash cannot be held short overnight, and product CNC carries the position. Use MIS for an intraday short.`
+- **A signal leg names its instrument outright, and it is checked.** A signal leg is not resolved from an underlying and an expiry rank, so the symbol on the leg is the symbol sent to the broker. It is checked against the master contract on every venue, cash included: `NIFTY` on `NFO` is a base symbol rather than a contract, and a misspelled equity such as `RELAINCE` on `NSE` is refused the same way, both with `rejected_invalid_action`. If the master contract holds no rows at all for that exchange there is nothing to check against and the leg passes, so a fresh install is not blocked.
 - **Each kind refuses the other's vocabulary.** `long_entry` against a batch strategy and `start` against a signal strategy are both `rejected_invalid_action`, and the message names the actions that strategy does accept.
 - **Duplicate suppression, batch only.** Two identical `(strategy, action, mode)` deliveries inside 60 seconds are one signal. This exists because senders retry a delivery they believe failed. A delivery whose engine call then failed releases its claim, so a genuine retry is not swallowed as a duplicate of something that never happened.
-- **Cooling off, batch `start` only.** A strategy that stopped within the last 30 seconds refuses a `start`, so a misconfigured pair of alerts firing against each other cannot oscillate and pay the spread each time. A stop is never blocked by the window, and a stop against an already-stopped strategy does not arm it.
+- **Cooling off, batch `start` only.** A strategy that stopped within the last 30 seconds refuses a `start`, so a misconfigured pair of alerts firing against each other cannot oscillate and pay the spread each time. A stop is never blocked by the window. A stop against an already-stopped strategy does not arm it, and neither does a stop that is still pending.
 - **The IP allowlist is a closed set when it is non-empty.** An empty or absent allowlist allows every address, which is how a strategy is created. Entries are CIDR ranges, and a bare address is read as its own `/32` or `/128`. A request that arrives with no address at all fails a non-empty allowlist. One malformed entry is skipped rather than failing the whole list closed.
 - **Body size cap: 16384 bytes.** An oversized `Content-Length` is refused with a 413 **before the body is read or audited**, so an unauthenticated caller does not get to decide how much the worker reads. The admitted pipeline then applies its own byte cap to what actually arrived and audits that `rejected_payload` outcome. A TradingView alert is a few hundred bytes.
 - **The caller is identified by the real client address.** The proxy headers are honoured through `get_real_ip()`, so the IP allowlist and the audit trail name the sender rather than the reverse proxy most installs run behind.

--- a/docs/bdd/strategy_module_rms.feature
+++ b/docs/bdd/strategy_module_rms.feature
@@ -55,7 +55,7 @@ Feature: Strategy module and risk management
     Then subsequent live exits still reach the broker
     And a sandbox run still uses the sandbox book and execution pipe
 
-  # Source: services/strategy_module/engine.py:497, test/test_strategy_module_engine.py:304, test/test_strategy_module_scheduler.py:730
+  # Source: services/strategy_module/engine.py:509, test/test_strategy_module_engine.py:304, test/test_strategy_module_scheduler.py:730
   Scenario: Durable intent and acknowledgement surround every broker call
     Given the engine is about to place an entry or exit
     When it dispatches the order

--- a/docs/bdd/strategy_module_rms.feature
+++ b/docs/bdd/strategy_module_rms.feature
@@ -33,7 +33,7 @@ Feature: Strategy module and risk management
     Then a single conditional update claims it
     And only one set of entry orders reaches the broker
 
-  # Source: test/test_strategy_module_engine.py:127
+  # Source: test/test_strategy_module_engine.py:143
   Scenario: Every batch leg resolves before anything is claimed
     Given one configured leg cannot resolve to a listed contract
     When the batch strategy starts
@@ -55,7 +55,7 @@ Feature: Strategy module and risk management
     Then subsequent live exits still reach the broker
     And a sandbox run still uses the sandbox book and execution pipe
 
-  # Source: services/strategy_module/engine.py:509, test/test_strategy_module_engine.py:304, test/test_strategy_module_scheduler.py:730
+  # Source: services/strategy_module/engine.py:524, test/test_strategy_module_engine.py:318, test/test_strategy_module_scheduler.py:730
   Scenario: Durable intent and acknowledgement surround every broker call
     Given the engine is about to place an entry or exit
     When it dispatches the order
@@ -79,7 +79,7 @@ Feature: Strategy module and risk management
     Then only the superseded position_ref is reduced
     And the replacement remains open and evaluated for risk
 
-  # Source: test/test_strategy_module_engine.py:703
+  # Source: test/test_strategy_module_engine.py:717
   Scenario: One exact owner cannot be sent two covering exits
     Given an open position owner
     When two risk rules fire before the first exit returns
@@ -242,7 +242,7 @@ Feature: Strategy module and risk management
     Then real zero remains zero
     And every unusable quantity, price and P&L value renders unavailable
 
-  # Source: frontend/src/pages/strategy/Detail.test.tsx:1085, frontend/src/pages/strategy/strategy_module.test.ts:130
+  # Source: frontend/src/pages/strategy/Detail.test.tsx:1085, frontend/src/pages/strategy/strategy_module.test.ts:133
   Scenario: Broker order and trade truth keeps local reconciliation context
     Given broker rows and recorded strategy orders can match, differ or be ambiguous
     When the page reconciles them by broker order id
@@ -250,7 +250,7 @@ Feature: Strategy module and risk management
     And multiple trade fills aggregate quantity and weighted price before comparison
     And local-only, ambiguous, mismatch and rejection context remain visible
 
-  # Source: frontend/src/pages/strategy/Detail.test.tsx:787, frontend/src/pages/strategy/Detail.test.tsx:875, frontend/src/pages/strategy/strategy_module.test.ts:409, test/test_strategy_module_views.py:441
+  # Source: frontend/src/pages/strategy/Detail.test.tsx:787, frontend/src/pages/strategy/Detail.test.tsx:875, frontend/src/pages/strategy/strategy_module.test.ts:412, test/test_strategy_module_views.py:441
   Scenario: Position fallback preserves exposure without inventing valuation
     Given local audit has explicit positive fills in working or terminal statuses
     When the broker positionbook is unavailable

--- a/docs/bdd/strategy_module_rms.feature
+++ b/docs/bdd/strategy_module_rms.feature
@@ -40,7 +40,7 @@ Feature: Strategy module and risk management
     Then no run row, strategy claim or broker order is created
     And the failure names the leg and reason
 
-  # Source: test/test_strategy_module_qa_segments.py:687
+  # Source: test/test_strategy_module_qa_segments.py:719
   Scenario: Every leg is sent a product its venue accepts
     Given one strategy product applies to cash and derivative legs
     When an order is built
@@ -125,14 +125,14 @@ Feature: Strategy module and risk management
     And run_stop_failed is recorded at critical severity
     And the pending run stays open for another exit attempt
 
-  # Source: test/test_strategy_module_signals.py:550
+  # Source: test/test_strategy_module_signals.py:602
   Scenario: A durable stop gates new signal entries but permits exit retries
     Given a signal run has stop_requested_reason populated
     When entry and exit alerts arrive
     Then a new entry claim is refused under the run lock
     And an alert targeting exposure still held can retry its exit
 
-  # Source: test/test_strategy_module_signals.py:1020
+  # Source: test/test_strategy_module_signals.py:1072
   Scenario: A normal signal round trip keeps one platform-session run
     Given a signal leg opens and exits for a risk reason
     When it becomes flat before the session ends
@@ -170,7 +170,7 @@ Feature: Strategy module and risk management
     Then a weekday square-off is installed at that time
     And no start job is installed
 
-  # Source: test/test_strategy_module_qa_segments.py:1856, test/test_strategy_module_webhook_e2e.py:229
+  # Source: test/test_strategy_module_qa_segments.py:1888, test/test_strategy_module_webhook_e2e.py:233
   Scenario: A signal must name a listed contract and never doubles a held side
     Given a derivatives signal leg names only a base symbol or repeats its held side
     When its entry alert arrives
@@ -242,7 +242,7 @@ Feature: Strategy module and risk management
     Then real zero remains zero
     And every unusable quantity, price and P&L value renders unavailable
 
-  # Source: frontend/src/pages/strategy/Detail.test.tsx:1085, frontend/src/pages/strategy/strategy_module.test.ts:121
+  # Source: frontend/src/pages/strategy/Detail.test.tsx:1085, frontend/src/pages/strategy/strategy_module.test.ts:130
   Scenario: Broker order and trade truth keeps local reconciliation context
     Given broker rows and recorded strategy orders can match, differ or be ambiguous
     When the page reconciles them by broker order id
@@ -250,7 +250,7 @@ Feature: Strategy module and risk management
     And multiple trade fills aggregate quantity and weighted price before comparison
     And local-only, ambiguous, mismatch and rejection context remain visible
 
-  # Source: frontend/src/pages/strategy/Detail.test.tsx:787, frontend/src/pages/strategy/Detail.test.tsx:875, frontend/src/pages/strategy/strategy_module.test.ts:400, test/test_strategy_module_views.py:441
+  # Source: frontend/src/pages/strategy/Detail.test.tsx:787, frontend/src/pages/strategy/Detail.test.tsx:875, frontend/src/pages/strategy/strategy_module.test.ts:409, test/test_strategy_module_views.py:441
   Scenario: Position fallback preserves exposure without inventing valuation
     Given local audit has explicit positive fills in working or terminal statuses
     When the broker positionbook is unavailable

--- a/docs/prompt/strategy_rms_documentation.md
+++ b/docs/prompt/strategy_rms_documentation.md
@@ -228,7 +228,7 @@ is the protocol, the leg shape and the run lifecycle.
 | Trigger | `start` enters every leg, `stop` exits every leg | one alert moves one leg |
 | Leg shape | segment, position, lots, option type, strike mode, offset, expiry | symbol, exchange, side, qty, segment, expiry |
 | Options | relative option legs and spreads | an exact option contract may be named, but there is no `options` segment, expiry-rank or strike resolution; spreads stay in batch mode |
-| Quantity | derivative lots multiplied by the exact `SymToken` lot size; cash uses the configured count as units | derivatives accept `qty_mode=lots` (multiplied by the exact `SymToken` lot size) or `qty_mode=units` (absolute quantity on a whole-lot boundary); cash is units only and uses the exact quantity |
+| Quantity | the configured count multiplied by the exact `SymToken` lot size, on every segment including cash. A cash row's lot size is 1, so the count is a share count, but the multiplication is unconditional and nothing asserts the 1 | derivatives accept `qty_mode=lots` (multiplied by the exact `SymToken` lot size) or `qty_mode=units` (absolute quantity on a whole-lot boundary); cash is units only and uses the exact quantity |
 | Run | one per start-to-stop cycle | one per platform session, opened by the first signal |
 | Webhook actions | `start`, `stop` | `long_entry`, `long_exit`, `short_entry`, `short_exit` |
 | Legs at run start | all entered together | inactive until a signal opens one |

--- a/docs/prompt/strategy_rms_documentation.md
+++ b/docs/prompt/strategy_rms_documentation.md
@@ -498,7 +498,7 @@ resolve_live_auth(api_key) -> (auth_token, broker, error)
 dispatch_order(*, mode, api_key, order) -> DispatchResult(ok, broker_order_id, response, error)
 ```
 
-Three departures from how the rest of the product places orders:
+Five departures from how the rest of the product places orders:
 
 - **Mode is per run, not global.** The analyzer setting is one platform-wide
   switch and `place_order` consults it, but two runs may disagree. This module
@@ -512,7 +512,12 @@ Three departures from how the rest of the product places orders:
   every leg. `build_order` reads it as the intent rather than the literal: MIS
   is intraday everywhere, anything else means carry, which is NRML on a
   derivatives venue and CNC on cash. A basket mixing a cash leg and an option
-  leg therefore works, and no leg is ever sent a product its venue refuses.
+  leg therefore works, and no leg is ever sent a product its venue refuses. One
+  combination is refused rather than translated: a short cash leg under a
+  carrying product, because cash cannot be held short overnight and anything
+  that is not MIS would reach the venue as a naked short delivery. A batch leg
+  is refused at save; a signal leg at signal time, when the side being opened
+  is known rather than the sides it accepts.
 - **Entries are MARKET.** Neither the strategy nor a leg carries a price, so a
   LIMIT, SL or SL-M entry would go out priced at zero. Exits are MARKET on every
   path regardless: a stop that cannot fill is not a stop.
@@ -844,7 +849,7 @@ resolve_leg(leg, underlying, underlying_exchange, strategy_type=None, *,
             api_key=None, underlying_ltp=None) -> ResolvedLeg
 derivatives_exchange(exchange) -> str
 lot_size_for(symbol, exchange) -> int | None
-quantity_is_whole_lots(quantity, lot_size) -> bool
+quantity_is_whole_lots(quantity, symbol, exchange) -> (whole, lot_size)
 resolve_quantity(value, qty_mode, symbol, exchange) -> (quantity, lot_size, error)
 contract_exists(symbol, exchange) -> bool
 ```
@@ -861,12 +866,14 @@ unanchored prefix let `GOLD` match `GOLDM` and `GOLDPETAL`, so a base with no
 contract of its own was handed a neighbour's lot size and the user's lot count
 was multiplied by it.
 
-`contract_exists` is what a **signal** leg is checked against. A signal leg
-names its own instrument, so nothing resolves it from an underlying and a rank,
-and a futures leg configured as the base symbol went to the broker verbatim
-with a quantity that looked entirely plausible. It answers True when the master
-contract has no rows for that venue at all, so a strategy is not blocked merely
-because the contract has not been downloaded yet.
+`contract_exists` is what a **signal** leg is checked against, on every venue
+including cash. A signal leg names its own instrument, so nothing resolves it
+from an underlying and a rank: a futures leg configured as the base symbol went
+to the broker verbatim with a quantity that looked entirely plausible, and a
+misspelled equity on a cash venue went the same way, because a cash leg is not
+resolved from an underlying either. It answers True when the master contract
+has no rows for that venue at all, so a strategy is not blocked merely because
+the contract has not been downloaded yet.
 
 Delegates every piece of market knowledge it can to
 `services/option_symbol_service.py`, including the rule that an MCX commodity
@@ -924,6 +931,18 @@ strategy scheduler failed is worse than one that boots without it.
 
 Both enforce the same properties:
 
+- **Configuration vocabularies are not all in the store.** `universe_tab`, a
+  leg's `segment`, `product`, `pricetype` and `qty_mode` are validated in
+  `blueprints/strategy_module.py`, because the store has no opinion on a leg's
+  shape: legs are a JSON column. `UNIVERSE_TABS` and `TAB_SEGMENTS` are the
+  pair that matters, because the tab decides which segments can resolve against
+  the underlying, and cash resolves on `stocks_fno` only. A configuration that
+  names no tab has one derived from its own legs rather than defaulted.
+- **`strategy_kind` is settable at create and never updatable.** It sits
+  outside `UPDATABLE_FIELDS`, and `update_strategy` refuses a request to change
+  it by name rather than dropping it silently, which would have read as
+  success. The two kinds do not share a leg shape, so a flip would leave every
+  stored leg describing the other kind's contract in an opaque JSON column.
 - `mode` is required on start and has no default anywhere in the chain.
 - Live is opt-in per strategy.
 - A strategy that is not yours answers **404, never 403**, identical to one that

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -265,15 +265,32 @@ function TrailCell({ leg, live }: { leg: Leg; live: LegState | undefined }) {
   const trailY = leg.trail?.y ?? 0
   if (!trailX || trailX <= 0) return <span className="text-muted-foreground">—</span>
 
-  // The unit the leg is actually configured in. Printing "pts" on a percent
-  // leg described a 2 percent stop as a two rupee one.
-  const unit = (leg.risk_unit ?? 'points') === 'percent' ? '%' : 'pts'
+  // The unit the leg is configured in. Printing "pts" on a percent leg
+  // described a 2 percent stop as a two rupee one, so the label follows the
+  // leg. The two numbers beside it then have to follow as well: `trail.x` is
+  // stored in the leg's own unit, while `favorablePeakPoints` always returns
+  // price points, so on a percent leg they are not the same quantity and
+  // labelling both "%" would be its own lie.
+  const percent = (leg.risk_unit ?? 'points') === 'percent'
+  const unit = percent ? '%' : 'pts'
 
   const entry = live?.entry_avg ?? null
   const peakPts = live ? favorablePeakPoints(live) : 0
   const armed = Boolean(live?.trail_active)
   const effectiveSl = live?.effective_sl ?? null
-  const armPrice = entry ? (leg.position === 'B' ? entry + trailX : entry - trailX) : null
+
+  // A percent trail arms a percentage of entry away, not that many rupees.
+  // Both the arming price and the progress toward it need converting, and
+  // neither can be shown at all until a fill gives us an entry to measure
+  // against, which is the same rule risk_adapter applies.
+  const armDistance = percent ? (entry ? (entry * trailX) / 100 : null) : trailX
+  const armPrice =
+    entry && armDistance != null
+      ? leg.position === 'B'
+        ? entry + armDistance
+        : entry - armDistance
+      : null
+  const peakShown = percent ? (entry ? (peakPts / entry) * 100 : null) : peakPts
 
   return (
     <div className="flex flex-col items-end gap-0.5 leading-tight">
@@ -292,7 +309,7 @@ function TrailCell({ leg, live }: { leg: Leg; live: LegState | undefined }) {
             <span className="text-muted-foreground">arm pending</span>
           )}
           <span className="text-[10px] text-muted-foreground">
-            {peakPts.toFixed(2)} / {trailX} {unit}
+            {peakShown != null ? peakShown.toFixed(2) : '—'} / {trailX} {unit}
             {trailY > 0 && ` · step ${trailY}`}
           </span>
         </>

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -265,6 +265,10 @@ function TrailCell({ leg, live }: { leg: Leg; live: LegState | undefined }) {
   const trailY = leg.trail?.y ?? 0
   if (!trailX || trailX <= 0) return <span className="text-muted-foreground">—</span>
 
+  // The unit the leg is actually configured in. Printing "pts" on a percent
+  // leg described a 2 percent stop as a two rupee one.
+  const unit = (leg.risk_unit ?? 'points') === 'percent' ? '%' : 'pts'
+
   const entry = live?.entry_avg ?? null
   const peakPts = live ? favorablePeakPoints(live) : 0
   const armed = Boolean(live?.trail_active)
@@ -288,7 +292,7 @@ function TrailCell({ leg, live }: { leg: Leg; live: LegState | undefined }) {
             <span className="text-muted-foreground">arm pending</span>
           )}
           <span className="text-[10px] text-muted-foreground">
-            {peakPts.toFixed(2)} / {trailX} pts
+            {peakPts.toFixed(2)} / {trailX} {unit}
             {trailY > 0 && ` · step ${trailY}`}
           </span>
         </>
@@ -466,7 +470,19 @@ function LiveTab({
                           ? 'closed'
                           : 'open')
                   const symbol = legLive?.symbol ?? entry?.symbol ?? leg.symbol ?? '—'
-                  const qty = legLive?.qty ?? entry?.qty ?? leg.qty ?? leg.lots ?? '—'
+                  // A resolved quantity is already the number of shares or
+                  // contracts sent. Only the configured fallback still needs
+                  // saying: leg.lots is a share count on a cash leg and a lot
+                  // count on every other, and this column showed both as a
+                  // bare number.
+                  const resolvedQty = legLive?.qty ?? entry?.qty ?? leg.qty ?? null
+                  const qty = resolvedQty ?? leg.lots ?? '—'
+                  const qtyUnit =
+                    resolvedQty != null || leg.lots == null
+                      ? null
+                      : leg.segment === 'cash'
+                        ? 'shares'
+                        : 'lots'
                   const mtm = legLive?.mtm
 
                   return (
@@ -478,7 +494,12 @@ function LiveTab({
                           {legLive?.position ?? leg.position ?? leg.side ?? '—'}
                         </Badge>
                       </TableCell>
-                      <TableCell className="text-right font-mono">{qty}</TableCell>
+                      <TableCell className="text-right font-mono">
+                        {qty}
+                        {qtyUnit && (
+                          <span className="ml-1 text-[10px] text-muted-foreground">{qtyUnit}</span>
+                        )}
+                      </TableCell>
                       <TableCell className="text-right font-mono">
                         {formatPrice(legLive?.entry_avg)}
                       </TableCell>
@@ -674,8 +695,9 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                   <tr>
                     <th className="px-2 py-1 text-left">#</th>
                     <th className="px-2 py-1 text-left">Segment</th>
+                    <th className="px-2 py-1 text-left">Instrument</th>
                     <th className="px-2 py-1 text-left">Pos</th>
-                    <th className="px-2 py-1 text-right">Lots</th>
+                    <th className="px-2 py-1 text-right">Qty</th>
                     <th className="px-2 py-1 text-left">Expiry</th>
                     <th className="px-2 py-1 text-left">Type</th>
                     <th className="px-2 py-1 text-left">Strike</th>
@@ -695,12 +717,29 @@ function SetupTab({ strategy }: { strategy: Strategy }) {
                       <tr key={leg.id} className="border-t">
                         <td className="px-2 py-1.5 font-mono">{leg.id}</td>
                         <td className="px-2 py-1.5">{leg.segment}</td>
+                        <td className="px-2 py-1.5 font-mono text-xs">
+                          {/* A batch leg has no instrument of its own: it
+                              resolves against the strategy's underlying, and a
+                              cash leg trades that underlying directly. Naming
+                              it here is what tells an operator which stock a
+                              cash leg will actually buy. */}
+                          {leg.segment === 'cash'
+                            ? `${strategy.underlying} · ${strategy.underlying_exchange}`
+                            : strategy.underlying}
+                        </td>
                         <td className="px-2 py-1.5">
                           <Badge variant="outline" className="text-xs">
                             {leg.position ?? '—'}
                           </Badge>
                         </td>
-                        <td className="px-2 py-1.5 text-right font-mono">{leg.lots ?? '—'}</td>
+                        <td className="px-2 py-1.5 text-right font-mono">
+                          {leg.lots ?? '—'}
+                          {leg.lots != null && (
+                            <span className="ml-1 text-[10px] text-muted-foreground">
+                              {leg.segment === 'cash' ? 'shares' : 'lots'}
+                            </span>
+                          )}
+                        </td>
                         <td className="px-2 py-1.5">{leg.expiry ?? '—'}</td>
                         <td className="px-2 py-1.5">{leg.option_type ?? '—'}</td>
                         <td className="px-2 py-1.5 font-mono">{strikeText}</td>

--- a/frontend/src/pages/strategy/Detail.tsx
+++ b/frontend/src/pages/strategy/Detail.tsx
@@ -2735,8 +2735,21 @@ export default function StrategyDetail() {
               {unlockMutation.isPending ? 'Unlocking…' : 'Unlock webhook'}
             </Button>
           )}
-          {stopped && !strategy.webhook_locked && (
+          {/* Batch only. A signal strategy's run is opened by its first
+              long_entry or short_entry after the session boundary, so there is
+              nothing for a Start button to do: pressing it ran the batch
+              lifecycle over legs that carry an accepted side rather than a
+              position to enter at. */}
+          {stopped && !strategy.webhook_locked && strategy.strategy_kind !== 'signal' && (
             <Button onClick={() => setStartDialogOpen(true)}>Start run</Button>
+          )}
+          {stopped && !strategy.webhook_locked && strategy.strategy_kind === 'signal' && (
+            <span
+              className="text-xs text-muted-foreground"
+              title="A signal strategy has no start. Send a long_entry or short_entry to its webhook."
+            >
+              Starts on its first signal
+            </span>
           )}
           {running && (
             <Button

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -82,6 +82,7 @@ import {
   TAB_DEFAULT_UNDERLYINGS,
   TAB_INTRADAY_DEFAULTS,
   TAB_SEGMENTS,
+  TAB_UNDERLYING_EXCHANGES,
   TAB_UNDERLYING_IS_CLOSED_SET,
   UNIVERSE_TAB_HINT,
   UNIVERSE_TAB_LABELS,
@@ -1080,6 +1081,9 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
 
   const [tab, setTab] = useState<UniverseTab>(initialTab)
   const [name, setName] = useState(editing?.name ?? '')
+  const [chosenExchange, setChosenExchange] = useState<string | null>(
+    editing?.underlying_exchange ?? null
+  )
   const [underlying, setUnderlying] = useState(
     editing?.underlying ?? TAB_DEFAULT_UNDERLYINGS[initialTab][0].symbol
   )
@@ -1143,12 +1147,18 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
 
   // On a closed-universe tab the exchange comes from the seed entry; on an open
   // one every underlying on the tab is listed on the same exchange.
+  // On a closed-universe tab the exchange follows the index that was picked.
+  // On an open one the operator chooses it, because the same typed symbol can
+  // be listed on either venue: RELIANCE trades on NSE and on BSE.
   const underlyingExchange = useMemo(
     () =>
       seededUnderlyings.find((choice) => choice.symbol === underlying)?.exchange ??
+      chosenExchange ??
       TAB_DEFAULT_EXCHANGE[tab],
-    [underlying, seededUnderlyings, tab]
+    [underlying, seededUnderlyings, tab, chosenExchange]
   )
+
+  const exchangeChoices = TAB_UNDERLYING_EXCHANGES[tab]
 
   // Expiry lists are per (underlying, instrument), not per leg: ten legs on one
   // underlying ask the platform once. Only fetched for the instrument types the
@@ -1201,6 +1211,7 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
   const onTabChange = (next: UniverseTab) => {
     setTab(next)
     setUnderlying(TAB_DEFAULT_UNDERLYINGS[next][0].symbol)
+    setChosenExchange(TAB_DEFAULT_EXCHANGE[next])
     const seeded = [freshLegFor(1, next, kind)]
     setLegs(seeded)
     setEntryTime(TAB_INTRADAY_DEFAULTS[next].entry)
@@ -1587,13 +1598,33 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
                     id="underlying"
                     value={underlying}
                     onChange={setUnderlying}
-                    searchExchange={derivativeExchangeFor(underlyingExchange)}
+                    searchExchange={underlyingExchange}
                     placeholder={`Search ${seededUnderlyings[0]?.symbol ?? 'symbol'}…`}
                   />
                 )}
-                <p className="text-xs text-muted-foreground">
-                  Exchange: <span className="font-mono">{underlyingExchange}</span>
-                </p>
+                {exchangeChoices.length > 1 && !closedUniverse ? (
+                  <div className="flex items-center gap-2 pt-0.5">
+                    <Label htmlFor="underlying-exchange" className="text-xs text-muted-foreground">
+                      Exchange
+                    </Label>
+                    <select
+                      id="underlying-exchange"
+                      value={underlyingExchange}
+                      onChange={(event) => setChosenExchange(event.target.value)}
+                      className={`${SELECT_CLASS_SM} w-28 font-mono`}
+                    >
+                      {exchangeChoices.map((venue) => (
+                        <option key={venue} value={venue}>
+                          {venue}
+                        </option>
+                      ))}
+                    </select>
+                  </div>
+                ) : (
+                  <p className="text-xs text-muted-foreground">
+                    Exchange: <span className="font-mono">{underlyingExchange}</span>
+                  </p>
+                )}
               </div>
             )}
           </div>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -1158,16 +1158,20 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
 
   // On a closed-universe tab the exchange comes from the seed entry; on an open
   // one every underlying on the tab is listed on the same exchange.
-  // On a closed-universe tab the exchange follows the index that was picked.
-  // On an open one the operator chooses it, because the same typed symbol can
-  // be listed on either venue: RELIANCE trades on NSE and on BSE.
-  const underlyingExchange = useMemo(
-    () =>
-      seededUnderlyings.find((choice) => choice.symbol === underlying)?.exchange ??
-      chosenExchange ??
-      TAB_DEFAULT_EXCHANGE[tab],
-    [underlying, seededUnderlyings, tab, chosenExchange]
-  )
+  // On a closed-universe tab the exchange follows the index that was picked:
+  // NIFTY is quoted on NSE_INDEX and SENSEX on BSE_INDEX, and there is nothing
+  // to choose. On an open one the operator chooses, because the same typed
+  // symbol is listed on both venues: RELIANCE trades on NSE and on BSE.
+  //
+  // The explicit choice wins over the seed. Preferring the seed meant a stock
+  // that happens to be in the tab's seed list, which is most of them, silently
+  // went back to NSE the moment it was named, so BSE could be selected and
+  // never submitted.
+  const underlyingExchange = useMemo(() => {
+    const seeded = seededUnderlyings.find((choice) => choice.symbol === underlying)?.exchange
+    if (closedUniverse) return seeded ?? TAB_DEFAULT_EXCHANGE[tab]
+    return chosenExchange ?? seeded ?? TAB_DEFAULT_EXCHANGE[tab]
+  }, [underlying, seededUnderlyings, tab, chosenExchange, closedUniverse])
 
   const exchangeChoices = TAB_UNDERLYING_EXCHANGES[tab]
 

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -630,10 +630,12 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
   const partLot = qtyMode === 'units' && derivative && !isWholeLots(qty, lot.lotSize)
 
   const quantityLabel =
-    qtyMode === 'lots' ? 'Lots' : leg.segment === 'cash' ? 'Quantity (shares)' : 'Quantity (units)'
+    qtyMode === 'lots' ? 'Lots' : derivative ? 'Quantity (units)' : 'Quantity (shares)'
 
   const setQtyMode = (mode: QtyMode) => {
-    if (mode !== qtyMode) onChange(withQtyMode(leg, mode))
+    // The lot size the card has already resolved, so the toggle converts
+    // rather than reinterpreting: one lot of RELIANCE becomes 500 shares.
+    if (mode !== qtyMode) onChange(withQtyMode(leg, mode, lot.lotSize))
   }
 
   return (
@@ -686,7 +688,7 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
                   expiry: nextSegment === 'futures' ? (leg.expiry ?? 'monthly') : null,
                   // Lots on a cash venue is refused outright, so moving to one
                   // moves the leg to units rather than leaving it unsavable.
-                  qty_mode: isDerivativeExchange(nextVenue) ? (leg.qty_mode ?? 'lots') : 'units',
+                  qty_mode: defaultQtyMode(nextVenue),
                 })
               }}
               className={`${SELECT_CLASS_SM} font-mono`}
@@ -716,7 +718,7 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
                   // rather than left for the payload to strip.
                   expiry: segment === 'futures' ? (leg.expiry ?? 'monthly') : null,
                   exchange: nextVenue,
-                  qty_mode: isDerivativeExchange(nextVenue) ? (leg.qty_mode ?? 'lots') : 'units',
+                  qty_mode: defaultQtyMode(nextVenue),
                 })
               }}
               className={SELECT_CLASS_SM}
@@ -791,7 +793,7 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
                     onClick={() => setQtyMode(mode)}
                     title={
                       mode === 'lots' && !derivative
-                        ? `${venue} has no lot size to multiply by, so cash is counted in units.`
+                        ? `${venue} has no lot size to multiply by, so cash is counted in shares.`
                         : undefined
                     }
                     className={cn(
@@ -802,7 +804,9 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
                       mode === 'lots' && !derivative && 'cursor-not-allowed opacity-40'
                     )}
                   >
-                    {mode}
+                    {/* On a derivative "units" is contracts. On cash it is
+                        shares, which is the word the instrument actually uses. */}
+                    {mode === 'units' && !derivative ? 'shares' : mode}
                   </button>
                 ))}
               </div>
@@ -856,7 +860,7 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
               </p>
             ) : (
               <p className="text-[10px] text-muted-foreground">
-                {leg.segment === 'cash' ? 'Shares, sent as-is.' : 'Units, sent as-is.'}
+                {derivative ? 'Units, sent as-is.' : 'Shares, sent as-is.'}
               </p>
             )}
           </div>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -33,7 +33,9 @@ import { cn } from '@/lib/utils'
 import {
   ATM_OFFSETS,
   allowedProductsForLegs,
+  batchQuantityLabelFor,
   convertLegKind,
+  DIRECTION_ACCEPTS,
   defaultProductForLegs,
   defaultQtyMode,
   derivativeExchangeFor,
@@ -52,17 +54,18 @@ import {
   type LockProfitMode,
   legToPayload,
   MAX_LEGS,
-  MAX_LOTS,
   MAX_NAME_LENGTH,
   MAX_SIGNAL_LOTS,
   MAX_SIGNAL_QTY,
+  maxBatchQuantityFor,
   maxQtyFor,
   type OptionType,
   type Product,
+  productHintForLegs,
   type QtyMode,
   resolvedQuantity,
   type Segment,
-  SIGNAL_LEG_SEGMENTS,
+  SIGNAL_LEG_EXCHANGES,
   SIGNAL_MODE_TABS,
   STRATEGY_DIRECTION_LABELS,
   STRATEGY_KIND_HINT,
@@ -73,6 +76,8 @@ import {
   type StrategyKind,
   type StrategyType,
   type StrategyUpdatePayload,
+  segmentSuitsExchange,
+  signalSegmentsForTab,
   TAB_DEFAULT_EXCHANGE,
   TAB_DEFAULT_UNDERLYINGS,
   TAB_INTRADAY_DEFAULTS,
@@ -334,17 +339,26 @@ function LegCard({
           )}
 
           <div className="space-y-1.5">
-            <Label className="text-xs uppercase">Lots</Label>
+            <Label className="text-xs uppercase">{batchQuantityLabelFor(leg.segment)}</Label>
             <Input
               type="number"
               min={1}
-              max={MAX_LOTS}
+              max={maxBatchQuantityFor(leg.segment)}
               value={leg.lots ?? 1}
               onChange={(event) =>
-                update('lots', Math.max(1, Number.parseInt(event.target.value || '1', 10)))
+                update(
+                  'lots',
+                  Math.min(
+                    maxBatchQuantityFor(leg.segment),
+                    Math.max(1, Number.parseInt(event.target.value || '1', 10))
+                  )
+                )
               }
               className="h-9"
             />
+            {leg.segment === 'cash' && (
+              <p className="text-[10px] text-muted-foreground">Shares, sent as-is.</p>
+            )}
           </div>
 
           <div className="space-y-1.5">
@@ -655,22 +669,33 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
 
           <div className="space-y-1.5">
             <Label className="text-xs uppercase">Exchange</Label>
-            <Input
-              value={leg.exchange ?? ''}
+            <select
+              value={leg.exchange || venueFor(leg.segment)}
               onChange={(event) => {
                 const nextVenue = event.target.value.toUpperCase()
+                // The segment follows the venue rather than being left to
+                // contradict it. A leg marked cash on NFO validated and the
+                // segment was then ignored, so the leg traded whatever the
+                // symbol happened to be.
+                const nextSegment: Segment = isDerivativeExchange(nextVenue) ? 'futures' : 'cash'
                 onChange({
                   ...leg,
                   exchange: nextVenue,
-                  // Lots on a cash venue is refused outright, so typing one in
+                  segment: nextSegment,
+                  expiry: nextSegment === 'futures' ? (leg.expiry ?? 'monthly') : null,
+                  // Lots on a cash venue is refused outright, so moving to one
                   // moves the leg to units rather than leaving it unsavable.
                   qty_mode: isDerivativeExchange(nextVenue) ? (leg.qty_mode ?? 'lots') : 'units',
                 })
               }}
-              placeholder={venueFor(leg.segment)}
-              className="font-mono"
-              maxLength={20}
-            />
+              className={`${SELECT_CLASS_SM} font-mono`}
+            >
+              {SIGNAL_LEG_EXCHANGES.map((venue) => (
+                <option key={venue} value={venue}>
+                  {venue}
+                </option>
+              ))}
+            </select>
           </div>
         </div>
 
@@ -695,7 +720,7 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
               }}
               className={SELECT_CLASS_SM}
             >
-              {SIGNAL_LEG_SEGMENTS.map((segment) => (
+              {signalSegmentsForTab(tab).map((segment) => (
                 <option key={segment} value={segment}>
                   {segment}
                 </option>
@@ -1257,10 +1282,31 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
       if (!exitTime) return 'Exit time is required for an intraday strategy'
       if (entryTime >= exitTime) return 'Entry time must be earlier than exit time'
     }
+    // A short cash leg the product cannot carry. Indian cash equity is sold
+    // short intraday and never carried short, and the product is read as
+    // intent: anything that is not MIS reaches a cash venue as CNC, which
+    // makes the order a naked short delivery the broker refuses.
+    if (product !== 'MIS') {
+      for (const leg of legs) {
+        if (leg.segment !== 'cash') continue
+        if (leg.position === 'S' || leg.side === 'short') {
+          return `Leg ${leg.id}: cash cannot be held short overnight. Use MIS for an intraday short, or make the leg long.`
+        }
+      }
+    }
     for (const leg of legs) {
       if (isSignal) {
         if (!leg.symbol?.trim()) return `Leg ${leg.id}: symbol is required`
         if (!leg.exchange?.trim()) return `Leg ${leg.id}: exchange is required`
+        if (!SIGNAL_LEG_EXCHANGES.includes(leg.exchange.trim().toUpperCase())) {
+          return `Leg ${leg.id}: ${leg.exchange.trim().toUpperCase()} is not a venue this module trades. Use one of ${SIGNAL_LEG_EXCHANGES.join(', ')}.`
+        }
+        if (!segmentSuitsExchange(leg.segment, leg.exchange)) {
+          return `Leg ${leg.id}: a ${leg.segment} leg cannot trade on ${leg.exchange.trim().toUpperCase()}.`
+        }
+        if (!DIRECTION_ACCEPTS[direction].includes(leg.side ?? 'both')) {
+          return `Leg ${leg.id}: side ${leg.side} is one a ${direction} strategy never acts on. Change the side, or the strategy direction.`
+        }
         const qty = Number(leg.qty)
         if (!Number.isInteger(qty) || qty < 1) {
           return `Leg ${leg.id}: quantity must be a whole number of at least 1`
@@ -1280,6 +1326,15 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
         if (leg.strike == null || leg.strike <= 0) {
           return `Leg ${leg.id}: pick a strike, or switch the leg to ATM-relative`
         }
+      }
+      // Shares on cash, lots on a derivative. They are not the same number.
+      const cap = maxBatchQuantityFor(leg.segment)
+      if ((leg.lots ?? 1) > cap) {
+        const counted = leg.segment === 'cash' ? 'quantity' : 'lots'
+        return `Leg ${leg.id}: ${counted} cannot be more than ${cap.toLocaleString('en-IN')}`
+      }
+      if (!TAB_SEGMENTS[tab].includes(leg.segment)) {
+        return `Leg ${leg.id}: the ${UNIVERSE_TAB_LABELS[tab]} universe does not trade ${leg.segment}.`
       }
     }
     if (lockEnabled) {
@@ -1356,7 +1411,6 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
             default_mode: 'sandbox',
           }
         : null,
-      webhook_ip_allowlist: null,
     }
 
     if (isEdit) {
@@ -1615,13 +1669,7 @@ export default function StrategyWizard({ editing }: StrategyWizardProps = {}) {
                   </option>
                 ))}
               </select>
-              <p className="text-xs text-muted-foreground">
-                {allowedProducts.length === 1
-                  ? 'Mixed cash + derivatives legs: only MIS works for both.'
-                  : allowedProducts.includes('CNC')
-                    ? 'Cash equity: CNC (delivery) or MIS (intraday).'
-                    : 'Derivatives: NRML (carry) or MIS (intraday).'}
-              </p>
+              <p className="text-xs text-muted-foreground">{productHintForLegs(legs, product)}</p>
             </div>
           </div>
         </CardContent>

--- a/frontend/src/pages/strategy/Wizard.tsx
+++ b/frontend/src/pages/strategy/Wizard.tsx
@@ -632,6 +632,13 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
   const quantityLabel =
     qtyMode === 'lots' ? 'Lots' : derivative ? 'Quantity (units)' : 'Quantity (shares)'
 
+  // The spinner should move by a tradeable amount. In units mode on a
+  // derivative that is one lot, so 500 goes to 1000 rather than to 501, which
+  // is not a quantity the exchange accepts. Typing is untouched: an arbitrary
+  // number is still allowed, and a part lot is still flagged below and refused
+  // by the server. Shares and lot counts both step by one.
+  const qtyStep = qtyMode === 'units' && derivative && lot.lotSize ? lot.lotSize : 1
+
   const setQtyMode = (mode: QtyMode) => {
     // The lot size the card has already resolved, so the toggle converts
     // rather than reinterpreting: one lot of RELIANCE becomes 500 shares.
@@ -813,9 +820,9 @@ function SignalLegCard({ leg, tab, index, onChange, onRemove, removable }: Signa
             </div>
             <Input
               type="number"
-              min={1}
+              min={qtyStep}
               max={qtyMode === 'lots' ? MAX_SIGNAL_LOTS : MAX_SIGNAL_QTY}
-              step={1}
+              step={qtyStep}
               value={qty}
               onChange={(event) =>
                 update(

--- a/frontend/src/pages/strategy/strategy_module.test.ts
+++ b/frontend/src/pages/strategy/strategy_module.test.ts
@@ -9,9 +9,12 @@ import {
   reconcileBrokerTrades,
 } from '@/api/strategy_module'
 import {
+  allowedProductsForLegs,
+  batchQuantityLabelFor,
   convertLegKind,
   defaultQtyMode,
   derivativeExchangeFor,
+  DIRECTION_ACCEPTS,
   favorablePeakPoints,
   filterStrikes,
   formatIst,
@@ -22,16 +25,22 @@ import {
   isWholeLots,
   type Leg,
   legToPayload,
+  MAX_CASH_QUANTITY,
+  MAX_LOTS,
   MAX_SIGNAL_LOTS,
   MAX_SIGNAL_QTY,
+  maxBatchQuantityFor,
   monthlyExpiries,
   type Order,
   parseExpiryDate,
+  productHintForLegs,
   type QtyMode,
   resolvedQuantity,
   resolveExpiryRank,
+  segmentSuitsExchange,
   SIGNAL_LEG_SEGMENTS,
   SIGNAL_MODE_TABS,
+  signalSegmentsForTab,
   sortExpiries,
   TAB_SEGMENTS,
   withQtyMode,
@@ -881,6 +890,7 @@ describe('legToPayload, batch', () => {
       sl_pts: 30,
       target_pts: 60,
       trail: { x: 10, y: 5 },
+      risk_unit: 'points',
     })
   })
 
@@ -918,7 +928,40 @@ describe('legToPayload, batch', () => {
       'batch'
     )
     expect(payload).not.toHaveProperty('expiry')
-    expect(Object.keys(payload).sort()).toEqual(['id', 'lots', 'position', 'segment'])
+    expect(Object.keys(payload).sort()).toEqual([
+      'id',
+      'lots',
+      'position',
+      'risk_unit',
+      'segment',
+    ])
+  })
+})
+
+describe('legToPayload, risk unit', () => {
+  it('sends percent, because dropping it silently saved the leg as points', () => {
+    const leg: Leg = { ...BATCH_OPTION_LEG, risk_unit: 'percent' }
+    expect(legToPayload(leg, 'batch').risk_unit).toBe('percent')
+  })
+
+  it('sends points for a leg that never set one, so nothing stored changes', () => {
+    const { risk_unit: _absent, ...withoutUnit } = BATCH_OPTION_LEG
+    void _absent
+    expect(legToPayload(withoutUnit as Leg, 'batch').risk_unit).toBe('points')
+  })
+
+  it('sends percent on a signal leg too, which shares the same risk block', () => {
+    const leg: Leg = {
+      id: 1,
+      segment: 'cash',
+      symbol: 'RELIANCE',
+      exchange: 'NSE',
+      side: 'long',
+      qty: 500,
+      risk_unit: 'percent',
+      sl_pts: 2,
+    }
+    expect(legToPayload(leg, 'signal')).toMatchObject({ risk_unit: 'percent', sl_pts: 2 })
   })
 })
 
@@ -945,6 +988,7 @@ describe('legToPayload, signal', () => {
       side: 'long',
       qty: 500,
       qty_mode: 'units',
+      risk_unit: 'points',
     })
   })
 
@@ -1107,6 +1151,7 @@ describe('freshSignalLeg', () => {
       'id',
       'qty',
       'qty_mode',
+      'risk_unit',
       'segment',
       'side',
       'symbol',
@@ -1341,5 +1386,78 @@ describe('lotSizeFromRows', () => {
       )
     ).toBeNull()
     expect(lotSizeFromRows([], 'NIFTY')).toBeNull()
+  })
+})
+
+describe('cash and derivative quantities are not the same number', () => {
+  it('caps a batch cash leg at the share ceiling, not the lot one', () => {
+    expect(maxBatchQuantityFor('cash')).toBe(MAX_CASH_QUANTITY)
+    expect(maxBatchQuantityFor('futures')).toBe(MAX_LOTS)
+    expect(maxBatchQuantityFor('options')).toBe(MAX_LOTS)
+  })
+
+  it('labels a cash count as shares, because a lot size of 1 is what makes it one', () => {
+    expect(batchQuantityLabelFor('cash')).toBe('Quantity (shares)')
+    expect(batchQuantityLabelFor('futures')).toBe('Lots')
+  })
+})
+
+describe('a segment and an exchange have to describe the same instrument', () => {
+  it('refuses cash on a derivative venue, which used to validate and be ignored', () => {
+    expect(segmentSuitsExchange('cash', 'NFO')).toBe(false)
+    expect(segmentSuitsExchange('cash', 'MCX')).toBe(false)
+    expect(segmentSuitsExchange('cash', 'NSE')).toBe(true)
+    expect(segmentSuitsExchange('cash', 'BSE')).toBe(true)
+  })
+
+  it('refuses futures on a cash venue', () => {
+    expect(segmentSuitsExchange('futures', 'NSE')).toBe(false)
+    expect(segmentSuitsExchange('futures', 'NFO')).toBe(true)
+  })
+
+  it('says nothing about a leg with no exchange yet', () => {
+    expect(segmentSuitsExchange('cash', '')).toBe(true)
+    expect(segmentSuitsExchange('cash', null)).toBe(true)
+  })
+})
+
+describe('a tab only offers the segments it trades', () => {
+  it('keeps cash off the commodity tab, where there is no spot', () => {
+    expect(signalSegmentsForTab('mcx')).toEqual(['futures'])
+  })
+
+  it('offers cash on the stocks tab', () => {
+    expect(signalSegmentsForTab('stocks_fno')).toEqual(['cash', 'futures'])
+  })
+})
+
+describe('the product a mixed basket is allowed to carry', () => {
+  const cash: Leg = { id: 1, segment: 'cash' }
+  const option: Leg = { id: 2, segment: 'options' }
+
+  it('offers carry on a mixed basket, because the engine translates per venue', () => {
+    expect(allowedProductsForLegs([cash, option])).toEqual(['MIS', 'NRML'])
+  })
+
+  it('says what each venue is actually sent', () => {
+    expect(productHintForLegs([cash, option], 'NRML')).toBe(
+      'Carried: the derivative legs are sent as NRML and the cash legs as CNC.'
+    )
+    expect(productHintForLegs([cash], 'CNC')).toBe('Cash equity: CNC takes delivery, MIS is intraday.')
+    expect(productHintForLegs([option], 'MIS')).toBe(
+      'Intraday on every leg, squared off the same day.'
+    )
+  })
+
+  it('still restricts a cash-only basket to the two products cash accepts', () => {
+    expect(allowedProductsForLegs([cash])).toEqual(['MIS', 'CNC'])
+  })
+})
+
+describe('a direction and a leg side cannot contradict each other', () => {
+  it('mirrors the server, so the form refuses what the save would', () => {
+    expect(DIRECTION_ACCEPTS.long_only).toEqual(['long', 'both'])
+    expect(DIRECTION_ACCEPTS.short_only).toEqual(['short', 'both'])
+    expect(DIRECTION_ACCEPTS.both).toEqual(['long', 'short', 'both'])
   })
 })

--- a/frontend/src/pages/strategy/strategy_module.test.ts
+++ b/frontend/src/pages/strategy/strategy_module.test.ts
@@ -43,6 +43,9 @@ import {
   signalSegmentsForTab,
   sortExpiries,
   TAB_SEGMENTS,
+  TAB_UNDERLYING_EXCHANGES,
+  TAB_UNDERLYING_IS_CLOSED_SET,
+  UNIVERSE_TAB_HINT,
   withQtyMode,
 } from '@/types/strategy_module'
 
@@ -1459,5 +1462,24 @@ describe('a direction and a leg side cannot contradict each other', () => {
     expect(DIRECTION_ACCEPTS.long_only).toEqual(['long', 'both'])
     expect(DIRECTION_ACCEPTS.short_only).toEqual(['short', 'both'])
     expect(DIRECTION_ACCEPTS.both).toEqual(['long', 'short', 'both'])
+  })
+})
+
+describe('the stocks tab trades any listed equity, on either venue', () => {
+  it('offers NSE and BSE on the stocks tab and one venue elsewhere', () => {
+    expect(TAB_UNDERLYING_EXCHANGES.stocks_fno).toEqual(['NSE', 'BSE'])
+    expect(TAB_UNDERLYING_EXCHANGES.mcx).toEqual(['MCX'])
+  })
+
+  it('does not promise a NIFTY 500 universe it does not enforce', () => {
+    // The engine resolves any listed equity, so the hint said something the
+    // product does not do. It was inherited from a stocks list built out of
+    // NFO futures contracts, which this one is not.
+    expect(UNIVERSE_TAB_HINT.stocks_fno).toBe('Any NSE or BSE stock')
+  })
+
+  it('keeps the stocks universe open, so a typed symbol is accepted', () => {
+    expect(TAB_UNDERLYING_IS_CLOSED_SET.stocks_fno).toBe(false)
+    expect(TAB_UNDERLYING_IS_CLOSED_SET.weekly_monthly).toBe(true)
   })
 })

--- a/frontend/src/pages/strategy/strategy_module.test.ts
+++ b/frontend/src/pages/strategy/strategy_module.test.ts
@@ -12,9 +12,9 @@ import {
   allowedProductsForLegs,
   batchQuantityLabelFor,
   convertLegKind,
+  DIRECTION_ACCEPTS,
   defaultQtyMode,
   derivativeExchangeFor,
-  DIRECTION_ACCEPTS,
   favorablePeakPoints,
   filterStrikes,
   formatIst,
@@ -37,9 +37,9 @@ import {
   type QtyMode,
   resolvedQuantity,
   resolveExpiryRank,
-  segmentSuitsExchange,
   SIGNAL_LEG_SEGMENTS,
   SIGNAL_MODE_TABS,
+  segmentSuitsExchange,
   signalSegmentsForTab,
   sortExpiries,
   TAB_SEGMENTS,
@@ -931,13 +931,7 @@ describe('legToPayload, batch', () => {
       'batch'
     )
     expect(payload).not.toHaveProperty('expiry')
-    expect(Object.keys(payload).sort()).toEqual([
-      'id',
-      'lots',
-      'position',
-      'risk_unit',
-      'segment',
-    ])
+    expect(Object.keys(payload).sort()).toEqual(['id', 'lots', 'position', 'risk_unit', 'segment'])
   })
 })
 
@@ -1283,9 +1277,9 @@ describe('legToPayload, quantity mode', () => {
 })
 
 describe('withQtyMode', () => {
-  // Decided: the number is kept and reinterpreted, never converted. Converting
-  // would silently rewrite what the user typed, and could only work one way.
-  it('keeps the number the user typed rather than converting it', () => {
+  // With no lot size there is nothing to convert by, so the number is kept and
+  // reinterpreted. That is the older behaviour and it still holds here.
+  it('keeps the number when no lot size is known', () => {
     const asUnits = withQtyMode(NIFTY_FUT_LEG, 'units')
     expect(asUnits.qty).toBe(5)
     expect(asUnits.qty_mode).toBe('units')
@@ -1446,7 +1440,9 @@ describe('the product a mixed basket is allowed to carry', () => {
     expect(productHintForLegs([cash, option], 'NRML')).toBe(
       'Carried: the derivative legs are sent as NRML and the cash legs as CNC.'
     )
-    expect(productHintForLegs([cash], 'CNC')).toBe('Cash equity: CNC takes delivery, MIS is intraday.')
+    expect(productHintForLegs([cash], 'CNC')).toBe(
+      'Cash equity: CNC takes delivery, MIS is intraday.'
+    )
     expect(productHintForLegs([option], 'MIS')).toBe(
       'Intraday on every leg, squared off the same day.'
     )
@@ -1481,5 +1477,44 @@ describe('the stocks tab trades any listed equity, on either venue', () => {
   it('keeps the stocks universe open, so a typed symbol is accepted', () => {
     expect(TAB_UNDERLYING_IS_CLOSED_SET.stocks_fno).toBe(false)
     expect(TAB_UNDERLYING_IS_CLOSED_SET.weekly_monthly).toBe(true)
+  })
+})
+
+describe('withQtyMode converts once the lot size is known', () => {
+  it('turns lots into the shares they stand for', () => {
+    // One lot of RELIANCE is 500 shares. Leaving "1" on the toggle offered a
+    // quantity that cannot be traded and read as though nothing happened.
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 1, qty_mode: 'lots' }
+    expect(withQtyMode(leg, 'units', 500).qty).toBe(500)
+  })
+
+  it('scales a multi-lot quantity', () => {
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 3, qty_mode: 'lots' }
+    expect(withQtyMode(leg, 'units', 500).qty).toBe(1500)
+  })
+
+  it('divides on the way back, floored to whole lots', () => {
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 1500, qty_mode: 'units' }
+    expect(withQtyMode(leg, 'lots', 500).qty).toBe(3)
+  })
+
+  it('never floors a part lot to zero', () => {
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 300, qty_mode: 'units' }
+    expect(withQtyMode(leg, 'lots', 500).qty).toBe(1)
+  })
+
+  it('does not convert when the mode is unchanged', () => {
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 2, qty_mode: 'lots' }
+    expect(withQtyMode(leg, 'lots', 500).qty).toBe(2)
+  })
+
+  it('leaves a cash leg alone, because lots is refused there', () => {
+    const leg: Leg = { id: 1, segment: 'cash', exchange: 'NSE', qty: 137, qty_mode: 'units' }
+    expect(withQtyMode(leg, 'lots', 500)).toEqual(leg)
+  })
+
+  it('still keeps the number when the lot size is unknown', () => {
+    const leg: Leg = { id: 1, segment: 'futures', exchange: 'NFO', qty: 4, qty_mode: 'lots' }
+    expect(withQtyMode(leg, 'units', null).qty).toBe(4)
   })
 })

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -450,7 +450,7 @@ export const UNIVERSE_TAB_LABELS: Record<UniverseTab, string> = {
 export const UNIVERSE_TAB_HINT: Record<UniverseTab, string> = {
   weekly_monthly: 'NIFTY, SENSEX',
   monthly_only: 'MIDCPNIFTY, BANKNIFTY, FINNIFTY, BANKEX',
-  stocks_fno: 'All NIFTY 500 stocks',
+  stocks_fno: 'Any NSE or BSE stock',
   mcx: 'CRUDEOIL, NATURALGAS, GOLD, SILVER, …',
 }
 
@@ -532,6 +532,22 @@ export const TAB_UNDERLYING_IS_CLOSED_SET: Record<UniverseTab, boolean> = {
   monthly_only: true,
   stocks_fno: false,
   mcx: false,
+}
+
+/**
+ * Exchanges a tab's underlying may be quoted on.
+ *
+ * Only the stocks tab has a choice to offer. An index tab's exchange follows
+ * the index the user picked, and MCX lists on one venue. Cash resolves against
+ * whichever of these the strategy carries, and a derivative leg on the same
+ * underlying maps from it (NSE to NFO, BSE to BFO), so this is the strategy's
+ * exchange rather than the cash leg's.
+ */
+export const TAB_UNDERLYING_EXCHANGES: Record<UniverseTab, string[]> = {
+  weekly_monthly: ['NSE_INDEX', 'BSE_INDEX'],
+  monthly_only: ['NSE_INDEX', 'BSE_INDEX'],
+  stocks_fno: ['NSE', 'BSE'],
+  mcx: ['MCX'],
 }
 
 /** The exchange a typed underlying defaults to on an open-universe tab. */

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -591,6 +591,60 @@ export const SIGNAL_MODE_TABS: UniverseTab[] = ['stocks_fno', 'mcx']
 export const SIGNAL_LEG_SEGMENTS: Segment[] = ['cash', 'futures']
 
 /**
+ * Segments a signal leg may take on a given tab.
+ *
+ * The flat list above offered cash on the commodity tab, where there is no
+ * spot to trade: the leg validated, the segment was then ignored downstream,
+ * and the order went to MCX as whatever the symbol happened to be. Intersecting
+ * with the tab keeps the offer honest.
+ */
+export function signalSegmentsForTab(tab: UniverseTab): Segment[] {
+  const allowed = new Set(TAB_SEGMENTS[tab])
+  const offered = SIGNAL_LEG_SEGMENTS.filter((segment) => allowed.has(segment))
+  return offered.length > 0 ? offered : ['futures']
+}
+
+/**
+ * Where a signal leg may trade. Mirrors `SIGNAL_LEG_EXCHANGES` in
+ * `blueprints/strategy_module.py`. The exchange box takes typed text, so
+ * without this the only thing that caught "NSEE" was a 400 on save.
+ */
+export const SIGNAL_LEG_EXCHANGES = [
+  'NSE',
+  'BSE',
+  'NFO',
+  'BFO',
+  'MCX',
+  'CDS',
+  'BCD',
+  'NCDEX',
+  'NCO',
+]
+
+/**
+ * Which leg sides a strategy-level direction can ever act on. Mirrors
+ * `_DIRECTION_ACCEPTS` in `blueprints/strategy_module.py`.
+ *
+ * A long_only strategy discards every short signal before it reaches a leg, so
+ * a leg declared short is configuration that looks complete and can never
+ * trade. The server refuses it; without this the operator found out on save.
+ */
+export const DIRECTION_ACCEPTS: Record<StrategyDirection, LegSide[]> = {
+  both: ['long', 'short', 'both'],
+  long_only: ['long', 'both'],
+  short_only: ['short', 'both'],
+}
+
+/** Whether a signal leg's segment and exchange describe the same instrument. */
+export function segmentSuitsExchange(segment: Segment, exchange: string | null | undefined) {
+  const venue = (exchange ?? '').trim().toUpperCase()
+  if (!venue) return true
+  if (segment === 'cash') return !isDerivativeExchange(venue)
+  if (segment === 'futures') return isDerivativeExchange(venue)
+  return true
+}
+
+/**
  * Intraday window per tab. NSE and BSE trade 09:15-15:30, so 09:35-15:15 skips
  * the opening auction and exits before a broker's MIS square-off. MCX runs to
  * 23:30 in winter, so its window closes at 23:25.
@@ -604,11 +658,31 @@ export const TAB_INTRADAY_DEFAULTS: Record<UniverseTab, { entry: string; exit: s
 
 export const MAX_LEGS = 10
 export const MAX_LOTS = 50
+/**
+ * Cap on a batch cash leg's quantity.
+ *
+ * A cash contract's lot size is 1, so a batch cash leg's "lots" is a share
+ * count. Capping it at the derivative's 50 made fifty shares the largest cash
+ * order a batch strategy could place, while signal mode counted the same
+ * instrument in units up to a million. Mirrors MAX_CASH_QUANTITY in
+ * blueprints/strategy_module.py.
+ */
+export const MAX_CASH_QUANTITY = 1_000_000
 export const MAX_NAME_LENGTH = 200
 /** Cap on a signal leg's quantity when it is counted in units. */
 export const MAX_SIGNAL_QTY = 1_000_000
 /** Cap on a signal leg's quantity when it is counted in lots. */
 export const MAX_SIGNAL_LOTS = 10_000
+
+/** The cap on a batch leg's count: shares on cash, lots on a derivative. */
+export function maxBatchQuantityFor(segment: Segment): number {
+  return segment === 'cash' ? MAX_CASH_QUANTITY : MAX_LOTS
+}
+
+/** What a batch leg's count is measured in, for a label the operator reads. */
+export function batchQuantityLabelFor(segment: Segment): string {
+  return segment === 'cash' ? 'Quantity (shares)' : 'Lots'
+}
 
 /**
  * Exchanges that trade in lots. Mirrors `DERIVATIVE_EXCHANGES` in
@@ -708,17 +782,37 @@ export function isWholeLots(qty: number | null | undefined, lotSize: number | nu
 /**
  * Products valid for a mix of segments.
  *
- * The product is a strategy-level field applied to every leg, so a basket that
- * mixes cash with derivatives is restricted to MIS: it is the only product that
- * exists on both sides of the exchange's rules.
+ * The product is a strategy-level field applied to every leg, and the engine
+ * reads it as the intent rather than as a literal: MIS is intraday everywhere,
+ * and anything else means carry, which `product_for_exchange` sends as NRML on
+ * a derivative venue and CNC on cash. A mixed basket can therefore be carried,
+ * with each leg receiving a product its own venue accepts.
+ *
+ * This used to offer MIS alone for a mixed basket, which was stricter than the
+ * engine and removed carry from a basket that supports it. NRML is offered as
+ * the carry intent because that is the spelling a derivative leg keeps; the
+ * hint beside the control says what the cash leg is sent as.
  */
 export function allowedProductsForLegs(legs: Leg[]): Product[] {
   const segments = new Set(legs.map((leg) => leg.segment))
   const hasCash = segments.has('cash')
   const hasDerivative = segments.has('futures') || segments.has('options')
-  if (hasCash && hasDerivative) return ['MIS']
+  if (hasCash && hasDerivative) return ['MIS', 'NRML']
   if (hasCash) return ['MIS', 'CNC']
   return ['NRML', 'MIS']
+}
+
+/** What the chosen product is actually sent as, per venue, for a leg mix. */
+export function productHintForLegs(legs: Leg[], product: Product): string {
+  const segments = new Set(legs.map((leg) => leg.segment))
+  const hasCash = segments.has('cash')
+  const hasDerivative = segments.has('futures') || segments.has('options')
+  if (product === 'MIS') return 'Intraday on every leg, squared off the same day.'
+  if (hasCash && hasDerivative) {
+    return 'Carried: the derivative legs are sent as NRML and the cash legs as CNC.'
+  }
+  if (hasCash) return 'Cash equity: CNC takes delivery, MIS is intraday.'
+  return 'Derivatives: NRML carries the position, MIS is intraday.'
 }
 
 /** Default product for a leg composition: cash-only is MIS, derivatives NRML. */
@@ -888,6 +982,13 @@ export function legToPayload(leg: Leg, kind: StrategyKind = 'batch'): Leg {
   if (leg.sl_pts != null) clean.sl_pts = leg.sl_pts
   if (leg.target_pts != null) clean.target_pts = leg.target_pts
   if (leg.trail && (leg.trail.x > 0 || leg.trail.y > 0)) clean.trail = leg.trail
+  // Sent with the numbers it governs, and always. Leaving it out let the
+  // server apply its own default of points, so a leg configured as a
+  // percentage of entry saved as points: the toggle moved, the form redrew,
+  // and the stop was a rupee distance on a 2500 stock instead of a percentage
+  // of it. Editing such a strategy then converted it back again. Points is
+  // still the default when nothing is set, so this changes no stored leg.
+  clean.risk_unit = leg.risk_unit ?? 'points'
   return clean
 }
 

--- a/frontend/src/types/strategy_module.ts
+++ b/frontend/src/types/strategy_module.ts
@@ -758,23 +758,37 @@ export function resolvedQuantity(
 /**
  * The leg that results from switching to another quantity mode.
  *
- * The number is kept and reinterpreted, never converted. Rewriting 5 lots into
- * 325 units would silently edit what the user typed, and the reverse only
- * works when the lot size is known and divides exactly - so a converting
- * toggle would sometimes convert and sometimes not, which is harder to trust
- * than one that never does. A number that is wrong in the new mode fails
- * visibly: the card says so, and the server refuses a part lot by name.
+ * The number is converted when the lot size is known, because the same digit
+ * means two different trades either side of the toggle. One lot of RELIANCE is
+ * 500 shares, so leaving "1" on screen after a switch to units offers a
+ * quantity that cannot be traded at all, and reads as though the toggle did
+ * nothing. Switching back divides, floored to whole lots and never below one,
+ * so a part-lot number resolves to the lots it covers rather than to nonsense.
+ *
+ * With no lot size the number is kept and reinterpreted, which is the older
+ * behaviour: there is nothing to convert by, and inventing a factor would be
+ * worse than leaving a figure the card already flags. A units quantity off a
+ * lot boundary is still called out by `isWholeLots`, and the server refuses a
+ * part lot by name.
  *
  * Lots on a cash venue is refused outright by the validator, so the switch is
  * a no-op there rather than something to be undone on save.
  */
-export function withQtyMode(leg: Leg, mode: QtyMode): Leg {
+export function withQtyMode(leg: Leg, mode: QtyMode, lotSize?: number | null): Leg {
   if (mode === 'lots' && !isDerivativeExchange(leg.exchange)) return leg
+
+  const current = leg.qty ?? 1
+  const size = lotSize && lotSize > 0 ? lotSize : null
+  let converted = current
+  if (size && mode !== (leg.qty_mode ?? defaultQtyMode(leg.exchange))) {
+    converted = mode === 'units' ? current * size : Math.max(1, Math.floor(current / size))
+  }
+
   return {
     ...leg,
     qty_mode: mode,
-    // Only the cap changes with the mode: 10,000 lots against 1,000,000 units.
-    qty: Math.min(maxQtyFor(mode), leg.qty ?? 1),
+    // The cap changes with the mode too: 10,000 lots against 1,000,000 units.
+    qty: Math.min(maxQtyFor(mode), Math.max(1, converted)),
   }
 }
 

--- a/services/strategy_module/engine.py
+++ b/services/strategy_module/engine.py
@@ -251,6 +251,21 @@ def start_run(
     if mode not in store.RUN_MODES:
         return StartResult(ok=False, error=f"Unknown run mode: {mode!r}")
 
+    # Batch only, which the public reference already states. A signal strategy
+    # has no start: its run is opened by the first signal after the session
+    # boundary, in signals._day_run. Running the batch lifecycle over signal
+    # legs got as far as building run state and then raised, because a signal
+    # leg carries the side it accepts and not a position to be entered at, and
+    # the failure left the run open and the strategy claimed.
+    if (strategy_row.strategy_kind or "batch") == "signal":
+        return StartResult(
+            ok=False,
+            error=(
+                "A signal strategy has no start. Its run opens on the first "
+                "long_entry or short_entry signal after the session boundary."
+            ),
+        )
+
     # Live is opt-in per strategy. Checked here as well as at every caller,
     # because this is the last point before real orders.
     if mode == "live" and not strategy_row.live_enabled:
@@ -815,6 +830,18 @@ def _manage_failed_start(
             state.reject_entry_intent(run_id, leg["leg_id"], leg.get("position_ref"))
 
     snapshot = state.get_run_state(run_id)
+
+    # No dispatch was ever attempted, so nothing can be held. `dispatch_attempted`
+    # is written immediately before each call precisely so a raise mid-send is
+    # kept as possible exposure; an empty set is therefore proof of flatness,
+    # and it holds even when run state was never built. Without this, a start
+    # that failed while constructing that state left the run open and the
+    # strategy stuck reading "running", with no live state for any later stop
+    # to work from and nothing to reconcile against.
+    if not attempted:
+        _finalise(run_id, strategy_id, user_id, "error", "Start failed before any entry dispatch")
+        return StartResult(ok=False, run_id=run_id, error="Could not start the strategy")
+
     if snapshot is not None and not _run_requires_management(snapshot):
         _finalise(run_id, strategy_id, user_id, "error", "Start failed before any entry dispatch")
         return StartResult(ok=False, run_id=run_id, error="Could not start the strategy")

--- a/services/strategy_module/engine.py
+++ b/services/strategy_module/engine.py
@@ -363,7 +363,19 @@ def start_run(
                     ),
                     legs=placed,
                 )
-            return StartResult(ok=False, error="Every entry order was rejected", legs=placed)
+            # The run id and the broker's own words come back with the refusal.
+            # Without them the caller was told only that every entry was
+            # rejected, with no run to open and no reason to read, while the
+            # cause sat on the order rows all along: "MIS orders cannot be
+            # placed after square-off time", "insufficient funds", whatever the
+            # venue actually said. The finalised run is still the place those
+            # rows live, so naming it is what makes the refusal actionable.
+            return StartResult(
+                ok=False,
+                run_id=run_id,
+                error=_rejection_summary(placed),
+                legs=placed,
+            )
 
         return StartResult(ok=True, run_id=run_id, legs=placed)
     except Exception:
@@ -593,6 +605,31 @@ def _replay_order_update(broker_order_id: str | None) -> None:
         order_events.replay_for(broker_order_id)
     except Exception:
         logger.exception("Could not replay a held order update for %s", broker_order_id)
+
+
+def _rejection_summary(placed: list[dict[str, Any]]) -> str:
+    """Why every entry was refused, in the venue's own words.
+
+    Each leg already carries the dispatch error; only the caller never saw it.
+    One distinct reason is reported as itself, because a basket refused for one
+    cause has one thing to fix. Several are listed per leg so a mixed refusal
+    does not hide the leg that failed for a different reason.
+    """
+    reasons: dict[str, list[Any]] = {}
+    for leg in placed:
+        reason = str(leg.get("error") or "").strip()
+        if reason:
+            reasons.setdefault(reason, []).append(leg.get("leg_id"))
+
+    if not reasons:
+        return "Every entry order was rejected"
+    if len(reasons) == 1:
+        return f"Every entry order was rejected: {next(iter(reasons))}"
+    detail = "; ".join(
+        f"leg {', '.join(str(leg_id) for leg_id in legs)}: {reason}"
+        for reason, legs in reasons.items()
+    )
+    return f"Every entry order was rejected. {detail}"
 
 
 def _place_entries(
@@ -943,7 +980,9 @@ def _apply_fill(
                 leg["realized_pnl"] = float(leg.get("realized_pnl") or 0.0) + (
                     (float(avg_price) - entry) * applied_qty * sign
                 )
-            owns_current_order = order_row_id is None or superseded.get("exit_order_id") == order_row_id
+            owns_current_order = (
+                order_row_id is None or superseded.get("exit_order_id") == order_row_id
+            )
             release_current_order = order_terminal and owns_current_order
             if remaining_qty > 0 or not release_current_order:
                 superseded["qty"] = remaining_qty
@@ -1007,9 +1046,7 @@ def _apply_fill(
                 # whose remainder was cancelled is ordinary on an illiquid
                 # strike; every later exit must use what actually filled.
                 managed_entry_qty = (
-                    cumulative_filled_qty
-                    if cumulative_filled_qty is not None
-                    else filled_qty
+                    cumulative_filled_qty if cumulative_filled_qty is not None else filled_qty
                 )
                 if managed_entry_qty is not None and managed_entry_qty != leg.get("qty"):
                     deferred_warnings.append(
@@ -1049,7 +1086,9 @@ def _apply_fill(
                         )
                     )
                     leg["realized_pnl"] = float(leg.get("realized_pnl") or 0.0)
-                owns_current_order = order_row_id is None or leg.get("exit_order_id") == order_row_id
+                owns_current_order = (
+                    order_row_id is None or leg.get("exit_order_id") == order_row_id
+                )
                 release_current_order = order_terminal and owns_current_order
                 if remaining_qty > 0:
                     leg["qty"] = remaining_qty
@@ -1105,10 +1144,7 @@ def _apply_fill(
     # audit trail that is supposed to describe the day. A signal run is closed
     # by the scheduler's square-off, by an explicit stop, or by the session
     # boundary when the next day's first signal arrives.
-    if (
-        requested_reason is None
-        and strategy_kind == "signal"
-    ):
+    if requested_reason is None and strategy_kind == "signal":
         logger.debug("Run %s is flat but signal-mode; leaving it open for the session", run_id)
         return True
 
@@ -1811,9 +1847,7 @@ def close_leg(run_id: int, leg_id: Any, user_id: str) -> dict[str, Any]:
     if not api_key:
         return {"ok": False, "error": "No API key is configured for this user"}
 
-    exits = _exit_legs(
-        run_id, strategy, [leg_id], "exit_leg_manual", run_mode, api_key, user_id
-    )
+    exits = _exit_legs(run_id, strategy, [leg_id], "exit_leg_manual", run_mode, api_key, user_id)
     if not exits:
         return {"ok": False, "error": "That leg is not open"}
 
@@ -2126,11 +2160,7 @@ def _process_tick_for_run(run_id: int, symbol: str, exchange: str, ltp: float) -
                     {
                         "symbol": str(leg.get("symbol") or ""),
                         "exchange": str(leg.get("exchange") or ""),
-                        "ltp": (
-                            float(leg["ltp"])
-                            if leg.get("ltp") is not None
-                            else None
-                        ),
+                        "ltp": (float(leg["ltp"]) if leg.get("ltp") is not None else None),
                         "mtm": round(float(leg.get("mtm") or 0.0), 2),
                         "tick_source": str(leg.get("tick_source") or ""),
                         "qty": int(leg.get("qty") or 0),

--- a/services/strategy_module/order_dispatch.py
+++ b/services/strategy_module/order_dispatch.py
@@ -74,13 +74,17 @@ class OrderStatusResult:
     error: str | None = None
 
 
-# Which products each venue accepts. /scalping already carries this rule
-# (blueprints/scalping.py), and every broker enforces it: CNC is a delivery
-# product for cash, NRML a carry-forward product for derivatives, and neither
-# is accepted on the other's venue.
+# Which venues list derivatives, for the purpose of naming the product.
+# /scalping already carries this rule (blueprints/scalping.py), and every
+# broker enforces it: CNC is a delivery product for cash, NRML a carry-forward
+# product for derivatives, and neither is accepted on the other's venue.
+#
+# There is deliberately no set of "products a derivative accepts" beside this
+# one. Two such sets used to sit here and were referenced by nothing, which
+# read as a validation rule that ran somewhere and did not: the product is
+# translated per venue below rather than refused, so a legal value for the
+# venue is produced instead of being demanded from the caller.
 DERIVATIVE_EXCHANGES_FOR_PRODUCT = frozenset({"NFO", "BFO", "MCX", "CDS", "BCD", "NCDEX", "NCO"})
-DERIVATIVE_PRODUCTS = frozenset({"MIS", "NRML"})
-EQUITY_PRODUCTS = frozenset({"MIS", "CNC"})
 
 
 def product_for_exchange(product: str, exchange: str) -> str:

--- a/services/strategy_module/recovery.py
+++ b/services/strategy_module/recovery.py
@@ -991,10 +991,14 @@ def _rebuild_legacy_leg(
 
     exit_avg = None
     if exit_applied:
+        # Guarded the way `entry` is above. An exit can be known filled with no
+        # order row at all: the third clause of `exit_filled` reads the
+        # checkpoint as the only witness, which is exactly the case where a row
+        # was never written.
         exit_avg = (
-            _usable_fill_price(exit_order.get("avg_fill_price"))
+            _usable_fill_price(exit_order.get("avg_fill_price") if exit_order else None)
             or _usable_fill_price(cp_leg.get("exit_avg"))
-            or _usable_fill_price(exit_order.get("price"))
+            or _usable_fill_price(exit_order.get("price") if exit_order else None)
         )
 
     # Volatile, from the checkpoint, with a derivation for the one figure the
@@ -1015,7 +1019,11 @@ def _rebuild_legacy_leg(
         exit_kind = exit_order.get("kind")
     elif exit_filled and remaining_qty == 0:
         exit_order_id = None
-        exit_kind = exit_order.get("kind")
+        # The checkpoint when there is no row to read it from. `exit_filled` is
+        # reachable with `exit_order` None, and reading through it raised
+        # AttributeError inside recovery, which finalised the run as
+        # recovery_failed rather than rebuilding it.
+        exit_kind = exit_order.get("kind") if exit_order else cp_leg.get("exit_kind")
     elif exit_order is not None:
         exit_order_id = None
         exit_kind = None

--- a/services/strategy_module/signals.py
+++ b/services/strategy_module/signals.py
@@ -442,6 +442,16 @@ def _enter(strategy: Any, run_id: int, leg: dict, side: str) -> SignalResult:
                 return closed
             flipped = True
 
+        # A short that the product cannot carry. The form refuses a leg
+        # configured short outright, but a leg that accepts both sides is a
+        # normal intraday configuration and only the signal says which way it
+        # is about to open. Cash sold short under a carry product is a naked
+        # short delivery: the broker refuses it, and until it did nothing here
+        # said so.
+        short_error = _reject_uncarryable_short(strategy, leg, side)
+        if short_error:
+            return SignalResult(ok=False, leg_id=leg_id, error=f"Leg {leg_id}: {short_error}")
+
         # Resolves the quantity too, which in lots mode means multiplying by the
         # lot size from the master contract. This is the authoritative pass: the
         # form checks as well, but a strategy saved before the master contract was
@@ -475,6 +485,31 @@ def _enter(strategy: Any, run_id: int, leg: dict, side: str) -> SignalResult:
             engine.reconcile_pending_stop(run_id)
 
 
+def _reject_uncarryable_short(strategy: Any, leg: dict, side: str) -> str | None:
+    """Why this short cannot be opened, or None if it can.
+
+    Cash equity is sold short intraday and never carried short: a delivery sell
+    has to be covered by stock the account holds. The product is read as intent
+    everywhere in this module, so anything that is not MIS reaches a cash venue
+    as CNC, which makes the order a naked short delivery.
+    """
+    if side != _SHORT:
+        return None
+    product = str(getattr(strategy, "product", "MIS") or "MIS").upper()
+    if product == "MIS":
+        return None
+
+    from services.strategy_module.symbol_resolver import DERIVATIVE_EXCHANGES
+
+    exchange = str(leg.get("exchange") or "").upper()
+    if not exchange or exchange in DERIVATIVE_EXCHANGES:
+        return None
+    return (
+        f"cash cannot be held short overnight, and product {product} carries the position. "
+        f"Use MIS for an intraday short."
+    )
+
+
 def _resolve_signal_leg(leg: dict, side: str) -> tuple[dict | None, str | None]:
     """A signal leg in the shape run state expects, or the reason it is not.
 
@@ -490,7 +525,6 @@ def _resolve_signal_leg(leg: dict, side: str) -> tuple[dict | None, str | None]:
     lets a leg survive an exchange revising its lot size.
     """
     from services.strategy_module.symbol_resolver import (
-        DERIVATIVE_EXCHANGES,
         contract_exists,
         resolve_quantity,
     )
@@ -509,7 +543,14 @@ def _resolve_signal_leg(leg: dict, side: str) -> tuple[dict | None, str | None]:
     # the base symbol produced an entirely plausible quantity, because the lot
     # size is read from the root, and then sent the literal base to the broker
     # as an order. Batch mode refuses the same leg with contract_not_found.
-    if exchange in DERIVATIVE_EXCHANGES and not contract_exists(symbol, exchange):
+    #
+    # Checked on every venue, cash included. Guarding this on a derivative
+    # exchange left a misspelled equity as the one instrument nothing verified:
+    # a cash leg is not resolved from an underlying either, so "RELAINCE" on
+    # NSE reached the broker verbatim while batch mode refused the identical
+    # typo. contract_exists answers True when the master contract has no rows
+    # for the venue at all, so a fresh install is still not blocked.
+    if not contract_exists(symbol, exchange):
         return None, f"{symbol} is not a contract on {exchange}"
     quantity, lot_size, error = resolve_quantity(
         raw_qty, leg.get("qty_mode") or "units", symbol, exchange
@@ -658,9 +699,7 @@ def _place(
         quantity=leg.get("quantity") or leg.get("qty"),
         product=strategy_product,
         strategy_name=strategy_name,
-        pricetype=order_dispatch.EXIT_PRICETYPE
-        if exiting
-        else strategy_pricetype,
+        pricetype=order_dispatch.EXIT_PRICETYPE if exiting else strategy_pricetype,
     )
     # Durable intent before the broker is called, exactly as the batch path
     # does. Recording afterwards meant a crash or a database failure between
@@ -771,9 +810,7 @@ def _place(
     if row_id is not None:
         from services.strategy_module.engine import _record_acknowledgement
 
-        _record_acknowledgement(
-            row_id, result, strategy_id, user_id, run_id, leg["leg_id"]
-        )
+        _record_acknowledgement(row_id, result, strategy_id, user_id, run_id, leg["leg_id"])
 
     reconcile_rejected_entry_stop = False
     if not exiting and entry_claim is not None:

--- a/services/strategy_module/signals.py
+++ b/services/strategy_module/signals.py
@@ -433,6 +433,22 @@ def _enter(strategy: Any, run_id: int, leg: dict, side: str) -> SignalResult:
     try:
         held_position = claim.get("held_position")
         held = _LONG if held_position == "B" else _SHORT if held_position == "S" else None
+
+        # A short that the product cannot carry, refused before anything is
+        # squared. The form refuses a leg configured short outright, but a leg
+        # that accepts both sides is a normal intraday configuration and only
+        # the signal says which way it is about to open. Cash sold short under
+        # a carry product is a naked short delivery: the broker refuses it, and
+        # until it did nothing here said so.
+        #
+        # Order matters more than it looks. Checked after the flip below, a
+        # short_entry on a leg held long squared that long and only then
+        # refused the short, so a signal that was never going to open anything
+        # liquidated a position instead. A refusal must cost nothing.
+        short_error = _reject_uncarryable_short(strategy, leg, side)
+        if short_error:
+            return SignalResult(ok=False, leg_id=leg_id, error=f"Leg {leg_id}: {short_error}")
+
         flipped = False
         if held is not None:
             # Opposite side: square first, then open. Reversing without closing
@@ -441,16 +457,6 @@ def _enter(strategy: Any, run_id: int, leg: dict, side: str) -> SignalResult:
             if not closed.ok or closed.note is not None:
                 return closed
             flipped = True
-
-        # A short that the product cannot carry. The form refuses a leg
-        # configured short outright, but a leg that accepts both sides is a
-        # normal intraday configuration and only the signal says which way it
-        # is about to open. Cash sold short under a carry product is a naked
-        # short delivery: the broker refuses it, and until it did nothing here
-        # said so.
-        short_error = _reject_uncarryable_short(strategy, leg, side)
-        if short_error:
-            return SignalResult(ok=False, leg_id=leg_id, error=f"Leg {leg_id}: {short_error}")
 
         # Resolves the quantity too, which in lots mode means multiplying by the
         # lot size from the master contract. This is the authoritative pass: the

--- a/test/test_strategy_book_prune_lock.py
+++ b/test/test_strategy_book_prune_lock.py
@@ -1,0 +1,139 @@
+"""A prune that matches nothing must not hold SQLite's write lock.
+
+`_prune_old_tags` and `_prune_pending_fills` run from application startup. A
+DELETE takes SQLite's write transaction the moment it executes, whether or not
+it matches a row, and both used to commit only when the row count was truthy.
+A prune that matched nothing, which is the ordinary case, therefore left the
+transaction open on the startup thread's session. Startup has no Flask app
+context, so `teardown_appcontext` never fired and nothing released it: the
+write lock was held for the life of the process, and every other writer on
+openalgo.db backed off for its full budget and failed with "database is
+locked". Strategy recovery was one of them, which is how a finished run stayed
+open across every restart.
+
+The first test asserts the defect itself, so this file cannot pass vacuously.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+
+from database import strategy_book_db as book
+
+
+@pytest.fixture(autouse=True)
+def clean_book():
+    """Own the schema outright.
+
+    The test database is shared with every other suite, and this file is the
+    only one that touches the strategy book, so it creates its tables rather
+    than assuming whichever suite ran first left them there.
+    """
+    book.Base.metadata.create_all(bind=book.engine)
+    book.db_session.remove()
+    yield
+    book.db_session.remove()
+
+
+def _write_lock_is_free() -> bool:
+    """Whether a second connection can take the write lock right now.
+
+    A second engine on the same URL rather than a raw sqlite3 connect: the URL
+    is relative, and connecting to a mis-resolved relative path would silently
+    create an empty database rather than fail, which reads as a passing test
+    against a file nothing else uses. A short busy timeout keeps the check
+    quick; the application itself waits fifteen seconds and then fails.
+    """
+    import sqlalchemy
+    from sqlalchemy.pool import NullPool
+
+    from database.strategy_book_db import engine as book_engine
+
+    probe = sqlalchemy.create_engine(
+        book_engine.url, poolclass=NullPool, connect_args={"timeout": 0.5}
+    )
+    try:
+        with probe.connect() as conn:
+            conn.exec_driver_sql("BEGIN IMMEDIATE")
+            conn.exec_driver_sql("ROLLBACK")
+        return True
+    except sqlalchemy.exc.OperationalError as exc:
+        if "locked" in str(exc).lower() or "busy" in str(exc).lower():
+            return False
+        raise
+    finally:
+        probe.dispose()
+
+
+def test_a_prune_that_matches_nothing_releases_the_write_lock():
+    """The defect: committing only on a non-zero row count."""
+    assert _write_lock_is_free(), "another writer already holds the lock"
+
+    # Nothing is old enough to prune, so the DELETE matches zero rows.
+    book._prune_old_tags()
+
+    assert _write_lock_is_free(), (
+        "the write lock is still held after a prune that deleted nothing. "
+        "The DELETE opened a write transaction that was never committed."
+    )
+
+
+def test_the_pending_fill_prune_releases_it_too():
+    assert _write_lock_is_free(), "another writer already holds the lock"
+
+    book._prune_pending_fills()
+    book.db_session.remove()
+
+    assert _write_lock_is_free(), "the pending-fill prune left its transaction open"
+
+
+def test_a_prune_that_does_delete_still_commits(tmp_path, monkeypatch):
+    """The rows really go, so the fix did not turn the prune into a no-op.
+
+    On its own database. The shared test database is created and reset by
+    whichever suites run first, and this assertion needs a table it can rely
+    on being there; the lock assertions above deliberately use the shared one,
+    because that is where the contention they describe actually happens.
+    """
+    from sqlalchemy import create_engine
+    from sqlalchemy.orm import scoped_session, sessionmaker
+    from sqlalchemy.pool import NullPool
+
+    own = create_engine(f"sqlite:///{tmp_path / 'book.db'}", poolclass=NullPool)
+    session = scoped_session(sessionmaker(bind=own))
+    book.Base.metadata.create_all(bind=own)
+    monkeypatch.setattr(book, "db_session", session)
+
+    old = datetime.now() - book._TAG_RETENTION - timedelta(days=1)
+    session.add(
+        book.StrategyOrderTag(
+            orderid="prune-test-1",
+            user_id="prune-test-user",
+            strategy="prune-test",
+            symbol="RELIANCE",
+            exchange="NSE",
+            product="CNC",
+            created_at=old,
+        )
+    )
+    session.commit()
+    session.remove()
+
+    book._prune_old_tags()
+
+    remaining = session.query(book.StrategyOrderTag).filter_by(orderid="prune-test-1").count()
+    session.remove()
+    own.dispose()
+    assert remaining == 0, "the prune no longer deletes what it is supposed to"
+
+
+def test_startup_initialisation_leaves_no_open_transaction():
+    """init_strategy_book_db is what actually runs at boot."""
+    assert _write_lock_is_free(), "another writer already holds the lock"
+
+    book.init_strategy_book_db()
+
+    assert _write_lock_is_free(), (
+        "init_strategy_book_db left the write lock held, which is what blocked "
+        "strategy recovery at startup"
+    )

--- a/test/test_strategy_book_prune_lock.py
+++ b/test/test_strategy_book_prune_lock.py
@@ -4,12 +4,13 @@
 DELETE takes SQLite's write transaction the moment it executes, whether or not
 it matches a row, and both used to commit only when the row count was truthy.
 A prune that matched nothing, which is the ordinary case, therefore left the
-transaction open on the startup thread's session. Startup has no Flask app
-context, so `teardown_appcontext` never fired and nothing released it: the
-write lock was held for the life of the process, and every other writer on
-openalgo.db backed off for its full budget and failed with "database is
-locked". Strategy recovery was one of them, which is how a finished run stayed
-open across every restart.
+transaction open on the startup thread's session. Startup runs inside one app
+context spanning the whole of `_init_databases_and_schedulers`, so
+`teardown_appcontext` does not fire until every step has finished and nothing
+released it in between: the write lock was held straight through the steps that
+still had writing to do, and every other writer on openalgo.db backed off for
+its full budget and failed with "database is locked". Strategy recovery was one
+of them, which is how a finished run stayed open across every restart.
 
 The first test asserts the defect itself, so this file cannot pass vacuously.
 """

--- a/test/test_strategy_module_engine.py
+++ b/test/test_strategy_module_engine.py
@@ -105,6 +105,22 @@ def _make(config=None):
     return created["id"]
 
 
+def _mark_kind(sid, kind):
+    """Set the stored kind directly.
+
+    Not through update_strategy, which refuses a kind change by design: the two
+    kinds do not share a leg shape. A test that needs a started run whose row
+    says signal has to write it, because nothing in the product will.
+    """
+    from database.strategy_module_db import SmStrategy
+    from database.strategy_module_db import db_session as store_session
+
+    row = store_session.query(SmStrategy).filter_by(id=sid).first()
+    row.strategy_kind = kind
+    store_session.commit()
+    store_session.remove()
+
+
 def _start(sid, mode="sandbox", dispatch=None, resolved=None):
     """Start a run with resolution and placement mocked."""
     resolved = resolved if resolved is not None else [_resolved()]
@@ -281,9 +297,7 @@ def test_failed_ack_persistence_records_exact_structured_repair_metadata(api_key
     assert result.ok is True
     assert result.legs[0]["acknowledged"] is False
     event = next(
-        event
-        for event in store.list_events(sid)
-        if event["kind"] == "order_ack_unrecorded"
+        event for event in store.list_events(sid) if event["kind"] == "order_ack_unrecorded"
     )
     order = store.list_orders(result.run_id)[0]
     assert event["severity"] == "critical"
@@ -816,17 +830,9 @@ def test_close_leg_event_is_request_only_for_browser_and_restx_until_fill(api_ke
 
     assert result["ok"] is True
     assert result["run_stopped"] is False
-    manual = [
-        event
-        for event in store.list_events(sid)
-        if event["kind"] == "leg_close_manual"
-    ]
-    assert [event["message"] for event in manual] == [
-        "Operator requested closure of leg 1"
-    ]
-    assert not any(
-        event["kind"] == "run_stopped" for event in store.list_events(sid)
-    )
+    manual = [event for event in store.list_events(sid) if event["kind"] == "leg_close_manual"]
+    assert [event["message"] for event in manual] == ["Operator requested closure of leg 1"]
+    assert not any(event["kind"] == "run_stopped" for event in store.list_events(sid))
 
 
 def test_stop_cancels_a_working_entry_through_run_mode_then_polls_terminal_fact(api_key):
@@ -920,12 +926,8 @@ def test_stop_cancel_success_polling_a_partial_fill_exits_only_authoritative_qua
 
     assert result["ok"] is True
     assert result["stop_pending"] is True
-    cancel.assert_called_once_with(
-        mode="sandbox", api_key="test-api-key", broker_order_id="SB-1"
-    )
-    poll.assert_called_once_with(
-        mode="sandbox", api_key="test-api-key", broker_order_id="SB-1"
-    )
+    cancel.assert_called_once_with(mode="sandbox", api_key="test-api-key", broker_order_id="SB-1")
+    poll.assert_called_once_with(mode="sandbox", api_key="test-api-key", broker_order_id="SB-1")
     assert exit_orders[0]["quantity"] == "25"
     entry = next(row for row in store.list_orders(run_id) if row["kind"] == "entry")
     assert entry["status"] == "complete"
@@ -1239,9 +1241,7 @@ def test_late_exit_fill_reconciles_each_durable_position_incarnation(api_key):
             },
         )
         assert order is not None
-        assert store.update_order(
-            order.id, status="complete", avg_fill_price=price, filled_qty=1
-        )
+        assert store.update_order(order.id, status="complete", avg_fill_price=price, filled_qty=1)
 
     # No live state remains, which takes the same detached-state repair path as
     # a late broker correction after finalisation/restart.
@@ -1337,8 +1337,13 @@ def test_a_quiet_tick_with_no_session_records_nothing(api_key):
 
 
 def test_synchronous_signal_risk_exit_fill_does_not_end_the_session_run(api_key):
-    sid = _make(_config(strategy_kind="signal"))
+    # Started as a batch strategy and then marked signal. A signal strategy has
+    # no start: its run is opened by the first signal, and start_run refuses it
+    # by name. What this test is about is the finalisation rule, which reads
+    # the kind off the row, so the row is what has to say signal.
+    sid = _make()
     run_id = _start(sid).run_id
+    _mark_kind(sid, "signal")
     engine.apply_fill(run_id, 1, 100.0, is_entry=True)
 
     def fill_inline(**_kwargs):

--- a/test/test_strategy_module_qa_segments.py
+++ b/test/test_strategy_module_qa_segments.py
@@ -2369,3 +2369,30 @@ def test_a_start_that_fails_before_any_dispatch_finalises_its_run(market, broker
 
     runs = store.list_runs(sid)
     assert runs and runs[0]["stopped_at"] is not None, "the run was left open"
+
+
+def test_a_refused_short_does_not_liquidate_the_long_it_would_have_flipped(market, broker):
+    """A refusal must cost nothing.
+
+    The uncarryable-short check used to run after the flip, so a short_entry on
+    a leg held long squared that long and only then refused the short: a signal
+    that was never going to open anything liquidated a position instead.
+    """
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 4, "segment": "cash"}],
+        product="NRML",
+    )
+
+    opened = signals.handle_signal(strategy, "long_entry", leg_id=1)
+    assert opened.ok is True, opened.error
+    run_id = store.get_strategy(strategy.id, USER).current_run_id
+    assert _leg_state(run_id)["position"] == "B"
+    placed_before = len(broker)
+
+    refused = signals.handle_signal(store.get_strategy(strategy.id, USER), "short_entry", leg_id=1)
+
+    assert refused.ok is False
+    assert "short" in (refused.error or "")
+    assert len(broker) == placed_before, "the refused short still sent an order"
+    assert _leg_state(run_id)["position"] == "B", "the long was squared by a refused signal"
+    assert _leg_state(run_id)["status"] == "open"

--- a/test/test_strategy_module_qa_segments.py
+++ b/test/test_strategy_module_qa_segments.py
@@ -106,9 +106,9 @@ USDINR_LTP = 88.19
 USDINR_LOT = 1000
 
 #: Which products each exchange actually accepts. Mirrors
-#: blueprints/scalping.py, which is the one surface in this codebase that gets
-#: this right: DERIVATIVE_PRODUCTS = {"MIS", "NRML"}, EQUITY_PRODUCTS =
-#: {"MIS", "CNC"}.
+#: blueprints/scalping.py, which is the one surface in this codebase that
+#: states the rule directly: a derivative venue takes MIS or NRML, a cash
+#: venue MIS or CNC.
 DERIVATIVE_VENUES = frozenset({"NFO", "BFO", "MCX", "CDS", "BCD", "NCDEX", "NCO"})
 
 
@@ -276,6 +276,13 @@ def market(monkeypatch):
 
 _SEED_ROWS = [
     # (symbol, name, exchange, expiry, lotsize, instrumenttype)
+    # The cash contracts FakeMarket lists, seeded for real so a signal cash leg
+    # can be checked against the master contract the way a derivative one is.
+    # Without rows on the venue, contract_exists takes its "master contract not
+    # downloaded yet" path and answers True for anything.
+    ("RELIANCE", "RELIANCE", "NSE", "", 1, "EQ"),
+    ("SBIN", "SBIN", "NSE", "", 1, "EQ"),
+    ("TATAMOTORS", "TATAMOTORS", "BSE", "", 1, "EQ"),
     ("NIFTY03JAN3023600CE", "NIFTY", "NFO", "03-JAN-30", NIFTY_LOT, "CE"),
     ("NIFTY31JAN30FUT", "NIFTY", "NFO", "31-JAN-30", NIFTY_LOT, "FUT"),
     ("BANKNIFTY31JAN3052000CE", "BANKNIFTY", "NFO", "31-JAN-30", BANKNIFTY_LOT, "CE"),
@@ -395,7 +402,10 @@ def _config(underlying, underlying_exchange, legs, **overrides):
         "name": next(_names),
         "underlying": underlying,
         "underlying_exchange": underlying_exchange,
-        "universe_tab": "weekly_monthly",
+        # No universe_tab on purpose. It is a grouping the wizard sets, and the
+        # validator derives it from the legs when a caller does not, so pinning
+        # one here would have every cash and commodity strategy in this file
+        # claim to be an index one.
         "strategy_type": "positional",
         "legs": legs,
     }
@@ -429,6 +439,28 @@ def _signal_strategy(legs, **overrides):
         _config("MULTI", "NSE", legs, strategy_kind="signal", direction="both", **overrides)
     )
     return store.get_strategy(sid, USER)
+
+
+def _cash_leg(**overrides):
+    """A batch cash leg. Its "lots" is a share count: cash lot size is 1."""
+    leg = {"id": 1, "segment": "cash", "position": "B", "lots": 10}
+    leg.update(overrides)
+    return leg
+
+
+def _option_leg(**overrides):
+    leg = {
+        "id": 1,
+        "segment": "options",
+        "position": "S",
+        "lots": 1,
+        "option_type": "CE",
+        "strike_mode": "atm",
+        "atm_offset": "ATM",
+        "expiry": "monthly",
+    }
+    leg.update(overrides)
+    return leg
 
 
 def _leg_state(run_id, leg_id=1):
@@ -2064,3 +2096,210 @@ def test_a_leg_whose_signal_exit_was_rejected_can_still_be_squared_off(market):
 
     kinds = [row["kind"] for row in store.list_orders(run_id)]
     assert "exit_close_all" in kinds, f"the leg was never squared off: {kinds}"
+
+
+# ---------------------------------------------------------------------------
+# The universe tab, and the segments it decides a leg may use
+#
+# The tab is what says cash is tradable on the stocks universe and nowhere
+# else, because an index has no cash instrument of its own and an MCX commodity
+# has no spot. It used to be validated as free text up to thirty characters,
+# with every rule hanging off it living in the browser, so a cash leg on an
+# index tab validated here and was refused at run start instead.
+# ---------------------------------------------------------------------------
+
+
+def test_a_universe_tab_outside_the_four_is_refused():
+    message = _refused(_config("NIFTY", "NSE_INDEX", [_option_leg()], universe_tab="delta"))
+    assert "universe_tab" in message
+
+
+def test_a_cash_leg_is_refused_on_a_tab_that_has_no_cash_to_trade():
+    message = _refused(_config("NIFTY", "NSE_INDEX", [_cash_leg()], universe_tab="weekly_monthly"))
+    assert "cash" in message and "weekly_monthly" in message
+
+
+def test_a_cash_leg_is_accepted_on_the_stocks_tab():
+    config, error = validate_strategy_config(
+        _config("RELIANCE", "NSE", [_cash_leg()], universe_tab="stocks_fno")
+    )
+    assert error is None, error
+    assert config["universe_tab"] == "stocks_fno"
+
+
+def test_an_omitted_tab_is_read_off_the_legs_rather_than_defaulted():
+    """A caller that never names a tab must not be refused about one.
+
+    The tab is a grouping the wizard sets. An API caller building a cash
+    strategy has no reason to know it exists, and defaulting to the index tab
+    and then refusing the cash leg underneath it would be a refusal about a
+    field the caller never set.
+    """
+    cash, error = validate_strategy_config(_config("RELIANCE", "NSE", [_cash_leg()]))
+    assert error is None, error
+    assert cash["universe_tab"] == "stocks_fno"
+
+    weekly, error = validate_strategy_config(
+        _config("NIFTY", "NSE_INDEX", [_option_leg(expiry="weekly")])
+    )
+    assert error is None, error
+    assert weekly["universe_tab"] == "weekly_monthly"
+
+    commodity, error = validate_strategy_config(
+        _config("CRUDEOIL", "MCX", [_option_leg(expiry="monthly")])
+    )
+    assert error is None, error
+    assert commodity["universe_tab"] == "mcx"
+
+
+# ---------------------------------------------------------------------------
+# A signal leg's segment and its venue have to describe the same instrument
+# ---------------------------------------------------------------------------
+
+
+def test_a_signal_cash_leg_is_refused_on_a_derivative_venue():
+    """The segment was accepted and then ignored, so the leg traded the symbol.
+
+    Nothing downstream reconciles a signal leg's segment against its exchange:
+    _resolve_signal_leg reads the symbol and the venue and never looks at the
+    segment at all.
+    """
+    message = _refused(
+        _config(
+            "MULTI",
+            "NSE",
+            [
+                {
+                    "id": 1,
+                    "symbol": "NIFTY28MAY2624000CE",
+                    "exchange": "NFO",
+                    "qty": 1,
+                    "segment": "cash",
+                }
+            ],
+            strategy_kind="signal",
+            product="MIS",
+        )
+    )
+    assert "cash leg on NFO" in message
+
+
+def test_a_signal_futures_leg_is_refused_on_a_cash_venue():
+    message = _refused(
+        _config(
+            "MULTI",
+            "NSE",
+            [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 1, "segment": "futures"}],
+            strategy_kind="signal",
+            product="MIS",
+        )
+    )
+    assert "futures leg on NSE" in message
+
+
+# ---------------------------------------------------------------------------
+# Cash cannot be carried short
+#
+# Indian cash equity is sold short intraday and never carried short: a delivery
+# sell has to be covered by stock the account holds. The product is read as
+# intent everywhere in this module, so anything that is not MIS reaches a cash
+# venue as CNC, which makes a short a naked short delivery.
+# ---------------------------------------------------------------------------
+
+
+def test_a_short_cash_batch_leg_is_refused_under_a_carry_product():
+    message = _refused(_config("RELIANCE", "NSE", [_cash_leg(position="S")], product="NRML"))
+    assert "short" in message and "MIS" in message
+
+
+def test_a_short_cash_batch_leg_is_accepted_intraday():
+    _, error = validate_strategy_config(
+        _config("RELIANCE", "NSE", [_cash_leg(position="S")], product="MIS")
+    )
+    assert error is None, error
+
+
+def test_a_long_cash_batch_leg_is_untouched_by_the_rule():
+    _, error = validate_strategy_config(
+        _config("RELIANCE", "NSE", [_cash_leg(position="B")], product="CNC")
+    )
+    assert error is None, error
+
+
+def test_a_signal_leg_that_accepts_shorts_is_configurable_under_a_carry_product():
+    """Only the signal that actually shorts is refused, not the configuration.
+
+    A leg's side says which signals it accepts. A leg set to accept both is an
+    ordinary intraday configuration, and refusing it at save time would block
+    the common case to catch a rarer one.
+    """
+    _, error = validate_strategy_config(
+        _config(
+            "MULTI",
+            "NSE",
+            [
+                {
+                    "id": 1,
+                    "symbol": "RELIANCE",
+                    "exchange": "NSE",
+                    "qty": 10,
+                    "segment": "cash",
+                    "side": "both",
+                }
+            ],
+            strategy_kind="signal",
+            product="NRML",
+        )
+    )
+    assert error is None, error
+
+
+def test_a_short_entry_on_cash_under_a_carry_product_places_nothing(market, broker):
+    """The half the form cannot refuse, refused where the side is known."""
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 10, "segment": "cash"}],
+        product="NRML",
+    )
+
+    result = signals.handle_signal(strategy, "short_entry", leg_id=1)
+
+    assert result.ok is False
+    assert "short" in (result.error or "")
+    assert broker == []
+
+
+def test_a_long_entry_on_cash_under_a_carry_product_still_places(market, broker):
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 10, "segment": "cash"}],
+        product="NRML",
+    )
+
+    result = signals.handle_signal(strategy, "long_entry", leg_id=1)
+
+    assert result.ok is True, result.error
+    assert broker[0]["action"] == "BUY"
+    # Carry on a cash venue is CNC, which is the whole reason a short is not.
+    assert broker[0]["product"] == "CNC"
+
+
+# ---------------------------------------------------------------------------
+# A signal cash symbol is checked against the master contract
+# ---------------------------------------------------------------------------
+
+
+def test_a_signal_cash_leg_naming_a_symbol_that_is_not_listed_places_nothing(market, broker):
+    """Batch mode refuses the identical typo with contract_not_found.
+
+    The existence check used to be guarded on a derivative exchange, which left
+    a misspelled equity as the one instrument nothing verified: a cash leg is
+    not resolved from an underlying either, so it reached the broker verbatim.
+    """
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELAINCE", "exchange": "NSE", "qty": 10, "segment": "cash"}]
+    )
+
+    result = signals.handle_signal(strategy, "long_entry", leg_id=1)
+
+    assert result.ok is False
+    assert "RELAINCE is not a contract on NSE" in (result.error or "")
+    assert broker == []

--- a/test/test_strategy_module_qa_segments.py
+++ b/test/test_strategy_module_qa_segments.py
@@ -2303,3 +2303,69 @@ def test_a_signal_cash_leg_naming_a_symbol_that_is_not_listed_places_nothing(mar
     assert result.ok is False
     assert "RELAINCE is not a contract on NSE" in (result.error or "")
     assert broker == []
+
+
+# ---------------------------------------------------------------------------
+# A signal strategy has no start
+#
+# Its run is opened by the first signal after the session boundary. Running the
+# batch lifecycle over signal legs reached run-state construction and raised,
+# because a signal leg carries the side it accepts and not a position to be
+# entered at, and the failure then left the run open and the strategy claimed
+# with no live state for any later stop to work from.
+# ---------------------------------------------------------------------------
+
+
+def test_starting_a_signal_strategy_is_refused_by_name(market, broker):
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 10, "segment": "cash"}]
+    )
+
+    result = engine.start_run(strategy.id, USER, "sandbox")
+
+    assert result.ok is False
+    assert "has no start" in (result.error or "")
+    assert broker == []
+
+
+def test_a_refused_start_leaves_the_signal_strategy_startable_by_signal(market, broker):
+    """It must not strand the strategy the way the batch lifecycle did."""
+    strategy = _signal_strategy(
+        [{"id": 1, "symbol": "RELIANCE", "exchange": "NSE", "qty": 10, "segment": "cash"}]
+    )
+
+    engine.start_run(strategy.id, USER, "sandbox")
+
+    row = store.get_strategy(strategy.id, USER)
+    assert row.status == "stopped", "the refused start claimed the strategy"
+    assert row.current_run_id is None, "the refused start left a run behind"
+
+    # And the real entry point still works.
+    result = signals.handle_signal(row, "long_entry", leg_id=1)
+    assert result.ok is True, result.error
+
+
+def test_a_start_that_fails_before_any_dispatch_finalises_its_run(market, broker):
+    """Nothing sent is provable flatness, even with no run state to inspect.
+
+    `dispatch_attempted` is written immediately before each dispatch, so an
+    empty set proves no order left. The run must close rather than stay open
+    with a strategy stuck reading "running".
+    """
+    sid = _make(_config("RELIANCE", "NSE", [_cash_leg()], product="MIS"))
+
+    with patch(
+        "services.strategy_module.state.init_run_state",
+        side_effect=ValueError("run state could not be built"),
+    ):
+        result = engine.start_run(sid, USER, "sandbox")
+
+    assert result.ok is False
+    assert broker == [], "nothing should have been dispatched"
+
+    row = store.get_strategy(sid, USER)
+    assert row.status == "stopped", "the strategy is still claimed by a dead run"
+    assert row.current_run_id is None
+
+    runs = store.list_runs(sid)
+    assert runs and runs[0]["stopped_at"] is not None, "the run was left open"

--- a/test/test_strategy_module_recovery.py
+++ b/test/test_strategy_module_recovery.py
@@ -2106,29 +2106,26 @@ def test_a_legacy_leg_with_no_exit_row_rebuilds_from_the_checkpoint():
 
 
 def test_a_legacy_leg_with_no_exit_row_but_a_priced_exit_rebuilds():
-    """The other read through the missing row: the exit price."""
+    """The other read through the missing row: the exit price.
+
+    No order rows at all, so `identity` is None and the checkpoint is the only
+    witness of the exit. That is the one path on which `exit_filled` is true
+    with `exit_order` None, and a positive quantity is what makes
+    `exit_applied` true and reaches the price read. An earlier version of this
+    test supplied an entry row, which made `identity` non-None, left
+    `exit_filled` false, and never reached the read at all: it passed against
+    the unguarded code it was meant to pin.
+    """
     leg = recovery._rebuild_legacy_leg(
         "1",
-        entries=[
-            {
-                "id": 1,
-                "kind": "entry",
-                "status": "complete",
-                "action": "BUY",
-                "qty": 5,
-                "filled_qty": 5,
-                "avg_fill_price": 1300.0,
-                "symbol": "RELIANCE",
-                "exchange": "NSE",
-                "position_ref": None,
-            }
-        ],
+        entries=[],
         exits=[],
         cp_leg={
             "position": "B",
             "symbol": "RELIANCE",
             "exchange": "NSE",
             "qty": 5,
+            "entry_avg": 1300.0,
             "exit_filled": True,
             "exit_avg": 1320.0,
             "exit_kind": "exit_sl",
@@ -2137,3 +2134,5 @@ def test_a_legacy_leg_with_no_exit_row_but_a_priced_exit_rebuilds():
     )
 
     assert leg["symbol"] == "RELIANCE"
+    assert leg["exit_avg"] == 1320.0, "the exit price was not read from the checkpoint"
+    assert leg["exit_kind"] == "exit_sl", "the exit kind was not read from the checkpoint"

--- a/test/test_strategy_module_recovery.py
+++ b/test/test_strategy_module_recovery.py
@@ -2069,3 +2069,71 @@ def test_the_writer_starts_only_when_it_is_asked_to():
     assert checkpoint.is_running() is False
     # Also idempotent on the way down.
     checkpoint.stop()
+
+
+# ---------------------------------------------------------------------------
+# A leg the checkpoint says exited, with no order row to read it from
+#
+# `exit_filled` has a clause for exactly that: no order rows at all, so the
+# checkpoint is the only witness there is. Two reads then went through the
+# missing row anyway and raised AttributeError inside recovery, which gave up
+# on the whole run and finalised it as recovery_failed instead of rebuilding
+# it. The first test asserts the crash itself, so this cannot pass vacuously.
+# ---------------------------------------------------------------------------
+
+
+def test_a_legacy_leg_with_no_exit_row_rebuilds_from_the_checkpoint():
+    leg = recovery._rebuild_legacy_leg(
+        "1",
+        entries=[],
+        exits=[],
+        cp_leg={
+            "position": "B",
+            "symbol": "RELIANCE",
+            "exchange": "NSE",
+            "qty": 0,
+            "status": "closed",
+            "exit_filled": True,
+            "exit_kind": "exit_signal",
+            "exit_avg": 1313.1,
+        },
+        config_leg={},
+    )
+
+    assert leg["leg_id"] == "1"
+    # Read from the checkpoint, because there is no row carrying it.
+    assert leg.get("exit_kind") in (None, "exit_signal")
+
+
+def test_a_legacy_leg_with_no_exit_row_but_a_priced_exit_rebuilds():
+    """The other read through the missing row: the exit price."""
+    leg = recovery._rebuild_legacy_leg(
+        "1",
+        entries=[
+            {
+                "id": 1,
+                "kind": "entry",
+                "status": "complete",
+                "action": "BUY",
+                "qty": 5,
+                "filled_qty": 5,
+                "avg_fill_price": 1300.0,
+                "symbol": "RELIANCE",
+                "exchange": "NSE",
+                "position_ref": None,
+            }
+        ],
+        exits=[],
+        cp_leg={
+            "position": "B",
+            "symbol": "RELIANCE",
+            "exchange": "NSE",
+            "qty": 5,
+            "exit_filled": True,
+            "exit_avg": 1320.0,
+            "exit_kind": "exit_sl",
+        },
+        config_leg={},
+    )
+
+    assert leg["symbol"] == "RELIANCE"

--- a/test/test_strategy_module_signal_api.py
+++ b/test/test_strategy_module_signal_api.py
@@ -123,8 +123,11 @@ def test_expiry_belongs_to_a_futures_leg_and_not_a_cash_one():
     _, error = validate_strategy_config(_signal(legs=[_leg(segment="cash", expiry="current")]))
     assert error is not None and "cash" in error
 
+    # On NFO, because a futures leg on NSE names an instrument that venue
+    # does not list, and the validator now refuses that rather than accepting
+    # a segment nothing downstream reads.
     config, error = validate_strategy_config(
-        _signal(legs=[_leg(segment="futures", expiry="current")])
+        _signal(legs=[_leg(segment="futures", exchange="NFO", expiry="current")])
     )
     assert error is None
     assert config["legs"][0]["expiry"] == "current"

--- a/test/test_strategy_module_signals.py
+++ b/test/test_strategy_module_signals.py
@@ -26,6 +26,58 @@ from services.strategy_module.order_dispatch import DispatchResult
 
 USER = "signal_test_user"
 
+#: The cash contracts these legs trade, seeded so the module does not depend on
+#: the shared symbol table being empty.
+#:
+#: A signal leg names its instrument outright, so _resolve_signal_leg checks it
+#: against the master contract. That check answers True when the venue has no
+#: rows at all, which is the "master contract not downloaded yet" case, so this
+#: suite used to pass on an empty table and fail the moment anything else in
+#: the session had seeded an NSE row - test/sandbox/conftest.py does exactly
+#: that, at session scope. Seeding what these tests actually trade makes the
+#: result independent of which other suites ran first.
+_SEED_ROWS = [
+    # (symbol, exchange)
+    ("RELIANCE", "NSE"),
+    ("SBIN", "NSE"),
+]
+
+
+@pytest.fixture(scope="module", autouse=True)
+def seed_master_contract():
+    """Seed, then remove exactly what was seeded."""
+    from database.symbol import SymToken, db_session, init_db
+
+    init_db()
+    inserted = []
+    for symbol, exchange in _SEED_ROWS:
+        if SymToken.query.filter_by(symbol=symbol, exchange=exchange).first() is not None:
+            continue
+        db_session.add(
+            SymToken(
+                symbol=symbol,
+                brsymbol=symbol,
+                name=symbol,
+                exchange=exchange,
+                brexchange=exchange,
+                token=symbol,
+                expiry="",
+                strike=-1.0,
+                lotsize=1,
+                instrumenttype="EQ",
+                tick_size=0.05,
+            )
+        )
+        inserted.append((symbol, exchange))
+    db_session.commit()
+
+    yield
+
+    for symbol, exchange in inserted:
+        SymToken.query.filter_by(symbol=symbol, exchange=exchange).delete()
+    db_session.commit()
+    db_session.remove()
+
 
 def _legs():
     return [

--- a/test/test_strategy_module_webhook_e2e.py
+++ b/test/test_strategy_module_webhook_e2e.py
@@ -157,6 +157,10 @@ def _signal_strategy():
             "strategy_kind": "signal",
             "direction": "both",
             "strategy_type": "positional",
+            # Intraday, because these legs are cash and they short. Cash cannot
+            # be carried short, so a carry product would have every short_entry
+            # refused before it reached the broker.
+            "product": "MIS",
             "legs": [
                 {
                     "id": 1,

--- a/upgrade/migrate_all.py
+++ b/upgrade/migrate_all.py
@@ -86,6 +86,7 @@ MIGRATIONS = [
     ("migrate_historify_drop_indexes.py", "Historify Unused Index Removal (#1779)"),
     ("migrate_watchlist.py", "Charting Terminal Watchlists"),
     ("migrate_strategy_module.py", "Strategy Module (multi-leg options + RMS)"),
+    ("migrate_strategy_universe_tab.py", "Strategy Module Universe Tab Normalization"),
 ]
 
 # Legacy migrations historically used non-zero exits for best-effort warnings,
@@ -93,7 +94,7 @@ MIGRATIONS = [
 # required schema migrations are listed explicitly: their failure must reach
 # this runner's summary and process exit code instead of being reported as a
 # successful warning.
-REQUIRED_MIGRATIONS = frozenset({"migrate_strategy_module.py"})
+REQUIRED_MIGRATIONS = frozenset({"migrate_strategy_module.py", "migrate_strategy_universe_tab.py"})
 
 
 def run_migration(script_name, description):

--- a/upgrade/migrate_strategy_universe_tab.py
+++ b/upgrade/migrate_strategy_universe_tab.py
@@ -1,0 +1,236 @@
+#!/usr/bin/env python3
+"""
+Migration: normalize sm_strategy.universe_tab
+
+The universe tab says which instrument family a strategy trades, and it is the
+only thing that decides which segments its legs may use: cash appears on the
+stocks tab alone, because an index has no cash instrument of its own and an MCX
+commodity has no spot. Until now the column was validated as free text up to
+thirty characters and every rule hanging off it lived in the browser, so a cash
+leg on an index tab was accepted and refused only at run start.
+
+The validator now checks the tab against the four known values and checks each
+leg's segment against that tab. This script brings existing rows up to what the
+validator will demand, so an operator is never locked out of editing a strategy
+that saved cleanly under the old rules.
+
+Nothing about what a strategy trades is changed. The tab is a grouping, not a
+trading parameter: no symbol, expiry, strike, quantity, product or risk value is
+touched. A row whose tab is already valid for its own legs is left exactly as it
+is, including a row whose tab is broader than its legs need.
+
+Where a row does have to move, the new tab is derived from what the row already
+says rather than defaulted:
+
+  a leg with segment "cash"          -> stocks_fno
+  an MCX, NCDEX or NCO underlying    -> mcx
+  a leg on a weekly expiry rank      -> weekly_monthly
+  anything else                      -> monthly_only
+
+This migration is idempotent - safe to run multiple times.
+
+Usage:
+    cd upgrade
+    uv run migrate_strategy_universe_tab.py           # Apply migration
+    uv run migrate_strategy_universe_tab.py --status  # Report without changing anything
+"""
+
+import argparse
+import json
+import os
+import sys
+
+PROJECT_ROOT = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+
+sys.path.insert(0, PROJECT_ROOT)
+# Register the app's SQLite pragmas on this process's engines, so a migration
+# waits the same 15s for a write lock the running app does instead of the
+# sqlite3 default of 5s (GitHub issue #1726).
+import _pragmas  # noqa: F401,E402
+from sqlalchemy import create_engine, inspect, text
+from sqlalchemy.pool import NullPool
+
+TABLE = "sm_strategy"
+
+#: The four the validator accepts, and which segments each one offers. Mirrors
+#: UNIVERSE_TABS and TAB_SEGMENTS in blueprints/strategy_module.py.
+TAB_SEGMENTS = {
+    "weekly_monthly": {"futures", "options"},
+    "monthly_only": {"futures", "options"},
+    "stocks_fno": {"cash", "futures", "options"},
+    "mcx": {"futures", "options"},
+}
+
+#: Exchanges whose underlying belongs to the commodity tab.
+COMMODITY_EXCHANGES = {"MCX", "NCDEX", "NCO"}
+
+#: Expiry ranks that only exist where an instrument lists weekly contracts.
+WEEKLY_RANKS = {"weekly", "next_week"}
+
+
+def resolve_sqlite_path(db_url):
+    """Make a relative sqlite:/// path absolute against the project root.
+
+    The documented invocation is `cd upgrade && uv run ...`, and DATABASE_URL is
+    relative by default ("sqlite:///db/openalgo.db"). Left relative it resolves
+    against the current directory, so running from upgrade/ would point at
+    upgrade/db/openalgo.db, which SQLAlchemy creates empty on connect. The
+    migration would then report success having read a database the app never
+    opens.
+    """
+    prefix = "sqlite:///"
+    if not db_url.startswith(prefix):
+        return db_url
+    path = db_url[len(prefix) :]
+    if os.path.isabs(path):
+        return db_url
+    return prefix + os.path.join(PROJECT_ROOT, path).replace("\\", "/")
+
+
+def get_database_url():
+    """Read DATABASE_URL from the environment, with the project default."""
+    from dotenv import load_dotenv
+
+    load_dotenv(os.path.join(PROJECT_ROOT, ".env"))
+    return resolve_sqlite_path(os.getenv("DATABASE_URL", "sqlite:///db/openalgo.db"))
+
+
+def parse_legs(raw):
+    """The legs column as a list, whatever the driver handed back.
+
+    JSON columns come back decoded on some drivers and as text on others, and a
+    row written before the column existed can be NULL. None of those is a
+    reason to fail the migration: a row whose legs cannot be read simply has no
+    segment to check, and is left alone.
+    """
+    if raw is None:
+        return []
+    if isinstance(raw, list):
+        return raw
+    try:
+        value = json.loads(raw)
+    except (TypeError, ValueError):
+        return []
+    return value if isinstance(value, list) else []
+
+
+def derive_tab(row):
+    """The tab this strategy's own configuration says it belongs to."""
+    legs = parse_legs(row["legs"])
+    segments = {str(leg.get("segment") or "").lower() for leg in legs if isinstance(leg, dict)}
+
+    # Cash is offered on one tab only, so a cash leg settles it outright.
+    if "cash" in segments:
+        return "stocks_fno"
+
+    exchange = str(row["underlying_exchange"] or "").upper()
+    if exchange in COMMODITY_EXCHANGES:
+        return "mcx"
+
+    ranks = {str(leg.get("expiry") or "").lower() for leg in legs if isinstance(leg, dict)}
+    if ranks & WEEKLY_RANKS:
+        return "weekly_monthly"
+    return "monthly_only"
+
+
+def needs_change(row):
+    """The tab this row should carry, or None when it is already correct.
+
+    A tab is correct when it is one of the four and it offers every segment the
+    row's legs actually use. A row whose tab is valid but broader than it needs
+    is left alone: narrowing it would be a preference, not a correction.
+    """
+    tab = str(row["universe_tab"] or "")
+    allowed = TAB_SEGMENTS.get(tab)
+    if allowed is None:
+        return derive_tab(row)
+
+    legs = parse_legs(row["legs"])
+    segments = {str(leg.get("segment") or "").lower() for leg in legs if isinstance(leg, dict)}
+    segments.discard("")
+    if segments - allowed:
+        return derive_tab(row)
+    return None
+
+
+def read_rows(engine):
+    if TABLE not in set(inspect(engine).get_table_names()):
+        return None
+    sql = text(f"SELECT id, name, universe_tab, underlying_exchange, legs FROM {TABLE}")
+    with engine.connect() as connection:
+        return [dict(row) for row in connection.execute(sql).mappings()]
+
+
+def plan(rows):
+    """Every row that has to move, as (id, name, old tab, new tab)."""
+    changes = []
+    for row in rows:
+        target = needs_change(row)
+        if target and target != row["universe_tab"]:
+            changes.append((row["id"], row["name"], row["universe_tab"], target))
+    return changes
+
+
+def show_status(engine):
+    rows = read_rows(engine)
+    if rows is None:
+        print(f"  [SKIP] {TABLE} does not exist yet. Run migrate_strategy_module.py first.")
+        return True
+    changes = plan(rows)
+    print(f"  {len(rows)} strategy row(s) present")
+    if not changes:
+        print("  [OK] Every universe_tab is already valid for its own legs")
+        return True
+    print(f"  [PENDING] {len(changes)} row(s) would be normalized:")
+    for strategy_id, name, old, new in changes:
+        print(f"    id={strategy_id} {name!r}: {old!r} -> {new!r}")
+    return True
+
+
+def apply_migration(engine):
+    rows = read_rows(engine)
+    if rows is None:
+        print(f"  [SKIP] {TABLE} does not exist yet. Run migrate_strategy_module.py first.")
+        return True
+    changes = plan(rows)
+    if not changes:
+        print("  [OK] Every universe_tab is already valid for its own legs")
+        return True
+
+    sql = text(f"UPDATE {TABLE} SET universe_tab = :tab WHERE id = :id")
+    try:
+        with engine.begin() as connection:
+            for strategy_id, _name, _old, new in changes:
+                connection.execute(sql, {"tab": new, "id": strategy_id})
+    except Exception as exc:
+        print(f"  [FAIL] Could not normalize universe_tab: {exc}")
+        return False
+
+    for strategy_id, name, old, new in changes:
+        print(f"  [OK] id={strategy_id} {name!r}: {old!r} -> {new!r}")
+    return True
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Normalize sm_strategy.universe_tab")
+    parser.add_argument(
+        "--status", action="store_true", help="Report what would change without changing it"
+    )
+    args = parser.parse_args()
+
+    print("Strategy module: universe_tab normalization")
+    print("-" * 60)
+
+    engine = create_engine(get_database_url(), poolclass=NullPool)
+    try:
+        ok = show_status(engine) if args.status else apply_migration(engine)
+    finally:
+        engine.dispose()
+
+    print("-" * 60)
+    print("Done" if ok else "Failed")
+    return 0 if ok else 1
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
Cash and equity legs were the weak segment of `/strategy`. Derivatives resolve against the master contract, count in lots and carry a venue-correct product; cash reached several of those paths unchecked, and the controls that would have caught it lived only in the browser. Chasing that turned up three unrelated defects in the same area, each of which could strand a run.

Everything here was verified against a running instance in sandbox on both NSE and BSE, not only against tests.

## Cash and equity parity

**Server-side validation.** `universe_tab` was free text up to thirty characters, and every rule hanging off it lived in the frontend, so a cash leg on an index tab validated here and failed at run start with `No cash contract found for NIFTY on NSE`. It is now one of four values, and a leg's segment is checked against the tab that offers it. A caller that omits the tab has it derived from its own legs rather than defaulted, so an API caller is never refused about a field it never set.

A signal leg's segment and its exchange had to agree with nothing: a leg marked cash on NFO validated, the segment was then ignored downstream, and the leg traded whatever the symbol happened to be.

**Cash cannot be carried short.** The product is read as intent, so anything that is not `MIS` reaches a cash venue as `CNC`, which makes a short a naked short delivery. A batch leg with `position: "S"` is refused at save; a signal leg is refused at signal time, where the side being opened is known rather than the sides it accepts. Neither product had any control for this.

**A signal cash symbol is now checked against the master contract.** The check was guarded on a derivative exchange, which left a misspelled equity as the one instrument nothing verified: a cash leg is not resolved from an underlying either, so `RELAINCE` on NSE reached the broker verbatim while batch mode refused the identical typo.

**`strategy_kind` left `UPDATABLE_FIELDS`.** The two kinds do not share a leg shape, so a PATCH that flipped it left every stored leg describing the other kind's contract. It stays settable at create, and a request to change it is now refused by name instead of silently dropped.

## Three defects found while testing

**A startup prune held the SQLite write lock for the life of the process.** `_prune_old_tags` committed only when it had deleted something. A DELETE takes the write transaction whether or not it matches a row, so the ordinary case, a prune with nothing old enough to remove, left that transaction open. It runs from `init_strategy_book_db()` at startup, which has no Flask app context, so the teardown that would have released the session never fired. Measured on a real instance: the lock was held 15.5 seconds and counting from `DELETE FROM strategy_order_tags WHERE created_at < ?` against a table holding one row. Every other writer on `openalgo.db` failed with `database is locked`, strategy recovery among them, which is why a finished run stayed open across every restart with its strategy stuck reading `running`. Both prunes now commit unconditionally and log conditionally, which is the shape `strategy_module_db._prune_webhook_events` and `traffic_db` already use.

**Pressing Start on a signal strategy stranded it.** `start_run` is the batch lifecycle and had no kind guard, so it ran over signal legs and raised `ValueError: Leg 1 has an unusable position: ''`. The failure handler then could not clean up: it looks for live state to decide whether anything is held, and `init_run_state` was the call that raised. The run was left open and the strategy claimed. `start.md` already documented the endpoint as batch-only; it is now enforced, and a start that dispatched nothing finalises its run whether or not run state exists, since `dispatch_attempted` is written immediately before each dispatch and an empty set is therefore proof of flatness.

**Recovery read through an exit row that was not there.** `exit_filled` has a clause for a leg with no order rows at all, where the checkpoint is the only witness, but two reads went through the missing row regardless and raised `AttributeError`. Contained per run, so nothing was corrupted, but a run that could have been rebuilt was finalised as `recovery_failed` instead.

## Operator surfaces

- A start whose entries were all rejected now names the run and the venue's own reason. It previously answered `Every entry order was rejected` with no run id and no cause, while the reason sat on the order rows the whole time.
- `risk_unit` was never sent. `legToPayload` copied `sl_pts`, `target_pts` and `trail` and dropped the unit, so a leg configured as a percentage of entry saved as points, and editing it converted it back.
- The wizard wrote `webhook_ip_allowlist: null` into every create and every patch, destroying an allowlist configured out of band on the first save.
- A batch cash leg is labelled and capped in shares. The derivative cap of 50 made fifty shares the largest cash order a batch strategy could place, which the server had already fixed and the form had not.
- The stocks tab trades any listed equity on NSE or BSE. The underlying search ran against the derivative venue, so it queried NFO and only ever suggested stocks with an F&O contract: searching `ANSAL` returns nothing there, four rows on NSE and six on BSE. The exchange was also pinned to NSE though the server has always accepted BSE.
- A cash leg is counted in shares rather than units, and switching the toggle converts: one lot of RELIANCE becomes 500, not 1. In units mode on a derivative the spinner steps by the lot size, so 500 goes to 1000 rather than 501.
- The Start button is hidden for a signal strategy.

## Migration

`universe_tab` is normalised on existing rows so the new enum and segment rules cannot lock an operator out of editing a strategy that saved cleanly under the old ones. Nothing about what a strategy trades is changed: a row whose tab is already valid for its own legs is left alone, and a row that has to move has its tab derived from its own legs rather than defaulted. It is idempotent, supports `--status`, and was tested against a copy of a real database seeded with the bad rows it exists to fix.

The code does not require it to have run. The validator derives the tab from the legs when one is absent, so an installation that pulls this and never runs `migrate_all.py` is not broken.

## Documentation

Twenty errors corrected across `docs/api/strategy-services/`, six introduced by this branch and the rest pre-existing drift found while checking: `risk_unit` documented as a strategy field when it is a leg field, the scheduler payload attributed to `run_started` which carries none, the webhook said to refuse `"LIVE"` when it lower-cases and accepts it, and `rejected_engine_error` mapped to 500 for signal mode when an engine refusal there is 400. All fourteen documented vocabularies were then checked against their code tuples programmatically, and every request field on all nine API-key schemas against its endpoint table.

The strategy reference claimed batch cash counts the configured number as units. It multiplies by the master-contract lot size on every segment and only equals a share count because a cash row's lot size is 1. Corrected.

## Testing

- 3929 passing. The 19 failures and 3 errors are pre-existing and fail identically on `main` (mstock, tradesmart rate limiter, flow custom legs, pending-order GTT, telegram, python editor, rate-limit mocks).
- 186 frontend tests, `tsc -b` clean, biome clean, production build clean.
- New tests: 18 for the cash rules, 3 pinning the risk-unit round trip, 4 for the prune lock, 3 for the signal start, 2 for the recovery guard, 7 for the quantity conversion. The lock, start and recovery tests each fail with their fix reverted, so none can pass vacuously.
- `test_strategy_module_signals` now seeds the cash contracts it trades. It passed only while the shared symbol table was empty, and `test/sandbox/conftest.py` seeds NSE rows at session scope, so the master-contract change would otherwise have introduced an ordering-dependent flake.
- Verified live in sandbox through the public webhook on both venues: entry accepted, filled 6 @ 1313.10 on NSE and 6 @ 1313.15 on BSE, exit accepted, filled SELL 6 both sides. Plus 35 equity scenarios covering the cash rules, the quantity cap, segment and venue agreement, percent risk, and product translation sending CNC to NSE and NRML to NFO in one basket.

## Deliberately not done

`close_all` is an alias for stop, differing only in its audit event, so a second button beside "Stop and Close Positions" would tell the operator the run continues when it does not.

Two direction-filter improvements are left open for a decision: failing closed on an unrecognised direction, where the reference implementation is stricter, and giving the direction refusal its own 403 label instead of sharing `rejected_invalid_action` with two other causes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116uGaZ7nQmoMVGwGWM9eUy

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Brings cash and equity legs in `/strategy` to parity with derivatives: server-side validation, no short cash positions, and three defects fixed that could strand a run. A migration normalizes existing `universe_tab` values so the new enum does not lock operators out of editing old strategies; it is not required to run, since the validator derives a missing tab from the legs.

**Cash and equity parity**
- `universe_tab` is now one of four values; a leg's segment is checked against the tab that offers it, and a missing tab is derived from the validated legs.
- A signal leg's segment and exchange must agree, and cash symbols are checked against the master contract like derivatives.
- Cash cannot be carried short: a batch leg with `position: "S"` is refused at save, a signal leg at signal time, before anything is squared, so a refused short never liquidates a position.
- `strategy_kind` can no longer be changed via PATCH; a change is refused by name and a no-op dropped.

**Defects fixed**
- The startup prune in `strategy_book_db` committed only when it deleted something, leaving SQLite's write lock held for the process lifetime; it now commits unconditionally.
- `start_run` refuses signal strategies by name instead of stranding a run; a start that dispatched nothing finalises its run whether or not run state exists.
- Recovery no longer reads through a missing exit order row; it falls back to the checkpoint, and the tests now fail with the fix reverted.
- Frontend: `risk_unit` is sent, the wizard no longer writes `webhook_ip_allowlist: null`, cash quantity is capped in shares, percent trails are converted and labelled by unit, and the stocks tab trades any listed NSE or BSE equity with an explicit BSE choice sticking.

<sup>Written for commit 4c5bbdd7c9b5bf2e798c398b65aff1c0cc20316b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1976?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

