### PR TITLE
fix(groww): report tradebook prices in the rupees Groww sent

### DIFF
--- a/broker/groww/api/order_api.py
+++ b/broker/groww/api/order_api.py
@@ -386,6 +386,53 @@ def get_order_book(auth):
     return direct_get_order_book(auth)
 
 
+def transform_groww_trade(trade):
+    """
+    Transform one normalised Groww trade into the shape map_trade_data and
+    transform_tradebook_data expect.
+
+    Groww reports the trade `price` in rupees, so it is carried through as-is.
+    An earlier value-based "paise to rupees" conversion divided any price above
+    100 by 100, which turned a genuine Rs 433.00 fill into Rs 4.33 and left the
+    scale discontinuous at Rs 100. Synthetic trades built from the order book
+    take their price from the same rupee-denominated source, so they were
+    corrupted the same way.
+
+    Args:
+        trade (dict): Trade as returned by get_order_trades(), or a synthetic
+            trade assembled from an executed order.
+
+    Returns:
+        dict: Trade in OpenAlgo's tradebook format.
+    """
+    price = trade.get("price", 0)
+
+    return {
+        # Fields expected by OpenAlgo's UI
+        "tradingSymbol": trade.get("symbol", ""),  # Capitalized for exact matching
+        "exchangeSegment": trade.get("exchange", ""),
+        "productType": trade.get("product", ""),
+        "transactionType": trade.get("transaction_type", ""),
+        "tradedQuantity": trade.get("quantity", 0),
+        "tradedPrice": price,
+        "orderId": trade.get("order_id", ""),
+        "updateTime": trade.get("trade_date_time", ""),
+        "tradeId": trade.get("trade_id", ""),
+        # Include additional fields that might be needed
+        "trade_id": trade.get("trade_id", ""),
+        "order_id": trade.get("order_id", ""),
+        "exchange": trade.get("exchange", ""),
+        "segment": trade.get("segment", ""),
+        "symbol": trade.get("symbol", ""),
+        "quantity": trade.get("quantity", 0),
+        "price": price,
+        "transaction_type": trade.get("transaction_type", ""),
+        "trade_date_time": trade.get("trade_date_time", ""),
+        "created_at": trade.get("created_at", ""),
+        "status": trade.get("trade_status", "EXECUTED"),
+    }
+
+
 def get_trade_book(auth):
     """
     Get list of all trades for the user using direct API calls
@@ -744,39 +791,7 @@ def get_trade_book(auth):
 
         # Format trades to match OpenAlgo's expected format (as used in the REST API)
         # This matches the format expected by the order_data.py mapping functions
-        openalgo_trades = []
-        for trade in all_trades:
-            # Convert price from paise to rupees if needed (Groww returns prices in paise)
-            price = trade.get("price", 0)
-            if price > 100:
-                price = price / 100
-
-            # Transform to the exact format expected by map_trade_data and transform_tradebook_data
-            openalgo_trade = {
-                # Fields expected by OpenAlgo's UI
-                "tradingSymbol": trade.get("symbol", ""),  # Capitalized for exact matching
-                "exchangeSegment": trade.get("exchange", ""),
-                "productType": trade.get("product", ""),
-                "transactionType": trade.get("transaction_type", ""),
-                "tradedQuantity": trade.get("quantity", 0),
-                "tradedPrice": price,
-                "orderId": trade.get("order_id", ""),
-                "updateTime": trade.get("trade_date_time", ""),
-                "tradeId": trade.get("trade_id", ""),
-                # Include additional fields that might be needed
-                "trade_id": trade.get("trade_id", ""),
-                "order_id": trade.get("order_id", ""),
-                "exchange": trade.get("exchange", ""),
-                "segment": trade.get("segment", ""),
-                "symbol": trade.get("symbol", ""),
-                "quantity": trade.get("quantity", 0),
-                "price": price,
-                "transaction_type": trade.get("transaction_type", ""),
-                "trade_date_time": trade.get("trade_date_time", ""),
-                "created_at": trade.get("created_at", ""),
-                "status": trade.get("trade_status", "EXECUTED"),
-            }
-            openalgo_trades.append(openalgo_trade)
+        openalgo_trades = [transform_groww_trade(trade) for trade in all_trades]
 
         # Log the first transformed trade for debugging
         if openalgo_trades:

--- a/test/test_groww_tradebook_price.py
+++ b/test/test_groww_tradebook_price.py
@@ -1,0 +1,70 @@
+"""Regression coverage for Groww tradebook prices.
+
+Groww's trade API reports `price` in rupees. broker/groww/api/order_api.py used
+to run every trade through a value-based "paise to rupees" conversion that
+divided any price above 100 by 100, so a genuine Rs 433.00 fill was reported as
+Rs 4.33 while Rs 99.00 came through untouched. A downstream strategy sized its
+successor order off the mangled price and Groww rejected it on circuit limits.
+
+The scale is now carried through unchanged, and these tests pin that at both the
+broker transform and the tradebook payload the API returns.
+"""
+
+import pytest
+
+from broker.groww.api.order_api import transform_groww_trade
+from broker.groww.mapping.order_data import transform_tradebook_data
+
+# Rupee prices straddling the old threshold: below it, exactly on it, a real
+# equity fill, and a value large enough that the old rule shifted it by two
+# orders of magnitude.
+RUPEE_PRICES = [99.0, 100.0, 433.0, 2500.0]
+
+
+def groww_trade(price):
+    """A trade in the shape get_order_trades() normalises Groww's payload to."""
+    return {
+        "trade_id": "GT250901000001",
+        "order_id": "GMK250901000001",
+        "exchange_trade_id": "",
+        "exchange_order_id": "",
+        "symbol": "RELIANCE",
+        "quantity": 10,
+        "price": price,
+        "trade_status": "EXECUTED",
+        "exchange": "NSE",
+        "segment": "CASH",
+        "product": "CNC",
+        "transaction_type": "BUY",
+        "created_at": "2026-09-01T10:15:00",
+        "trade_date_time": "2026-09-01T10:15:00",
+        "settlement_number": "",
+        "remarks": None,
+    }
+
+
+@pytest.mark.parametrize("price", RUPEE_PRICES)
+def test_transform_preserves_rupee_price(price):
+    """Groww's rupee price survives the broker-side transform unscaled."""
+    transformed = transform_groww_trade(groww_trade(price))
+
+    assert transformed["price"] == price
+    assert transformed["tradedPrice"] == price
+
+
+@pytest.mark.parametrize("price", RUPEE_PRICES)
+def test_tradebook_reports_rupee_price(price):
+    """The tradebook payload reports the same rupees, and values off them."""
+    (trade,) = transform_tradebook_data([transform_groww_trade(groww_trade(price))])
+
+    assert trade["average_price"] == price
+    assert trade["trade_price"] == price
+    assert trade["trade_value"] == 10 * price
+
+
+def test_missing_price_defaults_to_zero():
+    """A trade with no price still transforms, rather than raising."""
+    trade = groww_trade(0)
+    del trade["price"]
+
+    assert transform_groww_trade(trade)["price"] == 0


### PR DESCRIPTION
## What this PR does

Closes #1958.

Groww's trade API reports `price` in rupees. `get_trade_book()` in `broker/groww/api/order_api.py` ran every trade through a value-based "paise to rupees" conversion:

```python
price = trade.get("price", 0)
if price > 100:
    price = price / 100
```

So a genuine ₹433.00 fill was reported as ₹4.33 and ₹2,500.00 as ₹25.00, while ₹99.00 came through untouched — the scale was discontinuous right at ₹100. As reported in the issue, a downstream strategy sized its successor BUY off ₹4.25 and Groww rejected it on circuit controls.

## Why the conversion is wrong, not compensating for something

- `get_order_trades()` copies `price` straight off Groww's `trade_list[]`, which [Groww documents](https://groww.in/trade-api/docs/curl/orders) as the rupee price the trade executed at.
- The synthetic-trade fallbacks (used when the trades endpoint 404s on FNO orders) take their price from the order book, which this broker already treats as rupees everywhere else — order book `price` and holdings `average_price` are both passed through unscaled. Those synthetic trades were being corrupted the same way.
- Downstream `map_trade_data` / `transform_tradebook_data` apply no further scaling, so this divide was the only thing touching the value.

## The change

Carry Groww's rupee value through unchanged, and lift the per-trade transform out of `get_trade_book()` into a module-level `transform_groww_trade()` so the price scale can be pinned by a test without standing up the order-book and per-order HTTP calls that `get_trade_book()` makes. The emitted dict is otherwise identical — same keys, same values.

## Testing

New `test/test_groww_tradebook_price.py`, parameterized over the values requested in the issue (₹99, ₹100, ₹433, ₹2,500), asserting at both the broker transform and the tradebook payload, plus derived `trade_value`:

```
uv run pytest test/test_groww_tradebook_price.py -q
9 passed
```

The test is not vacuous — re-introducing the old `if price > 100` line fails it on exactly the affected values:

```
4 failed, 5 passed
FAILED test_transform_preserves_rupee_price[433.0]
FAILED test_transform_preserves_rupee_price[2500.0]
FAILED test_tradebook_reports_rupee_price[433.0]
FAILED test_tradebook_reports_rupee_price[2500.0]
```

CI's fast backend selection plus the existing `test_groww_holdings_mapping.py` and the new file: **69 passed**.

`ruff check` output on `order_api.py` is identical to the base file apart from one line-number shift in a pre-existing `F811`. The file's pre-existing `ruff format` failure is at line 2632, untouched here; the formatter leaves the new block unchanged.

## Out of scope

`get_positions()` has similar heuristics (`if avg_price > 1000: avg_price / 100`, alongside *unconditional* `/100` on `credit_price`/`debit_price`). Those read a different Groww endpoint whose fields do appear paise-denominated, so I did not touch them without real position data to check against — and per CONTRIBUTING.md this PR stays to one fix.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Groww tradebook prices being reported in the wrong scale. Groww's trade API reports `price` in rupees, but `get_trade_book()` divided any price above 100 by 100 — so a genuine ₹433.00 fill came back as ₹4.33 and a ₹2,500.00 fill as ₹25.00, while ₹99.00 passed through untouched. A downstream strategy sized its successor BUY off the mangled value and Groww rejected it on circuit controls. Closes #1958.

The rupee value now carries through unchanged, for both real trades and synthetic trades assembled from the order book. The per-trade transform is extracted into a module-level `transform_groww_trade()` so the price scale can be pinned by tests without standing up the HTTP calls `get_trade_book()` makes. New parameterized tests cover ₹99, ₹100, ₹433, and ₹2,500 at both the broker transform and the tradebook payload, including derived `trade_value`.

`get_positions()` keeps its existing heuristics — it reads a different endpoint whose fields do appear paise-denominated, so it wasn't touched without real position data to verify against.

<sup>Written for commit 85d22355a4fa000dcc801e1cb88e791ce642d19e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/1995?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

