### PR TITLE
Fix underlying picker showing company names on cash exchanges

### DIFF
--- a/frontend/src/api/strategy_module.ts
+++ b/frontend/src/api/strategy_module.ts
@@ -1640,8 +1640,9 @@ export interface UnderlyingSearch {
  * F&O cannot carry an options leg, and offering it would only produce a
  * strategy that fails to resolve when it starts.
  *
- * Search rows are contracts, so they are collapsed onto their `name` - one row
- * per underlying, carrying the instrument types seen for it.
+ * Search rows are contracts, so they are collapsed onto the underlying behind
+ * them - one row per underlying, carrying the instrument types seen for it.
+ * See `underlyingOf` for which field that is on which exchange.
  */
 async function searchSymbols(apiKey: string, term: string, exchange: string): Promise<SearchRow[]> {
   const response = await apiClient.post<{
@@ -1681,11 +1682,35 @@ export function useUnderlyingSearch(
   }
 }
 
+/**
+ * Exchanges whose symbols are decorated contracts - RELIANCE25AUGFUT,
+ * CRUDEOIL25SEP6000CE - so the row's `name` is the underlying root behind
+ * them. Mirrors DERIVATIVE_EXCHANGES in services/strategy_module/symbol_resolver.py.
+ */
+const CONTRACT_EXCHANGES = new Set(['NFO', 'BFO', 'MCX', 'CDS', 'NCO', 'BCD', 'NCDEX', 'CRYPTO'])
+
+/**
+ * The underlying a search row names.
+ *
+ * On a derivative exchange the symbol is a contract and `name` carries the
+ * root, so `name` is what an underlying is picked by. On the cash and index
+ * exchanges it is the other way round: `symbol` is the tradable name
+ * (RELIANCE, NIFTY) while `name` is the descriptive one - "RELIANCE
+ * INDUSTRIES LTD", "NIFTY 50". Collapsing on `name` everywhere put those
+ * company names in the picker, and stored one as the strategy's underlying,
+ * which then resolved to nothing at run start.
+ */
+export function underlyingOf(row: SearchRow): string {
+  const venue = (row.exchange || '').trim().toUpperCase()
+  const base = CONTRACT_EXCHANGES.has(venue) ? row.name || row.symbol : row.symbol || row.name
+  return (base || '').trim().toUpperCase()
+}
+
 /** Contract rows reduced to the underlyings behind them, best match first. */
 export function collapseToUnderlyings(rows: SearchRow[], term: string): UnderlyingSearchResult[] {
   const byName = new Map<string, Set<string>>()
   for (const row of rows) {
-    const base = (row.name || row.symbol || '').trim().toUpperCase()
+    const base = underlyingOf(row)
     if (!base) continue
     const kinds = byName.get(base) ?? new Set<string>()
     if (row.instrumenttype) kinds.add(row.instrumenttype.toUpperCase())
@@ -1762,7 +1787,7 @@ export function useLotSize(
  */
 export function lotSizeFromRows(rows: SearchRow[], root: string): number | null {
   const needle = root.trim().toUpperCase()
-  const mine = rows.filter((row) => (row.name || '').trim().toUpperCase() === needle)
+  const mine = rows.filter((row) => underlyingOf(row) === needle)
   const usable = (row: SearchRow) => typeof row.lotsize === 'number' && row.lotsize > 0
   const futures = mine.find(
     (row) => (row.instrumenttype || '').toUpperCase() === 'FUT' && usable(row)

--- a/frontend/src/pages/strategy/strategy_module.test.ts
+++ b/frontend/src/pages/strategy/strategy_module.test.ts
@@ -853,6 +853,36 @@ describe('collapseToUnderlyings', () => {
       collapseToUnderlyings([{ symbol: '', name: '', exchange: 'NFO', instrumenttype: '' }], 'X')
     ).toEqual([])
   })
+
+  it('names a cash row by its symbol, not the company behind it', () => {
+    // NSE rows carry the company name in `name`, so collapsing on `name` put
+    // "RELIANCE INDUSTRIES LTD" in the picker and stored it as the underlying.
+    const results = collapseToUnderlyings(
+      [
+        { symbol: 'RELIANCE', name: 'RELIANCE INDUSTRIES LTD', exchange: 'NSE', instrumenttype: 'EQ' },
+        { symbol: 'RELINFRA', name: 'RELIANCE INFRASTRUCTU LTD', exchange: 'NSE', instrumenttype: 'EQ' },
+      ],
+      'RELIANCE'
+    )
+    expect(results.map((result) => result.symbol)).toEqual(['RELIANCE', 'RELINFRA'])
+    expect(results[0].instruments).toBe('EQ')
+  })
+
+  it('names an index row by its symbol, not its description', () => {
+    const results = collapseToUnderlyings(
+      [{ symbol: 'NIFTY', name: 'NIFTY 50', exchange: 'NSE_INDEX', instrumenttype: 'INDEX' }],
+      'NIFTY'
+    )
+    expect(results[0].symbol).toBe('NIFTY')
+  })
+
+  it('still collapses derivative contracts onto their root', () => {
+    const results = collapseToUnderlyings(
+      [{ symbol: 'CRUDEOIL25SEPFUT', name: 'CRUDEOIL', exchange: 'MCX', instrumenttype: 'FUT' }],
+      'CRUDEOIL'
+    )
+    expect(results[0].symbol).toBe('CRUDEOIL')
+  })
 })
 
 // ---------------------------------------------------------------------------
@@ -1383,6 +1413,23 @@ describe('lotSizeFromRows', () => {
       )
     ).toBeNull()
     expect(lotSizeFromRows([], 'NIFTY')).toBeNull()
+  })
+
+  it('matches a cash row on its symbol, where the name is the company', () => {
+    expect(
+      lotSizeFromRows(
+        [
+          {
+            symbol: 'RELIANCE',
+            name: 'RELIANCE INDUSTRIES LTD',
+            exchange: 'NSE',
+            instrumenttype: 'EQ',
+            lotsize: 1,
+          },
+        ],
+        'RELIANCE'
+      )
+    ).toBe(1)
   })
 })
 


### PR DESCRIPTION
The strategy wizard's underlying search collapsed /api/v1/search rows onto row.name. That is the underlying root on a derivative exchange (RELIANCE25AUGFUT -> RELIANCE), but on NSE/BSE and the index exchanges name is the description - "RELIANCE INDUSTRIES LTD", "NIFTY 50" - while symbol is the tradable name. So the Stocks - Cash / F&O tab listed company names, and picking one stored that string as the strategy's underlying, which then resolved to nothing at run start.

Adds underlyingOf(row), which reads name on the derivative exchanges and symbol everywhere else; the exchange set mirrors DERIVATIVE_EXCHANGES in services/strategy_module/symbol_resolver.py. lotSizeFromRows matched on name the same way, so a cash leg never matched a row and its lot-size hint was always null; it now goes through the same helper.


Claude-Session: https://claude.ai/code/session_01GwdBD2EopeA3e2HacchN9e

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the strategy wizard's underlying picker showing company names (e.g. "RELIANCE INDUSTRIES LTD") instead of tradable symbols on cash and index exchanges, which also stored a non-resolvable underlying at run start. Lot-size hints for cash legs, which previously never matched and always returned null, now resolve too.

- Adds `underlyingOf()` to read the row's `name` on derivative exchanges and `symbol` everywhere else, mirroring `DERIVATIVE_EXCHANGES` in `services/strategy_module/symbol_resolver.py`.
- Routes both `collapseToUnderlyings` and `lotSizeFromRows` through the helper, and adds tests covering cash, index, and derivative exchanges.

<sup>Written for commit c03d612f00f494599fdd9c10e9be3a8ee5190487. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1989?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

