### PR TITLE
feat(orders): idempotent order placement via client_order_id

### DIFF
--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -1,0 +1,239 @@
+# database/idempotency_db.py
+"""
+Application-level order idempotency store.
+
+Maps (api_key_hash, client_order_id) -> broker orderid so a client that
+retries a timed-out /api/v1/placeorder POST gets the existing order echoed
+back instead of a duplicate position. Also records the caller-supplied
+`tag` so the orderbook can echo it.
+
+Design notes:
+
+* **Keyed by SHA-256 of the OpenAlgo apikey**, never the plaintext. The
+  auth module already treats the apikey as a secret (Argon2 verify, hashed
+  cache keys); this store must not introduce a plaintext copy.
+* **One row per placement attempt resolution.** A successful placement
+  writes (client_order_id -> orderid). A duplicate POST short-circuits at
+  the service layer and replays the recorded response — the broker is never
+  called twice for the same client_order_id.
+* **In-flight reservations.** A row is written before the broker call
+  (status="in_flight") so a retry racing a slow placement cannot double-fire.
+  If the placement fails, the reservation is released so a corrected retry
+  with the same id is not blocked forever.
+* **TTL.** Rows expire after ORDER_IDEMPOTENCY_TTL_HOURS (default 24h) so
+  the table cannot grow unbounded; a client_order_id reused after expiry is
+  treated as new. This matches broker-side order-book retention horizons
+  closely enough for the timeout-retry use case.
+* **Own SQLite file** (idempotency.db) with the project-wide NullPool
+  engine policy — writes are one per order placement, reads are one per
+  placement, so contention is negligible.
+"""
+
+import hashlib
+import os
+import threading
+from datetime import datetime, timedelta
+
+from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint, create_engine
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.ext.declarative import declarative_base
+from sqlalchemy.orm import scoped_session, sessionmaker
+from sqlalchemy.pool import NullPool
+
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+IDEMPOTENCY_DATABASE_URL = os.getenv("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency.db")
+
+if IDEMPOTENCY_DATABASE_URL and "sqlite" in IDEMPOTENCY_DATABASE_URL:
+    # SQLite: NullPool to prevent connection pool exhaustion (project-wide policy)
+    idempotency_engine = create_engine(
+        IDEMPOTENCY_DATABASE_URL, poolclass=NullPool, connect_args={"check_same_thread": False}
+    )
+else:
+    # For other databases like PostgreSQL, use connection pooling
+    idempotency_engine = create_engine(IDEMPOTENCY_DATABASE_URL, pool_size=10, max_overflow=20)
+
+IDEMPOTENCY_TTL_HOURS = int(os.getenv("ORDER_IDEMPOTENCY_TTL_HOURS", "24"))
+
+idempotency_session = scoped_session(
+    sessionmaker(autocommit=False, autoflush=False, bind=idempotency_engine)
+)
+IdempotencyBase = declarative_base()
+IdempotencyBase.query = idempotency_session.query_property()
+
+
+class ClientOrderId(IdempotencyBase):
+    """A client-supplied idempotency key and the order it resolved to."""
+
+    __tablename__ = "client_order_ids"
+
+    id = Column(Integer, primary_key=True)
+    api_key_hash = Column(
+        String(64), nullable=False, index=True
+    )  # sha256 hex of the OpenAlgo apikey
+    client_order_id = Column(String(128), nullable=False)
+    orderid = Column(String(64), nullable=True)  # broker/OpenAlgo orderid once known
+    tag = Column(
+        String(128), nullable=True
+    )  # caller's original `tag` passthrough, echoed in the orderbook
+    # in_flight: broker call not yet resolved. placed: orderid recorded.
+    status = Column(String(16), nullable=False, default="in_flight")
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
+
+    __table_args__ = (
+        # The idempotency key is (user, client id) — one resolution per pair.
+        UniqueConstraint("api_key_hash", "client_order_id", name="uq_client_order_ids_key"),
+    )
+
+
+_init_lock = threading.Lock()
+_initialized = False
+
+
+def _hash_api_key(api_key: str) -> str:
+    return hashlib.sha256(api_key.encode("utf-8")).hexdigest()
+
+
+def init_idempotency_db() -> None:
+    """Create tables if absent. Idempotent; safe to call per-request."""
+    global _initialized
+    if _initialized:
+        return
+    with _init_lock:
+        if _initialized:
+            return
+        IdempotencyBase.metadata.create_all(bind=idempotency_engine)
+        _initialized = True
+
+
+def _prune_expired(session) -> None:
+    """Delete rows older than the TTL. Called opportunistically on writes."""
+    cutoff = datetime.now() - timedelta(hours=IDEMPOTENCY_TTL_HOURS)
+    session.query(ClientOrderId).filter(ClientOrderId.created_at < cutoff).delete()
+    session.commit()
+
+
+def reserve_client_order_id(
+    api_key: str, client_order_id: str, tag: str | None = None
+) -> tuple[str, str | None]:
+    """Claim (api_key, client_order_id) before the broker call.
+
+    INSERT-first: the unique constraint on (api_key_hash, client_order_id)
+    makes the claim atomic, so two concurrent retries cannot both proceed.
+
+    Returns:
+        ("reserved", None) — this call created the reservation and must
+        proceed with the placement, then record_success() or release it.
+        ("existing", status) — another call already claimed the key; status
+        is "placed" (replay the recorded orderid) or "in_flight" (a placement
+        is racing right now; caller should report 409).
+    """
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    with _init_lock:
+        try:
+            row = ClientOrderId(
+                api_key_hash=key_hash,
+                client_order_id=client_order_id,
+                tag=tag,
+                status="in_flight",
+            )
+            idempotency_session.add(row)
+            _prune_expired(idempotency_session)
+            idempotency_session.commit()
+            return "reserved", None
+        except IntegrityError:
+            idempotency_session.rollback()
+            existing = (
+                idempotency_session.query(ClientOrderId)
+                .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
+                .one_or_none()
+            )
+            if existing is None:
+                # Row vanished between the conflict and the re-read (TTL prune).
+                # Nothing is in flight, so the caller may retry the reserve.
+                return "vacated", None
+            return "existing", existing.status
+
+
+def record_success(api_key: str, client_order_id: str, orderid: str) -> None:
+    """Attach the broker orderid to an in_flight reservation."""
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    with _init_lock:
+        row = (
+            idempotency_session.query(ClientOrderId)
+            .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
+            .one_or_none()
+        )
+        if row is None:
+            # Reservation lost (manual DB wipe mid-flight): record fresh so the
+            # mapping still exists for orderbook echo and dedupe.
+            row = ClientOrderId(
+                api_key_hash=key_hash, client_order_id=client_order_id, status="in_flight"
+            )
+            idempotency_session.add(row)
+        row.orderid = str(orderid)
+        row.status = "placed"
+        idempotency_session.commit()
+
+
+def release_client_order_id(api_key: str, client_order_id: str) -> None:
+    """Drop an in_flight reservation after a failed placement.
+
+    A retry with the same id must be allowed to proceed after a failure —
+    blocking it would turn one broker outage into a permanent 409 for that id.
+    """
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    with _init_lock:
+        row = (
+            idempotency_session.query(ClientOrderId)
+            .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
+            .one_or_none()
+        )
+        if row is not None and row.status == "in_flight":
+            idempotency_session.delete(row)
+            idempotency_session.commit()
+
+
+def get_resolution(api_key: str, client_order_id: str) -> dict | None:
+    """Return the recorded resolution for a key, or None if unknown.
+
+    Shape: {"orderid": str|None, "status": "in_flight"|"placed", "tag": str|None}
+    An in_flight resolution means a placement is racing right now.
+    """
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    row = (
+        idempotency_session.query(ClientOrderId)
+        .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
+        .one_or_none()
+    )
+    if row is None:
+        return None
+    return {"orderid": row.orderid, "status": row.status, "tag": row.tag}
+
+
+def get_labels_for_orderids(api_key: str, orderids: list[str]) -> dict[str, dict[str, str]]:
+    """Return {orderid: {"client_order_id", "tag"}} for the given orderids.
+
+    Used by the orderbook service to echo caller-supplied fields onto
+    broker-proxied orderbook rows.
+    """
+    if not orderids:
+        return {}
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    rows = (
+        idempotency_session.query(ClientOrderId)
+        .filter(
+            ClientOrderId.api_key_hash == key_hash,
+            ClientOrderId.orderid.in_([str(o) for o in orderids]),
+        )
+        .all()
+    )
+    return {row.orderid: {"client_order_id": row.client_order_id, "tag": row.tag} for row in rows}

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -34,7 +34,8 @@ import os
 import threading
 from datetime import datetime, timedelta
 
-from sqlalchemy import Column, DateTime, Integer, String, UniqueConstraint, create_engine
+from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint, create_engine
+from sqlalchemy import text as sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
@@ -89,6 +90,16 @@ class ClientOrderId(IdempotencyBase):
     )
 
 
+Index("ix_client_order_ids_created_at", ClientOrderId.created_at)
+# The orderbook echoes labels per orderid on every poll; (api_key_hash,
+# orderid) covers that lookup without scanning the user's partition.
+Index(
+    "ix_client_order_ids_api_key_hash_orderid",
+    ClientOrderId.api_key_hash,
+    ClientOrderId.orderid,
+)
+
+
 _init_lock = threading.Lock()
 _initialized = False
 
@@ -106,6 +117,18 @@ def init_idempotency_db() -> None:
         if _initialized:
             return
         IdempotencyBase.metadata.create_all(bind=idempotency_engine)
+        # create_all only builds indexes for new tables. Existing installs
+        # created client_order_ids without the created_at / (api_key_hash,
+        # orderid) indexes, so add them explicitly (IF NOT EXISTS semantics).
+        with idempotency_engine.connect() as conn:
+            for stmt in (
+                "CREATE INDEX IF NOT EXISTS ix_client_order_ids_created_at "
+                "ON client_order_ids (created_at)",
+                "CREATE INDEX IF NOT EXISTS ix_client_order_ids_api_key_hash_orderid "
+                "ON client_order_ids (api_key_hash, orderid)",
+            ):
+                conn.execute(sa_text(stmt))
+            conn.commit()
         _initialized = True
 
 

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -47,6 +47,17 @@ logger = get_logger(__name__)
 
 IDEMPOTENCY_DATABASE_URL = os.getenv("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency.db")
 
+# Defaults mirroring restx_api.schemas.OrderSchema, applied when a raw request
+# omits the field: the reserve path sees the raw payload (validate_order_data
+# discards the schema-loaded dict), so the store normalises here to keep
+# records faithful to what the broker will actually execute.
+DEFAULT_PRODUCT = "MIS"
+DEFAULT_PRICETYPE = "MARKET"
+# Price types with no caller-fixed execution price: for these the order book's
+# "price" is the broker's average fill, not a limit price, so a recorded
+# default price must not be compared against it.
+MARKETISH_PRICETYPES = frozenset({"", "MARKET", "SL-M"})
+
 # Project-wide pooling policy (database/engine_factory.py): SQLite engines
 # use NullPool so no descriptor is held between operations.
 idempotency_engine = create_db_engine(IDEMPOTENCY_DATABASE_URL)
@@ -84,11 +95,19 @@ class ClientOrderId(IdempotencyBase):
     symbol = Column(String(64), nullable=True)
     exchange = Column(String(32), nullable=True)
     action = Column(String(16), nullable=True)
-    quantity = Column(Integer, nullable=True)
+    # Float, not Integer: crypto/USDT perps trade fractional lots (0.001 BTC);
+    # an Integer column plus int() coercion made 1.1 and 1.9 compare equal.
+    quantity = Column(Float, nullable=True)
     price = Column(Float, nullable=True)
-    # naive local now(): the project-wide convention (see auth_db et al.);
-    # utcnow here would silently skew TTL pruning against rows written by
-    # earlier versions.
+    # Remaining request-shaping parameters recorded so a corrected retry
+    # changing any of them is refused instead of double-placing (a LIMIT
+    # retry must not slip through a MARKET reservation, etc.).
+    product = Column(String(16), nullable=True)
+    pricetype = Column(String(16), nullable=True)
+    trigger_price = Column(Float, nullable=True)
+    # naive local now(): the project-wide convention (see strategy_book_db /
+    # master_contract_status_db); utcnow here would silently skew TTL pruning
+    # against rows written by earlier versions.
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
 
@@ -148,8 +167,11 @@ _RECONCILIATION_COLUMNS = (
     ("symbol", "VARCHAR(64)"),
     ("exchange", "VARCHAR(32)"),
     ("action", "VARCHAR(16)"),
-    ("quantity", "INTEGER"),
+    ("quantity", "FLOAT"),
     ("price", "FLOAT"),
+    ("product", "VARCHAR(16)"),
+    ("pricetype", "VARCHAR(16)"),
+    ("trigger_price", "FLOAT"),
 )
 
 
@@ -207,8 +229,16 @@ def reserve_client_order_id(
                 symbol=params.get("symbol"),
                 exchange=params.get("exchange"),
                 action=params.get("action"),
-                quantity=int(params["quantity"]) if params.get("quantity") is not None else None,
-                price=float(params["price"]) if params.get("price") else None,
+                quantity=float(params["quantity"])
+                if params.get("quantity") is not None
+                else None,
+                # Absent ≡ schema default (see DEFAULT_* above); a LIMIT price
+                # of 0.0 must be recorded as 0.0, never NULL, or the replay
+                # check would silently skip the comparison.
+                price=float(params.get("price") or 0.0),
+                product=params.get("product") or DEFAULT_PRODUCT,
+                pricetype=params.get("pricetype") or DEFAULT_PRICETYPE,
+                trigger_price=float(params.get("trigger_price") or 0.0),
             )
             idempotency_session.add(row)
             _prune_expired(idempotency_session)
@@ -325,6 +355,9 @@ def get_resolution(api_key: str, client_order_id: str) -> dict | None:
         "action": row.action,
         "quantity": row.quantity,
         "price": row.price,
+        "product": row.product,
+        "pricetype": row.pricetype,
+        "trigger_price": row.trigger_price,
     }
 
 

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -222,11 +222,36 @@ def release_client_order_id(api_key: str, client_order_id: str) -> None:
             idempotency_session.commit()
 
 
+def mark_unresolved(api_key: str, client_order_id: str) -> None:
+    """Flag an in-flight reservation whose outcome is unknowable.
+
+    Used when the broker call failed ambiguously (transport error, 5xx, an
+    accepted-but-unacknowledged order): the order may exist at the broker,
+    so the reservation is kept — a retry must reconcile with the broker
+    before another placement instead of re-placing blindly. Never touches
+    a row that already resolved to "placed".
+    """
+    init_idempotency_db()
+    key_hash = _hash_api_key(api_key)
+    with _init_lock:
+        row = (
+            idempotency_session.query(ClientOrderId)
+            .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
+            .one_or_none()
+        )
+        if row is not None and row.status == "in_flight":
+            row.status = "unresolved"
+            idempotency_session.commit()
+
+
 def get_resolution(api_key: str, client_order_id: str) -> dict | None:
     """Return the recorded resolution for a key, or None if unknown.
 
-    Shape: {"orderid": str|None, "status": "in_flight"|"placed", "tag": str|None}
-    An in_flight resolution means a placement is racing right now.
+    Shape: {"orderid": str|None, "status": "in_flight"|"placed"|"unresolved",
+    "tag": str|None}
+    An in_flight resolution means a placement is racing right now; an
+    unresolved one means a previous attempt may or may not have reached the
+    broker.
     """
     init_idempotency_db()
     key_hash = _hash_api_key(api_key)

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -86,8 +86,11 @@ class ClientOrderId(IdempotencyBase):
     action = Column(String(16), nullable=True)
     quantity = Column(Integer, nullable=True)
     price = Column(Float, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
-    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
+    # naive local now(): the project-wide convention (see auth_db et al.);
+    # utcnow here would silently skew TTL pruning against rows written by
+    # earlier versions.
+    created_at = Column(DateTime, nullable=False, default=datetime.now)
+    updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
 
     __table_args__ = (
         # The idempotency key is (user, client id) — one resolution per pair.
@@ -162,7 +165,7 @@ def _add_missing_columns() -> None:
 
 def _prune_expired(session) -> None:
     """Delete rows older than the TTL. Called opportunistically on writes."""
-    cutoff = datetime.utcnow() - timedelta(hours=IDEMPOTENCY_TTL_HOURS)
+    cutoff = datetime.now() - timedelta(hours=IDEMPOTENCY_TTL_HOURS)
     session.query(ClientOrderId).filter(ClientOrderId.created_at < cutoff).delete()
     session.commit()
 

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -34,7 +34,7 @@ import os
 import threading
 from datetime import datetime, timedelta
 
-from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint
+from sqlalchemy import Column, DateTime, Float, Index, Integer, String, UniqueConstraint
 from sqlalchemy import text as sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
@@ -75,7 +75,17 @@ class ClientOrderId(IdempotencyBase):
         String(128), nullable=True
     )  # caller's original `tag` passthrough, echoed in the orderbook
     # in_flight: broker call not yet resolved. placed: orderid recorded.
+    # unresolved: an ambiguous failure (transport error, 5xx, 200 without an
+    # orderid) — the order may exist at the broker; a retry must reconcile.
     status = Column(String(16), nullable=False, default="in_flight")
+    # Original order parameters, recorded so an unresolved key can be
+    # reconciled against the broker order book on retry, and so a corrected
+    # retry (different parameters) can be refused instead of double-placing.
+    symbol = Column(String(64), nullable=True)
+    exchange = Column(String(32), nullable=True)
+    action = Column(String(16), nullable=True)
+    quantity = Column(Integer, nullable=True)
+    price = Column(Float, nullable=True)
     created_at = Column(DateTime, nullable=False, default=datetime.now)
     updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
 
@@ -124,7 +134,30 @@ def init_idempotency_db() -> None:
             ):
                 conn.execute(sa_text(stmt))
             conn.commit()
+        if IDEMPOTENCY_DATABASE_URL.startswith("sqlite"):
+            # Existing installs: add the reconciliation parameter columns
+            # (create_all only adds columns to brand-new tables).
+            _add_missing_columns()
         _initialized = True
+
+
+_RECONCILIATION_COLUMNS = (
+    ("symbol", "VARCHAR(64)"),
+    ("exchange", "VARCHAR(32)"),
+    ("action", "VARCHAR(16)"),
+    ("quantity", "INTEGER"),
+    ("price", "FLOAT"),
+)
+
+
+def _add_missing_columns() -> None:
+    """Add the reconciliation parameter columns when upgrading an existing store."""
+    with idempotency_engine.connect() as conn:
+        cols = {row[1] for row in conn.execute(sa_text("PRAGMA table_info(client_order_ids)"))}
+        for name, ddl in _RECONCILIATION_COLUMNS:
+            if name not in cols:
+                conn.execute(sa_text(f"ALTER TABLE client_order_ids ADD COLUMN {name} {ddl}"))
+        conn.commit()
 
 
 def _prune_expired(session) -> None:
@@ -135,22 +168,32 @@ def _prune_expired(session) -> None:
 
 
 def reserve_client_order_id(
-    api_key: str, client_order_id: str, tag: str | None = None
+    api_key: str,
+    client_order_id: str,
+    tag: str | None = None,
+    order_params: dict | None = None,
 ) -> tuple[str, str | None]:
     """Claim (api_key, client_order_id) before the broker call.
 
     INSERT-first: the unique constraint on (api_key_hash, client_order_id)
     makes the claim atomic, so two concurrent retries cannot both proceed.
 
+    Args:
+        order_params: the original request parameters (symbol/exchange/
+            action/quantity/price) recorded for broker reconciliation of
+            unresolved keys.
+
     Returns:
         ("reserved", None) — this call created the reservation and must
         proceed with the placement, then record_success() or release it.
         ("existing", status) — another call already claimed the key; status
-        is "placed" (replay the recorded orderid) or "in_flight" (a placement
-        is racing right now; caller should report 409).
+        is "placed" (replay the recorded orderid), "unresolved" (a previous
+        ambiguous attempt may have placed; reconcile first) or "in_flight"
+        (a placement is racing right now; caller should report 409).
     """
     init_idempotency_db()
     key_hash = _hash_api_key(api_key)
+    params = order_params or {}
     with _init_lock:
         try:
             row = ClientOrderId(
@@ -158,6 +201,11 @@ def reserve_client_order_id(
                 client_order_id=client_order_id,
                 tag=tag,
                 status="in_flight",
+                symbol=params.get("symbol"),
+                exchange=params.get("exchange"),
+                action=params.get("action"),
+                quantity=int(params["quantity"]) if params.get("quantity") is not None else None,
+                price=float(params["price"]) if params.get("price") else None,
             )
             idempotency_session.add(row)
             _prune_expired(idempotency_session)
@@ -265,7 +313,16 @@ def get_resolution(api_key: str, client_order_id: str) -> dict | None:
     idempotency_session.commit()
     if row is None:
         return None
-    return {"orderid": row.orderid, "status": row.status, "tag": row.tag}
+    return {
+        "orderid": row.orderid,
+        "status": row.status,
+        "tag": row.tag,
+        "symbol": row.symbol,
+        "exchange": row.exchange,
+        "action": row.action,
+        "quantity": row.quantity,
+        "price": row.price,
+    }
 
 
 def get_labels_for_orderids(api_key: str, orderids: list[str]) -> dict[str, dict[str, str]]:

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -34,27 +34,22 @@ import os
 import threading
 from datetime import datetime, timedelta
 
-from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint, create_engine
+from sqlalchemy import Column, DateTime, Index, Integer, String, UniqueConstraint
 from sqlalchemy import text as sa_text
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.ext.declarative import declarative_base
 from sqlalchemy.orm import scoped_session, sessionmaker
-from sqlalchemy.pool import NullPool
 
+from database.engine_factory import create_db_engine
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
 
 IDEMPOTENCY_DATABASE_URL = os.getenv("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency.db")
 
-if IDEMPOTENCY_DATABASE_URL and "sqlite" in IDEMPOTENCY_DATABASE_URL:
-    # SQLite: NullPool to prevent connection pool exhaustion (project-wide policy)
-    idempotency_engine = create_engine(
-        IDEMPOTENCY_DATABASE_URL, poolclass=NullPool, connect_args={"check_same_thread": False}
-    )
-else:
-    # For other databases like PostgreSQL, use connection pooling
-    idempotency_engine = create_engine(IDEMPOTENCY_DATABASE_URL, pool_size=10, max_overflow=20)
+# Project-wide pooling policy (database/engine_factory.py): SQLite engines
+# use NullPool so no descriptor is held between operations.
+idempotency_engine = create_db_engine(IDEMPOTENCY_DATABASE_URL)
 
 IDEMPOTENCY_TTL_HOURS = int(os.getenv("ORDER_IDEMPOTENCY_TTL_HOURS", "24"))
 
@@ -175,6 +170,10 @@ def reserve_client_order_id(
                 .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
                 .one_or_none()
             )
+            # End the read transaction: with NullPool the checked-out
+            # connection is held until the transaction closes, and the
+            # caller may not touch this thread's session again for a while.
+            idempotency_session.commit()
             if existing is None:
                 # Row vanished between the conflict and the re-read (TTL prune).
                 # Nothing is in flight, so the caller may retry the reserve.
@@ -236,6 +235,9 @@ def get_resolution(api_key: str, client_order_id: str) -> dict | None:
         .filter_by(api_key_hash=key_hash, client_order_id=client_order_id)
         .one_or_none()
     )
+    # End the read transaction so the NullPool connection is not held until
+    # this thread's next DB use (see utils/db_sessions.py).
+    idempotency_session.commit()
     if row is None:
         return None
     return {"orderid": row.orderid, "status": row.status, "tag": row.tag}
@@ -259,4 +261,7 @@ def get_labels_for_orderids(api_key: str, orderids: list[str]) -> dict[str, dict
         )
         .all()
     )
+    # End the read transaction so the NullPool connection is not held until
+    # this thread's next DB use (see utils/db_sessions.py).
+    idempotency_session.commit()
     return {row.orderid: {"client_order_id": row.client_order_id, "tag": row.tag} for row in rows}

--- a/database/idempotency_db.py
+++ b/database/idempotency_db.py
@@ -86,8 +86,8 @@ class ClientOrderId(IdempotencyBase):
     action = Column(String(16), nullable=True)
     quantity = Column(Integer, nullable=True)
     price = Column(Float, nullable=True)
-    created_at = Column(DateTime, nullable=False, default=datetime.now)
-    updated_at = Column(DateTime, nullable=False, default=datetime.now, onupdate=datetime.now)
+    created_at = Column(DateTime, nullable=False, default=datetime.utcnow)
+    updated_at = Column(DateTime, nullable=False, default=datetime.utcnow, onupdate=datetime.utcnow)
 
     __table_args__ = (
         # The idempotency key is (user, client id) — one resolution per pair.
@@ -162,7 +162,7 @@ def _add_missing_columns() -> None:
 
 def _prune_expired(session) -> None:
     """Delete rows older than the TTL. Called opportunistically on writes."""
-    cutoff = datetime.now() - timedelta(hours=IDEMPOTENCY_TTL_HOURS)
+    cutoff = datetime.utcnow() - timedelta(hours=IDEMPOTENCY_TTL_HOURS)
     session.query(ClientOrderId).filter(ClientOrderId.created_at < cutoff).delete()
     session.commit()
 

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -46,10 +46,31 @@ class OrderSchema(Schema):
     underlying_ltp = fields.Float(
         missing=None, allow_none=True
     )  # Optional: passed from options order for execution reference
+    client_order_id = fields.Str(
+        required=False,
+        missing=None,
+        allow_none=True,
+        validate=validate.Length(min=1, max=128),
+    )  # Optional application-level idempotency key; echoed on the orderbook
+    tag = fields.Str(
+        required=False,
+        missing=None,
+        allow_none=True,
+        validate=validate.Length(min=1, max=128),
+    )  # Optional free-form label, stored and echoed on the orderbook response
 
     @post_load
     def coerce_quantity(self, data, **kwargs):
         return _coerce_quantity_to_int(data)
+
+    @post_load
+    def normalize_client_fields(self, data, **kwargs):
+        """Drop the idempotency fields when absent so the broker payload stays unchanged."""
+        if data.get("client_order_id") is None:
+            data.pop("client_order_id", None)
+        if data.get("tag") is None:
+            data.pop("tag", None)
+        return data
 
 
 class SmartOrderSchema(Schema):

--- a/restx_api/schemas.py
+++ b/restx_api/schemas.py
@@ -68,6 +68,9 @@ class OrderSchema(Schema):
         """Drop the idempotency fields when absent so the broker payload stays unchanged."""
         if data.get("client_order_id") is None:
             data.pop("client_order_id", None)
+            # tag is only persisted alongside client_order_id; drop it when
+            # the idempotency key is absent so callers don't silently lose it.
+            data.pop("tag", None)
         if data.get("tag") is None:
             data.pop("tag", None)
         return data

--- a/services/orderbook_service.py
+++ b/services/orderbook_service.py
@@ -166,6 +166,27 @@ def get_orderbook_with_auth(
         formatted_orders = format_order_data(order_data)
         formatted_stats = format_statistics(order_stats)
 
+        # Echo caller-supplied labels (client_order_id / tag) recorded at
+        # placement time. The orderbook is proxied from the broker, which
+        # knows nothing of OpenAlgo-level idempotency keys, so this is the
+        # only place the association can be re-attached.
+        try:
+            from database.idempotency_db import get_labels_for_orderids
+
+            api_key = original_data.get("apikey") if original_data else None
+            orderids = [str(o.get("orderid", "")) for o in formatted_orders]
+            labels = get_labels_for_orderids(api_key, orderids)
+            if labels:
+                for order_row in formatted_orders:
+                    row_labels = labels.get(str(order_row.get("orderid", "")))
+                    if row_labels:
+                        order_row["client_order_id"] = row_labels["client_order_id"]
+                        if row_labels["tag"]:
+                            order_row["tag"] = row_labels["tag"]
+        except Exception:
+            # Label echo is decoration, never a reason to fail the orderbook.
+            logger.exception("Failed to attach client_order_id labels to orderbook")
+
         return (
             True,
             {

--- a/services/orderbook_service.py
+++ b/services/orderbook_service.py
@@ -174,8 +174,11 @@ def get_orderbook_with_auth(
             from database.idempotency_db import get_labels_for_orderids
 
             api_key = original_data.get("apikey") if original_data else None
-            orderids = [str(o.get("orderid", "")) for o in formatted_orders]
-            labels = get_labels_for_orderids(api_key, orderids)
+            if api_key:
+                orderids = [str(o.get("orderid", "")) for o in formatted_orders]
+                labels = get_labels_for_orderids(api_key, orderids)
+            else:
+                labels = {}
             if labels:
                 for order_row in formatted_orders:
                     row_labels = labels.get(str(order_row.get("orderid", "")))

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -292,12 +292,41 @@ def place_order_with_auth(
         return False, error_response, 500
 
     if res.status == 200:
+        if idempotent and not order_id:
+            # Broker ACKed but named no order — unknown at the broker. Not a
+            # failure (a retry could double-place) and not a success (there is
+            # no orderid to report or record). Keep the reservation in-flight:
+            # retries of this id keep getting 409 instead of re-placing, and a
+            # human or the ack reconciler can resolve the true orderid.
+            error_response = {
+                "status": "error",
+                "message": (
+                    "Order accepted by broker but no order id was returned; "
+                    "placement unresolved, retries with this client_order_id "
+                    "are blocked"
+                ),
+            }
+            if emit_event:
+                bus.publish(
+                    OrderFailedEvent(
+                        mode="live",
+                        api_type="placeorder",
+                        request_data=order_request_data,
+                        response_data=error_response,
+                        api_key=api_key,
+                        symbol=order_data.get("symbol", ""),
+                        exchange=order_data.get("exchange", ""),
+                        error_message="broker returned 200 without an order id",
+                    )
+                )
+            return False, error_response, 500
+
         order_response_data = {"status": "success", "orderid": order_id}
         if client_order_id:
             order_response_data["client_order_id"] = client_order_id
             if order_tag:
                 order_response_data["tag"] = order_tag
-        if idempotent and order_id:
+        if idempotent:
             from database.idempotency_db import record_success
 
             record_success(api_key, client_order_id, str(order_id))

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -198,9 +198,49 @@ def place_order_with_auth(
 
         return success, response, status_code
 
+    # Application-level idempotency (live path only): claim the caller-supplied
+    # client_order_id BEFORE the broker call, so a network-timeout retry with
+    # the same id replays the recorded orderid instead of double-placing.
+    # Sandbox placements are simulated, so the field is accepted but not
+    # recorded there; the claim is keyed by the apikey hash, never plaintext.
+    client_order_id = order_data.get("client_order_id")
+    order_tag = order_data.get("tag")
+    idempotent = bool(client_order_id and api_key)
+    if idempotent:
+        from database.idempotency_db import get_resolution, reserve_client_order_id
+
+        state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
+        if state == "vacated":
+            # Reservation vanished (TTL prune) between conflict and re-read:
+            # nothing is in flight, so reclaim and fall through on the result.
+            state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
+        if state == "existing":
+            if status == "placed":
+                resolution = get_resolution(api_key, client_order_id)
+                if resolution and resolution["orderid"]:
+                    replay_response = {
+                        "status": "success",
+                        "orderid": resolution["orderid"],
+                        "client_order_id": client_order_id,
+                        "duplicate": True,
+                    }
+                    if resolution.get("tag"):
+                        replay_response["tag"] = resolution["tag"]
+                    return True, replay_response, 200
+            # in_flight, or placed without a recorded orderid: never re-place.
+            error_response = {
+                "status": "error",
+                "message": "Order placement with this client_order_id is already in progress",
+            }
+            return False, error_response, 409
+
     # If not in analyze mode, proceed with actual order placement
     broker_module = import_broker_module(broker)
     if broker_module is None:
+        if idempotent:
+            from database.idempotency_db import release_client_order_id
+
+            release_client_order_id(api_key, client_order_id)
         error_response = {"status": "error", "message": "Broker-specific module not found"}
         bus.publish(
             OrderFailedEvent(
@@ -217,9 +257,22 @@ def place_order_with_auth(
         return False, error_response, 404
 
     try:
-        res, response_data, order_id = broker_module.place_order_api(order_data, auth_token)
+        # client_order_id is an application-level idempotency key, never a
+        # broker field: hand the broker a payload without it. (Broker mappers
+        # build explicit payloads and would ignore it, but stripping keeps the
+        # contract explicit.)
+        broker_order_data = (
+            {k: v for k, v in order_data.items() if k != "client_order_id"}
+            if "client_order_id" in order_data
+            else order_data
+        )
+        res, response_data, order_id = broker_module.place_order_api(broker_order_data, auth_token)
     except Exception as e:
         logger.exception(f"Error in broker_module.place_order_api: {e}")
+        if idempotent:
+            from database.idempotency_db import release_client_order_id
+
+            release_client_order_id(api_key, client_order_id)
         error_response = {
             "status": "error",
             "message": "Failed to place order due to internal error",
@@ -240,6 +293,14 @@ def place_order_with_auth(
 
     if res.status == 200:
         order_response_data = {"status": "success", "orderid": order_id}
+        if client_order_id:
+            order_response_data["client_order_id"] = client_order_id
+            if order_tag:
+                order_response_data["tag"] = order_tag
+        if idempotent and order_id:
+            from database.idempotency_db import record_success
+
+            record_success(api_key, client_order_id, str(order_id))
 
         if emit_event:
             bus.publish(
@@ -262,6 +323,10 @@ def place_order_with_auth(
 
         return True, order_response_data, 200
     else:
+        if idempotent:
+            from database.idempotency_db import release_client_order_id
+
+            release_client_order_id(api_key, client_order_id)
         message = (
             response_data.get("message", "Failed to place order")
             if isinstance(response_data, dict)

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -209,30 +209,57 @@ def place_order_with_auth(
     if idempotent:
         from database.idempotency_db import get_resolution, reserve_client_order_id
 
-        state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
-        if state == "vacated":
-            # Reservation vanished (TTL prune) between conflict and re-read:
-            # nothing is in flight, so reclaim and fall through on the result.
+        try:
             state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
-        if state == "existing":
-            if status == "placed":
-                resolution = get_resolution(api_key, client_order_id)
-                if resolution and resolution["orderid"]:
-                    replay_response = {
-                        "status": "success",
-                        "orderid": resolution["orderid"],
-                        "client_order_id": client_order_id,
-                        "duplicate": True,
-                    }
-                    if resolution.get("tag"):
-                        replay_response["tag"] = resolution["tag"]
-                    return True, replay_response, 200
-            # in_flight, or placed without a recorded orderid: never re-place.
+            if state == "vacated":
+                # Reservation vanished (TTL prune) between conflict and re-read:
+                # nothing is in flight, so reclaim and fall through on the result.
+                state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
+            if state == "existing":
+                if status == "placed":
+                    resolution = get_resolution(api_key, client_order_id)
+                    if resolution and resolution["orderid"]:
+                        replay_response = {
+                            "status": "success",
+                            "orderid": resolution["orderid"],
+                            "client_order_id": client_order_id,
+                            "duplicate": True,
+                        }
+                        if resolution.get("tag"):
+                            replay_response["tag"] = resolution["tag"]
+                        return True, replay_response, 200
+                # in_flight, or placed without a recorded orderid: never re-place.
+                error_response = {
+                    "status": "error",
+                    "message": "Order placement with this client_order_id is already in progress",
+                }
+                return False, error_response, 409
+        except Exception:
+            # Store unavailable (SQLite locked/IO error): nothing was committed,
+            # so there is no reservation to release. Proceeding would place the
+            # order without duplicate protection — the caller explicitly opted
+            # in via client_order_id, so refuse the placement instead.
+            logger.exception(
+                "Idempotency store failure while reserving client_order_id %s",
+                client_order_id,
+            )
             error_response = {
                 "status": "error",
-                "message": "Order placement with this client_order_id is already in progress",
+                "message": "Order idempotency store unavailable; order not placed",
             }
-            return False, error_response, 409
+            bus.publish(
+                OrderFailedEvent(
+                    mode="live",
+                    api_type="placeorder",
+                    request_data=order_request_data,
+                    response_data=error_response,
+                    api_key=api_key,
+                    symbol=order_data.get("symbol", ""),
+                    exchange=order_data.get("exchange", ""),
+                    error_message="idempotency store unavailable",
+                )
+            )
+            return False, error_response, 503
 
     # If not in analyze mode, proceed with actual order placement
     broker_module = import_broker_module(broker)

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -116,6 +116,15 @@ def validate_order_data(data: dict[str, Any]) -> tuple[bool, dict[str, Any] | No
         return False, None, str(err)
 
 
+# Broker/adapter statuses that prove the order was NOT placed: the request
+# was refused before acceptance (validation, auth, rate limit, unknown
+# route). Anything else — 5xx (including transport failures converted to
+# 500 inside adapters) and unknown codes — is ambiguous: the request may
+# have reached the broker and been accepted, so the idempotency reservation
+# must stay and the key must be reconciled before another placement.
+CONFIRMED_REJECTION_STATUSES = frozenset({400, 401, 403, 404, 405, 409, 422, 429})
+
+
 def place_order_with_auth(
     order_data: dict[str, Any],
     auth_token: str,
@@ -297,12 +306,19 @@ def place_order_with_auth(
     except Exception as e:
         logger.exception(f"Error in broker_module.place_order_api: {e}")
         if idempotent:
-            from database.idempotency_db import release_client_order_id
+            # Ambiguous outcome: the exception may have hit mid-call, after
+            # the broker accepted the order. Releasing the reservation would
+            # let a retry double-place, so the key is kept as unresolved.
+            from database.idempotency_db import mark_unresolved
 
-            release_client_order_id(api_key, client_order_id)
+            mark_unresolved(api_key, client_order_id)
         error_response = {
             "status": "error",
-            "message": "Failed to place order due to internal error",
+            "message": (
+                "Failed to place order due to internal error; placement "
+                "unresolved — retries with this client_order_id are blocked "
+                "until the order is reconciled"
+            ),
         }
         bus.publish(
             OrderFailedEvent(
@@ -322,9 +338,9 @@ def place_order_with_auth(
         if idempotent and not order_id:
             # Broker ACKed but named no order — unknown at the broker. Not a
             # failure (a retry could double-place) and not a success (there is
-            # no orderid to report or record). Keep the reservation in-flight:
-            # retries of this id keep getting 409 instead of re-placing, and a
-            # human or the ack reconciler can resolve the true orderid.
+            # no orderid to report or record). The reservation moves to the
+            # unresolved state: retries of this id keep getting 409 instead
+            # of re-placing, and reconciliation can resolve the true orderid.
             error_response = {
                 "status": "error",
                 "message": (
@@ -346,6 +362,10 @@ def place_order_with_auth(
                         error_message="broker returned 200 without an order id",
                     )
                 )
+            if idempotent:
+                from database.idempotency_db import mark_unresolved
+
+                mark_unresolved(api_key, client_order_id)
             return False, error_response, 500
 
         order_response_data = {"status": "success", "orderid": order_id}
@@ -379,15 +399,30 @@ def place_order_with_auth(
 
         return True, order_response_data, 200
     else:
+        # Release only when the broker/adapter provably refused the order;
+        # for inconclusive statuses the key stays reserved (see
+        # CONFIRMED_REJECTION_STATUSES) so a retry cannot double-place.
+        unresolved = idempotent and res.status not in CONFIRMED_REJECTION_STATUSES
         if idempotent:
-            from database.idempotency_db import release_client_order_id
+            if unresolved:
+                from database.idempotency_db import mark_unresolved
 
-            release_client_order_id(api_key, client_order_id)
+                mark_unresolved(api_key, client_order_id)
+            else:
+                from database.idempotency_db import release_client_order_id
+
+                release_client_order_id(api_key, client_order_id)
         message = (
             response_data.get("message", "Failed to place order")
             if isinstance(response_data, dict)
             else "Failed to place order"
         )
+        if unresolved:
+            message = (
+                f"{message}; placement unresolved — the broker response was "
+                "inconclusive, so retries with this client_order_id are "
+                "blocked until the order is reconciled"
+            )
         error_response = {"status": "error", "message": message}
         bus.publish(
             OrderFailedEvent(

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -125,6 +125,134 @@ def validate_order_data(data: dict[str, Any]) -> tuple[bool, dict[str, Any] | No
 CONFIRMED_REJECTION_STATUSES = frozenset({400, 401, 403, 404, 405, 409, 422, 429})
 
 
+def _params_match_reservation(resolution: dict, order_data: dict) -> bool:
+    """True when the retry's parameters equal the reservation's originals.
+
+    A retry that changes parameters (a "corrected" order) must never reuse
+    an unresolved key: the ambiguous attempt may still be live with the
+    original parameters, so releasing or replaying on its behalf would be
+    wrong either way.
+    """
+
+    def _norm_str(value) -> str:
+        return str(value or "").strip().upper()
+
+    if _norm_str(resolution.get("symbol")) != _norm_str(order_data.get("symbol")):
+        return False
+    if _norm_str(resolution.get("exchange")) != _norm_str(order_data.get("exchange")):
+        return False
+    if _norm_str(resolution.get("action")) != _norm_str(order_data.get("action")):
+        return False
+    try:
+        if int(resolution.get("quantity") or 0) != int(order_data.get("quantity") or 0):
+            return False
+    except (TypeError, ValueError):
+        return False
+    stored_price = resolution.get("price")
+    if stored_price is not None:
+        try:
+            if abs(float(stored_price) - float(order_data.get("price") or 0)) > 1e-9:
+                return False
+        except (TypeError, ValueError):
+            return False
+    return True
+
+
+def _reconcile_unresolved_key(
+    auth_token: str, broker: str, api_key: str, client_order_id: str, order_data: dict
+):
+    """Best-effort broker reconciliation for an unresolved idempotency key.
+
+    Returns ``(ok, response, status_code)`` to answer the retry with, or
+    ``None`` when reconciliation proved the original attempt never reached
+    the broker (the key is released; the caller may place fresh). The
+    outcome is deliberately conservative: replaying a matching order is
+    safe (it already exists), while any ambiguity blocks the key instead
+    of risking a double placement.
+    """
+    from database.idempotency_db import (
+        get_resolution,
+        record_success,
+        release_client_order_id,
+    )
+    from services.orderbook_service import get_orderbook_with_auth
+
+    original = get_resolution(api_key, client_order_id)
+    if original is None:
+        # Key vanished (TTL prune) since the reserve: nothing to protect.
+        return None
+
+    if not _params_match_reservation(original, order_data):
+        return False, {
+            "status": "error",
+            "message": (
+                "Previous placement with this client_order_id is unresolved "
+                "and the new request parameters differ; verify the order book "
+                "and use a new client_order_id"
+            ),
+        }, 409
+
+    ok, book, _code = get_orderbook_with_auth(auth_token, broker, original_data=None)
+    if not ok or not isinstance(book, dict) or book.get("status") != "success":
+        return False, {
+            "status": "error",
+            "message": (
+                "Previous placement with this client_order_id is unresolved "
+                "and the broker order book is unavailable; verify the order "
+                "book before reusing this id"
+            ),
+        }, 409
+
+    orders = (book.get("data") or {}).get("orders") or []
+    candidates = []
+    for order in orders:
+        if not isinstance(order, dict):
+            continue
+        status = str(order.get("order_status", "")).strip().upper()
+        if status in ("REJECTED", "CANCELLED"):
+            continue
+        if _params_match_reservation(original, order):
+            candidates.append(order)
+
+    if len(candidates) > 1:
+        return False, {
+            "status": "error",
+            "message": (
+                "Previous placement with this client_order_id is unresolved "
+                "and multiple matching orders were found in the order book; "
+                "reconcile manually before reusing this id"
+            ),
+        }, 409
+
+    if len(candidates) == 1:
+        orderid = str(candidates[0].get("orderid", "") or "")
+        if not orderid:
+            return False, {
+                "status": "error",
+                "message": (
+                    "Previous placement with this client_order_id is "
+                    "unresolved; the matching order has no id to replay"
+                ),
+            }, 409
+        record_success(api_key, client_order_id, orderid)
+        replay_response = {
+            "status": "success",
+            "orderid": orderid,
+            "client_order_id": client_order_id,
+            "duplicate": True,
+            "reconciled": True,
+        }
+        if original.get("tag"):
+            replay_response["tag"] = original["tag"]
+        return True, replay_response, 200
+
+    # No live candidate: the broker book proves the attempt never placed an
+    # order (rejected/cancelled entries are excluded above). Release the key
+    # and let the caller place fresh.
+    release_client_order_id(api_key, client_order_id)
+    return None
+
+
 def place_order_with_auth(
     order_data: dict[str, Any],
     auth_token: str,
@@ -218,12 +346,27 @@ def place_order_with_auth(
     if idempotent:
         from database.idempotency_db import get_resolution, reserve_client_order_id
 
+        # Recorded on the reservation so an unresolved key can be reconciled
+        # against the broker order book, and so a corrected retry (different
+        # parameters) is refused instead of silently double-placing.
+        order_params = {
+            "symbol": order_data.get("symbol"),
+            "exchange": order_data.get("exchange"),
+            "action": order_data.get("action"),
+            "quantity": order_data.get("quantity"),
+            "price": order_data.get("price"),
+        }
+
         try:
-            state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
+            state, status = reserve_client_order_id(
+                api_key, client_order_id, tag=order_tag, order_params=order_params
+            )
             if state == "vacated":
                 # Reservation vanished (TTL prune) between conflict and re-read:
                 # nothing is in flight, so reclaim and fall through on the result.
-                state, status = reserve_client_order_id(api_key, client_order_id, tag=order_tag)
+                state, status = reserve_client_order_id(
+                    api_key, client_order_id, tag=order_tag, order_params=order_params
+                )
             if state == "existing":
                 if status == "placed":
                     resolution = get_resolution(api_key, client_order_id)
@@ -237,12 +380,40 @@ def place_order_with_auth(
                         if resolution.get("tag"):
                             replay_response["tag"] = resolution["tag"]
                         return True, replay_response, 200
-                # in_flight, or placed without a recorded orderid: never re-place.
-                error_response = {
-                    "status": "error",
-                    "message": "Order placement with this client_order_id is already in progress",
-                }
-                return False, error_response, 409
+                if status == "unresolved":
+                    # A previous attempt ended ambiguously: ask the broker
+                    # order book what actually happened before re-placing.
+                    # Reconciliation must never surface as a store failure —
+                    # any error means the key stays blocked, never released.
+                    try:
+                        reconciled = _reconcile_unresolved_key(
+                            auth_token, broker, api_key, client_order_id, order_data
+                        )
+                    except Exception:
+                        logger.exception(
+                            "Reconciliation failed for client_order_id %s", client_order_id
+                        )
+                        reconciled = False, {
+                            "status": "error",
+                            "message": (
+                                "Previous placement with this client_order_id "
+                                "is unresolved and could not be reconciled with "
+                                "the broker; verify the order book before "
+                                "reusing this id"
+                            ),
+                        }, 409
+                    if reconciled is not None:
+                        return reconciled
+                    # Reconciliation proved the order never reached the broker
+                    # and released the key: fall through to a fresh placement.
+                else:
+                    # in_flight, or placed without a recorded orderid: never
+                    # re-place.
+                    error_response = {
+                        "status": "error",
+                        "message": "Order placement with this client_order_id is already in progress",
+                    }
+                    return False, error_response, 409
         except Exception:
             # Store unavailable (SQLite locked/IO error): nothing was committed,
             # so there is no reservation to release. Proceeding would place the

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -137,6 +137,12 @@ def _params_match_reservation(resolution: dict, order_data: dict) -> bool:
     def _norm_str(value) -> str:
         return str(value or "").strip().upper()
 
+    from database.idempotency_db import (
+        DEFAULT_PRICETYPE,
+        DEFAULT_PRODUCT,
+        MARKETISH_PRICETYPES,
+    )
+
     if _norm_str(resolution.get("symbol")) != _norm_str(order_data.get("symbol")):
         return False
     if _norm_str(resolution.get("exchange")) != _norm_str(order_data.get("exchange")):
@@ -150,20 +156,29 @@ def _params_match_reservation(resolution: dict, order_data: dict) -> bool:
             return False
     except (TypeError, ValueError):
         return False
+    # Rows created before product/pricetype/trigger_price existed (ALTER
+    # migration leaves existing rows NULL) were stored under the original
+    # five-field semantics: compare them with exactly those semantics.
+    if resolution.get("pricetype") is None and resolution.get("product") is None:
+        return True
     # Request-shaping parameters: a corrected retry must not reuse an
     # unresolved reservation (a LIMIT retry must not slip through a MARKET
-    # reservation, a CNC retry through an MIS one, etc.).
-    stored_pricetype = _norm_str(resolution.get("pricetype"))
-    if stored_pricetype != _norm_str(order_data.get("pricetype")):
+    # reservation, a CNC retry through an MIS one, etc.). BOTH sides are
+    # normalized with the schema defaults: the retry may repeat the original
+    # raw request, which omitted these fields (the reserve path recorded the
+    # defaults), and broker book rows always carry them explicitly.
+    stored_pricetype = _norm_str(resolution.get("pricetype") or DEFAULT_PRICETYPE)
+    if stored_pricetype != _norm_str(order_data.get("pricetype") or DEFAULT_PRICETYPE):
         return False
-    if _norm_str(resolution.get("product")) != _norm_str(order_data.get("product")):
+    if _norm_str(resolution.get("product") or DEFAULT_PRODUCT) != _norm_str(
+        order_data.get("product") or DEFAULT_PRODUCT
+    ):
         return False
     # For price-fixed types the recorded limit price must match the request.
     # For MARKET/SL-M the order book's "price" is the broker's average fill
-    # (see broker/*/mapping/order_data.py), so a stored default price must
-    # not be compared against it (mirrors MARKETISH_PRICETYPES in
-    # database/idempotency_db.py).
-    if stored_pricetype not in ("", "MARKET", "SL-M"):
+    # (see broker/*/mapping/order_data.py), so a recorded default price must
+    # not be compared against it.
+    if stored_pricetype not in MARKETISH_PRICETYPES:
         stored_price = resolution.get("price")
         if stored_price is not None:
             try:

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -367,6 +367,14 @@ def place_order_with_auth(
                 state, status = reserve_client_order_id(
                     api_key, client_order_id, tag=order_tag, order_params=order_params
                 )
+            if state not in ("reserved", "existing"):
+                # Could not obtain a reservation after retry — refuse placement
+                # rather than proceeding without duplicate protection.
+                error_response = {
+                    "status": "error",
+                    "message": "Could not reserve idempotency key; please retry",
+                }
+                return False, error_response, 503
             if state == "existing":
                 if status == "placed":
                     resolution = get_resolution(api_key, client_order_id)
@@ -545,9 +553,18 @@ def place_order_with_auth(
             if order_tag:
                 order_response_data["tag"] = order_tag
         if idempotent:
-            from database.idempotency_db import record_success
+            try:
+                from database.idempotency_db import record_success
 
-            record_success(api_key, client_order_id, str(order_id))
+                record_success(api_key, client_order_id, str(order_id))
+            except Exception:
+                logger.exception(
+                    "CRITICAL: Order %s placed at broker but idempotency DB "
+                    "write failed for client_order_id=%s — row will remain "
+                    "in_flight until TTL expiry",
+                    order_id,
+                    client_order_id,
+                )
 
         if emit_event:
             bus.publish(

--- a/services/place_order_service.py
+++ b/services/place_order_service.py
@@ -144,14 +144,37 @@ def _params_match_reservation(resolution: dict, order_data: dict) -> bool:
     if _norm_str(resolution.get("action")) != _norm_str(order_data.get("action")):
         return False
     try:
-        if int(resolution.get("quantity") or 0) != int(order_data.get("quantity") or 0):
+        # Float (not int()) compare: fractional crypto lots must not compare
+        # equal (1.1 vs 1.9), which a plain int() coercion produced.
+        if abs(float(resolution.get("quantity") or 0) - float(order_data.get("quantity") or 0)) > 1e-9:
             return False
     except (TypeError, ValueError):
         return False
-    stored_price = resolution.get("price")
-    if stored_price is not None:
+    # Request-shaping parameters: a corrected retry must not reuse an
+    # unresolved reservation (a LIMIT retry must not slip through a MARKET
+    # reservation, a CNC retry through an MIS one, etc.).
+    stored_pricetype = _norm_str(resolution.get("pricetype"))
+    if stored_pricetype != _norm_str(order_data.get("pricetype")):
+        return False
+    if _norm_str(resolution.get("product")) != _norm_str(order_data.get("product")):
+        return False
+    # For price-fixed types the recorded limit price must match the request.
+    # For MARKET/SL-M the order book's "price" is the broker's average fill
+    # (see broker/*/mapping/order_data.py), so a stored default price must
+    # not be compared against it (mirrors MARKETISH_PRICETYPES in
+    # database/idempotency_db.py).
+    if stored_pricetype not in ("", "MARKET", "SL-M"):
+        stored_price = resolution.get("price")
+        if stored_price is not None:
+            try:
+                if abs(float(stored_price) - float(order_data.get("price") or 0)) > 1e-9:
+                    return False
+            except (TypeError, ValueError):
+                return False
+    stored_trigger = resolution.get("trigger_price")
+    if stored_trigger is not None:
         try:
-            if abs(float(stored_price) - float(order_data.get("price") or 0)) > 1e-9:
+            if abs(float(stored_trigger) - float(order_data.get("trigger_price") or 0)) > 1e-9:
                 return False
         except (TypeError, ValueError):
             return False
@@ -209,7 +232,8 @@ def _reconcile_unresolved_key(
         if not isinstance(order, dict):
             continue
         status = str(order.get("order_status", "")).strip().upper()
-        if status in ("REJECTED", "CANCELLED"):
+        # Both cancellation spellings appear across broker adapters.
+        if status in ("REJECTED", "CANCELLED", "CANCELED"):
             continue
         if _params_match_reservation(original, order):
             candidates.append(order)
@@ -355,6 +379,9 @@ def place_order_with_auth(
             "action": order_data.get("action"),
             "quantity": order_data.get("quantity"),
             "price": order_data.get("price"),
+            "product": order_data.get("product"),
+            "pricetype": order_data.get("pricetype"),
+            "trigger_price": order_data.get("trigger_price"),
         }
 
         try:

--- a/services/strategy_module/order_dispatch.py
+++ b/services/strategy_module/order_dispatch.py
@@ -344,18 +344,22 @@ def _dispatch_sandbox(api_key: str, order: dict[str, Any]) -> DispatchResult:
 
 
 def _dispatch_live(api_key: str, order: dict[str, Any]) -> DispatchResult:
-    auth_token, broker, error = resolve_live_auth(api_key)
-    if error:
-        # Deliberately not attempted. See the module docstring: refusing and
-        # saying so leaves a recoverable situation, and a silent failure does
-        # not.
-        return DispatchResult(ok=False, error=error)
-
     from services.place_order_service import place_order_with_auth
 
-    original = dict(order)
-    original["apikey"] = api_key
     try:
+        # Inside the try so the finally below releases the scoped sessions
+        # resolve_live_auth opens (auth_db) even on the early-return path —
+        # strategy dispatch runs on the tick-feed green thread, where no
+        # teardown_appcontext ever fires (see utils/db_sessions.py).
+        auth_token, broker, error = resolve_live_auth(api_key)
+        if error:
+            # Deliberately not attempted. See the module docstring: refusing and
+            # saying so leaves a recoverable situation, and a silent failure does
+            # not.
+            return DispatchResult(ok=False, error=error)
+
+        original = dict(order)
+        original["apikey"] = api_key
         ok, response, _status = place_order_with_auth(
             dict(order),
             auth_token,

--- a/services/strategy_module/order_dispatch.py
+++ b/services/strategy_module/order_dispatch.py
@@ -369,6 +369,15 @@ def _dispatch_live(api_key: str, order: dict[str, Any]) -> DispatchResult:
     except Exception:
         logger.exception("Live order placement raised for %s", order.get("symbol"))
         return DispatchResult(ok=False, error="Live order placement failed")
+    finally:
+        # Strategy dispatch runs on the tick-feed green thread, outside any
+        # Flask request context — no teardown_appcontext ever fires here, so
+        # the scoped sessions opened for the placement (including the
+        # idempotency store) are released explicitly per the contract in
+        # utils/db_sessions.py.
+        from utils.db_sessions import remove_all_scoped_sessions
+
+        remove_all_scoped_sessions()
 
     return _normalise(ok, response)
 

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -335,6 +335,61 @@ class TestPlaceOrderIdempotency:
         assert code == 200
         assert response["orderid"] is None
 
+    def test_reserve_store_failure_fails_closed_503(self, monkeypatch):
+        broker = _FakeBrokerModule()
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+        monkeypatch.setattr(
+            idempotency_db,
+            "reserve_client_order_id",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("database is locked")),
+        )
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        # Without the store we cannot dedupe, so proceeding would risk a
+        # double placement. Fail closed with a retryable error instead of
+        # leaking the exception as an unstyled 500.
+        assert ok is False
+        assert code == 503
+        assert "unavailable" in response["message"]
+        assert len(broker.calls) == 0
+
+    def test_resolution_read_failure_never_replaces(self, monkeypatch):
+        broker = _FakeBrokerModule()
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+        monkeypatch.setattr(
+            idempotency_db,
+            "reserve_client_order_id",
+            lambda *a, **k: ("existing", "placed"),
+        )
+        monkeypatch.setattr(
+            idempotency_db,
+            "get_resolution",
+            lambda *a, **k: (_ for _ in ()).throw(RuntimeError("database is locked")),
+        )
+
+        # The id may already exist at the broker; an unreadable resolution
+        # must block the placement, never fall through to a re-place.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 503
+        assert len(broker.calls) == 0
+
     def test_no_client_order_id_is_unchanged(self, fake_broker):
         ok, response, code = place_order_service.place_order(BASE_ORDER, api_key=API_KEY)
         assert ok is True

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -1,0 +1,267 @@
+# test/test_place_order_idempotency.py
+"""
+Tests for application-level order idempotency via client_order_id.
+
+Covers:
+- OrderSchema acceptance/normalisation of client_order_id and tag
+- The reservation store's reserve / record / release / replay lifecycle
+- place_order_with_auth behaviour: dedupe replay, 409 on in-flight races,
+  reservation release on broker failure, broker payload stripping
+- Orderbook label echo
+"""
+
+import os
+
+# Isolate the idempotency store before the module (and its engine) is imported.
+os.environ.setdefault("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency-test.db")
+os.makedirs("db", exist_ok=True)
+
+import pytest  # noqa: E402
+from marshmallow import ValidationError  # noqa: E402
+
+from database import idempotency_db  # noqa: E402
+from restx_api.schemas import OrderSchema  # noqa: E402
+from services import place_order_service  # noqa: E402
+
+
+@pytest.fixture(autouse=True)
+def clean_store():
+    idempotency_db.init_idempotency_db()
+    idempotency_db.idempotency_session.query(idempotency_db.ClientOrderId).delete()
+    idempotency_db.idempotency_session.commit()
+    yield
+    idempotency_db.idempotency_session.rollback()
+    idempotency_db.idempotency_session.remove()
+
+
+API_KEY = "test-api-key-1234"
+OTHER_API_KEY = "other-api-key-5678"
+CID = "retry-abc-123"
+
+BASE_ORDER = {
+    "apikey": API_KEY,
+    "symbol": "RELIANCE",
+    "exchange": "NSE",
+    "action": "BUY",
+    "quantity": 1,
+    "pricetype": "MARKET",
+    "product": "MIS",
+    "strategy": "test-strategy",
+}
+
+
+class TestOrderSchema:
+    def test_accepts_client_order_id_and_tag(self):
+        data = OrderSchema().load({**BASE_ORDER, "client_order_id": CID, "tag": "scalp-1"})
+        assert data["client_order_id"] == CID
+        assert data["tag"] == "scalp-1"
+
+    def test_absent_fields_are_dropped(self):
+        data = OrderSchema().load(BASE_ORDER)
+        assert "client_order_id" not in data
+        assert "tag" not in data
+
+    def test_null_fields_are_dropped(self):
+        data = OrderSchema().load({**BASE_ORDER, "client_order_id": None, "tag": None})
+        assert "client_order_id" not in data
+        assert "tag" not in data
+
+    def test_client_order_id_max_length(self):
+        with pytest.raises(ValidationError):
+            OrderSchema().load({**BASE_ORDER, "client_order_id": "x" * 129})
+
+    def test_empty_client_order_id_rejected(self):
+        with pytest.raises(ValidationError):
+            OrderSchema().load({**BASE_ORDER, "client_order_id": ""})
+
+
+class TestReservationStore:
+    def test_reserve_then_conflict(self):
+        assert idempotency_db.reserve_client_order_id(API_KEY, CID) == ("reserved", None)
+        assert idempotency_db.reserve_client_order_id(API_KEY, CID) == ("existing", "in_flight")
+
+    def test_reserve_is_scoped_per_api_key(self):
+        assert idempotency_db.reserve_client_order_id(API_KEY, CID) == ("reserved", None)
+        assert idempotency_db.reserve_client_order_id(OTHER_API_KEY, CID) == ("reserved", None)
+
+    def test_record_success_makes_replay_available(self):
+        idempotency_db.reserve_client_order_id(API_KEY, CID, tag="scalp-1")
+        idempotency_db.record_success(API_KEY, CID, "250106000012345")
+        assert idempotency_db.reserve_client_order_id(API_KEY, CID) == ("existing", "placed")
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution["orderid"] == "250106000012345"
+        assert resolution["status"] == "placed"
+        assert resolution["tag"] == "scalp-1"
+
+    def test_release_after_failure_allows_retry(self):
+        idempotency_db.reserve_client_order_id(API_KEY, CID)
+        idempotency_db.release_client_order_id(API_KEY, CID)
+        assert idempotency_db.get_resolution(API_KEY, CID) is None
+        assert idempotency_db.reserve_client_order_id(API_KEY, CID) == ("reserved", None)
+
+    def test_release_ignores_completed_rows(self):
+        # A failed retry must never erase a completed resolution.
+        idempotency_db.reserve_client_order_id(API_KEY, CID)
+        idempotency_db.record_success(API_KEY, CID, "ORD1")
+        idempotency_db.release_client_order_id(API_KEY, CID)
+        assert idempotency_db.get_resolution(API_KEY, CID)["orderid"] == "ORD1"
+
+    def test_unknown_key_returns_none(self):
+        assert idempotency_db.get_resolution(API_KEY, CID) is None
+
+    def test_labels_lookup_by_orderid(self):
+        idempotency_db.reserve_client_order_id(API_KEY, CID, tag="scalp-1")
+        idempotency_db.record_success(API_KEY, CID, "ORD1")
+        idempotency_db.reserve_client_order_id(API_KEY, "plain-cid")
+        idempotency_db.record_success(API_KEY, "plain-cid", "ORD2")
+        labels = idempotency_db.get_labels_for_orderids(API_KEY, ["ORD1", "ORD2", "ORD9"])
+        assert labels["ORD1"] == {"client_order_id": CID, "tag": "scalp-1"}
+        assert labels["ORD2"] == {"client_order_id": "plain-cid", "tag": None}
+        assert "ORD9" not in labels
+
+
+class _FakeResponse:
+    def __init__(self, status):
+        self.status = status
+
+
+class _FakeBrokerModule:
+    def __init__(self, order_id="250106000012345", status=200, exc=None):
+        self.order_id = order_id
+        self.status = status
+        self.exc = exc
+        self.calls = []
+
+    def place_order_api(self, order_data, auth_token):
+        self.calls.append(order_data)
+        if self.exc is not None:
+            raise self.exc
+        return _FakeResponse(self.status), {}, self.order_id
+
+
+@pytest.fixture
+def fake_broker(monkeypatch):
+    broker = _FakeBrokerModule()
+    monkeypatch.setattr(
+        place_order_service,
+        "get_auth_token_broker",
+        lambda api_key: ("fake-auth-token", "fakebroker"),
+    )
+    monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+    monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+    return broker
+
+
+class TestPlaceOrderIdempotency:
+    def test_first_call_places_and_echoes(self, fake_broker):
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID, "tag": "scalp-1"}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["orderid"] == "250106000012345"
+        assert response["client_order_id"] == CID
+        assert response["tag"] == "scalp-1"
+        assert len(fake_broker.calls) == 1
+
+    def test_retry_with_same_id_replays_without_replacing(self, fake_broker):
+        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["status"] == "success"
+        assert response["orderid"] == "250106000012345"
+        assert response["duplicate"] is True
+        assert len(fake_broker.calls) == 1  # broker hit exactly once
+
+    def test_retry_different_id_places_again(self, fake_broker):
+        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        ok, _, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": "another-id"}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert len(fake_broker.calls) == 2
+
+    def test_broker_payload_has_no_client_order_id(self, fake_broker):
+        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        assert fake_broker.calls, "broker should have been called"
+        assert "client_order_id" not in fake_broker.calls[0]
+
+    def test_broker_failure_releases_reservation(self, monkeypatch):
+        broker = _FakeBrokerModule(exc=RuntimeError("broker down"))
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 500
+        # The retry after a failure must be allowed to proceed.
+        assert idempotency_db.get_resolution(API_KEY, CID) is None
+
+        broker.exc = None
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert len(broker.calls) == 2
+
+    def test_broker_non_200_releases_reservation(self, monkeypatch):
+        broker = _FakeBrokerModule(status=400, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert idempotency_db.get_resolution(API_KEY, CID) is None
+
+    def test_in_flight_reservation_returns_409(self, fake_broker):
+        idempotency_db.reserve_client_order_id(API_KEY, CID)
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert "already in progress" in response["message"]
+        assert len(fake_broker.calls) == 0
+
+    def test_placed_without_orderid_returns_409(self, fake_broker):
+        idempotency_db.reserve_client_order_id(API_KEY, CID)
+        idempotency_db.record_success(API_KEY, CID, "ORD1")
+        # Force the placed-without-orderid guard by wiping the orderid column.
+        row = (
+            idempotency_db.idempotency_session.query(idempotency_db.ClientOrderId)
+            .filter_by(api_key_hash=idempotency_db._hash_api_key(API_KEY), client_order_id=CID)
+            .one()
+        )
+        row.orderid = None
+        idempotency_db.idempotency_session.commit()
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+
+    def test_no_client_order_id_is_unchanged(self, fake_broker):
+        ok, response, code = place_order_service.place_order(BASE_ORDER, api_key=API_KEY)
+        assert ok is True
+        assert code == 200
+        assert set(response) == {"status", "orderid"}
+        assert "client_order_id" not in response

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -119,6 +119,22 @@ class TestReservationStore:
         assert labels["ORD2"] == {"client_order_id": "plain-cid", "tag": None}
         assert "ORD9" not in labels
 
+    def test_prune_and_label_lookups_are_indexed(self):
+        # _prune_expired runs a created_at-range DELETE on every reserve and
+        # get_labels_for_orderids maps orderids on every orderbook poll; on a
+        # growing table both are full scans unless the columns are indexed.
+        # Assert at the metadata level so the check needs no query planner.
+        client_order_ids = idempotency_db.ClientOrderId.__table__
+        index_cols = {
+            ix.name: {c.name for c in ix.columns} for ix in client_order_ids.indexes
+        }
+        assert any(cols == {"created_at"} for cols in index_cols.values()), (
+            "created_at must be indexed for TTL pruning"
+        )
+        assert any(
+            cols == {"api_key_hash", "orderid"} for cols in index_cols.values()
+        ), "(api_key_hash, orderid) must be indexed for orderbook label echo"
+
 
 class _FakeResponse:
     def __init__(self, status):

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -259,6 +259,66 @@ class TestPlaceOrderIdempotency:
         assert ok is False
         assert code == 409
 
+    def test_200_without_orderid_is_reported_unresolved(self, monkeypatch):
+        broker = _FakeBrokerModule(status=200, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        # The broker ACCEPTED the request, so this is not a plain failure:
+        # reporting success would lie about the orderid, and releasing the
+        # reservation would let a retry double-place. The placement must come
+        # back as an explicit unresolved error and the key must stay claimed.
+        assert ok is False
+        assert code == 500
+        assert "unresolved" in response["message"]
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution is not None and resolution["status"] == "in_flight"
+
+    def test_200_without_orderid_retry_stays_blocked(self, monkeypatch):
+        broker = _FakeBrokerModule(status=200, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        broker.order_id = "250106000012345"
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        # Even after the broker recovers, a retry with the same id must not
+        # re-place: the first request may already exist at the broker.
+        assert ok is False
+        assert code == 409
+        assert len(broker.calls) == 1
+
+    def test_200_without_orderid_non_idempotent_unchanged(self, monkeypatch):
+        broker = _FakeBrokerModule(status=200, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        # Legacy behaviour without a client_order_id is untouched.
+        ok, response, code = place_order_service.place_order(BASE_ORDER, api_key=API_KEY)
+        assert ok is True
+        assert code == 200
+        assert response["orderid"] is None
+
     def test_no_client_order_id_is_unchanged(self, fake_broker):
         ok, response, code = place_order_service.place_order(BASE_ORDER, api_key=API_KEY)
         assert ok is True

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -396,3 +396,34 @@ class TestPlaceOrderIdempotency:
         assert code == 200
         assert set(response) == {"status", "orderid"}
         assert "client_order_id" not in response
+
+
+class TestSessionHygiene:
+    """The store must not hold NullPool connections between operations.
+
+    Registered in utils/db_sessions.SCOPED_SESSION_MODULES so request
+    teardown releases it, and read helpers end their own transactions so
+    background callers (strategy dispatch) never pin a connection.
+    """
+
+    def test_session_registered_in_central_cleanup_registry(self):
+        from utils.db_sessions import SCOPED_SESSION_MODULES, remove_all_scoped_sessions
+
+        assert ("database.idempotency_db", "idempotency_session") in SCOPED_SESSION_MODULES
+        # Must not raise with the idempotency module loaded.
+        remove_all_scoped_sessions()
+
+    def test_reads_do_not_hold_transaction_open(self):
+        idempotency_db.init_idempotency_db()
+        idempotency_db.get_resolution(API_KEY, "unknown-id")
+        assert not idempotency_db.idempotency_session().in_transaction()
+
+    def test_label_reads_do_not_hold_transaction_open(self):
+        idempotency_db.init_idempotency_db()
+        idempotency_db.get_labels_for_orderids(API_KEY, ["123"])
+        assert not idempotency_db.idempotency_session().in_transaction()
+
+    def test_engine_uses_project_pooling_policy(self):
+        from sqlalchemy.pool import NullPool
+
+        assert isinstance(idempotency_db.idempotency_engine.pool, NullPool)

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -13,8 +13,9 @@ Covers:
 import os
 
 # Isolate the idempotency store before the module (and its engine) is imported.
-os.environ.setdefault("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency-test.db")
-os.makedirs("db", exist_ok=True)
+# Unconditional assignment: an exported env var must never point clean_store
+# at the real database.
+os.environ["IDEMPOTENCY_DATABASE_URL"] = "sqlite://"
 
 import pytest  # noqa: E402
 from marshmallow import ValidationError  # noqa: E402

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -588,6 +588,52 @@ class TestUnresolvedReconciliation:
         assert code == 200
         assert response["reconciled"] is True
 
+    def test_identical_raw_retry_reconciles_not_409(self, monkeypatch):
+        # THE raw-request P1: a retry that repeats the original request must
+        # reconcile, not 409. Both sides normalize with the schema defaults
+        # — the pre-fix matcher compared the stored defaults against the
+        # retry's ABSENT fields and refused the identical request.
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        raw_request = {
+            k: v for k, v in BASE_ORDER.items() if k not in ("pricetype", "product")
+        }
+        self._make_unresolved(monkeypatch, broker, **{
+            k: v for k, v in raw_request.items() if k != "client_order_id"
+        })
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+
+        ok, response, code = place_order_service.place_order(
+            {**raw_request, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["reconciled"] is True
+        assert len(broker.calls) == 1
+
+    def test_legacy_null_shaping_rows_keep_five_field_semantics(self, monkeypatch):
+        # Rows created before product/pricetype/trigger_price existed (the
+        # ALTER migration leaves them NULL) must stay reconcilable: the
+        # matcher compares them with the original five-field semantics
+        # instead of inventing defaults the original request never had.
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+        sess = idempotency_db.idempotency_session
+        row = sess.query(idempotency_db.ClientOrderId).filter_by(
+            api_key_hash=idempotency_db._hash_api_key(API_KEY), client_order_id=CID
+        ).one()
+        row.product = None
+        row.pricetype = None
+        row.trigger_price = None
+        sess.commit()
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["reconciled"] is True
+
     def _make_unresolved(self, monkeypatch, broker, **param_overrides):
         monkeypatch.setattr(
             place_order_service,

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -11,11 +11,15 @@ Covers:
 """
 
 import os
+import tempfile
 
-# Isolate the idempotency store before the module (and its engine) is imported.
-# Unconditional assignment: an exported env var must never point clean_store
-# at the real database.
-os.environ["IDEMPOTENCY_DATABASE_URL"] = "sqlite://"
+# Isolate the idempotency store before the module (and its engine) is
+# imported. Unconditional assignment: an exported IDEMPOTENCY_DATABASE_URL
+# must never point clean_store at a real database. File-backed, not in
+# memory: the store engine uses NullPool, so sqlite:// would hand every
+# operation a fresh, empty database.
+_TMP_STORE_DIR = tempfile.mkdtemp(prefix="idempotency-test-")
+os.environ["IDEMPOTENCY_DATABASE_URL"] = f"sqlite:///{_TMP_STORE_DIR}/idempotency-test.db"
 
 import pytest  # noqa: E402
 from marshmallow import ValidationError  # noqa: E402

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -483,3 +483,137 @@ class TestSessionHygiene:
         from sqlalchemy.pool import NullPool
 
         assert isinstance(idempotency_db.idempotency_engine.pool, NullPool)
+
+
+class TestUnresolvedReconciliation:
+    """A retry of an unresolved key must reconcile with the broker first.
+
+    The reconciliation compares the reservation's original parameters
+    against the broker order book: exactly one live match replays that
+    order, zero live matches (book reachable) releases the key for a fresh
+    placement, and anything ambiguous keeps blocking the key.
+    """
+
+    MATCHING_ORDER = {
+        "orderid": "250106000099999",
+        "symbol": "RELIANCE",
+        "exchange": "NSE",
+        "action": "BUY",
+        "quantity": 1,
+        "price": 0.0,
+        "order_status": "OPEN",
+    }
+
+    def _make_unresolved(self, monkeypatch, broker):
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+        broker.status = 500  # ambiguous adapter failure -> unresolved
+        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        assert idempotency_db.get_resolution(API_KEY, CID)["status"] == "unresolved"
+        broker.status = 200
+        broker.order_id = "250106000012345"
+
+    def _stub_orderbook(self, monkeypatch, orders, ok=True):
+        from services import orderbook_service
+
+        def fake_get_orderbook_with_auth(auth_token, broker, original_data=None):
+            if not ok:
+                return False, {"status": "error", "message": "order book unavailable"}, 503
+            return True, {"status": "success", "data": {"orders": orders, "statistics": {}}}, 200
+
+        monkeypatch.setattr(
+            orderbook_service, "get_orderbook_with_auth", fake_get_orderbook_with_auth
+        )
+
+    def test_single_live_match_is_replayed(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["duplicate"] is True
+        assert response["reconciled"] is True
+        assert response["orderid"] == "250106000099999"
+        # The broker was never asked to place again.
+        assert len(broker.calls) == 1
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution["status"] == "placed"
+        assert resolution["orderid"] == "250106000099999"
+
+    def test_no_match_releases_key_and_places_fresh(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [])
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        # The book proves the attempt never placed: the retry places fresh.
+        assert ok is True
+        assert code == 200
+        assert response["orderid"] == "250106000012345"
+        assert "duplicate" not in response
+        assert len(broker.calls) == 2
+
+    def test_rejected_only_book_releases_key(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        rejected = dict(self.MATCHING_ORDER, order_status="REJECTED")
+        self._stub_orderbook(monkeypatch, [rejected])
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert len(broker.calls) == 2
+
+    def test_unavailable_book_keeps_key_blocked(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [], ok=False)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert len(broker.calls) == 1
+
+    def test_multiple_matches_keeps_key_blocked(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(
+            monkeypatch, [dict(self.MATCHING_ORDER), dict(self.MATCHING_ORDER)]
+        )
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert len(broker.calls) == 1
+
+    def test_corrected_params_are_refused(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+
+        # A "corrected" retry (different quantity) must never reuse the key:
+        # the ambiguous attempt may still be live with the original params.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID, "quantity": 5}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert "parameters differ" in response["message"]
+        assert len(broker.calls) == 1

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -206,7 +206,7 @@ class TestPlaceOrderIdempotency:
         assert fake_broker.calls, "broker should have been called"
         assert "client_order_id" not in fake_broker.calls[0]
 
-    def test_broker_failure_releases_reservation(self, monkeypatch):
+    def test_broker_exception_keeps_reservation_unresolved(self, monkeypatch):
         broker = _FakeBrokerModule(exc=RuntimeError("broker down"))
         monkeypatch.setattr(
             place_order_service,
@@ -221,10 +221,66 @@ class TestPlaceOrderIdempotency:
         )
         assert ok is False
         assert code == 500
-        # The retry after a failure must be allowed to proceed.
+        # The exception is ambiguous — it may have hit after the broker
+        # accepted the order. The reservation must survive as unresolved and
+        # the same-id retry must be blocked instead of double-placing.
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution is not None and resolution["status"] == "unresolved"
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert len(broker.calls) == 1
+
+    def test_ambiguous_500_keeps_reservation_unresolved(self, monkeypatch):
+        # A transport failure converted into an adapter 500 is the exact
+        # lost-ack shape the review reproduced: the request may have been
+        # accepted, so the retry must not re-place.
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution is not None and resolution["status"] == "unresolved"
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert len(broker.calls) == 1
+
+    def test_rate_limited_429_releases_reservation(self, monkeypatch):
+        broker = _FakeBrokerModule(status=429, order_id=None)
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is False
+        # 429 proves the broker refused the order: a retry with a fresh
+        # placement is safe and must be allowed.
         assert idempotency_db.get_resolution(API_KEY, CID) is None
 
-        broker.exc = None
+        broker.status = 200
+        broker.order_id = "250106000012345"
         ok, response, code = place_order_service.place_order(
             {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
         )
@@ -296,7 +352,7 @@ class TestPlaceOrderIdempotency:
         assert code == 500
         assert "unresolved" in response["message"]
         resolution = idempotency_db.get_resolution(API_KEY, CID)
-        assert resolution is not None and resolution["status"] == "in_flight"
+        assert resolution is not None and resolution["status"] == "unresolved"
 
     def test_200_without_orderid_retry_stays_blocked(self, monkeypatch):
         broker = _FakeBrokerModule(status=200, order_id=None)

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -43,6 +43,19 @@ API_KEY = "test-api-key-1234"
 OTHER_API_KEY = "other-api-key-5678"
 CID = "retry-abc-123"
 
+# The order_params shape reserve_client_order_id records (mirrors the
+# place-order schema defaults: price/trigger_price default to 0.0, not NULL).
+PARAMS = {
+    "symbol": "RELIANCE",
+    "exchange": "NSE",
+    "action": "BUY",
+    "quantity": 1,
+    "price": 0.0,
+    "pricetype": "MARKET",
+    "product": "MIS",
+    "trigger_price": 0.0,
+}
+
 BASE_ORDER = {
     "apikey": API_KEY,
     "symbol": "RELIANCE",
@@ -113,6 +126,42 @@ class TestReservationStore:
 
     def test_unknown_key_returns_none(self):
         assert idempotency_db.get_resolution(API_KEY, CID) is None
+
+    def test_fractional_quantity_is_preserved(self):
+        # Crypto/USDT perps trade fractional lots; the old Integer column plus
+        # int() coercion made 1.1 and 1.9 indistinguishable.
+        idempotency_db.reserve_client_order_id(
+            API_KEY, CID, order_params={**PARAMS, "quantity": 1.1}
+        )
+        assert idempotency_db.get_resolution(API_KEY, CID)["quantity"] == 1.1
+
+    def test_zero_price_is_recorded_not_nulled(self):
+        # The old truthiness recording turned price 0.0 into NULL, which made
+        # the replay check silently skip the price comparison.
+        idempotency_db.reserve_client_order_id(
+            API_KEY, CID, order_params={**PARAMS, "price": 0.0}
+        )
+        assert idempotency_db.get_resolution(API_KEY, CID)["price"] == 0.0
+
+    def test_absent_shaping_params_get_schema_defaults(self):
+        # place_order_with_auth sees the RAW request (validate_order_data
+        # discards the schema-loaded dict), so the store must apply the
+        # schema defaults itself or LIMIT-vs-MARKET corrections would
+        # compare NULL against values.
+        raw = {k: v for k, v in PARAMS.items() if k not in ("pricetype", "product", "price", "trigger_price")}
+        idempotency_db.reserve_client_order_id(API_KEY, CID, order_params=raw)
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution["pricetype"] == "MARKET"
+        assert resolution["product"] == "MIS"
+        assert resolution["price"] == 0.0
+        assert resolution["trigger_price"] == 0.0
+
+    def test_request_shaping_params_are_recorded(self):
+        idempotency_db.reserve_client_order_id(API_KEY, CID, order_params=PARAMS)
+        resolution = idempotency_db.get_resolution(API_KEY, CID)
+        assert resolution["product"] == "MIS"
+        assert resolution["pricetype"] == "MARKET"
+        assert resolution["trigger_price"] == 0.0
 
     def test_labels_lookup_by_orderid(self):
         idempotency_db.reserve_client_order_id(API_KEY, CID, tag="scalp-1")
@@ -506,10 +555,40 @@ class TestUnresolvedReconciliation:
         "action": "BUY",
         "quantity": 1,
         "price": 0.0,
+        "pricetype": "MARKET",
+        "product": "MIS",
+        "trigger_price": 0.0,
         "order_status": "OPEN",
     }
 
-    def _make_unresolved(self, monkeypatch, broker):
+    def test_raw_request_defaults_do_not_block_reconciliation(self, monkeypatch):
+        # A request that omitted pricetype/product must reconcile against the
+        # book once the store applied the schema defaults — the pre-fix code
+        # stored NULL and the strict compare would then reject every match.
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        raw_request = {
+            k: v for k, v in BASE_ORDER.items() if k not in ("pricetype", "product")
+        }
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+        broker.status = 500
+        place_order_service.place_order({**raw_request, "client_order_id": CID}, api_key=API_KEY)
+        assert idempotency_db.get_resolution(API_KEY, CID)["status"] == "unresolved"
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert response["reconciled"] is True
+
+    def _make_unresolved(self, monkeypatch, broker, **param_overrides):
         monkeypatch.setattr(
             place_order_service,
             "get_auth_token_broker",
@@ -518,7 +597,9 @@ class TestUnresolvedReconciliation:
         monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
         monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
         broker.status = 500  # ambiguous adapter failure -> unresolved
-        place_order_service.place_order({**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY)
+        place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID, **param_overrides}, api_key=API_KEY
+        )
         assert idempotency_db.get_resolution(API_KEY, CID)["status"] == "unresolved"
         broker.status = 200
         broker.order_id = "250106000012345"
@@ -622,3 +703,97 @@ class TestUnresolvedReconciliation:
         assert code == 409
         assert "parameters differ" in response["message"]
         assert len(broker.calls) == 1
+
+    def test_fractional_quantities_never_compare_equal(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker, quantity=1.1, exchange="CRYPTO")
+        book_row = dict(self.MATCHING_ORDER, exchange="CRYPTO", quantity=1.1)
+        self._stub_orderbook(monkeypatch, [book_row])
+
+        # 1.1 vs 1.9 must not collapse to the same int and slip through.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "exchange": "CRYPTO", "quantity": 1.9, "client_order_id": CID},
+            api_key=API_KEY,
+        )
+        assert ok is False
+        assert code == 409
+        assert "parameters differ" in response["message"]
+        assert len(broker.calls) == 1
+
+        # Same fractional quantity reconciles to the existing order.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "exchange": "CRYPTO", "quantity": 1.1, "client_order_id": CID},
+            api_key=API_KEY,
+        )
+        assert ok is True
+        assert code == 200
+        assert response["reconciled"] is True
+        assert len(broker.calls) == 1
+
+    def test_limit_price_must_match_for_price_fixed_types(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker, pricetype="LIMIT", price=1500.5)
+        self._stub_orderbook(
+            monkeypatch, [dict(self.MATCHING_ORDER, pricetype="LIMIT", price=1500.5)]
+        )
+
+        # Same limit price reconciles.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "pricetype": "LIMIT", "price": 1500.5, "client_order_id": CID},
+            api_key=API_KEY,
+        )
+        assert ok is True
+        assert code == 200
+        assert len(broker.calls) == 1
+
+    def test_different_limit_price_is_refused(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker, pricetype="LIMIT", price=1500.5)
+        self._stub_orderbook(
+            monkeypatch, [dict(self.MATCHING_ORDER, pricetype="LIMIT", price=1500.5)]
+        )
+
+        # A different limit price is a corrected order, not a retry.
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "pricetype": "LIMIT", "price": 1600.0, "client_order_id": CID},
+            api_key=API_KEY,
+        )
+        assert ok is False
+        assert code == 409
+        assert "parameters differ" in response["message"]
+        assert len(broker.calls) == 1
+
+    @pytest.mark.parametrize("field,value", [
+        ("pricetype", "LIMIT"),
+        ("product", "CNC"),
+    ])
+    def test_corrected_shaping_params_are_refused(self, monkeypatch, field, value):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
+
+        # A retry that changes pricetype/product must be refused: the
+        # unresolved attempt may still be live with the original shape
+        # (e.g. a LIMIT retry must not slip through a MARKET reservation).
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID, field: value}, api_key=API_KEY
+        )
+        assert ok is False
+        assert code == 409
+        assert "parameters differ" in response["message"]
+        assert len(broker.calls) == 1
+
+    def test_canceled_single_l_book_row_is_skipped(self, monkeypatch):
+        broker = _FakeBrokerModule(status=500, order_id=None)
+        self._make_unresolved(monkeypatch, broker)
+        # Single-L 'CANCELED' appears on some broker adapters; it must be
+        # treated as dead exactly like 'CANCELLED'.
+        canceled = dict(self.MATCHING_ORDER, order_status="CANCELED")
+        self._stub_orderbook(monkeypatch, [canceled])
+
+        ok, response, code = place_order_service.place_order(
+            {**BASE_ORDER, "client_order_id": CID}, api_key=API_KEY
+        )
+        assert ok is True
+        assert code == 200
+        assert len(broker.calls) == 2

--- a/test/test_place_order_idempotency.py
+++ b/test/test_place_order_idempotency.py
@@ -590,16 +590,32 @@ class TestUnresolvedReconciliation:
 
     def test_identical_raw_retry_reconciles_not_409(self, monkeypatch):
         # THE raw-request P1: a retry that repeats the original request must
-        # reconcile, not 409. Both sides normalize with the schema defaults
-        # — the pre-fix matcher compared the stored defaults against the
-        # retry's ABSENT fields and refused the identical request.
+        # reconcile, not 409. The ORIGINAL placement goes in raw too (no
+        # pricetype/product): the store records the schema defaults, and the
+        # pre-fix matcher compared those stored defaults against the retry's
+        # ABSENT fields and refused the identical request.
         broker = _FakeBrokerModule(status=500, order_id=None)
         raw_request = {
             k: v for k, v in BASE_ORDER.items() if k not in ("pricetype", "product")
         }
-        self._make_unresolved(monkeypatch, broker, **{
-            k: v for k, v in raw_request.items() if k != "client_order_id"
-        })
+        monkeypatch.setattr(
+            place_order_service,
+            "get_auth_token_broker",
+            lambda api_key: ("fake-auth-token", "fakebroker"),
+        )
+        monkeypatch.setattr(place_order_service, "get_analyze_mode", lambda: False)
+        monkeypatch.setattr(place_order_service, "import_broker_module", lambda name: broker)
+        broker.status = 500  # ambiguous adapter failure -> unresolved
+        place_order_service.place_order(
+            {**raw_request, "client_order_id": CID}, api_key=API_KEY
+        )
+        reservation = idempotency_db.get_resolution(API_KEY, CID)
+        assert reservation["status"] == "unresolved"
+        # The store applied the schema defaults to the raw original.
+        assert reservation["pricetype"] == "MARKET"
+        assert reservation["product"] == "MIS"
+        broker.status = 200
+        broker.order_id = "250106000012345"
         self._stub_orderbook(monkeypatch, [dict(self.MATCHING_ORDER)])
 
         ok, response, code = place_order_service.place_order(

--- a/upgrade/migrate_all.py
+++ b/upgrade/migrate_all.py
@@ -88,6 +88,7 @@ MIGRATIONS = [
     ("migrate_strategy_module.py", "Strategy Module (multi-leg options + RMS)"),
     ("migrate_strategy_universe_tab.py", "Strategy Module Universe Tab Normalization"),
     ("migrate_agent.py", "Agent Module (LLM chat and chart surfaces)"),
+    ("migrate_idempotency_store.py", "Order Idempotency Store (client_order_id)"),
 ]
 
 # Legacy migrations historically used non-zero exits for best-effort warnings,

--- a/upgrade/migrate_idempotency_store.py
+++ b/upgrade/migrate_idempotency_store.py
@@ -1,0 +1,146 @@
+#!/usr/bin/env python
+"""
+Order Idempotency Store Migration Script for OpenAlgo
+
+Creates the application-level order idempotency store (see
+database/idempotency_db.py): a (api_key, client_order_id) -> broker orderid
+mapping so a client that retries a timed-out placement gets the existing
+order echoed back instead of a duplicate position.
+
+Changes:
+- Creates the client_order_ids table in db/idempotency.db if absent
+- Creates the lookup indexes (created_at, (api_key_hash, orderid))
+
+Usage:
+    cd upgrade
+    uv run migrate_idempotency_store.py           # Apply migration
+    uv run migrate_idempotency_store.py --status  # Check status
+"""
+
+import argparse
+import os
+import sys
+from pathlib import Path
+
+# Add parent directory to path for imports
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+# Register the app's SQLite pragmas on this process's engines, so a migration
+# waits the same 15s for a write lock the running app does instead of the
+# sqlite3 default of 5s (GitHub issue #1726).
+import _pragmas  # noqa: F401,E402
+from dotenv import load_dotenv
+from sqlalchemy import inspect, text
+
+from database.engine_factory import create_db_engine
+from utils.logging import get_logger
+
+logger = get_logger(__name__)
+
+# Migration metadata
+MIGRATION_NAME = "order_idempotency_store"
+
+# Load environment
+parent_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+load_dotenv(os.path.join(parent_dir, ".env"))
+
+TABLE_SQL = """
+CREATE TABLE IF NOT EXISTS client_order_ids (
+    id INTEGER NOT NULL PRIMARY KEY,
+    api_key_hash VARCHAR(64) NOT NULL,
+    client_order_id VARCHAR(128) NOT NULL,
+    orderid VARCHAR(64),
+    tag VARCHAR(128),
+    status VARCHAR(16) NOT NULL DEFAULT 'in_flight',
+    created_at DATETIME NOT NULL,
+    updated_at DATETIME NOT NULL,
+    CONSTRAINT uq_client_order_ids_key UNIQUE (api_key_hash, client_order_id)
+)
+"""
+
+INDEX_SQL = [
+    "CREATE INDEX IF NOT EXISTS ix_client_order_ids_api_key_hash "
+    "ON client_order_ids (api_key_hash)",
+    "CREATE INDEX IF NOT EXISTS ix_client_order_ids_created_at ON client_order_ids (created_at)",
+    "CREATE INDEX IF NOT EXISTS ix_client_order_ids_api_key_hash_orderid "
+    "ON client_order_ids (api_key_hash, orderid)",
+]
+
+
+def get_idempotency_db_engine():
+    """Get the idempotency store engine (db/idempotency.db by default)."""
+    db_url = os.getenv("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency.db")
+
+    if db_url.startswith("sqlite:///"):
+        db_path = db_url.replace("sqlite:///", "")
+        if not os.path.isabs(db_path):
+            # Resolve relative paths against the repo root, not the CWD the
+            # migration was invoked from (upgrade/ per migrate_all.py).
+            db_path = os.path.join(parent_dir, db_path)
+            db_url = f"sqlite:///{db_path}"
+        Path(db_path).parent.mkdir(parents=True, exist_ok=True)
+
+    return create_db_engine(db_url)
+
+
+def migration_status(engine):
+    """Return (table_exists, missing_index_names)."""
+    insp = inspect(engine)
+    table_exists = insp.has_table("client_order_ids")
+    missing = []
+    if table_exists:
+        existing = {ix["name"] for ix in insp.get_indexes("client_order_ids")}
+        missing = [
+            name
+            for name in (
+                "ix_client_order_ids_api_key_hash",
+                "ix_client_order_ids_created_at",
+                "ix_client_order_ids_api_key_hash_orderid",
+            )
+            if name not in existing
+        ]
+    return table_exists, missing
+
+
+def migrate(engine):
+    applied = False
+    with engine.connect() as conn:
+        conn.execute(text(TABLE_SQL))
+        for stmt in INDEX_SQL:
+            conn.execute(text(stmt))
+        conn.commit()
+        applied = True
+    return applied
+
+
+def main():
+    parser = argparse.ArgumentParser(description=MIGRATION_NAME)
+    parser.add_argument(
+        "--status", action="store_true", help="Show migration status without applying"
+    )
+    args = parser.parse_args()
+
+    engine = get_idempotency_db_engine()
+
+    table_exists, missing = migration_status(engine)
+
+    if args.status:
+        print(f"Migration: {MIGRATION_NAME}")
+        if not table_exists:
+            print("  Table client_order_ids: MISSING (indexes: n/a)")
+        else:
+            print("  Table client_order_ids: present")
+            print(f"  Missing indexes: {', '.join(missing)}" if missing else "  Indexes: present")
+        print(f"  Status: {'applied' if table_exists and not missing else 'pending'}")
+        return 0
+
+    if table_exists and not missing:
+        print(f"[{MIGRATION_NAME}] already applied, skipping")
+        return 0
+
+    migrate(engine)
+    print(f"[{MIGRATION_NAME}] applied: client_order_ids table and indexes ready")
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/upgrade/migrate_idempotency_store.py
+++ b/upgrade/migrate_idempotency_store.py
@@ -71,8 +71,11 @@ RECONCILIATION_COLUMNS = (
     ("symbol", "VARCHAR(64)"),
     ("exchange", "VARCHAR(32)"),
     ("action", "VARCHAR(16)"),
-    ("quantity", "INTEGER"),
+    ("quantity", "FLOAT"),
     ("price", "FLOAT"),
+    ("product", "VARCHAR(16)"),
+    ("pricetype", "VARCHAR(16)"),
+    ("trigger_price", "FLOAT"),
 )
 
 
@@ -80,8 +83,14 @@ def get_idempotency_db_engine():
     """Get the idempotency store engine (db/idempotency.db by default)."""
     db_url = os.getenv("IDEMPOTENCY_DATABASE_URL", "sqlite:///db/idempotency.db")
 
-    if db_url.startswith("sqlite:///"):
-        db_path = db_url.replace("sqlite:///", "")
+    # SQLAlchemy accepts both the bare sqlite scheme and the fully qualified
+    # dialect scheme (sqlite+pysqlite); handle both so the relative db/ path
+    # resolves against the repo root instead of the CWD the migration was
+    # invoked from.
+    sqlite_schemes = ("sqlite:///", "sqlite+pysqlite:///")
+    matched_scheme = next((s for s in sqlite_schemes if db_url.startswith(s)), None)
+    if matched_scheme:
+        db_path = db_url[len(matched_scheme):]
         if not os.path.isabs(db_path):
             # Resolve relative paths against the repo root, not the CWD the
             # migration was invoked from (upgrade/ per migrate_all.py).

--- a/upgrade/migrate_idempotency_store.py
+++ b/upgrade/migrate_idempotency_store.py
@@ -65,6 +65,16 @@ INDEX_SQL = [
     "ON client_order_ids (api_key_hash, orderid)",
 ]
 
+# Reconciliation parameter columns added after the initial release; existing
+# stores are upgraded in place (mirrors database/idempotency_db.py).
+RECONCILIATION_COLUMNS = (
+    ("symbol", "VARCHAR(64)"),
+    ("exchange", "VARCHAR(32)"),
+    ("action", "VARCHAR(16)"),
+    ("quantity", "INTEGER"),
+    ("price", "FLOAT"),
+)
+
 
 def get_idempotency_db_engine():
     """Get the idempotency store engine (db/idempotency.db by default)."""
@@ -83,10 +93,11 @@ def get_idempotency_db_engine():
 
 
 def migration_status(engine):
-    """Return (table_exists, missing_index_names)."""
+    """Return (table_exists, missing_index_names, missing_column_names)."""
     insp = inspect(engine)
     table_exists = insp.has_table("client_order_ids")
     missing = []
+    missing_cols = []
     if table_exists:
         existing = {ix["name"] for ix in insp.get_indexes("client_order_ids")}
         missing = [
@@ -98,7 +109,9 @@ def migration_status(engine):
             )
             if name not in existing
         ]
-    return table_exists, missing
+        present_cols = {col["name"] for col in insp.get_columns("client_order_ids")}
+        missing_cols = [name for name, _ddl in RECONCILIATION_COLUMNS if name not in present_cols]
+    return table_exists, missing, missing_cols
 
 
 def migrate(engine):
@@ -107,6 +120,10 @@ def migrate(engine):
         conn.execute(text(TABLE_SQL))
         for stmt in INDEX_SQL:
             conn.execute(text(stmt))
+        present_cols = {col[1] for col in conn.execute(text("PRAGMA table_info(client_order_ids)"))}
+        for name, ddl in RECONCILIATION_COLUMNS:
+            if name not in present_cols:
+                conn.execute(text(f"ALTER TABLE client_order_ids ADD COLUMN {name} {ddl}"))
         conn.commit()
         applied = True
     return applied
@@ -121,7 +138,7 @@ def main():
 
     engine = get_idempotency_db_engine()
 
-    table_exists, missing = migration_status(engine)
+    table_exists, missing, missing_cols = migration_status(engine)
 
     if args.status:
         print(f"Migration: {MIGRATION_NAME}")
@@ -130,10 +147,13 @@ def main():
         else:
             print("  Table client_order_ids: present")
             print(f"  Missing indexes: {', '.join(missing)}" if missing else "  Indexes: present")
-        print(f"  Status: {'applied' if table_exists and not missing else 'pending'}")
+            if missing_cols:
+                print(f"  Missing columns: {', '.join(missing_cols)}")
+        applied = table_exists and not missing and not missing_cols
+        print(f"  Status: {'applied' if applied else 'pending'}")
         return 0
 
-    if table_exists and not missing:
+    if table_exists and not missing and not missing_cols:
         print(f"[{MIGRATION_NAME}] already applied, skipping")
         return 0
 

--- a/utils/db_sessions.py
+++ b/utils/db_sessions.py
@@ -46,6 +46,7 @@ SCOPED_SESSION_MODULES = [
     ("database.oauth_db", "db_session"),
     ("database.whatsapp_db", "db_session"),
     ("database.agent_db", "db_session"),
+    ("database.idempotency_db", "idempotency_session"),
 ]
 
 


### PR DESCRIPTION
feat(orders): idempotent order placement via client_order_id

Adds an optional client_order_id to the placeorder API. A retry of a
timed-out request with the same id replays the original broker response
instead of double-placing the order.

- database/idempotency_db.py: (sha256(apikey), client_order_id) ->
  {orderid, tag, status} store with in-flight reservations, release on
  failure, and 24h TTL; own SQLite DB, NullPool per project policy
- place_order_with_auth: reserve before the broker call, replay 200 +
  duplicate:true on placed keys, 409 while in flight, release on any
  failure so corrected retries are not blocked; live path only (sandbox
  accepts but does not record the field)
- orderbook_service: echo recorded client_order_id / tag onto
  broker-proxied order rows, keyed by orderid
- OrderSchema: optional client_order_id and tag (1-128 chars), dropped
  when absent so existing payloads are unchanged; tag keeps its native
  broker-side flow, client_order_id is never forwarded to brokers

Closes the double-placement half of the client_order_id feature request
(Discord). Idempotency is scoped per apikey; the plaintext key is never
stored.


---

Happy to adjust the response shape (`duplicate` flag, 409 semantics) or scope to maintainer preference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an optional `client_order_id` to the placeorder API so retrying a timed-out request with the same id replays the original broker response instead of double-placing the order. Requests without it keep the existing behavior.

- A retry while the original placement is in flight returns 409; a confirmed broker rejection releases the key so a corrected retry can proceed.
- Ambiguous outcomes (exceptions, 5xx, ACK without an order id) block the key; a retry reconciles against the broker order book — one live match with matching parameters (normalized to schema defaults on both sides) replays it, none releases it, and ambiguity or a changed-order retry (different quantity, price, product, or pricetype) keeps it blocked.
- Store failures refuse the placement with 503 instead of placing without duplicate protection; a write failure after a successful broker placement still returns the broker's 200.
- Keys are scoped per apikey (SHA-256 hashed, plaintext never stored), expire after 24 hours, and are created on existing installs by `upgrade/migrate_idempotency_store.py`.
- `client_order_id` is never forwarded to brokers; `tag` is only persisted alongside it and keeps its existing broker-side flow.
- Live path only — sandbox accepts the field but does not record it; orderbook rows echo the recorded `client_order_id` and `tag`.

<sup>Written for commit 0646838ee6696b1866b99415d58b0c57f243374f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1991?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

