### PR TITLE
fix(python-strategy): stale is_running metadata must not block deletion

### DIFF
--- a/blueprints/python_strategy.py
+++ b/blueprints/python_strategy.py
@@ -905,6 +905,27 @@ def terminate_popen_safely(process, pid, terminate_timeout=5, kill_timeout=2):
         return process.poll() is not None
 
 
+def _strategy_may_still_be_running(strategy_id) -> bool:
+    """Whether anything suggests this strategy still has a live process.
+
+    A failed stop is not by itself evidence of one. `is_running` in the config
+    goes stale whenever the app exits without running its cleanup, a crash or a
+    hard restart, and the process it names is long gone. Refusing to delete on
+    that would leave the strategy permanently undeletable, since every later
+    attempt takes the same path and fails the same way.
+
+    So the question is asked of the actual state rather than of the stop's
+    return value: is it still tracked, is a stop still in flight, or does the
+    recorded PID answer. Only then is there something to protect.
+    """
+    with PROCESS_LOCK:
+        if strategy_id in RUNNING_STRATEGIES or strategy_id in STOPPING_STRATEGIES:
+            return True
+        pid = (STRATEGY_CONFIGS.get(strategy_id) or {}).get("pid")
+
+    return bool(pid) and check_process_status(pid)
+
+
 def terminate_process_cross_platform(pid):
     """Terminate a process in a cross-platform way"""
     try:
@@ -2106,7 +2127,7 @@ def delete_strategy(strategy_id):
         )
     if needs_stop:
         stopped, stop_message = stop_strategy_process(strategy_id)
-        if not stopped:
+        if not stopped and _strategy_may_still_be_running(strategy_id):
             # Deleting now would take the config and the file with it while the
             # process is still running, leaving a live strategy with nothing
             # tracking it and no route to stop it. Two ways to get here: the

--- a/test/test_python_strategy_stop_lock.py
+++ b/test/test_python_strategy_stop_lock.py
@@ -212,7 +212,9 @@ def test_a_second_stop_during_the_wait_does_not_signal_twice(quiet_stop, monkeyp
     # record any attempt to terminate it by that route.
     orphan_kills = []
     monkeypatch.setattr(ps, "check_process_status", lambda pid: True)
-    monkeypatch.setattr(ps, "terminate_process_cross_platform", lambda pid: orphan_kills.append(pid))
+    monkeypatch.setattr(
+        ps, "terminate_process_cross_platform", lambda pid: orphan_kills.append(pid)
+    )
 
     results = {}
     second_started = threading.Event()
@@ -389,3 +391,64 @@ def test_stops_a_real_subprocess():
         if process.poll() is None:  # pragma: no cover - safety net
             process.kill()
             process.wait(timeout=5)
+
+
+# ---------------------------------------------------------------------------
+# Deleting a strategy must abort on a live process, but not on stale metadata.
+#
+# delete_strategy now refuses when the stop fails, so that a running process is
+# never left with its config and file deleted underneath it. `is_running` in the
+# config goes stale whenever the app exits without running cleanup, though, and
+# the stop for one of those returns "Strategy not running". Refusing on that
+# made the strategy permanently undeletable: every later attempt took the same
+# path and failed the same way.
+# ---------------------------------------------------------------------------
+
+
+def test_stale_running_metadata_does_not_block_deletion(quiet_stop, monkeypatch):
+    """A dead PID left behind by an unclean shutdown must still be deletable."""
+    monkeypatch.setattr(ps, "check_process_status", lambda pid: False)
+
+    ps.STRATEGY_CONFIGS["sid-stale"] = {
+        "id": "sid-stale",
+        "name": "sid-stale",
+        "is_running": True,  # stale: the app died without clearing it
+        "pid": 999999,  # long gone
+    }
+
+    stopped, message = ps.stop_strategy_process("sid-stale")
+    assert stopped is False
+    assert message == "Strategy not running"
+
+    # The guard delete_strategy consults must not treat this as protectable.
+    assert ps._strategy_may_still_be_running("sid-stale") is False
+
+
+def test_a_live_process_still_blocks_deletion(quiet_stop, monkeypatch):
+    """The protection itself must survive the fix above."""
+    monkeypatch.setattr(ps, "check_process_status", lambda pid: True)
+
+    ps.STRATEGY_CONFIGS["sid-live"] = {
+        "id": "sid-live",
+        "name": "sid-live",
+        "is_running": True,
+        "pid": 4242,
+    }
+
+    assert ps._strategy_may_still_be_running("sid-live") is True
+
+
+def test_a_tracked_or_stopping_strategy_blocks_deletion(quiet_stop, monkeypatch):
+    """Tracked, or mid-stop, both count as still running."""
+    monkeypatch.setattr(ps, "check_process_status", lambda pid: False)
+
+    process = FakePopen(alive_for=0.0)
+    _register("sid-tracked", process)
+    assert ps._strategy_may_still_be_running("sid-tracked") is True
+
+    ps.RUNNING_STRATEGIES.pop("sid-tracked", None)
+    ps.STRATEGY_CONFIGS["sid-tracked"]["pid"] = None
+    assert ps._strategy_may_still_be_running("sid-tracked") is False
+
+    ps.STOPPING_STRATEGIES.add("sid-tracked")
+    assert ps._strategy_may_still_be_running("sid-tracked") is True


### PR DESCRIPTION
Follow-up to #1979, from a cubic finding posted three minutes before that merge and missed at the time.

## The regression

The delete guard added in #1979 refused deletion whenever the stop failed. That is right when a process is genuinely alive, and wrong for the most common way a stop fails.

`is_running` in the config goes stale whenever the app exits without running its cleanup, a crash or a hard restart, and the process it names is long gone. `needs_stop` is true for one of those, the stop correctly returns `"Strategy not running"`, and the guard then refused the deletion. Every later attempt took the same path and failed the same way, so **the strategy became permanently undeletable**.

Stale `is_running` is a common state, not an exotic one, so this would have reached users quickly.

## Fix

The question is now asked of the actual state rather than of the stop's return value. `_strategy_may_still_be_running` reports true only when:

- the strategy is still in `RUNNING_STRATEGIES`, or
- a stop is still in flight and holds the claim, or
- the recorded PID answers `check_process_status`.

Checking state rather than matching on the message string also keeps the guard working the next time one of those strings is reworded.

The protection is unchanged: a process that survives termination, or a concurrent stop holding the claim, still aborts the delete with a 409.

## Testing

Three new tests: stale metadata does not block deletion, a live PID does, and tracked or mid-stop both count as running.

```
uv run pytest test/test_python_strategy_stop_lock.py -q          # 13 passed
uv run pytest test/ -k "strategy or python_strat or lock"        # 1354 passed, 3 skipped, 1 xfailed
uv run ruff check blueprints/python_strategy.py test/test_python_strategy_stop_lock.py
```

The `ruff format` drift in `python_strategy.py` still pre-exists on `main` and none of it is on lines this PR touches. The test file is formatted clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_0116uGaZ7nQmoMVGwGWM9eUy


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes strategy deletion being blocked by stale `is_running` metadata. A failed stop used to block deletion, so strategies left with stale metadata after a crash or hard restart became permanently undeletable; deletion now checks the actual process state instead.

- Deletion is blocked only while the strategy is in `RUNNING_STRATEGIES` or `STOPPING_STRATEGIES`, or the recorded PID passes `check_process_status`.
- A live process still blocks deletion with a 409.
- Adds tests for stale metadata, a live PID, and a mid-stop strategy.

<sup>Written for commit 414f32385e868641225c39da2867fbd767722bd9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1980?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

