### PR TITLE
feat(websocket): guaranteed Quote-mode tick field contract

### DIFF
--- a/docs/websocket-quote-feed.md
+++ b/docs/websocket-quote-feed.md
@@ -100,16 +100,23 @@ OpenAlgo provides a unified WebSocket server (port 8765 by default) that normali
 
 ## Data Formats
 
+Market data messages arrive as a JSON envelope: the broker payload is
+nested under `data`, `mode` is the numeric mode (1 LTP, 2 Quote, 3 Depth),
+and `broker` names the adapter that produced the tick when known.
+
 ### LTP Data
 
 ```json
 {
     "type": "market_data",
-    "mode": "LTP",
+    "mode": 1,
     "symbol": "SBIN",
     "exchange": "NSE",
-    "ltp": 625.50,
-    "timestamp": "2024-01-15T10:30:00+05:30"
+    "broker": "zerodha",
+    "data": {
+        "last_price": 625.50,
+        "timestamp": "2024-01-15T10:30:00+05:30"
+    }
 }
 ```
 
@@ -118,47 +125,81 @@ OpenAlgo provides a unified WebSocket server (port 8765 by default) that normali
 ```json
 {
     "type": "market_data",
-    "mode": "QUOTE",
+    "mode": 2,
     "symbol": "SBIN",
     "exchange": "NSE",
-    "ltp": 625.50,
-    "open": 620.00,
-    "high": 628.00,
-    "low": 618.50,
-    "close": 622.00,
-    "volume": 1500000,
-    "change": 3.50,
-    "change_percent": 0.56,
-    "timestamp": "2024-01-15T10:30:00+05:30"
+    "broker": "zerodha",
+    "data": {
+        "ltp": 625.50,
+        "open": 620.00,
+        "high": 628.00,
+        "low": 618.50,
+        "close": 622.00,
+        "volume": 1500000,
+        "timestamp": "2024-01-15T10:30:00+05:30"
+    }
 }
 ```
+
+### Quote-Mode Field Contract
+
+Adapters forward broker payloads with their own key conventions, and some
+mappers only add OHLC fields when the broker snapshot happens to carry
+them. The server normalizes every Quote-mode (`mode: 2`) tick before
+delivery, so clients can rely on a guaranteed field set:
+
+| Field | Guarantee |
+|-------|-----------|
+| `ltp` | Always present. Falls back to `last_price` when an adapter uses that key; `null` when neither is supplied. |
+| `open`, `high`, `low`, `close` | Always present. `null` when the broker did not supply the value. |
+| `volume` | Always present. `null` for instruments without volume (e.g. indices). |
+| `timestamp` | Always present. `null` when the broker did not stamp the tick. |
+
+Semantics:
+
+- **Absence is `null`, never a fabricated value.** A `0` would render as a
+  doji bar on OHLC charts and corrupt interval aggregation, so missing
+  broker values are always `null`.
+- **Broker-supplied values are passed through verbatim**, including zeros —
+  the server never overwrites adapter data.
+- Higher modes include lower-mode data: a Depth-mode tick (delivered to a
+  Quote subscriber as `mode: 2`) carries the same guaranteed field set,
+  plus `depth` when the adapter provided it.
 
 ### Depth Data
 
 ```json
 {
     "type": "market_data",
-    "mode": "DEPTH",
+    "mode": 3,
     "symbol": "SBIN",
     "exchange": "NSE",
-    "ltp": 625.50,
-    "depth": {
-        "buy": [
-            {"price": 625.45, "quantity": 1000, "orders": 5},
-            {"price": 625.40, "quantity": 2500, "orders": 8},
-            {"price": 625.35, "quantity": 1800, "orders": 6},
-            {"price": 625.30, "quantity": 3200, "orders": 12},
-            {"price": 625.25, "quantity": 2100, "orders": 7}
-        ],
-        "sell": [
-            {"price": 625.50, "quantity": 800, "orders": 3},
-            {"price": 625.55, "quantity": 1200, "orders": 4},
-            {"price": 625.60, "quantity": 1500, "orders": 5},
-            {"price": 625.65, "quantity": 2000, "orders": 6},
-            {"price": 625.70, "quantity": 1700, "orders": 5}
-        ]
-    },
-    "timestamp": "2024-01-15T10:30:00+05:30"
+    "broker": "zerodha",
+    "data": {
+        "ltp": 625.50,
+        "open": 620.00,
+        "high": 628.00,
+        "low": 618.50,
+        "close": 622.00,
+        "volume": 1500000,
+        "depth": {
+            "buy": [
+                {"price": 625.45, "quantity": 1000, "orders": 5},
+                {"price": 625.40, "quantity": 2500, "orders": 8},
+                {"price": 625.35, "quantity": 1800, "orders": 6},
+                {"price": 625.30, "quantity": 3200, "orders": 12},
+                {"price": 625.25, "quantity": 2100, "orders": 7}
+            ],
+            "sell": [
+                {"price": 625.50, "quantity": 800, "orders": 3},
+                {"price": 625.55, "quantity": 1200, "orders": 4},
+                {"price": 625.60, "quantity": 1500, "orders": 5},
+                {"price": 625.65, "quantity": 2000, "orders": 6},
+                {"price": 625.70, "quantity": 1700, "orders": 5}
+            ]
+        },
+        "timestamp": "2024-01-15T10:30:00+05:30"
+    }
 }
 ```
 
@@ -200,7 +241,7 @@ async def connect_quote_feed():
         while True:
             data = await ws.recv()
             tick = json.loads(data)
-            print(f"{tick['symbol']}: {tick['ltp']}")
+            print(f"{tick['symbol']}: {tick['data']['ltp']}")
 
 asyncio.run(connect_quote_feed())
 ```

--- a/test/test_quote_tick_contract.py
+++ b/test/test_quote_tick_contract.py
@@ -1,0 +1,111 @@
+"""Tests for websocket_proxy.tick_contract (Quote-mode field contract).
+
+Adapters forward broker payloads verbatim, and several mappers only add
+OHLC when the broker snapshot carries it. The contract guarantees the
+documented Quote Data fields on every Quote-mode tick, using null (never
+a fabricated 0) for values the broker did not supply. Imports the
+lightweight tick_contract module directly so the tests don't depend on
+broker adapters or the database layer.
+"""
+
+import importlib.util
+import pathlib
+
+import pytest
+
+_MODULE_PATH = (
+    pathlib.Path(__file__).resolve().parent.parent / "websocket_proxy" / "tick_contract.py"
+)
+
+
+def _load_tick_contract():
+    spec = importlib.util.spec_from_file_location("_tick_contract_under_test", _MODULE_PATH)
+    mod = importlib.util.module_from_spec(spec)
+    spec.loader.exec_module(mod)
+    return mod
+
+
+_mod = _load_tick_contract()
+normalize_quote_tick = _mod.normalize_quote_tick
+QUOTE_MODE = _mod.QUOTE_MODE
+QUOTE_REQUIRED_FIELDS = _mod.QUOTE_REQUIRED_FIELDS
+
+
+class TestQuoteModeContract:
+    def test_missing_ohlc_becomes_null_not_zero(self):
+        # Zerodha-style mapper that omits OHLC when the snapshot lacks it.
+        tick = {"symbol": "SBIN", "exchange": "NSE", "ltp": 625.5, "volume": 100}
+        normalized = normalize_quote_tick(tick)
+        for field in ("open", "high", "low", "close"):
+            assert normalized[field] is None  # null, never a fabricated 0
+
+    def test_all_required_fields_present_after_normalisation(self):
+        tick = {"ltp": 100.0}
+        normalized = normalize_quote_tick(tick)
+        for field in QUOTE_REQUIRED_FIELDS:
+            assert field in normalized
+
+    def test_broker_supplied_values_preserved(self):
+        tick = {
+            "ltp": 625.5,
+            "open": 620.0,
+            "high": 628.0,
+            "low": 618.5,
+            "close": 622.0,
+            "volume": 1500000,
+            "timestamp": "2024-01-15T10:30:00+05:30",
+        }
+        before = dict(tick)
+        assert normalize_quote_tick(tick) == before
+
+    def test_zero_values_are_never_overwritten(self):
+        # A broker-supplied 0 is real data as far as this module is
+        # concerned — normalisation fills absences, it never edits values.
+        tick = {"ltp": 625.5, "open": 0, "volume": 0}
+        normalized = normalize_quote_tick(tick)
+        assert normalized["open"] == 0
+        assert normalized["volume"] == 0
+
+    def test_ltp_aliased_from_last_price(self):
+        tick = {"last_price": 625.5}
+        normalized = normalize_quote_tick(tick)
+        assert normalized["ltp"] == 625.5
+        # The adapter's own key is untouched.
+        assert normalized["last_price"] == 625.5
+
+    def test_missing_volume_and_timestamp_become_null(self):
+        tick = {"ltp": 625.5}
+        normalized = normalize_quote_tick(tick)
+        assert normalized["volume"] is None  # indices carry no volume
+        assert normalized["timestamp"] is None
+
+    def test_idempotent(self):
+        tick = {"last_price": 42.0, "open": 41.0}
+        once = normalize_quote_tick(dict(tick))
+        twice = normalize_quote_tick(dict(once))
+        assert once == twice
+
+    def test_non_dict_payload_passes_through(self):
+        for payload in (None, 42, "oops", [1, 2]):
+            assert normalize_quote_tick(payload) is payload
+
+    def test_empty_dict_gets_full_contract(self):
+        normalized = normalize_quote_tick({})
+        for field in QUOTE_REQUIRED_FIELDS:
+            assert field in normalized
+            assert normalized[field] is None
+
+    def test_quote_mode_constant_matches_mode_utils(self):
+        # Guard against the mirror drifting from websocket_proxy.mode_utils.
+        spec = importlib.util.spec_from_file_location(
+            "_mode_utils_guard",
+            pathlib.Path(__file__).resolve().parent.parent / "websocket_proxy" / "mode_utils.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+        assert QUOTE_MODE == mod.MODE_BY_UPPER_LABEL["QUOTE"]
+
+    def test_mutates_in_place_and_returns_same_object(self):
+        tick = {"ltp": 1.0}
+        result = normalize_quote_tick(tick)
+        assert result is tick

--- a/test/test_quote_tick_contract.py
+++ b/test/test_quote_tick_contract.py
@@ -27,7 +27,7 @@ def _load_tick_contract():
 
 _mod = _load_tick_contract()
 normalize_quote_tick = _mod.normalize_quote_tick
-QUOTE_MODE = _mod.QUOTE_MODE
+MODE_QUOTE = _mod.MODE_QUOTE
 QUOTE_REQUIRED_FIELDS = _mod.QUOTE_REQUIRED_FIELDS
 
 
@@ -103,7 +103,7 @@ class TestQuoteModeContract:
         )
         mod = importlib.util.module_from_spec(spec)
         spec.loader.exec_module(mod)
-        assert QUOTE_MODE == mod.MODE_BY_UPPER_LABEL["QUOTE"]
+        assert MODE_QUOTE == mod.MODE_BY_UPPER_LABEL["QUOTE"]
 
     def test_mutates_in_place_and_returns_same_object(self):
         tick = {"ltp": 1.0}

--- a/test/test_websocket_quote_contract_delivery.py
+++ b/test/test_websocket_quote_contract_delivery.py
@@ -1,0 +1,131 @@
+"""Integration contract: Depth topics delivered to Quote subscribers.
+
+The proxy deliberately downgrades higher-mode ticks to lower-mode
+subscribers (a Depth tick reaches a Quote subscriber relabeled as mode 2),
+so the guaranteed Quote field contract must hold on that delivery path too —
+not only on native QUOTE topics. These tests exercise the production
+_handle_market_data path without opening a port, socket, thread or ZMQ
+context (same approach as test_websocket_unsubscribe_contract.py).
+"""
+
+import asyncio
+import json
+from collections import defaultdict
+from typing import Any
+
+import pytest
+
+from websocket_proxy import server as proxy_server
+from websocket_proxy.server import WebSocketProxy
+from websocket_proxy.tick_contract import QUOTE_REQUIRED_FIELDS
+
+
+class _StubMDS:
+    """Stands in for MarketDataService so no app/database machinery starts."""
+
+    def __init__(self) -> None:
+        self.seen: list[dict[str, Any]] = []
+
+    def process_market_data(self, payload: dict[str, Any]) -> None:
+        self.seen.append(payload)
+
+
+def _make_proxy(subscribed_mode: int) -> tuple[WebSocketProxy, list[dict[str, Any]]]:
+    proxy = WebSocketProxy.__new__(WebSocketProxy)
+    proxy.clients = {101: object()}
+    proxy.user_mapping = {101: "user1"}
+    proxy.user_broker_mapping = {"user1": "zerodha"}
+    proxy.subscription_index = defaultdict(set)
+    proxy.subscription_index[("SBIN", "NSE", subscribed_mode)] = {101}
+    proxy.last_message_time = {}
+    proxy.last_tick_time = {}
+    proxy._messages_processed = 0
+    sent: list[dict[str, Any]] = []
+
+    async def fake_send(client_id, message):
+        sent.append(message)
+
+    proxy.send_message = fake_send
+    return proxy, sent
+
+
+def _deliver(proxy, topic: str, payload: dict, monkeypatch) -> _StubMDS:
+    stub = _StubMDS()
+    monkeypatch.setattr(proxy_server, "get_market_data_service", lambda: stub)
+    asyncio.run(proxy._handle_market_data(topic, json.dumps(payload)))
+    return stub
+
+
+class TestDepthDeliveredToQuoteSubscriber:
+    def test_depth_tick_reaches_quote_subscriber_with_contract_fields(self, monkeypatch):
+        # Zerodha-style depth payload: ltp present, OHLC/volume/timestamp absent.
+        depth_tick = {
+            "symbol": "SBIN",
+            "exchange": "NSE",
+            "ltp": 625.5,
+            "last_qty": 50,
+            "bid_price": 625.4,
+            "ask_price": 625.6,
+            "depth": {"buy": [{"price": 625.4, "quantity": 100}], "sell": []},
+        }
+        proxy, sent = _make_proxy(subscribed_mode=2)
+
+        _deliver(proxy, "NSE_SBIN_DEPTH", depth_tick, monkeypatch)
+
+        assert len(sent) == 1
+        message = sent[0]
+        # Relabeled to the subscriber's mode: clients see a mode 2 message.
+        assert message["mode"] == 2
+        assert message["symbol"] == "SBIN"
+        assert message["exchange"] == "NSE"
+        data = message["data"]
+        for field in QUOTE_REQUIRED_FIELDS:
+            assert field in data, f"contract field {field} missing on depth->quote path"
+        # Absent fields are null, never a fabricated 0.
+        for field in ("open", "high", "low", "close", "volume", "timestamp"):
+            assert data[field] is None
+        # Broker-supplied values are preserved verbatim, depth fields intact.
+        assert data["ltp"] == 625.5
+        assert data["depth"] == depth_tick["depth"]
+
+    def test_market_data_service_receives_normalized_depth_tick(self, monkeypatch):
+        depth_tick = {"symbol": "SBIN", "exchange": "NSE", "ltp": 625.5}
+        proxy, _ = _make_proxy(subscribed_mode=2)
+
+        stub = _deliver(proxy, "NSE_SBIN_DEPTH", depth_tick, monkeypatch)
+
+        # Backend consumers sit behind the same normalizer, so they observe
+        # the contract too — with the original topic mode preserved.
+        assert len(stub.seen) == 1
+        assert stub.seen[0]["mode"] == 3
+        assert stub.seen[0]["data"]["open"] is None
+        assert stub.seen[0]["data"]["ltp"] == 625.5
+
+
+class TestNativeQuoteTopicUnchanged:
+    def test_quote_tick_still_normalized_for_quote_subscriber(self, monkeypatch):
+        quote_tick = {"symbol": "SBIN", "exchange": "NSE", "ltp": 625.5, "volume": 100}
+        proxy, sent = _make_proxy(subscribed_mode=2)
+
+        _deliver(proxy, "NSE_SBIN_QUOTE", quote_tick, monkeypatch)
+
+        assert len(sent) == 1
+        assert sent[0]["mode"] == 2
+        data = sent[0]["data"]
+        for field in ("open", "high", "low", "close", "timestamp"):
+            assert data[field] is None
+        assert data["volume"] == 100  # supplied zeros/values never overwritten
+
+
+class TestLtpTopicUnaffected:
+    def test_ltp_tick_forwarded_without_quote_fields(self, monkeypatch):
+        ltp_tick = {"symbol": "SBIN", "exchange": "NSE", "ltp": 625.5}
+        proxy, sent = _make_proxy(subscribed_mode=1)
+
+        _deliver(proxy, "NSE_SBIN_LTP", ltp_tick, monkeypatch)
+
+        assert len(sent) == 1
+        assert sent[0]["mode"] == 1
+        # The contract is a Quote-mode guarantee; LTP delivery stays lean.
+        assert "open" not in sent[0]["data"]
+        assert sent[0]["data"]["ltp"] == 625.5

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -27,6 +27,7 @@ from .mode_utils import (
     normalize_mode_or_none,
 )
 from .port_check import find_available_port, is_port_in_use
+from .tick_contract import MODE_QUOTE, normalize_quote_tick
 
 # Initialize logger
 logger = get_logger("websocket_proxy")
@@ -2072,6 +2073,14 @@ class WebSocketProxy:
                     logger.warning(f"Invalid mode in topic: {mode_str}")
                     continue
                 mode, _ = normalized
+
+                # Quote-mode field contract: adapters forward broker payloads
+                # verbatim, and several mappers only add OHLC when the broker
+                # snapshot carries it. Guarantee the documented Quote fields
+                # with null (never 0) so clients can chart without per-broker
+                # key checks. See websocket_proxy/tick_contract.py.
+                if mode == MODE_QUOTE:
+                    normalize_quote_tick(market_data)
 
                 # No server-side LTP throttling: the previous time-based
                 # throttle dropped intra-window ticks instead of coalescing

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -1956,6 +1956,160 @@ class WebSocketProxy:
         except Exception as e:
             logger.exception(f"Error clearing auth cache for user {user_id}: {e}")
 
+    async def _handle_market_data(self, topic_str: str, data_str: str) -> None:
+        """Parse, normalize and fan out one EXCHANGE_SYMBOL_MODE market-data topic.
+
+        Extracted verbatim from zmq_listener so the mode routing — including
+        the higher-mode-to-lower-mode downgrade delivery — is testable without
+        opening a socket or ZMQ context.
+        """
+        market_data = json.loads(data_str)
+
+        # Extract topic components from ZMQ topic string.
+        # All adapters publish: EXCHANGE_SYMBOL_MODE
+        # Mode (LTP/QUOTE/DEPTH) is always the LAST segment.
+        # Exchange is the first segment (NSE, BSE, NFO, MCX, CRYPTO, …)
+        #   except NSE_INDEX / BSE_INDEX which span two segments.
+        # Symbol is everything between exchange and mode — may contain
+        # underscores for crypto spot pairs (e.g. CRYPTO_SOL_INR_LTP).
+        parts = topic_str.split("_")
+
+        if len(parts) < 3:
+            logger.warning(f"Invalid topic format: {topic_str}")
+            return
+
+        broker_name = "unknown"
+
+        # Mode is always the last segment
+        mode_str = parts[-1]
+        remaining = parts[:-1]  # everything except mode
+
+        # Detect two-segment exchange prefixes (NSE_INDEX, BSE_INDEX,
+        # MCX_INDEX, GLOBAL_INDEX, NSEIX_INDEX). Add new index/multi-segment
+        # exchanges here when introducing them.
+        _MULTI_SEGMENT_EXCHANGE_PREFIXES = (
+            ("NSE", "INDEX"),
+            ("BSE", "INDEX"),
+            ("MCX", "INDEX"),
+            ("GLOBAL", "INDEX"),
+        )
+        if len(remaining) >= 2 and (remaining[0], remaining[1]) in _MULTI_SEGMENT_EXCHANGE_PREFIXES:
+            exchange = f"{remaining[0]}_{remaining[1]}"
+            symbol = "_".join(remaining[2:])
+        else:
+            exchange = remaining[0]
+            symbol = "_".join(remaining[1:])
+
+        if not symbol:
+            logger.warning(f"Invalid topic format (no symbol): {topic_str}")
+            return
+
+        # Route through the single normalizer so topic parsing stays
+        # consistent with client-side mode handling.
+        normalized = normalize_mode_or_none(mode_str)
+        if normalized is None:
+            logger.warning(f"Invalid mode in topic: {mode_str}")
+            return
+        mode, _ = normalized
+
+        # Quote-mode field contract: adapters forward broker payloads
+        # verbatim, and several mappers only add OHLC when the broker
+        # snapshot carries it. Guarantee the documented Quote fields
+        # with null (never 0) so clients can chart without per-broker
+        # key checks. The fan-out below delivers every higher mode to
+        # lower-mode subscribers (a Depth tick reaches Quote subscribers
+        # relabeled as mode 2), so the contract must hold for every mode
+        # >= QUOTE, not just QUOTE topics. See websocket_proxy/tick_contract.py.
+        if mode >= MODE_QUOTE:
+            normalize_quote_tick(market_data)
+
+        # No server-side LTP throttling: the previous time-based
+        # throttle dropped intra-window ticks instead of coalescing
+        # them, so clients could miss the latest price during bursts
+        # (e.g. NIFTY expiry, circuit triggers). With the O(1)
+        # subscription_index, fan-out is cheap enough to forward every
+        # tick. If CPU pressure ever returns, replace this with a
+        # trailing-edge coalescer that emits the latest pending tick.
+        sub_key = (symbol, exchange, mode)
+        current_time = time.time()
+        self.last_message_time[sub_key] = current_time
+
+        # Feed market data to MarketDataService for backend consumers
+        # (sandbox execution engine, position MTM, RMS, etc.)
+        # This runs regardless of whether WebSocket clients are subscribed
+        try:
+            mds_data = {
+                "symbol": symbol,
+                "exchange": exchange,
+                "mode": mode,
+                "data": market_data,
+            }
+            market_data_service = get_market_data_service()
+            market_data_service.process_market_data(mds_data)
+        except Exception as mds_error:
+            # Don't block WebSocket delivery if MarketDataService has issues
+            logger.debug(f"MarketDataService processing error: {mds_error}")
+
+        # OPTIMIZATION 2: O(1) lookup using subscription index
+        # Higher modes include all lower-mode data (Depth > Quote > LTP),
+        # so also deliver to subscribers at lower modes.
+        # Maps client_id -> the mode they subscribed to (for correct message tagging)
+        all_client_modes = {}
+        for m in range(1, mode + 1):
+            for cid in self.subscription_index.get((symbol, exchange, m), set()):
+                all_client_modes[cid] = m
+
+        if not all_client_modes:
+            return  # No WebSocket clients subscribed, skip delivery
+
+        # OPTIMIZATION 3: Batch message sends for parallel delivery
+        send_tasks = []
+
+        # OPTIMIZATION 4: Pre-create base message (reused for all clients)
+        # This avoids creating the same dict 1000 times
+        base_message = {
+            "type": "market_data",
+            "symbol": symbol,
+            "exchange": exchange,
+            "mode": mode,
+            "data": market_data,
+        }
+
+        for client_id, client_mode in all_client_modes.items():
+            # Verify client still exists
+            if client_id not in self.clients:
+                continue
+
+            # Verify user mapping exists
+            user_id = self.user_mapping.get(client_id)
+            if not user_id:
+                continue
+
+            # OBSERVABILITY: record that this user's feed is live (a tick
+            # was delivered). Cheap dict write; lets _log_stale_adapters()
+            # detect connected-but-silent adapters.
+            self.last_tick_time[user_id] = current_time
+
+            # Check broker match (important for multi-broker setups)
+            client_broker = self.user_broker_mapping.get(user_id)
+            if broker_name != "unknown" and client_broker and client_broker != broker_name:
+                continue
+
+            # Tag message with client's subscribed mode so frontend renders correctly
+            message = base_message.copy()
+            message["mode"] = client_mode
+            message["broker"] = broker_name if broker_name != "unknown" else client_broker
+
+            # Add to batch
+            send_tasks.append(self.send_message(client_id, message))
+
+        # Send all messages in parallel (non-blocking)
+        if send_tasks:
+            await aio.gather(*send_tasks, return_exceptions=True)
+
+        # METRICS: Track message count for health monitoring
+        self._messages_processed += 1
+
     async def zmq_listener(self):
         """
         OPTIMIZED: Listen for messages from broker adapters via ZeroMQ and forward to clients
@@ -2025,149 +2179,8 @@ class WebSocketProxy:
                     logger.debug(f"Skipping private event topic: {topic_str}")
                     continue
 
-                market_data = json.loads(data_str)
-
-                # Extract topic components from ZMQ topic string.
-                # All adapters publish: EXCHANGE_SYMBOL_MODE
-                # Mode (LTP/QUOTE/DEPTH) is always the LAST segment.
-                # Exchange is the first segment (NSE, BSE, NFO, MCX, CRYPTO, …)
-                #   except NSE_INDEX / BSE_INDEX which span two segments.
-                # Symbol is everything between exchange and mode — may contain
-                # underscores for crypto spot pairs (e.g. CRYPTO_SOL_INR_LTP).
-                parts = topic_str.split("_")
-
-                if len(parts) < 3:
-                    logger.warning(f"Invalid topic format: {topic_str}")
-                    continue
-
-                broker_name = "unknown"
-
-                # Mode is always the last segment
-                mode_str = parts[-1]
-                remaining = parts[:-1]  # everything except mode
-
-                # Detect two-segment exchange prefixes (NSE_INDEX, BSE_INDEX,
-                # MCX_INDEX, GLOBAL_INDEX, NSEIX_INDEX). Add new index/multi-segment
-                # exchanges here when introducing them.
-                _MULTI_SEGMENT_EXCHANGE_PREFIXES = (
-                    ("NSE", "INDEX"),
-                    ("BSE", "INDEX"),
-                    ("MCX", "INDEX"),
-                    ("GLOBAL", "INDEX"),
-                )
-                if len(remaining) >= 2 and (remaining[0], remaining[1]) in _MULTI_SEGMENT_EXCHANGE_PREFIXES:
-                    exchange = f"{remaining[0]}_{remaining[1]}"
-                    symbol = "_".join(remaining[2:])
-                else:
-                    exchange = remaining[0]
-                    symbol = "_".join(remaining[1:])
-
-                if not symbol:
-                    logger.warning(f"Invalid topic format (no symbol): {topic_str}")
-                    continue
-
-                # Route through the single normalizer so topic parsing stays
-                # consistent with client-side mode handling.
-                normalized = normalize_mode_or_none(mode_str)
-                if normalized is None:
-                    logger.warning(f"Invalid mode in topic: {mode_str}")
-                    continue
-                mode, _ = normalized
-
-                # Quote-mode field contract: adapters forward broker payloads
-                # verbatim, and several mappers only add OHLC when the broker
-                # snapshot carries it. Guarantee the documented Quote fields
-                # with null (never 0) so clients can chart without per-broker
-                # key checks. See websocket_proxy/tick_contract.py.
-                if mode == MODE_QUOTE:
-                    normalize_quote_tick(market_data)
-
-                # No server-side LTP throttling: the previous time-based
-                # throttle dropped intra-window ticks instead of coalescing
-                # them, so clients could miss the latest price during bursts
-                # (e.g. NIFTY expiry, circuit triggers). With the O(1)
-                # subscription_index, fan-out is cheap enough to forward every
-                # tick. If CPU pressure ever returns, replace this with a
-                # trailing-edge coalescer that emits the latest pending tick.
-                sub_key = (symbol, exchange, mode)
-                current_time = time.time()
-                self.last_message_time[sub_key] = current_time
-
-                # Feed market data to MarketDataService for backend consumers
-                # (sandbox execution engine, position MTM, RMS, etc.)
-                # This runs regardless of whether WebSocket clients are subscribed
-                try:
-                    mds_data = {
-                        "symbol": symbol,
-                        "exchange": exchange,
-                        "mode": mode,
-                        "data": market_data,
-                    }
-                    market_data_service = get_market_data_service()
-                    market_data_service.process_market_data(mds_data)
-                except Exception as mds_error:
-                    # Don't block WebSocket delivery if MarketDataService has issues
-                    logger.debug(f"MarketDataService processing error: {mds_error}")
-
-                # OPTIMIZATION 2: O(1) lookup using subscription index
-                # Higher modes include all lower-mode data (Depth > Quote > LTP),
-                # so also deliver to subscribers at lower modes.
-                # Maps client_id -> the mode they subscribed to (for correct message tagging)
-                all_client_modes = {}
-                for m in range(1, mode + 1):
-                    for cid in self.subscription_index.get((symbol, exchange, m), set()):
-                        all_client_modes[cid] = m
-
-                if not all_client_modes:
-                    continue  # No WebSocket clients subscribed, skip delivery
-
-                # OPTIMIZATION 3: Batch message sends for parallel delivery
-                send_tasks = []
-
-                # OPTIMIZATION 4: Pre-create base message (reused for all clients)
-                # This avoids creating the same dict 1000 times
-                base_message = {
-                    "type": "market_data",
-                    "symbol": symbol,
-                    "exchange": exchange,
-                    "mode": mode,
-                    "data": market_data,
-                }
-
-                for client_id, client_mode in all_client_modes.items():
-                    # Verify client still exists
-                    if client_id not in self.clients:
-                        continue
-
-                    # Verify user mapping exists
-                    user_id = self.user_mapping.get(client_id)
-                    if not user_id:
-                        continue
-
-                    # OBSERVABILITY: record that this user's feed is live (a tick
-                    # was delivered). Cheap dict write; lets _log_stale_adapters()
-                    # detect connected-but-silent adapters.
-                    self.last_tick_time[user_id] = current_time
-
-                    # Check broker match (important for multi-broker setups)
-                    client_broker = self.user_broker_mapping.get(user_id)
-                    if broker_name != "unknown" and client_broker and client_broker != broker_name:
-                        continue
-
-                    # Tag message with client's subscribed mode so frontend renders correctly
-                    message = base_message.copy()
-                    message["mode"] = client_mode
-                    message["broker"] = broker_name if broker_name != "unknown" else client_broker
-
-                    # Add to batch
-                    send_tasks.append(self.send_message(client_id, message))
-
-                # Send all messages in parallel (non-blocking)
-                if send_tasks:
-                    await aio.gather(*send_tasks, return_exceptions=True)
-
-                # METRICS: Track message count for health monitoring
-                self._messages_processed += 1
+                # Market-data topic: parse, normalize and fan out.
+                await self._handle_market_data(topic_str, data_str)
 
             except Exception as e:
                 logger.exception(f"Error in ZeroMQ listener: {e}")

--- a/websocket_proxy/tick_contract.py
+++ b/websocket_proxy/tick_contract.py
@@ -1,0 +1,65 @@
+# websocket_proxy/tick_contract.py
+"""
+Quote-mode tick field contract.
+
+Broker adapters publish their mapped payloads verbatim over ZeroMQ, and
+several mappers only add OHLC fields when the broker snapshot happens to
+carry them (see e.g. broker/zerodha/streaming/zerodha_mapping.py, which
+updates open/high/low/close only "if available"). Clients that chart from
+Quote-mode ticks therefore cannot tell "field absent" from "field coming
+later", and every broker behaves differently.
+
+This module guarantees the documented Quote Data field set:
+
+* Every Quote-mode tick contains ltp, open, high, low, close, volume and
+  timestamp keys after normalisation.
+* A field the broker did not supply is set to ``None`` — never to 0. A
+  fabricated 0 is worse than a visible null: OHLC zeros render as doji
+  bars on client charts and corrupt interval aggregation, while null is
+  unambiguous "not provided".
+* Fields the broker did supply — including zeros — are preserved
+  verbatim. This module never overwrites adapter values.
+
+The normaliser is deliberately stdlib-only so it can be unit-tested
+standalone (see test/test_quote_tick_contract.py) and is safe on the hot
+path: it mutates the freshly-parsed tick dict in place and does no work
+when the contract is already satisfied.
+"""
+
+# Numeric Quote mode, mirroring websocket_proxy.mode_utils (kept as a
+# literal here so this module stays dependency-free).
+QUOTE_MODE = 2
+
+# Fields a Quote-mode tick guarantees after normalisation.
+QUOTE_REQUIRED_FIELDS = ("ltp", "open", "high", "low", "close", "volume", "timestamp")
+
+# Adapters disagree on the last-traded-price key name.
+_LTP_ALIASES = ("ltp", "last_price")
+
+
+def normalize_quote_tick(tick):
+    """Enforce the Quote-mode field contract on a parsed tick.
+
+    Args:
+        tick: The market-data payload forwarded by the adapter (expected
+            to be a dict from json.loads; other types pass through).
+
+    Returns:
+        The same tick dict, with any missing contract fields added as
+        None. Existing values are never modified.
+
+    Idempotent: a tick that already satisfies the contract is returned
+    unchanged, making repeat normalisation a no-op.
+    """
+    if not isinstance(tick, dict):
+        return tick
+
+    for field in QUOTE_REQUIRED_FIELDS:
+        if field in tick:
+            continue
+        if field == "ltp":
+            aliased = next((tick[name] for name in _LTP_ALIASES if name in tick), None)
+            tick["ltp"] = aliased
+        else:
+            tick[field] = None
+    return tick

--- a/websocket_proxy/tick_contract.py
+++ b/websocket_proxy/tick_contract.py
@@ -26,9 +26,11 @@ path: it mutates the freshly-parsed tick dict in place and does no work
 when the contract is already satisfied.
 """
 
-# Numeric Quote mode, mirroring websocket_proxy.mode_utils (kept as a
-# literal here so this module stays dependency-free).
-QUOTE_MODE = 2
+# Numeric Quote mode. The value mirrors websocket_proxy.mode_utils
+# (QUOTE = 2); the MODE_* name follows the constant convention used across
+# the broker adapters, which server.py shares. Kept as a literal here so
+# this module stays dependency-free.
+MODE_QUOTE = 2
 
 # Fields a Quote-mode tick guarantees after normalisation.
 QUOTE_REQUIRED_FIELDS = ("ltp", "open", "high", "low", "close", "volume", "timestamp")


### PR DESCRIPTION
feat(websocket): guaranteed Quote-mode tick field contract

Adapters forward broker payloads verbatim, and several mappers only add
OHLC when the broker snapshot carries it (zerodha_mapping.py updates
open/high/low/close only 'if available'). Quote-mode clients could not
tell 'field absent' from 'field coming later', and every broker behaved
differently.

- websocket_proxy/tick_contract.py: stdlib-only normalizer guaranteeing
  ltp, open, high, low, close, volume, timestamp on every Quote-mode
  (mode 2) tick. Missing broker values become explicit null - never a
  fabricated 0, which would render as doji bars on OHLC charts.
  Broker-supplied values (including zeros) are passed through verbatim.
  No-op when the contract is already satisfied; idempotent.
- server.py zmq_listener: normalize Quote-mode ticks once before the
  MarketDataService feed and client fan-out.
- docs/websocket-quote-feed.md: correct the data-format examples to the
  actual wire envelope (payload nested under 'data', numeric mode,
  broker tag) and document the guaranteed field set and null semantics.
- test/test_quote_tick_contract.py: standalone unit tests mirroring the
  test_mode_normalization.py pattern, including a guard that ties the
  module's QUOTE_MODE constant to mode_utils.


---

Problem in one line: some adapters ship OHLC in Quote ticks, others are LTP-only; with no documented guarantee, clients must probe per broker or synthesize doji bars. Happy to adjust scope to maintainer preference.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Guarantees every Quote-mode tick carries `ltp`, `open`, `high`, `low`, `close`, `volume`, and `timestamp`, including Depth ticks delivered to Quote subscribers on the mode-downgrade path. Missing broker values become explicit `null` (never a fabricated 0 that renders as doji bars), and broker-supplied values — including zeros — pass through untouched.

- Adds a stdlib-only normalizer (`tick_contract.py`) applied before fan-out; it runs on every mode ≥ Quote and is idempotent, so LTP stays lean and Depth→Quote deliveries carry the contract fields.
- Extracts the per-tick parse/normalize/fan-out from `zmq_listener` into `_handle_market_data` so the delivery path is testable without a live socket.
- Renames the module constant to `MODE_QUOTE`, fixing an ImportError when importing `websocket_proxy.server`.
- Corrects the WebSocket docs' data-format examples to the actual wire envelope (`data`-nested payload, numeric mode, `broker` tag) and documents the field guarantee and null semantics.
- Adds standalone unit tests and delivery-path integration tests, including a guard tying the module's constant to `mode_utils`.

<sup>Written for commit e29f92ff9e23aeceabf3e788e00f7b7c6aac1411. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1992?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

