### PR TITLE
feat(auth): apikey_or_session decorator for analytics blueprints

### DIFF
--- a/app.py
+++ b/app.py
@@ -280,6 +280,11 @@ def create_app():
 
     # Exempt API endpoints from CSRF protection (they use API key authentication)
     csrf.exempt(api_v1_bp)
+    # Stream B1 (2026-08-08): the analytics blueprints now accept an
+    # apikey in the request body (apikey_or_session decorator) exactly like
+    # the /api/v1 restx surface — bearer-token requests are not CSRF-
+    # vulnerable, so exempt them from CSRF the same way. Session-authed
+    # calls are still protected by the decorator's session check.
 
     # Initialize security middleware before traffic logging
     init_security_middleware(app)
@@ -332,6 +337,12 @@ def create_app():
     app.register_blueprint(gex_bp)  # Register GEX blueprint
     app.register_blueprint(ivsmile_bp)  # Register IV Smile blueprint
     app.register_blueprint(oiprofile_bp)  # Register OI Profile blueprint
+    # Stream B1 (2026-08-08): analytics endpoints accept an apikey in the
+    # request body (apikey_or_session) like the restx API — bearer-token
+    # requests are not CSRF-vulnerable, so exempt them the same way.
+    for _analytics_bp in (gex_bp, gamma_density_bp, ivchart_bp, ivsmile_bp,
+                          vol_surface_bp, oiprofile_bp, oitracker_bp):
+        csrf.exempt(_analytics_bp)
     app.register_blueprint(arbitrage_bp)  # Register Arbitrage blueprint
     app.register_blueprint(flow_bp)  # Register Flow blueprint
     app.register_blueprint(broker_credentials_bp)  # Register Broker credentials blueprint

--- a/blueprints/gamma_density.py
+++ b/blueprints/gamma_density.py
@@ -12,13 +12,13 @@ Underlyings and expiries are served by the shared search blueprint
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.gamma_density_service import calculate_gamma_density
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -27,11 +27,11 @@ gamma_density_bp = Blueprint("gamma_density_bp", __name__, url_prefix="/")
 
 @gamma_density_bp.route("/gammadensity/api/gamma-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def gamma_data():
     """Get gamma density (Γ×OI) and convexity-zone data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/gamma_density.py
+++ b/blueprints/gamma_density.py
@@ -18,7 +18,7 @@ from flask_cors import cross_origin
 from database.auth_db import get_api_key_for_tradingview
 from services.gamma_density_service import calculate_gamma_density
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/gex.py
+++ b/blueprints/gex.py
@@ -8,13 +8,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.gex_service import get_gex_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -23,11 +23,11 @@ gex_bp = Blueprint("gex_bp", __name__, url_prefix="/")
 
 @gex_bp.route("/gex/api/gex-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def gex_data():
     """Get GEX data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/gex.py
+++ b/blueprints/gex.py
@@ -14,7 +14,7 @@ from flask_cors import cross_origin
 from database.auth_db import get_api_key_for_tradingview
 from services.gex_service import get_gex_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -3,14 +3,14 @@ IV Chart Blueprint
 Serves intraday Implied Volatility chart data for ATM options.
 """
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token
+from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
 from services.intervals_service import get_intervals
 from services.iv_chart_service import get_default_symbols, get_iv_chart_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -19,15 +19,17 @@ ivchart_bp = Blueprint("ivchart_bp", __name__, url_prefix="/")
 
 @ivchart_bp.route("/ivchart/api/iv-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def iv_data():
     """Get intraday IV time series for ATM CE and PE options."""
     try:
-        broker = session.get("broker")
+        data0 = request.get_json(silent=True) or {}
+        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 
-        login_username = session["user"]
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         auth_token = get_auth_token(login_username)
         if auth_token is None:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
@@ -68,11 +70,11 @@ def iv_data():
 
 @ivchart_bp.route("/ivchart/api/default-symbols", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def default_symbols():
     """Get ATM CE and PE symbol names for the given underlying and expiry."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -108,11 +110,11 @@ def default_symbols():
 
 @ivchart_bp.route("/ivchart/api/intervals", methods=["GET"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def intervals():
     """Get broker-supported intraday intervals."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -10,7 +10,6 @@ from database.auth_db import (
     get_api_key_for_tradingview,
     get_auth_token,
     get_broker_name_for_user,
-    get_username_by_apikey,
 )
 from services.intervals_service import get_intervals
 from services.iv_chart_service import get_default_symbols, get_iv_chart_data
@@ -28,17 +27,19 @@ ivchart_bp = Blueprint("ivchart_bp", __name__, url_prefix="/")
 def iv_data():
     """Get intraday IV time series for ATM CE and PE options."""
     try:
-        # Broker comes from the identity the decorator already verified (the
-        # apikey arrived via body, ?apikey or X-API-Key — all surfaced as
-        # g.openalgo_apikey); browser logins fall back to the session, which
-        # stores the broker name directly. Resolving via the verified
-        # username (not the raw key) keeps usable credentials out of
-        # broker_cache (cubic review, 2026-09-06).
+        # The decorator already verified the credential (body, ?apikey or
+        # X-API-Key — all surfaced as g.openalgo_apikey) and stored the
+        # username in g.openalgo_user: resolve the broker from that verified
+        # identity — no second key verification (its result could even
+        # race a key rotation), and the raw key never touches broker_cache.
+        # Browser logins fall back to the session, which stores the broker
+        # name directly.
         decorator_api_key = getattr(g, "openalgo_apikey", None)
-        if decorator_api_key:
-            broker = get_broker_name_for_user(get_username_by_apikey(decorator_api_key))
-        else:
-            broker = session.get("broker")
+        broker = (
+            get_broker_name_for_user(g.openalgo_user)
+            if decorator_api_key
+            else session.get("broker")
+        )
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -6,7 +6,12 @@ Serves intraday Implied Volatility chart data for ATM options.
 from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
+from database.auth_db import (
+    get_api_key_for_tradingview,
+    get_auth_token,
+    get_broker_name_for_user,
+    get_username_by_apikey,
+)
 from services.intervals_service import get_intervals
 from services.iv_chart_service import get_default_symbols, get_iv_chart_data
 from utils.logging import get_logger
@@ -23,13 +28,17 @@ ivchart_bp = Blueprint("ivchart_bp", __name__, url_prefix="/")
 def iv_data():
     """Get intraday IV time series for ATM CE and PE options."""
     try:
-        # Broker comes from the apikey the decorator already verified (body,
-        # ?apikey or X-API-Key — all surfaced as g.openalgo_apikey), falling
-        # back to the session only for browser logins. Reading session['broker']
-        # first left apikey-only clients with a spurious 400 (P1, cubic review
-        # 2026-09-06).
+        # Broker comes from the identity the decorator already verified (the
+        # apikey arrived via body, ?apikey or X-API-Key — all surfaced as
+        # g.openalgo_apikey); browser logins fall back to the session, which
+        # stores the broker name directly. Resolving via the verified
+        # username (not the raw key) keeps usable credentials out of
+        # broker_cache (cubic review, 2026-09-06).
         decorator_api_key = getattr(g, "openalgo_apikey", None)
-        broker = get_broker_name(decorator_api_key) if decorator_api_key else session.get("broker")
+        if decorator_api_key:
+            broker = get_broker_name_for_user(get_username_by_apikey(decorator_api_key))
+        else:
+            broker = session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -25,6 +25,8 @@ def iv_data():
     try:
         data0 = request.get_json(silent=True) or {}
         body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        if not isinstance(body_apikey, str):
+            body_apikey = None
         broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -10,7 +10,7 @@ from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_br
 from services.intervals_service import get_intervals
 from services.iv_chart_service import get_default_symbols, get_iv_chart_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/ivchart.py
+++ b/blueprints/ivchart.py
@@ -23,11 +23,13 @@ ivchart_bp = Blueprint("ivchart_bp", __name__, url_prefix="/")
 def iv_data():
     """Get intraday IV time series for ATM CE and PE options."""
     try:
-        data0 = request.get_json(silent=True) or {}
-        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
-        if not isinstance(body_apikey, str):
-            body_apikey = None
-        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
+        # Broker comes from the apikey the decorator already verified (body,
+        # ?apikey or X-API-Key — all surfaced as g.openalgo_apikey), falling
+        # back to the session only for browser logins. Reading session['broker']
+        # first left apikey-only clients with a spurious 400 (P1, cubic review
+        # 2026-09-06).
+        decorator_api_key = getattr(g, "openalgo_apikey", None)
+        broker = get_broker_name(decorator_api_key) if decorator_api_key else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/ivsmile.py
+++ b/blueprints/ivsmile.py
@@ -8,13 +8,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.iv_smile_service import get_iv_smile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -23,11 +23,11 @@ ivsmile_bp = Blueprint("ivsmile_bp", __name__, url_prefix="/")
 
 @ivsmile_bp.route("/ivsmile/api/iv-smile-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def iv_smile_data():
     """Get IV Smile data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/ivsmile.py
+++ b/blueprints/ivsmile.py
@@ -14,7 +14,7 @@ from flask_cors import cross_origin
 from database.auth_db import get_api_key_for_tradingview
 from services.iv_smile_service import get_iv_smile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/oiprofile.py
+++ b/blueprints/oiprofile.py
@@ -9,14 +9,14 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.intervals_service import get_intervals
 from services.oi_profile_service import get_oi_profile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -28,11 +28,11 @@ oiprofile_bp = Blueprint("oiprofile_bp", __name__, url_prefix="/")
 
 @oiprofile_bp.route("/oiprofile/api/profile-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def profile_data():
     """Get OI Profile data (futures candles + OI + OI change)."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -97,11 +97,11 @@ def profile_data():
 
 @oiprofile_bp.route("/oiprofile/api/intervals", methods=["GET"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def intervals():
     """Get broker-supported intervals filtered to 1m, 5m, 15m."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/oiprofile.py
+++ b/blueprints/oiprofile.py
@@ -16,7 +16,7 @@ from database.auth_db import get_api_key_for_tradingview
 from services.intervals_service import get_intervals
 from services.oi_profile_service import get_oi_profile_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/oitracker.py
+++ b/blueprints/oitracker.py
@@ -9,13 +9,13 @@ Endpoints:
 
 import re
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
 from database.auth_db import get_api_key_for_tradingview
 from services.oi_tracker_service import calculate_max_pain, get_oi_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -24,11 +24,11 @@ oitracker_bp = Blueprint("oitracker_bp", __name__, url_prefix="/")
 
 @oitracker_bp.route("/oitracker/api/oi-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def oi_data():
     """Get Open Interest data for all strikes."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 
@@ -76,11 +76,11 @@ def oi_data():
 
 @oitracker_bp.route("/oitracker/api/maxpain", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def maxpain():
     """Calculate Max Pain for an underlying/expiry."""
     try:
-        login_username = session.get("user")
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         if not login_username:
             return jsonify({"status": "error", "message": "Authentication required"}), 401
 

--- a/blueprints/oitracker.py
+++ b/blueprints/oitracker.py
@@ -15,7 +15,7 @@ from flask_cors import cross_origin
 from database.auth_db import get_api_key_for_tradingview
 from services.oi_tracker_service import calculate_max_pain, get_oi_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -3,13 +3,13 @@ Volatility Surface Blueprint
 Serves 3D implied volatility surface data for index options.
 """
 
-from flask import Blueprint, jsonify, request, session
+from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token
+from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
 from services.vol_surface_service import get_vol_surface_data
 from utils.logging import get_logger
-from utils.session import check_session_validity
+from utils.session import check_session_validity, apikey_or_session
 
 logger = get_logger(__name__)
 
@@ -18,15 +18,17 @@ vol_surface_bp = Blueprint("vol_surface_bp", __name__, url_prefix="/")
 
 @vol_surface_bp.route("/volsurface/api/surface-data", methods=["POST"])
 @cross_origin()
-@check_session_validity
+@apikey_or_session
 def surface_data():
     """Get 3D volatility surface data across strikes and expiries."""
     try:
-        broker = session.get("broker")
+        data0 = request.get_json(silent=True) or {}
+        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 
-        login_username = session["user"]
+        login_username = getattr(g, "openalgo_user", None) or session.get("user")
         auth_token = get_auth_token(login_username)
         if auth_token is None:
             return jsonify({"status": "error", "message": "Authentication required"}), 401

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -9,7 +9,7 @@ from flask_cors import cross_origin
 from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
 from services.vol_surface_service import get_vol_surface_data
 from utils.logging import get_logger
-from utils.session import check_session_validity, apikey_or_session
+from utils.session import apikey_or_session, check_session_validity
 
 logger = get_logger(__name__)
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -10,7 +10,6 @@ from database.auth_db import (
     get_api_key_for_tradingview,
     get_auth_token,
     get_broker_name_for_user,
-    get_username_by_apikey,
 )
 from services.vol_surface_service import get_vol_surface_data
 from utils.logging import get_logger
@@ -27,17 +26,19 @@ vol_surface_bp = Blueprint("vol_surface_bp", __name__, url_prefix="/")
 def surface_data():
     """Get 3D volatility surface data across strikes and expiries."""
     try:
-        # Broker comes from the identity the decorator already verified (the
-        # apikey arrived via body, ?apikey or X-API-Key — all surfaced as
-        # g.openalgo_apikey); browser logins fall back to the session, which
-        # stores the broker name directly. Resolving via the verified
-        # username (not the raw key) keeps usable credentials out of
-        # broker_cache (cubic review, 2026-09-06).
+        # The decorator already verified the credential (body, ?apikey or
+        # X-API-Key — all surfaced as g.openalgo_apikey) and stored the
+        # username in g.openalgo_user: resolve the broker from that verified
+        # identity — no second key verification (its result could even
+        # race a key rotation), and the raw key never touches broker_cache.
+        # Browser logins fall back to the session, which stores the broker
+        # name directly.
         decorator_api_key = getattr(g, "openalgo_apikey", None)
-        if decorator_api_key:
-            broker = get_broker_name_for_user(get_username_by_apikey(decorator_api_key))
-        else:
-            broker = session.get("broker")
+        broker = (
+            get_broker_name_for_user(g.openalgo_user)
+            if decorator_api_key
+            else session.get("broker")
+        )
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -22,11 +22,13 @@ vol_surface_bp = Blueprint("vol_surface_bp", __name__, url_prefix="/")
 def surface_data():
     """Get 3D volatility surface data across strikes and expiries."""
     try:
-        data0 = request.get_json(silent=True) or {}
-        body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
-        if not isinstance(body_apikey, str):
-            body_apikey = None
-        broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
+        # Broker comes from the apikey the decorator already verified (body,
+        # ?apikey or X-API-Key — all surfaced as g.openalgo_apikey), falling
+        # back to the session only for browser logins. Reading session['broker']
+        # first left apikey-only clients with a spurious 400 (P1, cubic review
+        # 2026-09-06).
+        decorator_api_key = getattr(g, "openalgo_apikey", None)
+        broker = get_broker_name(decorator_api_key) if decorator_api_key else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -6,7 +6,12 @@ Serves 3D implied volatility surface data for index options.
 from flask import Blueprint, g, jsonify, request, session
 from flask_cors import cross_origin
 
-from database.auth_db import get_api_key_for_tradingview, get_auth_token, get_broker_name
+from database.auth_db import (
+    get_api_key_for_tradingview,
+    get_auth_token,
+    get_broker_name_for_user,
+    get_username_by_apikey,
+)
 from services.vol_surface_service import get_vol_surface_data
 from utils.logging import get_logger
 from utils.session import apikey_or_session, check_session_validity
@@ -22,13 +27,17 @@ vol_surface_bp = Blueprint("vol_surface_bp", __name__, url_prefix="/")
 def surface_data():
     """Get 3D volatility surface data across strikes and expiries."""
     try:
-        # Broker comes from the apikey the decorator already verified (body,
-        # ?apikey or X-API-Key — all surfaced as g.openalgo_apikey), falling
-        # back to the session only for browser logins. Reading session['broker']
-        # first left apikey-only clients with a spurious 400 (P1, cubic review
-        # 2026-09-06).
+        # Broker comes from the identity the decorator already verified (the
+        # apikey arrived via body, ?apikey or X-API-Key — all surfaced as
+        # g.openalgo_apikey); browser logins fall back to the session, which
+        # stores the broker name directly. Resolving via the verified
+        # username (not the raw key) keeps usable credentials out of
+        # broker_cache (cubic review, 2026-09-06).
         decorator_api_key = getattr(g, "openalgo_apikey", None)
-        broker = get_broker_name(decorator_api_key) if decorator_api_key else session.get("broker")
+        if decorator_api_key:
+            broker = get_broker_name_for_user(get_username_by_apikey(decorator_api_key))
+        else:
+            broker = session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400
 

--- a/blueprints/vol_surface.py
+++ b/blueprints/vol_surface.py
@@ -24,6 +24,8 @@ def surface_data():
     try:
         data0 = request.get_json(silent=True) or {}
         body_apikey = data0.get("apikey") if isinstance(data0, dict) else None
+        if not isinstance(body_apikey, str):
+            body_apikey = None
         broker = get_broker_name(body_apikey) if body_apikey else session.get("broker")
         if not broker:
             return jsonify({"status": "error", "message": "Broker not set in session"}), 400

--- a/database/auth_db.py
+++ b/database/auth_db.py
@@ -977,16 +977,25 @@ def get_username_by_apikey(provided_api_key):
 
 
 def get_broker_name_for_user(username):
-    """Get the broker name for a verified username (no API key involved).
+    """Get the broker name for a verified username, cached by that username.
 
     For callers that already hold a VERIFIED username (e.g. the
-    apikey_or_session decorator), this avoids both a redundant key
-    verification and any use of the raw key as a cache key (cubic review,
-    2026-09-06: broker_cache must not accumulate usable credentials).
+    apikey_or_session decorator), this avoids a redundant key verification,
+    and the cache is keyed by the username — never by an API key — so
+    broker_cache cannot accumulate usable credentials (cubic review,
+    2026-09-06). Cleared by the existing broker_cache.clear() paths on
+    token upsert/revoke.
     """
+    if not username:
+        return None
+
+    if username in broker_cache:
+        return broker_cache[username]
+
     try:
         auth_obj = Auth.query.filter_by(name=username).first()
         if auth_obj and not auth_obj.is_revoked:
+            broker_cache[username] = auth_obj.broker
             return auth_obj.broker
         logger.warning(f"No valid broker found for user_id '{username}'.")
         return None
@@ -1001,16 +1010,10 @@ def get_broker_name(provided_api_key):
     if not user_id:
         return None
 
-    # Cache keyed by the verified user_id, never the raw API key: keying by
-    # the key itself would leave usable credentials inspectable in
-    # broker_cache for its full TTL.
-    if user_id in broker_cache:
-        return broker_cache[user_id]
-
-    broker = get_broker_name_for_user(user_id)
-    if broker is not None:
-        broker_cache[user_id] = broker
-    return broker
+    # broker_cache is keyed by the verified user_id, never the raw API key:
+    # keying by the key itself would leave usable credentials inspectable in
+    # the cache for its full TTL.
+    return get_broker_name_for_user(user_id)
 
 
 def get_auth_token_broker(provided_api_key, include_feed_token=False):

--- a/database/auth_db.py
+++ b/database/auth_db.py
@@ -976,29 +976,41 @@ def get_username_by_apikey(provided_api_key):
     return verify_api_key(provided_api_key)
 
 
+def get_broker_name_for_user(username):
+    """Get the broker name for a verified username (no API key involved).
+
+    For callers that already hold a VERIFIED username (e.g. the
+    apikey_or_session decorator), this avoids both a redundant key
+    verification and any use of the raw key as a cache key (cubic review,
+    2026-09-06: broker_cache must not accumulate usable credentials).
+    """
+    try:
+        auth_obj = Auth.query.filter_by(name=username).first()
+        if auth_obj and not auth_obj.is_revoked:
+            return auth_obj.broker
+        logger.warning(f"No valid broker found for user_id '{username}'.")
+        return None
+    except Exception as e:
+        logger.exception(f"Error while querying the database for broker name: {e}")
+        return None
+
+
 def get_broker_name(provided_api_key):
     """Get only the broker name for a valid API key with caching"""
-    # Check if broker name is in cache
-    if provided_api_key in broker_cache:
-        return broker_cache[provided_api_key]
-
-    # Not in cache, need to look it up
     user_id = verify_api_key(provided_api_key)
+    if not user_id:
+        return None
 
-    if user_id:
-        try:
-            auth_obj = Auth.query.filter_by(name=user_id).first()
-            if auth_obj and not auth_obj.is_revoked:
-                # Cache the broker name
-                broker_cache[provided_api_key] = auth_obj.broker
-                return auth_obj.broker
-            else:
-                logger.warning(f"No valid broker found for user_id '{user_id}'.")
-                return None
-        except Exception as e:
-            logger.exception(f"Error while querying the database for broker name: {e}")
-            return None
-    return None
+    # Cache keyed by the verified user_id, never the raw API key: keying by
+    # the key itself would leave usable credentials inspectable in
+    # broker_cache for its full TTL.
+    if user_id in broker_cache:
+        return broker_cache[user_id]
+
+    broker = get_broker_name_for_user(user_id)
+    if broker is not None:
+        broker_cache[user_id] = broker
+    return broker
 
 
 def get_auth_token_broker(provided_api_key, include_feed_token=False):

--- a/test/test_analytics_apikey_or_session.py
+++ b/test/test_analytics_apikey_or_session.py
@@ -1,0 +1,124 @@
+"""Auth matrix for the analytics apikey_or_session decorator.
+
+The analytics blueprints are CSRF-exempt at registration (headless apikey
+clients carry no token, and a bearer credential in the body is not
+CSRF-able), so the decorator must re-enforce CSRF on the session fallback
+branch itself — otherwise the exemption would drop the token check that
+these routes enforced before the apikey path existed (PR #1990 review
+finding).
+
+Uses a real registered analytics blueprint (oitracker) with the heavy data
+calls patched out: the layer under test is authentication, not the
+analytics math.
+"""
+
+from datetime import datetime, timedelta
+
+import pytest
+import pytz
+from flask import Flask, jsonify
+from flask_wtf.csrf import CSRFProtect, generate_csrf
+
+import blueprints.oitracker as oitracker_module
+import database.auth_db as auth_db_module
+from blueprints.oitracker import oitracker_bp
+
+VALID_PARAMS = {"underlying": "NIFTY", "exchange": "NFO", "expiry_date": "15OCT26"}
+
+
+def _oi_data_success(**kwargs):
+    return True, {"status": "success", "data": []}, 200
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret-key"
+    app.config["TESTING"] = True
+
+    csrf = CSRFProtect(app)
+    # Mirror app.py: the analytics blueprints are registered CSRF-exempt.
+    csrf.exempt(oitracker_bp)
+    app.register_blueprint(oitracker_bp)
+
+    @app.route("/_test/csrf")
+    def _csrf_token():
+        return jsonify({"token": generate_csrf()})
+
+    # Patch the credential lookups and the data call; the auth layer must
+    # be exercised through the real decorator and real blueprint routes.
+    monkeypatch.setattr(
+        auth_db_module,
+        "get_username_by_apikey",
+        lambda key: "testuser" if key == "valid-key" else None,
+    )
+    monkeypatch.setattr(oitracker_module, "get_api_key_for_tradingview", lambda user: "sk-test")
+    monkeypatch.setattr(oitracker_module, "get_oi_data", _oi_data_success)
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+def _login(client, login_time=None):
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+        sess["user"] = "testuser"
+        sess["login_time"] = login_time or datetime.now(pytz.timezone("Asia/Kolkata")).isoformat()
+
+
+def _csrf_token(client):
+    return client.get("/_test/csrf").get_json()["token"]
+
+
+class TestApikeyPath:
+    def test_valid_apikey_authenticates_without_csrf_token(self, client):
+        # Headless clients have no CSRF token; a bearer apikey must not need one.
+        resp = client.post("/oitracker/api/oi-data", json={"apikey": "valid-key", **VALID_PARAMS})
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+
+    def test_invalid_apikey_rejected(self, client):
+        resp = client.post("/oitracker/api/oi-data", json={"apikey": "wrong-key", **VALID_PARAMS})
+        assert resp.status_code == 401
+        assert resp.get_json()["message"] == "Invalid openalgo apikey"
+
+
+class TestSessionPath:
+    def test_missing_auth_rejected(self, client):
+        resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
+        assert resp.status_code == 401
+        assert resp.get_json()["message"] == "Authentication required"
+
+    def test_expired_session_rejected(self, client):
+        expired = datetime.now(pytz.timezone("Asia/Kolkata")) - timedelta(days=2)
+        _login(client, login_time=expired.isoformat())
+        resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
+        assert resp.status_code == 401
+
+    def test_valid_session_without_csrf_token_rejected(self, client):
+        # THE review finding: the blueprint exemption must not remove the
+        # token check for browser users — the decorator re-applies it.
+        _login(client)
+        resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
+        assert resp.status_code == 400
+
+    def test_valid_session_with_csrf_token_accepted(self, client):
+        _login(client)
+        token = _csrf_token(client)
+        resp = client.post(
+            "/oitracker/api/oi-data",
+            json=VALID_PARAMS,
+            headers={"X-CSRFToken": token},
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+
+    def test_csrf_disabled_allows_session_post_without_token(self, client, app, monkeypatch):
+        # CSRF_ENABLED=FALSE deployments: protect() must no-op, not hard-fail.
+        monkeypatch.setitem(app.config, "WTF_CSRF_ENABLED", False)
+        _login(client)
+        resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
+        assert resp.status_code == 200

--- a/test/test_analytics_apikey_or_session.py
+++ b/test/test_analytics_apikey_or_session.py
@@ -45,6 +45,12 @@ def app(monkeypatch):
     def _csrf_token():
         return jsonify({"token": generate_csrf()})
 
+    # check_session_validity parity: the unauthenticated non-AJAX branch
+    # redirects to auth.login, which the real app provides.
+    @app.route("/login", endpoint="auth.login")
+    def _login_page():
+        return "login page", 200
+
     # Patch the credential lookups and the data call; the auth layer must
     # be exercised through the real decorator and real blueprint routes.
     monkeypatch.setattr(
@@ -88,9 +94,24 @@ class TestApikeyPath:
 
 class TestSessionPath:
     def test_missing_auth_rejected(self, client):
+        # Mirrors check_session_validity: JSON requests get the
+        # session_expired contract instead of a bare message.
         resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
         assert resp.status_code == 401
-        assert resp.get_json()["message"] == "Authentication required"
+        body = resp.get_json()
+        assert body["error"] == "session_expired"
+        assert body["status"] == "error"
+
+    def test_missing_auth_non_ajax_redirects_to_login(self, client):
+        # Non-AJAX callers get the same redirect check_session_validity
+        # produced before the apikey path existed.
+        resp = client.post(
+            "/oitracker/api/oi-data",
+            data="",
+            content_type="text/plain",
+        )
+        assert resp.status_code == 302
+        assert "/login" in resp.headers["Location"]
 
     def test_expired_session_rejected(self, client):
         expired = datetime.now(pytz.timezone("Asia/Kolkata")) - timedelta(days=2)
@@ -122,3 +143,53 @@ class TestSessionPath:
         _login(client)
         resp = client.post("/oitracker/api/oi-data", json=VALID_PARAMS)
         assert resp.status_code == 200
+
+
+class TestApikeySources:
+    """The apikey may arrive in the JSON body, the query string, or the
+    X-API-Key header (needed for the GET endpoints, e.g. the interval
+    lists, which cannot carry a JSON body)."""
+
+    def _patch_capture(self, monkeypatch):
+        from flask import g
+
+        import blueprints.oitracker as oitracker_module
+
+        captured = {}
+
+        def _capture(**kwargs):
+            captured["user"] = getattr(g, "openalgo_user", None)
+            captured["apikey"] = getattr(g, "openalgo_apikey", None)
+            return True, {"status": "success", "data": []}, 200
+
+        monkeypatch.setattr(oitracker_module, "get_oi_data", _capture)
+        return captured
+
+    def test_apikey_from_query_param(self, client, monkeypatch):
+        captured = self._patch_capture(monkeypatch)
+        resp = client.post(
+            "/oitracker/api/oi-data?apikey=valid-key", json=VALID_PARAMS
+        )
+        assert resp.status_code == 200
+        assert captured["user"] == "testuser"
+        assert captured["apikey"] == "valid-key"
+
+    def test_apikey_from_header(self, client, monkeypatch):
+        captured = self._patch_capture(monkeypatch)
+        resp = client.post(
+            "/oitracker/api/oi-data",
+            json=VALID_PARAMS,
+            headers={"X-API-Key": "valid-key"},
+        )
+        assert resp.status_code == 200
+        assert captured["user"] == "testuser"
+        assert captured["apikey"] == "valid-key"
+
+    def test_invalid_apikey_from_header_rejected(self, client):
+        resp = client.post(
+            "/oitracker/api/oi-data",
+            json=VALID_PARAMS,
+            headers={"X-API-Key": "wrong-key"},
+        )
+        assert resp.status_code == 401
+        assert resp.get_json()["message"] == "Invalid openalgo apikey"

--- a/test/test_ivchart_vol_surface_broker_source.py
+++ b/test/test_ivchart_vol_surface_broker_source.py
@@ -1,0 +1,177 @@
+"""Broker resolution for the IV Chart / Vol Surface analytics routes.
+
+The apikey_or_session decorator surfaces the verified credential as
+``g.openalgo_apikey`` regardless of where it arrived (JSON body, ?apikey
+query parameter, X-API-Key header). The routes must resolve the broker
+from THAT credential and fall back to the session only for browser
+logins — reading session['broker'] first left apikey-only clients with a
+spurious 400 "Broker not set in session" (cubic review, 2026-09-06).
+"""
+
+import pytest
+from flask import Flask, jsonify
+from flask_wtf.csrf import CSRFProtect, generate_csrf
+from datetime import datetime
+
+import pytz
+
+import blueprints.ivchart as ivchart_module
+import blueprints.vol_surface as vol_surface_module
+import database.auth_db as auth_db_module
+from blueprints.ivchart import ivchart_bp
+from blueprints.vol_surface import vol_surface_bp
+
+
+@pytest.fixture()
+def app(monkeypatch):
+    app = Flask(__name__)
+    app.config["SECRET_KEY"] = "test-secret-key"
+    app.config["TESTING"] = True
+
+    csrf = CSRFProtect(app)
+    csrf.exempt(ivchart_bp)
+    csrf.exempt(vol_surface_bp)
+    app.register_blueprint(ivchart_bp)
+    app.register_blueprint(vol_surface_bp)
+
+    @app.route("/_test/csrf")
+    def _csrf_token():
+        return jsonify({"token": generate_csrf()})
+
+    monkeypatch.setattr(
+        auth_db_module,
+        "get_username_by_apikey",
+        lambda key: "testuser" if key == "valid-key" else None,
+    )
+    # Broker lookup: patched per-test via _patch_broker(); default to a
+    # registered broker for both the apikey and session credentials.
+    monkeypatch.setattr(ivchart_module, "get_broker_name", lambda key: "zerodha" if key else None)
+    monkeypatch.setattr(
+        vol_surface_module, "get_broker_name", lambda key: "zerodha" if key else None
+    )
+    monkeypatch.setattr(ivchart_module, "get_auth_token", lambda user: "tok-testuser")
+    monkeypatch.setattr(vol_surface_module, "get_auth_token", lambda user: "tok-testuser")
+    monkeypatch.setattr(ivchart_module, "get_api_key_for_tradingview", lambda user: "sk-test")
+    monkeypatch.setattr(vol_surface_module, "get_api_key_for_tradingview", lambda user: "sk-test")
+    monkeypatch.setattr(
+        ivchart_module,
+        "get_iv_chart_data",
+        lambda **kwargs: (True, {"status": "success", "data": []}, 200),
+    )
+    monkeypatch.setattr(
+        vol_surface_module,
+        "get_vol_surface_data",
+        lambda **kwargs: (True, {"status": "success", "data": []}, 200),
+    )
+    return app
+
+
+@pytest.fixture()
+def client(app):
+    return app.test_client()
+
+
+IV_PARAMS = {"underlying": "NIFTY", "exchange": "NFO", "expiry_date": "15OCT26"}
+VS_PARAMS = {"underlying": "NIFTY", "exchange": "NFO", "expiry_dates": ["15OCT26"]}
+
+
+def _login(client):
+    with client.session_transaction() as sess:
+        sess["logged_in"] = True
+        sess["user"] = "testuser"
+        sess["broker"] = "zerodha"  # stored by the real login flow
+        sess["login_time"] = datetime.now(pytz.timezone("Asia/Kolkata")).isoformat()
+
+
+def _csrf_token(client):
+    return client.get("/_test/csrf").get_json()["token"]
+
+
+def _patch_broker_capture(monkeypatch, source="ivchart"):
+    """Capture which credential get_broker_name is called with."""
+    module = ivchart_module if source == "ivchart" else vol_surface_module
+    captured = {}
+
+    def _spy(key):
+        captured["key"] = key
+        return "zerodha" if key else None
+
+    monkeypatch.setattr(module, "get_broker_name", _spy)
+    return captured
+
+
+class TestIvchartBrokerSource:
+    def test_apikey_only_client_gets_broker(self, client, monkeypatch):
+        # The P1: an X-API-Key client authenticated fine but the route read
+        # the broker from the empty session and returned 400.
+        captured = _patch_broker_capture(monkeypatch, "ivchart")
+        resp = client.post("/ivchart/api/iv-data", json=IV_PARAMS, headers={"X-API-Key": "valid-key"})
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+        # The broker was resolved from the decorator's verified apikey.
+        assert captured["key"] == "valid-key"
+
+    def test_query_param_apikey_gets_broker(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "ivchart")
+        resp = client.post("/ivchart/api/iv-data?apikey=valid-key", json=IV_PARAMS)
+        assert resp.status_code == 200
+        assert captured["key"] == "valid-key"
+
+    def test_session_client_skips_apikey_lookup(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "ivchart")
+        _login(client)
+        resp = client.post(
+            "/ivchart/api/iv-data",
+            json=IV_PARAMS,
+            headers={"X-CSRFToken": _csrf_token(client)},
+        )
+        assert resp.status_code == 200
+        # Browser sessions carry the broker name directly: get_broker_name
+        # must not be consulted at all on the session path.
+        assert captured == {}
+
+    def test_unknown_apikey_still_rejected_by_broker_check(self, client, monkeypatch):
+        # A credential that authenticates but has no broker registered (or a
+        # lookup failure) must keep failing closed with the same 400.
+        monkeypatch.setattr(ivchart_module, "get_broker_name", lambda key: None)
+        resp = client.post("/ivchart/api/iv-data", json=IV_PARAMS, headers={"X-API-Key": "valid-key"})
+        assert resp.status_code == 400
+        assert resp.get_json()["message"] == "Broker not set in session"
+
+
+class TestVolSurfaceBrokerSource:
+    def test_apikey_only_client_gets_broker(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "vol_surface")
+        resp = client.post(
+            "/volsurface/api/surface-data", json=VS_PARAMS, headers={"X-API-Key": "valid-key"}
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+        assert captured["key"] == "valid-key"
+
+    def test_query_param_apikey_gets_broker(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "vol_surface")
+        resp = client.post("/volsurface/api/surface-data?apikey=valid-key", json=VS_PARAMS)
+        assert resp.status_code == 200
+        assert captured["key"] == "valid-key"
+
+    def test_session_client_skips_apikey_lookup(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "vol_surface")
+        _login(client)
+        resp = client.post(
+            "/volsurface/api/surface-data",
+            json=VS_PARAMS,
+            headers={"X-CSRFToken": _csrf_token(client)},
+        )
+        assert resp.status_code == 200
+        # Browser sessions carry the broker name directly: get_broker_name
+        # must not be consulted at all on the session path.
+        assert captured == {}
+
+    def test_unknown_apikey_still_rejected_by_broker_check(self, client, monkeypatch):
+        monkeypatch.setattr(vol_surface_module, "get_broker_name", lambda key: None)
+        resp = client.post(
+            "/volsurface/api/surface-data", json=VS_PARAMS, headers={"X-API-Key": "valid-key"}
+        )
+        assert resp.status_code == 400
+        assert resp.get_json()["message"] == "Broker not set in session"

--- a/test/test_ivchart_vol_surface_broker_source.py
+++ b/test/test_ivchart_vol_surface_broker_source.py
@@ -157,11 +157,11 @@ class TestBrokerUsernameCache:
     must never key on the raw API key)."""
 
     def test_caches_by_username_never_by_key(self, monkeypatch):
-        calls = {"n": 0}
+        seen_filters = []
 
         class _FakeQuery:
             def filter_by(self, **kwargs):
-                calls["n"] += 1
+                seen_filters.append(kwargs)
                 return self
 
             def first(self):
@@ -171,13 +171,29 @@ class TestBrokerUsernameCache:
             query = _FakeQuery()
 
         monkeypatch.setattr(auth_db_module, "Auth", _FakeAuth)
+        monkeypatch.setattr(
+            auth_db_module,
+            "verify_api_key",
+            lambda key: "testuser" if key == "valid-key" else None,
+        )
         auth_db_module.broker_cache.clear()
         try:
+            # Username path (what the analytics routes use): the lookup filters
+            # on the verified username exactly, and the repeat is cached.
             assert auth_db_module.get_broker_name_for_user("testuser") == "zerodha"
             assert auth_db_module.get_broker_name_for_user("testuser") == "zerodha"
-            assert calls["n"] == 1  # second call served from the cache
+            assert seen_filters == [{"name": "testuser"}]  # 2nd call: cache hit
             assert auth_db_module.broker_cache["testuser"] == "zerodha"
+
+            # API-key path through the REAL helper chain: verify once, then the
+            # username helper + its cache — the raw key is never a cache key.
+            assert auth_db_module.get_broker_name("valid-key") == "zerodha"
+            assert seen_filters == [{"name": "testuser"}]  # served from cache
             assert "valid-key" not in auth_db_module.broker_cache
+
+            # An unverifiable key never touches the database or the cache.
+            assert auth_db_module.get_broker_name("bad-key") is None
+            assert seen_filters == [{"name": "testuser"}]
         finally:
             auth_db_module.broker_cache.clear()
 

--- a/test/test_ivchart_vol_surface_broker_source.py
+++ b/test/test_ivchart_vol_surface_broker_source.py
@@ -8,6 +8,7 @@ logins — reading session['broker'] first left apikey-only clients with a
 spurious 400 "Broker not set in session" (cubic review, 2026-09-06).
 """
 
+import types
 from datetime import datetime
 
 import pytest
@@ -40,11 +41,9 @@ def app(monkeypatch):
 
     username_for_key = lambda key: "testuser" if key == "valid-key" else None  # noqa: E731
     monkeypatch.setattr(auth_db_module, "get_username_by_apikey", username_for_key)
-    monkeypatch.setattr(ivchart_module, "get_username_by_apikey", username_for_key)
-    monkeypatch.setattr(vol_surface_module, "get_username_by_apikey", username_for_key)
     # Broker lookup: patched per-test via _patch_broker_capture(); the routes
-    # resolve the broker from the VERIFIED USERNAME (never the raw key), so
-    # default to a registered broker for the known user only.
+    # resolve the broker from the decorator's VERIFIED USERNAME (g.openalgo_user,
+    # never the raw key), so default to a registered broker for the known user.
     monkeypatch.setattr(
         ivchart_module, "get_broker_name_for_user", lambda user: "zerodha" if user else None
     )
@@ -150,6 +149,37 @@ class TestIvchartBrokerSource:
         resp = client.post("/ivchart/api/iv-data", json=IV_PARAMS, headers={"X-API-Key": "valid-key"})
         assert resp.status_code == 400
         assert resp.get_json()["message"] == "Broker not set in session"
+
+
+class TestBrokerUsernameCache:
+    """get_broker_name_for_user caches by verified username (cubic round 3:
+    chart polling must not hit the database per request, and broker_cache
+    must never key on the raw API key)."""
+
+    def test_caches_by_username_never_by_key(self, monkeypatch):
+        calls = {"n": 0}
+
+        class _FakeQuery:
+            def filter_by(self, **kwargs):
+                calls["n"] += 1
+                return self
+
+            def first(self):
+                return types.SimpleNamespace(is_revoked=False, broker="zerodha")
+
+        class _FakeAuth:
+            query = _FakeQuery()
+
+        monkeypatch.setattr(auth_db_module, "Auth", _FakeAuth)
+        auth_db_module.broker_cache.clear()
+        try:
+            assert auth_db_module.get_broker_name_for_user("testuser") == "zerodha"
+            assert auth_db_module.get_broker_name_for_user("testuser") == "zerodha"
+            assert calls["n"] == 1  # second call served from the cache
+            assert auth_db_module.broker_cache["testuser"] == "zerodha"
+            assert "valid-key" not in auth_db_module.broker_cache
+        finally:
+            auth_db_module.broker_cache.clear()
 
 
 class TestVolSurfaceBrokerSource:

--- a/test/test_ivchart_vol_surface_broker_source.py
+++ b/test/test_ivchart_vol_surface_broker_source.py
@@ -8,12 +8,12 @@ logins — reading session['broker'] first left apikey-only clients with a
 spurious 400 "Broker not set in session" (cubic review, 2026-09-06).
 """
 
-import pytest
-from flask import Flask, jsonify
-from flask_wtf.csrf import CSRFProtect, generate_csrf
 from datetime import datetime
 
+import pytest
 import pytz
+from flask import Flask, jsonify
+from flask_wtf.csrf import CSRFProtect, generate_csrf
 
 import blueprints.ivchart as ivchart_module
 import blueprints.vol_surface as vol_surface_module
@@ -38,16 +38,18 @@ def app(monkeypatch):
     def _csrf_token():
         return jsonify({"token": generate_csrf()})
 
+    username_for_key = lambda key: "testuser" if key == "valid-key" else None  # noqa: E731
+    monkeypatch.setattr(auth_db_module, "get_username_by_apikey", username_for_key)
+    monkeypatch.setattr(ivchart_module, "get_username_by_apikey", username_for_key)
+    monkeypatch.setattr(vol_surface_module, "get_username_by_apikey", username_for_key)
+    # Broker lookup: patched per-test via _patch_broker_capture(); the routes
+    # resolve the broker from the VERIFIED USERNAME (never the raw key), so
+    # default to a registered broker for the known user only.
     monkeypatch.setattr(
-        auth_db_module,
-        "get_username_by_apikey",
-        lambda key: "testuser" if key == "valid-key" else None,
+        ivchart_module, "get_broker_name_for_user", lambda user: "zerodha" if user else None
     )
-    # Broker lookup: patched per-test via _patch_broker(); default to a
-    # registered broker for both the apikey and session credentials.
-    monkeypatch.setattr(ivchart_module, "get_broker_name", lambda key: "zerodha" if key else None)
     monkeypatch.setattr(
-        vol_surface_module, "get_broker_name", lambda key: "zerodha" if key else None
+        vol_surface_module, "get_broker_name_for_user", lambda user: "zerodha" if user else None
     )
     monkeypatch.setattr(ivchart_module, "get_auth_token", lambda user: "tok-testuser")
     monkeypatch.setattr(vol_surface_module, "get_auth_token", lambda user: "tok-testuser")
@@ -88,19 +90,28 @@ def _csrf_token(client):
 
 
 def _patch_broker_capture(monkeypatch, source="ivchart"):
-    """Capture which credential get_broker_name is called with."""
+    """Capture which identity get_broker_name_for_user is called with."""
     module = ivchart_module if source == "ivchart" else vol_surface_module
     captured = {}
 
-    def _spy(key):
-        captured["key"] = key
-        return "zerodha" if key else None
+    def _spy(username):
+        captured["username"] = username
+        return "zerodha" if username else None
 
-    monkeypatch.setattr(module, "get_broker_name", _spy)
+    monkeypatch.setattr(module, "get_broker_name_for_user", _spy)
     return captured
 
 
 class TestIvchartBrokerSource:
+    def test_body_apikey_gets_broker(self, client, monkeypatch):
+        # The documented primary source: apikey in the JSON body (the first
+        # source the decorator checks).
+        captured = _patch_broker_capture(monkeypatch, "ivchart")
+        resp = client.post("/ivchart/api/iv-data", json={"apikey": "valid-key", **IV_PARAMS})
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+        assert captured["username"] == "testuser"
+
     def test_apikey_only_client_gets_broker(self, client, monkeypatch):
         # The P1: an X-API-Key client authenticated fine but the route read
         # the broker from the empty session and returned 400.
@@ -108,14 +119,16 @@ class TestIvchartBrokerSource:
         resp = client.post("/ivchart/api/iv-data", json=IV_PARAMS, headers={"X-API-Key": "valid-key"})
         assert resp.status_code == 200
         assert resp.get_json()["status"] == "success"
-        # The broker was resolved from the decorator's verified apikey.
-        assert captured["key"] == "valid-key"
+        # The broker was resolved from the decorator's verified identity, and
+        # the raw key never entered broker_cache.
+        assert captured["username"] == "testuser"
+        assert "valid-key" not in auth_db_module.broker_cache
 
     def test_query_param_apikey_gets_broker(self, client, monkeypatch):
         captured = _patch_broker_capture(monkeypatch, "ivchart")
         resp = client.post("/ivchart/api/iv-data?apikey=valid-key", json=IV_PARAMS)
         assert resp.status_code == 200
-        assert captured["key"] == "valid-key"
+        assert captured["username"] == "testuser"
 
     def test_session_client_skips_apikey_lookup(self, client, monkeypatch):
         captured = _patch_broker_capture(monkeypatch, "ivchart")
@@ -130,16 +143,25 @@ class TestIvchartBrokerSource:
         # must not be consulted at all on the session path.
         assert captured == {}
 
-    def test_unknown_apikey_still_rejected_by_broker_check(self, client, monkeypatch):
+    def test_broker_lookup_failure_still_returns_400(self, client, monkeypatch):
         # A credential that authenticates but has no broker registered (or a
         # lookup failure) must keep failing closed with the same 400.
-        monkeypatch.setattr(ivchart_module, "get_broker_name", lambda key: None)
+        monkeypatch.setattr(ivchart_module, "get_broker_name_for_user", lambda user: None)
         resp = client.post("/ivchart/api/iv-data", json=IV_PARAMS, headers={"X-API-Key": "valid-key"})
         assert resp.status_code == 400
         assert resp.get_json()["message"] == "Broker not set in session"
 
 
 class TestVolSurfaceBrokerSource:
+    def test_body_apikey_gets_broker(self, client, monkeypatch):
+        captured = _patch_broker_capture(monkeypatch, "vol_surface")
+        resp = client.post(
+            "/volsurface/api/surface-data", json={"apikey": "valid-key", **VS_PARAMS}
+        )
+        assert resp.status_code == 200
+        assert resp.get_json()["status"] == "success"
+        assert captured["username"] == "testuser"
+
     def test_apikey_only_client_gets_broker(self, client, monkeypatch):
         captured = _patch_broker_capture(monkeypatch, "vol_surface")
         resp = client.post(
@@ -147,13 +169,14 @@ class TestVolSurfaceBrokerSource:
         )
         assert resp.status_code == 200
         assert resp.get_json()["status"] == "success"
-        assert captured["key"] == "valid-key"
+        assert captured["username"] == "testuser"
+        assert "valid-key" not in auth_db_module.broker_cache
 
     def test_query_param_apikey_gets_broker(self, client, monkeypatch):
         captured = _patch_broker_capture(monkeypatch, "vol_surface")
         resp = client.post("/volsurface/api/surface-data?apikey=valid-key", json=VS_PARAMS)
         assert resp.status_code == 200
-        assert captured["key"] == "valid-key"
+        assert captured["username"] == "testuser"
 
     def test_session_client_skips_apikey_lookup(self, client, monkeypatch):
         captured = _patch_broker_capture(monkeypatch, "vol_surface")
@@ -168,8 +191,8 @@ class TestVolSurfaceBrokerSource:
         # must not be consulted at all on the session path.
         assert captured == {}
 
-    def test_unknown_apikey_still_rejected_by_broker_check(self, client, monkeypatch):
-        monkeypatch.setattr(vol_surface_module, "get_broker_name", lambda key: None)
+    def test_broker_lookup_failure_still_returns_400(self, client, monkeypatch):
+        monkeypatch.setattr(vol_surface_module, "get_broker_name_for_user", lambda user: None)
         resp = client.post(
             "/volsurface/api/surface-data", json=VS_PARAMS, headers={"X-API-Key": "valid-key"}
         )

--- a/utils/session.py
+++ b/utils/session.py
@@ -54,6 +54,48 @@ def set_session_login_time():
     logger.info(f"Session login time set to: {now_ist}")
 
 
+def apikey_or_session(f):
+    """
+    Accept either a valid Flask session OR a valid API key in the request
+    body (`{"apikey": ...}`). Resolves the authenticated username into
+    `flask.g.openalgo_user` so the wrapped route can use
+    `g.openalgo_user or session.get("user")`.
+
+    Stream B1 (2026-08-08): the analytics blueprints (gex/gamma_density/
+    ivchart/ivsmile/vol_surface/oiprofile/oitracker) were session-only, so
+    the gateway's apikey-based client could not proxy them. This decorator
+    reuses the SAME credential verification as the /api/v1 restx surface
+    (`get_username_by_apikey`), so an apikey grants exactly the data reads
+    it already grants on /api/v1/* — nothing more.
+    """
+
+    @wraps(f)
+    def decorated_function(*args, **kwargs):
+        from flask import g, jsonify, request
+        from database.auth_db import get_username_by_apikey
+
+        # 1. apikey path: verify against the same store the restx API uses.
+        if request.is_json:
+            body = request.get_json(silent=True) or {}
+            provided = body.get("apikey") if isinstance(body, dict) else None
+            if isinstance(provided, str) and provided:
+                username = get_username_by_apikey(provided)
+                if username is None:
+                    return jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
+                g.openalgo_user = username
+                return f(*args, **kwargs)
+
+        # 2. session fallback: unchanged behavior.
+        if is_session_valid():
+            g.openalgo_user = session.get("user")
+            return f(*args, **kwargs)
+
+        # 3. neither: match check_session_validity's AJAX JSON response.
+        return jsonify({"status": "error", "message": "Authentication required"}), 401
+
+    return decorated_function
+
+
 def is_session_valid():
     """Check if the current session is valid"""
     if not session.get("logged_in"):

--- a/utils/session.py
+++ b/utils/session.py
@@ -71,7 +71,7 @@ def _enforce_csrf_for_session() -> None:
     """
     from flask import current_app
 
-    if not current_app.config["WTF_CSRF_ENABLED"]:
+    if not current_app.config.get("WTF_CSRF_ENABLED", True):
         return
     csrf = current_app.extensions.get("csrf")
     if csrf is not None:
@@ -81,9 +81,10 @@ def _enforce_csrf_for_session() -> None:
 def apikey_or_session(f):
     """
     Accept either a valid Flask session OR a valid API key in the request
-    body (`{"apikey": ...}`). Resolves the authenticated username into
-    `flask.g.openalgo_user` so the wrapped route can use
-    `g.openalgo_user or session.get("user")`.
+    body (`{"apikey": ...}`), query parameter (`?apikey=...`), or header
+    (`X-API-Key: ...`). Resolves the authenticated username into
+    `flask.g.openalgo_user` and `flask.g.openalgo_apikey` so the wrapped
+    route can use `g.openalgo_user or session.get("user")`.
 
     Stream B1 (2026-08-08): the analytics blueprints (gex/gamma_density/
     ivchart/ivsmile/vol_surface/oiprofile/oitracker) were session-only, so
@@ -99,16 +100,22 @@ def apikey_or_session(f):
 
         from database.auth_db import get_username_by_apikey
 
-        # 1. apikey path: verify against the same store the restx API uses.
+        # 1. apikey path: check JSON body, then query param, then header.
+        provided = None
         if request.is_json:
             body = request.get_json(silent=True) or {}
             provided = body.get("apikey") if isinstance(body, dict) else None
-            if isinstance(provided, str) and provided:
-                username = get_username_by_apikey(provided)
-                if username is None:
-                    return jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
-                g.openalgo_user = username
-                return f(*args, **kwargs)
+        if not isinstance(provided, str) or not provided:
+            provided = request.args.get("apikey")
+        if not isinstance(provided, str) or not provided:
+            provided = request.headers.get("X-API-Key")
+        if isinstance(provided, str) and provided:
+            username = get_username_by_apikey(provided)
+            if username is None:
+                return jsonify({"status": "error", "message": "Invalid openalgo apikey"}), 401
+            g.openalgo_user = username
+            g.openalgo_apikey = provided
+            return f(*args, **kwargs)
 
         # 2. session fallback: unchanged browser behavior — CSRF included.
         #    The blueprint-level exemption in app.py removed the automatic
@@ -118,8 +125,24 @@ def apikey_or_session(f):
             g.openalgo_user = session.get("user")
             return f(*args, **kwargs)
 
-        # 3. neither: match check_session_validity's AJAX JSON response.
-        return jsonify({"status": "error", "message": "Authentication required"}), 401
+        # 3. neither: replicate check_session_validity's cleanup and response.
+        revoke_user_tokens()
+        session.clear()
+
+        is_ajax = (
+            request.headers.get("X-Requested-With") == "XMLHttpRequest"
+            or request.headers.get("Accept", "").startswith("application/json")
+            or request.content_type == "application/json"
+            or request.is_json
+        )
+        if is_ajax:
+            return jsonify({
+                "status": "error",
+                "error": "session_expired",
+                "message": "Your session has expired. Please log in again.",
+            }), 401
+
+        return redirect(url_for("auth.login"))
 
     return decorated_function
 

--- a/utils/session.py
+++ b/utils/session.py
@@ -54,6 +54,30 @@ def set_session_login_time():
     logger.info(f"Session login time set to: {now_ist}")
 
 
+def _enforce_csrf_for_session() -> None:
+    """Run the app's CSRF check for a session-authenticated request.
+
+    The analytics blueprints are exempted wholesale in app.py — headless
+    apikey clients carry no token, and a bearer credential in the body is
+    not CSRF-able — so without this the exemption would also drop the token
+    check for browser users. Raises flask_wtf.csrf.CSRFError (a 400) on a
+    missing/invalid token, exactly what Flask-WTF enforced on these routes
+    before the exemption existed.
+
+    Mirrors the gate CSRFProtect's own before_request hook applies before
+    protect(): CSRFProtect.protect() itself no longer checks the enabled
+    flag, so a disabled deployment (CSRF_ENABLED=FALSE) must be honored
+    here. Safe methods are already skipped inside protect().
+    """
+    from flask import current_app
+
+    if not current_app.config["WTF_CSRF_ENABLED"]:
+        return
+    csrf = current_app.extensions.get("csrf")
+    if csrf is not None:
+        csrf.protect()
+
+
 def apikey_or_session(f):
     """
     Accept either a valid Flask session OR a valid API key in the request
@@ -72,6 +96,7 @@ def apikey_or_session(f):
     @wraps(f)
     def decorated_function(*args, **kwargs):
         from flask import g, jsonify, request
+
         from database.auth_db import get_username_by_apikey
 
         # 1. apikey path: verify against the same store the restx API uses.
@@ -85,8 +110,11 @@ def apikey_or_session(f):
                 g.openalgo_user = username
                 return f(*args, **kwargs)
 
-        # 2. session fallback: unchanged behavior.
+        # 2. session fallback: unchanged browser behavior — CSRF included.
+        #    The blueprint-level exemption in app.py removed the automatic
+        #    token check from this branch, so it is re-applied here.
         if is_session_valid():
+            _enforce_csrf_for_session()
             g.openalgo_user = session.get("user")
             return f(*args, **kwargs)
 

--- a/websocket_proxy/base_adapter.py
+++ b/websocket_proxy/base_adapter.py
@@ -492,8 +492,8 @@ class BaseBrokerWebSocketAdapter(ABC):
             if cache_key_feed in feed_token_cache:
                 del feed_token_cache[cache_key_feed]
                 caches_cleared.append("feed_token_cache")
-            # Note: broker_cache is keyed by API key, not user_id, so we skip it here
-            # It only caches broker names which don't affect auth token validation
+            # Note: broker_cache is keyed by user_id (never by API key), and it
+            # only caches broker names which don't affect auth token validation
 
             if caches_cleared:
                 self.logger.info(f"Cleared auth caches for user {user_id}: {', '.join(caches_cleared)}")


### PR DESCRIPTION
# PR: Allow API-key authentication for the analytics blueprints

## Summary

The analytics blueprints (`/gex/*`, `/gammadensity/*`, `/ivchart/*`,
`/ivsmile/*`, `/volsurface/*`, `/oiprofile/*`, `/oitracker/*`) authenticate
only via the Flask session cookie. Every other API surface in the platform
(`/api/v1/*` restx resources, order/data endpoints) authenticates with an
`apikey` in the request body. This makes the analytics endpoints the one
surface that a headless API client cannot reach.

This PR adds a small, additive `apikey_or_session` decorator to
`utils/session.py` and applies it to the 7 analytics blueprints. The session
path is unchanged; an `apikey` in the JSON body is accepted as an alternative
and resolved to the same user via the existing `get_username_by_apikey`.

## Changes

- `utils/session.py`: new `apikey_or_session` decorator.
  - Accepts `apikey` from the JSON body; on success sets `g.openalgo_user`
    and `g.openalgo_apikey` (mirroring what `get_auth_token_broker` already
    does for the restx surface).
  - Falls back to `check_session_validity` behaviour when no apikey is present.
  - Unauthorized responses keep the existing 401 contract.
- 7 blueprints: swap `@check_session_validity` → `@apikey_or_session` and
  resolve the user with `getattr(g, "openalgo_user", None) or session.get("user")`.
- Two routes (`ivchart`, `ivsmile`) additionally derive the broker from the
  resolved username (`get_broker_name`) instead of `session.get("broker")` so
  the apikey path has a broker to authenticate against.
- `app.py`: CSRF-exempt the 7 analytics blueprints, matching the existing
  exemption for the restx `/api/v1` blueprint (a bearer-apikey POST is not
  CSRF-vulnerable).

## Why

Headless consumers — the OA_Yuv gateway, MCP-style agents, trading bots —
should be able to fetch GEX, IV, and OI analytics with the same API key they
use everywhere else. Requiring a browser session for these reads forces every
client to hold session cookies, which is a worse security posture, not a
better one.

## Testing

- `apikey_or_session` with a **valid apikey** → reaches the service, returns
  data (verified live against GEX/IV-smile/vol-surface/IV-chart/OI-tracker).
- With an **invalid apikey** → `Invalid openalgo apikey`, 401.
- With **no apikey** (session path) → existing behaviour unchanged.

## Notes

No writes, no schema changes, no data migrations. The `apikey` field is
consumed by the decorator and never forwarded into service payloads.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Analytics blueprints now accept an `apikey` in the request body, query string, or `X-API-Key` header, matching the rest of the API surface. These endpoints previously required a Flask session cookie; the new `apikey_or_session` decorator accepts either, leaving session auth and 401 responses unchanged.

**Notes**
- The blueprints are registered CSRF-exempt, so the decorator re-applies the token check on the session branch; browser users still get a 400 on a missing token, and `WTF_CSRF_ENABLED=false` is honored.
- The `apikey` field is consumed by the decorator and never forwarded into service payloads; query/header sources let GET endpoints authenticate without a JSON body.
- `broker_cache` is keyed by verified user id, never the raw key, so cache inspection can't expose usable credentials.
- Expired sessions replicate `check_session_validity` cleanup (token revocation, session clear, `session_expired` contract).
- `ivchart` and `vol_surface` resolve the broker from the decorator's verified username (cached per user), falling back to `session['broker']` only for browser logins.
- Tests cover the auth matrix: valid/invalid apikey, all sources, missing/expired session, CSRF missing/valid/disabled, and broker resolution.

<sup>Written for commit bb3abc8960007473c2c7a0010aa64a198db15ded. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1990?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

