### PR TITLE
Issues in #1983 resolved and follow up for Kotak PRs #1971 & #1973

### DIFF
--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -86,10 +86,15 @@ def _backfill_ltp(response, auth_token):
     leaves positions without a price, exactly as before this function
     existed - it must never break the positions endpoint itself.
     """
-    positions = response.get("data")
-    if not positions:
-        return
     try:
+        # Inside the try, not ahead of it: this is the one statement that can
+        # reach a payload Kotak did not shape as an object (an error body that
+        # decodes to a list, say), and the docstring's promise that positions
+        # never break on our account has to cover it too.
+        positions = response.get("data")
+        if not positions:
+            return
+
         from broker.kotak.api.data import BrokerData
         from broker.kotak.mapping.order_data import _openalgo_symbol
 
@@ -103,11 +108,19 @@ def _backfill_ltp(response, auth_token):
             return
 
         broker_data = BrokerData(auth_token)
-        symbols = [{"symbol": s, "exchange": e} for _, s, e in resolved]
-        # One batched call for every position (get_multiquotes already
-        # handles Kotak's own <50-symbol batch cap internally) - not one
-        # call per position, which is the per-symbol-latency concern that
-        # stalled an earlier, unrelated Kotak P&L PR (#1224).
+        # One quote per *distinct* instrument. The same symbol is routinely
+        # held under two products (MIS and NRML), and one entry per position
+        # would send it twice in the same request - wasted room against a
+        # batch cap that get_multiquotes splits at 25. dict.fromkeys keeps
+        # the first-seen order; the price is matched back per position below,
+        # so both rows still get stamped.
+        symbols = [
+            {"symbol": s, "exchange": e} for s, e in dict.fromkeys((s, e) for _, s, e in resolved)
+        ]
+        # One batched call for every position (get_multiquotes splits at
+        # Kotak's own sub-50 cap internally, 25 per request since #1961) -
+        # not one call per position, which is the per-symbol-latency concern
+        # that stalled an earlier, unrelated Kotak P&L PR (#1224).
         quotes = broker_data.get_multiquotes(symbols)
 
         ltp_by_key = {}

--- a/broker/kotak/api/order_api.py
+++ b/broker/kotak/api/order_api.py
@@ -140,6 +140,22 @@ def _backfill_ltp(response, auth_token):
 
 def get_positions(auth_token):
     response = get_api_response("/quick/user/positions", auth_token)
+    if not isinstance(response, dict):
+        # Every caller indexes this as an object - the positionbook mapping,
+        # the smart-order position lookup, close_all_positions - so a payload
+        # that is not one can only fail. Failing here names it; letting it
+        # through surfaced as "list indices must be integers" from inside the
+        # mapping layer, several frames from the cause.
+        #
+        # Deliberately NOT normalized to an empty book. close_all_positions
+        # reads a response with no positions in it as "No Open Positions Found"
+        # and returns 200, which close_position_service reports as a successful
+        # square-off - so quietly standing in for a failed read would tell an
+        # operator their positions were closed while the broker still held them.
+        # A read that did not work has to say so.
+        raise Exception(
+            f"Kotak returned a positions payload that is not an object: {type(response).__name__}"
+        )
     _backfill_ltp(response, auth_token)
     return response
 
@@ -254,7 +270,7 @@ def place_order_api(data, auth_token):
 
     try:
         response = client.post(url, headers=headers, content=payload)
-        logger.debug(f"PLACE ORDER API Response: {response.status_code} {response.text}")
+        logger.info(f"PLACE ORDER API Response: {response.status_code} {response.text}")
 
         # Add status attribute for compatibility with the existing codebase
         response.status = response.status_code

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -236,6 +236,28 @@ def map_position_data(position_data):
     return map_order_data(position_data)
 
 
+def _number(position, field):
+    """One of Kotak's numeric position fields as a float.
+
+    Kotak sends these as strings, and an optional one can arrive as null or
+    empty on a row that never had that leg - float() raises on both, which
+    would abort the entire position book over a single field on a single row.
+    Anything unusable reads as zero, which is what the field's absence already
+    meant.
+
+    Args:
+        position: One raw Kotak position row.
+        field: The field name to read.
+
+    Returns:
+        float: The field's value, or 0.0 if it is absent, null or not a number.
+    """
+    try:
+        return float(position.get(field) or 0)
+    except (TypeError, ValueError):
+        return 0.0
+
+
 def _price_factor(position):
     """The price scaling terms of Kotak's documented P&L formula.
 
@@ -253,11 +275,7 @@ def _price_factor(position):
     """
 
     def term(field):
-        try:
-            value = float(position.get(field, 1) or 1)
-        except (TypeError, ValueError):
-            return 1.0
-        return value or 1.0
+        return _number(position, field) or 1.0
 
     return (
         term("multiplier") * (term("genNum") / term("genDen")) * (term("prcNum") / term("prcDen"))
@@ -267,22 +285,28 @@ def _price_factor(position):
 def transform_positions_data(positions_data):
     transformed_data = []
     for position in positions_data:
+        # "_ltp" is a scratch field get_positions() stamps on before this
+        # function runs (see order_api.py's _backfill_ltp) - Kotak's own
+        # positions endpoint never returns a live price at all, open or closed,
+        # unlike Zerodha's (which reads "last_price" directly from Kite here).
+        # Kept unrounded for the P&L arithmetic below and rounded only on the
+        # way out: CDS prices carry four decimals (USDINR ticks at 0.0025), so
+        # marking a position against the display value costs real money on a
+        # large one.
+        ltp = _number(position, "_ltp")
         transformed_position = {
             "symbol": position.get("trdSym", ""),
             "exchange": position.get("exSeg", ""),
             "product": position.get("prod", ""),
-            "quantity": (int(position.get("flBuyQty", 0)) - int(position.get("flSellQty", 0)))
-            + (int(position.get("cfBuyQty", 0)) - int(position.get("cfSellQty", 0))),
+            "quantity": int(
+                (_number(position, "flBuyQty") - _number(position, "flSellQty"))
+                + (_number(position, "cfBuyQty") - _number(position, "cfSellQty"))
+            ),
             "average_price": position.get("avgnetprice", 0.0),
-            # "_ltp" is a scratch field get_positions() stamps on before this
-            # function runs (see order_api.py's _backfill_ltp) - Kotak's own
-            # positions endpoint never returns a live price at all, open or
-            # closed, unlike Zerodha's (which reads "last_price" directly
-            # from Kite here). Matches Zerodha's "ltp" key/shape exactly so
-            # every consumer of transform_positions_data can treat brokers
-            # uniformly - always present, defaults to 0.0 if the backfill
-            # couldn't resolve a quote for this symbol.
-            "ltp": round(position.get("_ltp", 0.0), 2),
+            # Matches Zerodha's "ltp" key/shape exactly so every consumer of
+            # transform_positions_data can treat brokers uniformly - always
+            # present, defaults to 0.0 if the backfill couldn't resolve a quote.
+            "ltp": round(ltp, 2),
         }
         # Totals across the carried-forward leg and today's, which Kotak keeps
         # in separate fields. "quantity" above already sums both, so the average
@@ -292,10 +316,10 @@ def transform_positions_data(positions_data):
         # That then also stopped the positions page marking the position to
         # market, since it only computes an unrealized P&L when average_price is
         # above zero - so a carried-forward holding showed no cost and no P&L.
-        total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
-        total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
-        buy_qty = float(position.get("flBuyQty", 0)) + float(position.get("cfBuyQty", 0))
-        sell_qty = float(position.get("flSellQty", 0)) + float(position.get("cfSellQty", 0))
+        total_buy_amt = _number(position, "cfBuyAmt") + _number(position, "buyAmt")
+        total_sell_amt = _number(position, "cfSellAmt") + _number(position, "sellAmt")
+        buy_qty = _number(position, "flBuyQty") + _number(position, "cfBuyQty")
+        sell_qty = _number(position, "flSellQty") + _number(position, "cfSellQty")
 
         if transformed_position["quantity"] > 0 and buy_qty > 0:
             transformed_position["average_price"] = round(total_buy_amt / buy_qty, 2)
@@ -330,9 +354,9 @@ def transform_positions_data(positions_data):
 
         if not net_qty:
             transformed_position["pnl"] = round(realized, 2)
-        elif transformed_position["ltp"]:
+        elif ltp:
             transformed_position["pnl"] = round(
-                realized + net_qty * transformed_position["ltp"] * _price_factor(position), 2
+                realized + net_qty * ltp * _price_factor(position), 2
             )
         else:
             # Open, but with no price to mark against - the LTP backfill in

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -236,6 +236,34 @@ def map_position_data(position_data):
     return map_order_data(position_data)
 
 
+def _price_factor(position):
+    """The price scaling terms of Kotak's documented P&L formula.
+
+    "multiplier * (genNum/genDen) * (prcNum/prcDen)", which scales the
+    mark-to-market leg. Every one of them is "1" on the segments reachable
+    through OpenAlgo today, so this is a no-op in practice - but they are the
+    documented terms, and a field that arrives absent, unparseable or zero must
+    not take the whole position book down with a ZeroDivisionError.
+
+    Args:
+        position: One raw Kotak position row.
+
+    Returns:
+        float: The combined scaling factor, 1.0 when Kotak sends nothing usable.
+    """
+
+    def term(field):
+        try:
+            value = float(position.get(field, 1) or 1)
+        except (TypeError, ValueError):
+            return 1.0
+        return value or 1.0
+
+    return (
+        term("multiplier") * (term("genNum") / term("genDen")) * (term("prcNum") / term("prcDen"))
+    )
+
+
 def transform_positions_data(positions_data):
     transformed_data = []
     for position in positions_data:
@@ -258,7 +286,6 @@ def transform_positions_data(positions_data):
         }
         buy_qty = float(position.get("flBuyQty", 0))
         sell_qty = float(position.get("flSellQty", 0))
-        cf_buy_qty = float(position.get("cfBuyQty", 0))
 
         if transformed_position["quantity"] > 0 and buy_qty > 0:
             transformed_position["average_price"] = round(
@@ -270,18 +297,47 @@ def transform_positions_data(positions_data):
             )
         elif transformed_position["quantity"] != 0:
             transformed_position["average_price"] = 0.0
-        elif buy_qty + cf_buy_qty > 0:
-            # Fully closed (net quantity 0, but there was a real round trip
-            # today or carried forward) - Kotak never returns a pnl field
-            # for positions at all (transform_holdings_data two functions
-            # below does; this function didn't). Kotak's own Positions.md
-            # ("Profit N Loss" formula) reduces to sellAmt - buyAmt once Net
-            # Qty is 0; cfBuyAmt/cfSellAmt are included so a leg carried
-            # forward and closed today still gets its full realized P&L,
-            # not just today's fresh-leg portion. See openalgo issue #1970.
-            total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
-            total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
-            transformed_position["pnl"] = round(total_sell_amt - total_buy_amt, 2)
+
+        # Kotak's documented "Profit N Loss" formula (Positions.md), in full:
+        #
+        #   PnL = (Total Sell Amt - Total Buy Amt)
+        #         + Net Qty * LTP * multiplier * (genNum/genDen) * (prcNum/prcDen)
+        #
+        # The amount difference is the realized leg; the Net Qty term marks an
+        # open position to market. Kotak's positions endpoint returns no pnl
+        # field of its own, so it has to be computed here. Writing the whole
+        # formula rather than the two halves separately is deliberate: it
+        # collapses to the realized-only form when Net Qty is 0, so a
+        # fully-closed leg keeps reporting exactly what #1970's fix gave it.
+        # cfBuyAmt/cfSellAmt are included so a leg carried forward reports its
+        # entire P&L, not just today's slice.
+        #
+        # "pnl" is set on every row, open or closed, because that is the shape
+        # the rest of the platform already expects from the other broker
+        # adapters: the positions CSV writes a P&L column, and Flow's Position
+        # Check reads pos.get("pnl", 0) for its pnl_above/pnl_below guards. With
+        # the key absent on open positions those guards read 0 and could never
+        # fire - which is the half a closed-position-only fix leaves broken,
+        # since a P&L stop is only meaningful while the position is still open.
+        total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
+        total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
+        realized = total_sell_amt - total_buy_amt
+        net_qty = transformed_position["quantity"]
+
+        if not net_qty:
+            transformed_position["pnl"] = round(realized, 2)
+        elif transformed_position["ltp"]:
+            transformed_position["pnl"] = round(
+                realized + net_qty * transformed_position["ltp"] * _price_factor(position), 2
+            )
+        else:
+            # Open, but with no price to mark against - the LTP backfill in
+            # order_api.py is best-effort and leaves the row alone when the
+            # quotes call fails. The realized leg on its own is not a P&L: for
+            # a freshly opened long it is the entire cost of the position and
+            # would read as a total loss. Report 0.0, which is what every
+            # consumer already fell back to while the key was missing.
+            transformed_position["pnl"] = 0.0
 
         transformed_data.append(transformed_position)
 

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -284,17 +284,23 @@ def transform_positions_data(positions_data):
             # couldn't resolve a quote for this symbol.
             "ltp": round(position.get("_ltp", 0.0), 2),
         }
-        buy_qty = float(position.get("flBuyQty", 0))
-        sell_qty = float(position.get("flSellQty", 0))
+        # Totals across the carried-forward leg and today's, which Kotak keeps
+        # in separate fields. "quantity" above already sums both, so the average
+        # has to as well: dividing today's amount by today's quantity reported
+        # 0.00 for a position carried forward with no fills today, because
+        # flBuyQty is 0 there and the branch fell through to the zero default.
+        # That then also stopped the positions page marking the position to
+        # market, since it only computes an unrealized P&L when average_price is
+        # above zero - so a carried-forward holding showed no cost and no P&L.
+        total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
+        total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
+        buy_qty = float(position.get("flBuyQty", 0)) + float(position.get("cfBuyQty", 0))
+        sell_qty = float(position.get("flSellQty", 0)) + float(position.get("cfSellQty", 0))
 
         if transformed_position["quantity"] > 0 and buy_qty > 0:
-            transformed_position["average_price"] = round(
-                float(position.get("buyAmt", 0)) / buy_qty, 2
-            )
+            transformed_position["average_price"] = round(total_buy_amt / buy_qty, 2)
         elif transformed_position["quantity"] < 0 and sell_qty > 0:
-            transformed_position["average_price"] = round(
-                float(position.get("sellAmt", 0)) / sell_qty, 2
-            )
+            transformed_position["average_price"] = round(total_sell_amt / sell_qty, 2)
         elif transformed_position["quantity"] != 0:
             transformed_position["average_price"] = 0.0
 
@@ -319,8 +325,6 @@ def transform_positions_data(positions_data):
         # the key absent on open positions those guards read 0 and could never
         # fire - which is the half a closed-position-only fix leaves broken,
         # since a P&L stop is only meaningful while the position is still open.
-        total_buy_amt = float(position.get("cfBuyAmt", 0)) + float(position.get("buyAmt", 0))
-        total_sell_amt = float(position.get("cfSellAmt", 0)) + float(position.get("sellAmt", 0))
         realized = total_sell_amt - total_buy_amt
         net_qty = transformed_position["quantity"]
 

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -433,7 +433,8 @@ class MstockWebSocket:
                     self.auth_failure_reason = None
                 else:
                     self._notify_feed_dead(
-                        f"auth failure with no fresh token available ({self.auth_failure_reason})"
+                        f"auth failure with no fresh token available ({self.auth_failure_reason})",
+                        generation=generation,
                     )
                     break
 
@@ -441,7 +442,9 @@ class MstockWebSocket:
             if self._reconnect_attempts >= max_attempts:
                 # Just as terminal as a dead credential: the thread exits and
                 # nothing reconnects, so the owner must stop advertising it.
-                self._notify_feed_dead(f"max reconnect attempts ({max_attempts}) reached")
+                self._notify_feed_dead(
+                    f"max reconnect attempts ({max_attempts}) reached", generation=generation
+                )
                 break
 
             delay = min(RECONNECT_BASE_DELAY * (1.5**self._reconnect_attempts), RECONNECT_MAX_DELAY)
@@ -515,22 +518,39 @@ class MstockWebSocket:
             on_close=guard(self._on_ws_close),
         )
 
-    def _notify_feed_dead(self, reason: str) -> None:
+    def _notify_feed_dead(self, reason: str, generation: int | None = None) -> None:
         """Tell the owner the feed will not recover without a fresh login.
 
         Every terminal exit from the reconnect loop lands here: an expired
         credential and an exhausted retry budget both leave a client that is
         never coming back, and an owner still advertising connected=True keeps
-        a cached adapter that cannot produce another tick. Idempotent, so the
-        paths can overlap.
-        """
-        if self._feed_dead:
-            return
-        self._feed_dead = True
+        a cached adapter that cannot produce another tick.
 
-        self.running = False
-        self._connected = False
-        self._logged_in = False
+        The caller passes the generation it serves, checked against the current
+        one under the state lock. A worker retiring while a new connect_stream()
+        has already started would otherwise clear the *new* connection's flags
+        and fire its callback, killing a feed that had just come up. Idempotent
+        within a generation, so overlapping terminal paths report once.
+
+        Args:
+            reason: What ended the feed, for the log
+            generation: The connect_stream() generation the caller serves;
+                None skips the check, for callers outside the reconnect loop
+        """
+        with self._state_lock:
+            if generation is not None and generation != self._generation:
+                logger.debug(
+                    f"Ignoring feed-dead notice from retired generation {generation}: {reason}"
+                )
+                return
+            if self._feed_dead:
+                return
+            self._feed_dead = True
+
+            self.running = False
+            self._connected = False
+            self._logged_in = False
+
         logger.error(f"mstock feed is down and will not self-recover: {reason}")
 
         if self.auth_failure_callback is not None:

--- a/broker/mstock/api/mstockwebsocket.py
+++ b/broker/mstock/api/mstockwebsocket.py
@@ -89,6 +89,9 @@ class MstockWebSocket:
         # Optional zero-arg callable invoked when the feed gives up for good, so
         # the owner can stop advertising a connection that will never recover.
         self.auth_failure_callback = None
+        # Set once the feed is terminally down, so the notice fires exactly
+        # once however many terminal paths are reached.
+        self._feed_dead = False
         self.subscriptions: dict[str, dict] = {}
         self._ws_thread: threading.Thread | None = None
         self._logged_in = False
@@ -363,6 +366,7 @@ class MstockWebSocket:
         self.auth_failure_callback = auth_failure_callback
         self.running = True
         self._logged_in = False
+        self._feed_dead = False
         self._login_event.clear()
         self._stop_event.clear()
 
@@ -428,26 +432,16 @@ class MstockWebSocket:
                     self.auth_failed = False
                     self.auth_failure_reason = None
                 else:
-                    logger.error(
-                        f"mstock auth failure with no fresh token available "
-                        f"({self.auth_failure_reason}); stopping reconnect until next login"
+                    self._notify_feed_dead(
+                        f"auth failure with no fresh token available ({self.auth_failure_reason})"
                     )
-                    self.running = False
-                    self._connected = False
-                    self._logged_in = False
-                    # The feed is dead until a new login. Tell the owner, or it
-                    # keeps advertising connected=True and the proxy serves a
-                    # cached adapter that will never produce a tick again.
-                    if self.auth_failure_callback is not None:
-                        try:
-                            self.auth_failure_callback()
-                        except Exception:
-                            logger.exception("mstock auth_failure_callback failed")
                     break
 
             self._reconnect_attempts += 1
             if self._reconnect_attempts >= max_attempts:
-                logger.error("Max reconnect attempts reached")
+                # Just as terminal as a dead credential: the thread exits and
+                # nothing reconnects, so the owner must stop advertising it.
+                self._notify_feed_dead(f"max reconnect attempts ({max_attempts}) reached")
                 break
 
             delay = min(RECONNECT_BASE_DELAY * (1.5**self._reconnect_attempts), RECONNECT_MAX_DELAY)
@@ -520,6 +514,30 @@ class MstockWebSocket:
             on_error=guard(self._on_ws_error),
             on_close=guard(self._on_ws_close),
         )
+
+    def _notify_feed_dead(self, reason: str) -> None:
+        """Tell the owner the feed will not recover without a fresh login.
+
+        Every terminal exit from the reconnect loop lands here: an expired
+        credential and an exhausted retry budget both leave a client that is
+        never coming back, and an owner still advertising connected=True keeps
+        a cached adapter that cannot produce another tick. Idempotent, so the
+        paths can overlap.
+        """
+        if self._feed_dead:
+            return
+        self._feed_dead = True
+
+        self.running = False
+        self._connected = False
+        self._logged_in = False
+        logger.error(f"mstock feed is down and will not self-recover: {reason}")
+
+        if self.auth_failure_callback is not None:
+            try:
+                self.auth_failure_callback()
+            except Exception:
+                logger.exception("mstock feed-dead callback failed")
 
     def _mark_logged_in(self, reason: str) -> None:
         """

--- a/broker/mstock/streaming/mstock_adapter.py
+++ b/broker/mstock/streaming/mstock_adapter.py
@@ -52,6 +52,13 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # tokens per exchangeType, so the whole batch fits in one message.
         self.subscription_queue: list[dict] = []
         self.batch_timer: threading.Timer | None = None
+        # Per-token requeue budget. A refused send is retried, but a socket that
+        # keeps refusing while still reporting connected would otherwise requeue
+        # and re-arm every batch_delay forever, spinning the timer and filling
+        # the log. After the budget is spent the token is left for the resync,
+        # which runs on the next login.
+        self.send_retries: dict[str, int] = {}
+        self.max_send_retries = max(1, int(_env_float("MSTOCK_WS_SEND_RETRIES", 3)))
         # Coalescing window; overridable from .env for deployments that want a
         # tighter or looser batch than the fleet default.
         self.batch_delay = _env_float("MSTOCK_WS_BATCH_DELAY", 0.5)
@@ -117,17 +124,22 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.ws_client.connect_stream(
             self._on_data,
             resync_callback=self._resync_subscriptions,
-            auth_failure_callback=self._on_auth_failure,
+            auth_failure_callback=self._on_feed_dead,
         )
         self.connected = True
         self.logger.info("mstock WebSocket adapter connected")
 
-    def _on_auth_failure(self) -> None:
-        """Stop advertising a feed that will not recover without a new login."""
+    def _on_feed_dead(self) -> None:
+        """Stop advertising a feed that will not recover without a new login.
+
+        Reached on an expired credential and on an exhausted reconnect budget.
+        Without this the proxy keeps serving a cached adapter whose thread has
+        already exited, so subscribes succeed and no tick ever arrives.
+        """
         self.connected = False
         self.logger.error(
-            "mstock feed stopped on an auth failure; marking the adapter "
-            "disconnected so it is rebuilt on the next login"
+            "mstock feed is terminally down; marking the adapter disconnected "
+            "so it is rebuilt on the next login"
         )
 
     def _on_data(self, quote_data: dict) -> None:
@@ -394,6 +406,7 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
             # The broker retains nothing across a reconnect.
             self.token_modes.clear()
             self.token_correlation_ids.clear()
+            self.send_retries.clear()
             self.subscription_queue = [
                 {
                     "token": token,
@@ -509,26 +522,35 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         for entry in subs:
                             self.token_correlation_ids[entry["token"]] = entry["correlation_id"]
                             self.token_modes[entry["token"]] = mode
+                            self.send_retries.pop(entry["token"], None)
                     self.logger.info(f"Batch subscribed {len(subs)} token(s) in mode {mode}")
                 else:
                     # Requeue rather than wait for a resync: the client is still
                     # connected, so no login is coming and nothing else would
                     # ever send these. token_modes stays unset either way.
-                    self.logger.warning(
-                        f"Batch subscription failed for {len(subs)} token(s) in mode {mode}; "
-                        f"requeuing for another attempt"
-                    )
                     with self.lock:
                         queued_tokens = {q["token"] for q in self.subscription_queue}
+                        requeued, exhausted = [], []
                         for entry in subs:
-                            if entry["token"] in queued_tokens:
+                            token = entry["token"]
+                            if token in queued_tokens:
                                 continue
-                            sub = latest.get(entry["token"])
+                            sub = latest.get(token)
                             if sub is None:
                                 continue
+
+                            attempts = self.send_retries.get(token, 0) + 1
+                            if attempts > self.max_send_retries:
+                                # Spent: leave it unconfirmed for the resync
+                                # rather than re-arming the timer forever.
+                                exhausted.append(token)
+                                continue
+
+                            self.send_retries[token] = attempts
+                            requeued.append(token)
                             self.subscription_queue.append(
                                 {
-                                    "token": entry["token"],
+                                    "token": token,
                                     "mode": mode,
                                     "exchange_type": entry["exchange_type"],
                                     "symbol": sub["symbol"],
@@ -538,6 +560,19 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
                             )
                         if self.subscription_queue and self.batch_timer is None:
                             self._start_batch_timer()
+
+                    if requeued:
+                        self.logger.warning(
+                            f"Batch subscription failed for {len(subs)} token(s) in mode {mode}; "
+                            f"requeued {len(requeued)} (attempt "
+                            f"{max(self.send_retries[t] for t in requeued)} of "
+                            f"{self.max_send_retries})"
+                        )
+                    if exhausted:
+                        self.logger.error(
+                            f"Giving up sending {len(exhausted)} token(s) in mode {mode} after "
+                            f"{self.max_send_retries} attempts; left unconfirmed for the resync"
+                        )
 
         except Exception as e:
             self.logger.exception(f"Error processing subscription batch: {str(e)}")

--- a/broker/mstock/streaming/mstock_adapter.py
+++ b/broker/mstock/streaming/mstock_adapter.py
@@ -120,13 +120,25 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info("Connecting to mstock WebSocket in streaming mode...")
         self.running = True
 
+        # Set before the thread starts. connect_stream() returns immediately but
+        # the worker is already live, and a connection that fails outright can
+        # reach _on_feed_dead() first - setting the flag afterwards would
+        # overwrite its False and hand the proxy a feed whose thread has exited.
+        self.connected = True
+
         # Start streaming — returns immediately (same as Angel/Upstox pattern)
         self.ws_client.connect_stream(
             self._on_data,
             resync_callback=self._resync_subscriptions,
             auth_failure_callback=self._on_feed_dead,
         )
-        self.connected = True
+
+        # And re-check, in case the worker died between the two statements.
+        if not self.ws_client.running:
+            self.connected = False
+            self.logger.error("mstock feed died during connect; adapter left disconnected")
+            return
+
         self.logger.info("mstock WebSocket adapter connected")
 
     def _on_feed_dead(self) -> None:
@@ -611,6 +623,11 @@ class MstockWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.subscription_queue = [
                     queued for queued in self.subscription_queue if queued["token"] != token
                 ]
+                # Drop the retry budget with the subscription. Kept, a token
+                # that had exhausted it would come back already spent, so a
+                # later subscribe got its one send and no retry at all - and
+                # the dict would grow a permanent entry per token ever seen.
+                self.send_retries.pop(token, None)
 
             current_mstock_mode = self.token_modes.get(token, 0)
             if max_mode_for_token < current_mstock_mode:

--- a/test/test_kotak_positions_ltp.py
+++ b/test/test_kotak_positions_ltp.py
@@ -1,0 +1,126 @@
+"""Kotak position LTP backfill.
+
+Kotak's /quick/user/positions payload carries no live price field at all, so
+get_positions() batch-fetches one and stamps it on for transform_positions_data
+to read (issue #1972). These cover the two edges that are easy to regress: the
+batch must not carry the same instrument twice, and a payload Kotak did not
+shape as an object must not turn a positions read into an exception.
+"""
+
+import copy
+
+import pytest
+
+import broker.kotak.api.data as kotak_data
+import broker.kotak.api.order_api as order_api
+import broker.kotak.mapping.order_data as order_mapping
+
+AUTH = "sess:::sid:::https://gw-napi.kotaksecurities.com:::acc"
+
+_EQUITY = {
+    "trdSym": "YESBANK-EQ",
+    "exSeg": "nse_cm",
+    "tok": "11915",
+    "flBuyQty": "100",
+    "flSellQty": "0",
+    "cfBuyQty": "0",
+    "cfSellQty": "0",
+    "buyAmt": "2100",
+    "sellAmt": "0",
+    "avgnetprice": 0.0,
+}
+_OPTION = {
+    "trdSym": "SENSEX2690376900CE",
+    "exSeg": "bse_fo",
+    "tok": "845001",
+    "prod": "MIS",
+    "flBuyQty": "20",
+    "flSellQty": "20",
+    "cfBuyQty": "0",
+    "cfSellQty": "0",
+    "buyAmt": "1400",
+    "sellAmt": "1500",
+    "avgnetprice": 0.0,
+}
+
+# The same instrument under two products, which is how a book grows duplicates.
+RAW_POSITIONS = {
+    "stat": "Ok",
+    "data": [dict(_EQUITY, prod="MIS"), dict(_EQUITY, prod="NRML"), _OPTION],
+}
+
+TOKEN_TO_SYMBOL = {
+    ("11915", "NSE"): "YESBANK",
+    ("845001", "BFO"): "SENSEX03SEP2676900CE",
+}
+LTPS = {("YESBANK", "NSE"): 21.35, ("SENSEX03SEP2676900CE", "BFO"): 60.6}
+
+
+@pytest.fixture
+def quote_batches(monkeypatch):
+    """Stub the two external edges; symbol resolution runs for real."""
+    batches = []
+
+    class FakeBrokerData:
+        def __init__(self, auth_token):
+            pass
+
+        def get_multiquotes(self, symbols):
+            batches.append([(s["symbol"], s["exchange"]) for s in symbols])
+            return [
+                {
+                    "symbol": s["symbol"],
+                    "exchange": s["exchange"],
+                    "data": {"ltp": LTPS[(s["symbol"], s["exchange"])]},
+                }
+                for s in symbols
+            ]
+
+    monkeypatch.setattr(kotak_data, "BrokerData", FakeBrokerData)
+    monkeypatch.setattr(order_api, "get_api_response", lambda *a, **k: copy.deepcopy(RAW_POSITIONS))
+    monkeypatch.setattr(
+        order_mapping,
+        "get_symbol",
+        lambda token, exchange: TOKEN_TO_SYMBOL.get((str(token), exchange)),
+    )
+    monkeypatch.setattr(order_mapping, "get_oa_symbol", lambda symbol, exchange: None)
+    return batches
+
+
+def _positionbook():
+    raw = order_api.get_positions(AUTH)
+    return order_mapping.transform_positions_data(order_mapping.map_position_data(raw))
+
+
+def test_duplicate_instruments_are_quoted_once(quote_batches):
+    positions = _positionbook()
+
+    assert len(quote_batches) == 1, "the whole book must go out in one batched call"
+    batch = quote_batches[0]
+    assert batch == list(dict.fromkeys(batch)), f"same instrument sent twice: {batch}"
+    assert len(batch) == 2 and len(positions) == 3
+
+
+def test_both_product_rows_of_a_duplicate_still_get_a_price(quote_batches):
+    positions = _positionbook()
+
+    assert [p["ltp"] for p in positions] == [21.35, 21.35, 60.6]
+    assert [p["product"] for p in positions] == ["MIS", "NRML", "MIS"]
+
+
+@pytest.mark.parametrize("payload", [["error"], "gateway timeout", None, 0])
+def test_a_payload_that_is_not_an_object_does_not_raise(monkeypatch, payload):
+    """The backfill is best-effort; it must never turn a read into a 500."""
+    monkeypatch.setattr(order_api, "get_api_response", lambda *a, **k: copy.deepcopy(payload))
+
+    assert order_api.get_positions(AUTH) == payload
+
+
+def test_a_quotes_outage_leaves_prices_at_zero(monkeypatch, quote_batches):
+    class BoomBrokerData:
+        def __init__(self, auth_token):
+            raise Exception("simulated quotes outage")
+
+    monkeypatch.setattr(kotak_data, "BrokerData", BoomBrokerData)
+
+    assert [p["ltp"] for p in _positionbook()] == [0.0, 0.0, 0.0]

--- a/test/test_kotak_positions_ltp.py
+++ b/test/test_kotak_positions_ltp.py
@@ -109,11 +109,23 @@ def test_both_product_rows_of_a_duplicate_still_get_a_price(quote_batches):
 
 
 @pytest.mark.parametrize("payload", [["error"], "gateway timeout", None, 0])
-def test_a_payload_that_is_not_an_object_does_not_raise(monkeypatch, payload):
-    """The backfill is best-effort; it must never turn a read into a 500."""
+def test_a_payload_that_is_not_an_object_is_rejected_by_name(monkeypatch, payload):
+    """Loudly, and before the mapping layer turns it into a puzzle.
+
+    Not normalized to an empty book on purpose: close_all_positions reads a
+    response with no positions in it as a successful square-off, so standing in
+    for a failed read would report closed positions the broker still holds.
+    """
     monkeypatch.setattr(order_api, "get_api_response", lambda *a, **k: copy.deepcopy(payload))
 
-    assert order_api.get_positions(AUTH) == payload
+    with pytest.raises(Exception, match="not an object"):
+        order_api.get_positions(AUTH)
+
+
+@pytest.mark.parametrize("payload", [["error"], "gateway timeout", None, 0])
+def test_the_backfill_itself_never_raises(monkeypatch, payload):
+    """The rejection above is get_positions'. _backfill_ltp stays best-effort."""
+    order_api._backfill_ltp(payload, AUTH)
 
 
 def test_a_quotes_outage_leaves_prices_at_zero(monkeypatch, quote_batches):

--- a/test/test_kotak_positions_pnl.py
+++ b/test/test_kotak_positions_pnl.py
@@ -1,0 +1,143 @@
+"""Kotak position P&L.
+
+Kotak's /quick/user/positions payload carries no pnl field, so
+transform_positions_data computes one from Kotak's documented "Profit N Loss"
+formula (issue #1970). The realized half is covered for closed legs; these pin
+the open half, where the mark-to-market term applies and where a missing key
+used to leave Flow's pnl_above/pnl_below guards evaluating 0.
+"""
+
+import pytest
+
+from broker.kotak.mapping.order_data import transform_positions_data
+
+
+def row(**kw):
+    """One raw Kotak position row, flat by default."""
+    base = {
+        "trdSym": "YESBANK",
+        "exSeg": "NSE",
+        "prod": "MIS",
+        "flBuyQty": "0",
+        "flSellQty": "0",
+        "cfBuyQty": "0",
+        "cfSellQty": "0",
+        "buyAmt": "0.00",
+        "sellAmt": "0.00",
+        "cfBuyAmt": "0.00",
+        "cfSellAmt": "0.00",
+        "avgnetprice": 0.0,
+    }
+    base.update(kw)
+    return base
+
+
+def one(**kw):
+    return transform_positions_data([row(**kw)])[0]
+
+
+# --- the realized half, which must not regress -------------------------------
+
+# The four real SENSEX legs from issue #1970, all fully squared off.
+CLOSED_LEGS = [
+    ("SENSEX2690376900CE", "1641.00", "1810.00", 169.00),
+    ("SENSEX2690376300CE", "6466.00", "5683.00", -783.00),
+    ("SENSEX2690375700PE", "1455.00", "595.00", -860.00),
+    ("SENSEX2690376300PE", "2735.00", "5197.00", 2462.00),
+]
+
+
+@pytest.mark.parametrize(("symbol", "buy_amt", "sell_amt", "expected"), CLOSED_LEGS)
+def test_a_closed_leg_reports_its_realized_pnl(symbol, buy_amt, sell_amt, expected):
+    position = one(trdSym=symbol, flBuyQty="20", flSellQty="20", buyAmt=buy_amt, sellAmt=sell_amt)
+
+    assert position["quantity"] == 0
+    assert position["pnl"] == expected
+
+
+def test_the_closed_book_totals_what_the_account_made():
+    positions = transform_positions_data(
+        [
+            row(trdSym=s, flBuyQty="20", flSellQty="20", buyAmt=b, sellAmt=sl)
+            for s, b, sl, _ in CLOSED_LEGS
+        ]
+    )
+
+    assert round(sum(p["pnl"] for p in positions), 2) == 988.00
+
+
+def test_a_leg_carried_forward_and_closed_today_counts_the_carried_amounts():
+    position = one(flSellQty="10", cfBuyQty="10", cfBuyAmt="450.00", sellAmt="500.00")
+
+    assert position["quantity"] == 0
+    assert position["pnl"] == 50.0
+
+
+def test_a_row_with_no_trades_at_all_reports_zero():
+    assert one()["pnl"] == 0.0
+
+
+# --- the open half -----------------------------------------------------------
+
+
+def test_an_open_long_is_marked_to_market():
+    # 100 bought for 2100 (avg 21.00), now worth 22.50 -> +150.
+    position = one(flBuyQty="100", buyAmt="2100.00", _ltp=22.50)
+
+    assert position["quantity"] == 100
+    assert position["pnl"] == 150.0
+
+
+def test_an_open_short_profits_when_the_price_falls():
+    # 100 sold for 2100 (avg 21.00), now worth 19.50 -> +150.
+    position = one(flSellQty="100", sellAmt="2100.00", _ltp=19.50)
+
+    assert position["quantity"] == -100
+    assert position["pnl"] == 150.0
+
+
+def test_a_partly_closed_position_counts_both_halves():
+    # 100 bought at 21.00, 40 sold at 22.00 (realized +40), 60 held at 22.50
+    # (unrealized +90).
+    position = one(flBuyQty="100", buyAmt="2100.00", flSellQty="40", sellAmt="880.00", _ltp=22.50)
+
+    assert position["quantity"] == 60
+    assert position["pnl"] == 130.0
+
+
+def test_an_open_position_with_no_quote_reports_zero_not_its_cost():
+    """The LTP backfill is best-effort; a failed quote must not read as a loss."""
+    position = one(flBuyQty="100", buyAmt="2100.00")
+
+    assert position["ltp"] == 0.0
+    assert position["pnl"] == 0.0
+
+
+def test_every_row_carries_a_pnl_key():
+    """Flow's Position Check reads pos.get("pnl", 0); a missing key reads as 0."""
+    positions = transform_positions_data(
+        [
+            row(flBuyQty="100", buyAmt="2100.00", _ltp=22.50),
+            row(flBuyQty="20", flSellQty="20", buyAmt="1641.00", sellAmt="1810.00"),
+            row(),
+        ]
+    )
+
+    assert all("pnl" in p for p in positions)
+
+
+# --- the scaling terms -------------------------------------------------------
+
+
+def test_the_documented_multiplier_scales_the_open_leg():
+    position = one(flBuyQty="10", buyAmt="1000.00", _ltp=110.0, multiplier="2")
+
+    # realized -1000, marked 10 * 110 * 2 = 2200.
+    assert position["pnl"] == 1200.0
+
+
+@pytest.mark.parametrize("scaling", [{}, {"genDen": "0"}, {"prcNum": ""}, {"multiplier": None}])
+def test_an_unusable_scaling_field_falls_back_to_one(scaling):
+    position = one(flBuyQty="100", buyAmt="2100.00", _ltp=22.50, **scaling)
+
+    assert position["pnl"] == 150.0

--- a/test/test_kotak_positions_pnl.py
+++ b/test/test_kotak_positions_pnl.py
@@ -176,3 +176,36 @@ def test_a_position_opened_and_partly_closed_today_keeps_its_entry_price():
 
     assert position["quantity"] == 60
     assert position["average_price"] == 21.0
+
+
+# --- fields Kotak sent in a shape we cannot use ------------------------------
+
+
+@pytest.mark.parametrize(
+    "bad",
+    [
+        {"cfBuyAmt": None},
+        {"cfSellAmt": ""},
+        {"sellAmt": "NA"},
+        {"cfBuyQty": None},
+        {"flSellQty": ""},
+        {"_ltp": None},
+    ],
+)
+def test_one_unusable_field_does_not_take_the_whole_book_down(bad):
+    positions = transform_positions_data([row(flBuyQty="10", buyAmt="1000.00", **bad)])
+
+    assert len(positions) == 1
+    assert "pnl" in positions[0]
+
+
+def test_an_open_position_is_marked_against_the_unrounded_price():
+    """CDS quotes carry four decimals, so the display value is not good enough.
+
+    USDINR ticks at 0.0025. Marking 10,000 against 83.47 instead of 83.4725
+    understates the position by 25 rupees.
+    """
+    position = one(flBuyQty="10000", buyAmt="834000.00", _ltp=83.4725)
+
+    assert position["ltp"] == 83.47
+    assert position["pnl"] == 725.0

--- a/test/test_kotak_positions_pnl.py
+++ b/test/test_kotak_positions_pnl.py
@@ -141,3 +141,38 @@ def test_an_unusable_scaling_field_falls_back_to_one(scaling):
     position = one(flBuyQty="100", buyAmt="2100.00", _ltp=22.50, **scaling)
 
     assert position["pnl"] == 150.0
+
+
+# --- average price across the carried-forward leg ----------------------------
+
+
+def test_a_carried_forward_position_reports_what_it_cost():
+    """flBuyQty is 0 with nothing filled today, which used to give 0.00."""
+    position = one(cfBuyQty="50", cfBuyAmt="40000.00", _ltp=815.0)
+
+    assert position["quantity"] == 50
+    assert position["average_price"] == 800.0
+    assert position["pnl"] == 750.0
+
+
+def test_an_average_blends_the_carried_leg_with_todays():
+    # 50 carried at 800.00, 20 more bought today at 810.00.
+    position = one(cfBuyQty="50", cfBuyAmt="40000.00", flBuyQty="20", buyAmt="16200.00")
+
+    assert position["quantity"] == 70
+    assert position["average_price"] == 802.86
+
+
+def test_a_carried_forward_short_reports_what_it_sold_for():
+    position = one(cfSellQty="50", cfSellAmt="40000.00", _ltp=790.0)
+
+    assert position["quantity"] == -50
+    assert position["average_price"] == 800.0
+    assert position["pnl"] == 500.0
+
+
+def test_a_position_opened_and_partly_closed_today_keeps_its_entry_price():
+    position = one(flBuyQty="100", buyAmt="2100.00", flSellQty="40", sellAmt="880.00")
+
+    assert position["quantity"] == 60
+    assert position["average_price"] == 21.0

--- a/test/test_mstock_websocket_resilience.py
+++ b/test/test_mstock_websocket_resilience.py
@@ -217,7 +217,10 @@ def test_a_permanently_refused_send_stops_retrying(adapter):
     adapter.ws_client.subscribe_batch = always_refuse
 
     want(adapter, "S")
-    wait_until(lambda: adapter.batch_timer is None and not adapter.subscription_queue)
+    # Wait on the attempt count, not on the queue draining: the flush clears
+    # the queue and the timer as its first act, so a poll landing in that gap
+    # would return before the send was even recorded.
+    wait_until(lambda: len(attempts) == 1 + adapter.max_send_retries)
 
     assert len(attempts) == 1 + adapter.max_send_retries, "one send plus its retry budget"
     assert adapter.batch_timer is None, "the timer must not stay armed"
@@ -382,6 +385,82 @@ def test_every_terminal_exit_reports_the_feed_dead(monkeypatch):
         assert thread.is_alive() is False, label
         assert fired == [1], f"{label}: the owner must be told exactly once"
         assert c._connected is False, label
+
+
+def test_a_retiring_generation_cannot_kill_the_live_stream():
+    """THE DEFECT: a worker retiring after a restart tore down the new feed.
+
+    connect_stream() resets _feed_dead, so the old worker's terminal path
+    passed the idempotency guard and cleared the flags - and fired the
+    callback - of the connection that had just replaced it.
+    """
+    fired = []
+    c = MstockWebSocket(auth_token="t")
+    c.auth_failure_callback = lambda: fired.append(1)
+    c._generation = 2  # a newer connect_stream() has already run
+    c.running, c._connected, c._feed_dead = True, True, False
+
+    c._notify_feed_dead("generation 1 gave up", generation=1)
+
+    assert c.running is True, "the live stream must survive an old worker retiring"
+    assert c._connected is True
+    assert fired == []
+
+    c._notify_feed_dead("generation 2 gave up", generation=2)
+    assert c.running is False, "the current generation is still honoured"
+    assert fired == [1]
+
+
+def test_a_feed_that_dies_during_connect_leaves_the_adapter_disconnected(monkeypatch, adapter):
+    """connect() set connected=True after starting the thread, so a connection
+    that failed outright had its False overwritten and the proxy cached a feed
+    whose worker had already exited."""
+
+    class DyingApp:
+        def __init__(self, url, **kwargs):
+            self.closed = False
+
+        def run_forever(self, **kwargs):
+            return False
+
+        def close(self):
+            self.closed = True
+
+    monkeypatch.setattr(ws_module, "WebSocketApp", DyingApp)
+    monkeypatch.setattr(ws_mod, "RECONNECT_MAX_ATTEMPTS", 1)
+    monkeypatch.setattr(ws_mod, "RECONNECT_BASE_DELAY", 0.01)
+    monkeypatch.setattr(ws_mod, "RECONNECT_MAX_DELAY", 0.02)
+
+    adapter.ws_client = MstockWebSocket(auth_token="t")
+    adapter.running = True
+    adapter.connect()
+    wait_until(lambda: adapter.ws_client.running is False)
+
+    assert adapter.connected is False, "a dead feed must not be advertised as connected"
+
+
+def test_unsubscribing_restores_the_retry_budget(adapter):
+    """An exhausted token came back already spent, so a later subscribe got
+    its one send and no retry, and the dict grew an entry per token seen."""
+    attempts = []
+
+    def refuse(subs, mode):
+        attempts.append(mode)
+        return False
+
+    adapter.ws_client.subscribe_batch = refuse
+
+    want(adapter, "S")
+    wait_until(lambda: len(attempts) == 1 + adapter.max_send_retries)
+    assert adapter.send_retries == {"22": 3}
+
+    adapter.unsubscribe("S", "NSE", 3)
+    assert adapter.send_retries == {}, "the budget goes with the subscription"
+
+    attempts.clear()
+    want(adapter, "S")
+    wait_until(lambda: len(attempts) == 1 + adapter.max_send_retries)
+    assert len(attempts) == 1 + adapter.max_send_retries, "a fresh budget, not a spent one"
 
 
 def test_a_deliberate_disconnect_is_not_a_dead_feed(monkeypatch):

--- a/test/test_mstock_websocket_resilience.py
+++ b/test/test_mstock_websocket_resilience.py
@@ -118,6 +118,7 @@ def adapter(monkeypatch):
     a.lock = threading.Lock()
     a.subscriptions, a.token_modes, a.token_correlation_ids = {}, {}, {}
     a.subscription_queue, a.batch_timer, a.batch_delay = [], None, 0.05
+    a.send_retries, a.max_send_retries = {}, 3
     a.running, a.connected = True, True
     a.ws_client = MstockWebSocket(auth_token="t")
     a.ws_client.ws = FakeWs()
@@ -198,6 +199,47 @@ def test_refused_send_leaves_the_token_retryable(adapter):
     assert wait_until(lambda: refused), "the batch was never offered to the broker"
 
     assert adapter.token_modes == {}, "a refused send must not be confirmed"
+
+
+def test_a_permanently_refused_send_stops_retrying(adapter):
+    """A refused send is retried, but must not re-arm the timer forever.
+
+    Requeuing without a budget spun the batch timer every batch_delay and
+    logged a warning each time, for as long as the socket kept refusing while
+    still reporting itself connected.
+    """
+    attempts = []
+
+    def always_refuse(subs, mode):
+        attempts.append(mode)
+        return False
+
+    adapter.ws_client.subscribe_batch = always_refuse
+
+    want(adapter, "S")
+    wait_until(lambda: adapter.batch_timer is None and not adapter.subscription_queue)
+
+    assert len(attempts) == 1 + adapter.max_send_retries, "one send plus its retry budget"
+    assert adapter.batch_timer is None, "the timer must not stay armed"
+    assert adapter.subscription_queue == []
+    assert adapter.token_modes == {}, "left unconfirmed so the resync recovers it"
+
+
+def test_a_transient_refusal_still_recovers(adapter):
+    """The budget must not cost recovery from a couple of failed sends."""
+    calls = {"n": 0}
+
+    def flaky(subs, mode):
+        calls["n"] += 1
+        return calls["n"] > 2
+
+    adapter.ws_client.subscribe_batch = flaky
+
+    want(adapter, "S")
+    wait_until(lambda: adapter.token_modes)
+
+    assert adapter.token_modes == {"22": 3}
+    assert adapter.send_retries == {}, "the budget resets once the send lands"
 
 
 def test_resync_uses_the_highest_requested_mode(adapter):
@@ -305,6 +347,74 @@ def test_dead_token_retries_once_when_a_fresh_one_exists(monkeypatch):
         c.running = False
         c.disconnect_stream()
         thread.join(timeout=6)
+
+
+def test_every_terminal_exit_reports_the_feed_dead(monkeypatch):
+    """THE DEFECT: only the auth path told the owner.
+
+    A client whose reconnect budget is spent is just as dead as one holding an
+    expired credential - the thread exits and nothing reconnects - but the
+    adapter kept reporting connected=True, so the proxy served a cached feed
+    that could never produce another tick.
+    """
+    monkeypatch.setattr(ws_module, "WebSocketApp", FakeApp)
+    monkeypatch.setattr(ws_mod, "RECONNECT_MAX_ATTEMPTS", 2)
+    monkeypatch.setattr(ws_mod, "RECONNECT_BASE_DELAY", 0.01)
+    monkeypatch.setattr(ws_mod, "RECONNECT_MAX_DELAY", 0.02)
+
+    for label, arm in (
+        ("auth stand-down", lambda c: setattr(c, "auth_failed", True)),
+        ("max attempts", lambda c: None),
+    ):
+        fired = []
+        c = MstockWebSocket(auth_token="t", token_provider=lambda: "t", auth_error_check=auth_check)
+        # Bind per iteration: a bare closure would capture the loop's name.
+        c.auth_failure_callback = lambda seen=fired: seen.append(1)
+        c.running, c._generation, c.ws = True, 1, FakeApp("u")
+        c._stop_event.clear()
+        c._feed_dead = False
+        arm(c)
+
+        thread = threading.Thread(target=c._run_websocket, args=(1, c.ws), daemon=True)
+        thread.start()
+        thread.join(timeout=10)
+
+        assert thread.is_alive() is False, label
+        assert fired == [1], f"{label}: the owner must be told exactly once"
+        assert c._connected is False, label
+
+
+def test_a_deliberate_disconnect_is_not_a_dead_feed(monkeypatch):
+    """Teardown is not a failure; the owner already knows it asked to stop."""
+    monkeypatch.setattr(ws_module, "WebSocketApp", FakeApp)
+    monkeypatch.setattr(ws_mod, "RECONNECT_BASE_DELAY", 2.0)
+    monkeypatch.setattr(ws_mod, "RECONNECT_MAX_DELAY", 5.0)
+
+    fired = []
+    c = MstockWebSocket(auth_token="t")
+    c.auth_failure_callback = lambda: fired.append(1)
+    c.running, c._generation, c.ws = True, 1, FakeApp("u")
+    c._stop_event.clear()
+    c._feed_dead = False
+
+    thread = threading.Thread(target=c._run_websocket, args=(1, c.ws), daemon=True)
+    thread.start()
+    wait_until(lambda: c._reconnect_attempts >= 1)
+    c.disconnect_stream()
+    thread.join(timeout=5)
+
+    assert fired == [], "a requested teardown must not look like a dead feed"
+
+
+def test_the_dead_feed_notice_is_idempotent():
+    fired = []
+    c = MstockWebSocket(auth_token="t")
+    c.auth_failure_callback = lambda: fired.append(1)
+
+    c._notify_feed_dead("first")
+    c._notify_feed_dead("second")
+
+    assert fired == [1]
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Issues in #1983 resolved and follow up for Kotak PRs #1971 & #1973

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Resolves the issues filed in #1983: Kotak position rows now carry correct P&L and average price, and the mStock WebSocket stops advertising a dead feed as connected.

**Kotak positions**
- Open positions now report mark-to-market P&L using Kotak's documented formula; previously only closed legs had a `pnl` key, so Flow's `pnl_above`/`pnl_below` guards silently read 0.
- Average price now sums carried-forward and today's quantities and amounts; a carried-forward position with no fills today previously showed 0.00 and no P&L.
- LTP backfill quotes each distinct instrument once (MIS/NRML duplicates were sent twice per request), and P&L is marked against the unrounded quote so four-decimal prices aren't shortchanged.
- Null, empty, or unparseable numeric fields read as zero instead of aborting the book; missing or zero scaling terms fall back to 1.0, and an open position with no quote reports 0.0 rather than its cost.
- A positions payload that isn't an object now fails loudly in `get_positions` instead of surfacing as "list indices must be integers" from inside the mapping layer.

**mStock WebSocket**
- A refused subscribe send is retried up to `MSTOCK_WS_SEND_RETRIES` (default 3) then left for the resync, and the retry budget resets on unsubscribe so a token can't come back already spent.
- Both terminal exits — expired credential and exhausted reconnect budget — notify the owner exactly once; a deliberate disconnect does not, and the notice is scoped to its generation so a retiring worker can't tear down the stream that replaced it.
- The adapter marks itself disconnected on terminal failure; `connect()` now sets the flag before the thread starts so a feed that dies during startup isn't advertised as connected.

<sup>Written for commit 4989cb3a6b37104c540375733024057d7c8667d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1985?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

