### PR TITLE
fix(kotak): report average_price on holdings

### DIFF
--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -382,6 +382,10 @@ def transform_holdings_data(holdings_data):
             "exchange": holding.get("exchangeSegment", ""),
             "quantity": holding.get("quantity", 0),
             "product": holding.get("instrumentType", ""),
+            # Kotak's holdings API does return a per-share averagePrice
+            # directly -- unlike LTP (deliberately omitted, see order_api.py's
+            # _backfill_ltp), so no workaround is needed here.
+            "average_price": round(float(holding.get("averagePrice", 0.0)), 2),
             "pnl": round(
                 (float(holding.get("mktValue", 0.0)) - float(holding.get("holdingCost", 0.0))), 2
             ),


### PR DESCRIPTION
Fixes #2000.

\`transform_holdings_data()\` never populated \`average_price\` for a Kotak
holding, even though Kotak's own \`/holdings\` response carries it directly
in the \`averagePrice\` field. Unlike LTP (which genuinely needs the
\`_backfill_ltp\` workaround from #1973), no workaround is needed here — the
field is already in the response and simply wasn't read.

Verified against a live account with 3 holdings: raw Kotak response
carries \`averagePrice\` on every row (e.g. \`"averagePrice": "2323.5"\`),
unused anywhere downstream. After reading it, \`/api/v1/holdings\`
correctly returns \`average_price\` 1049.42 / 279.05 / 2323.5 for the three
holdings, matching the account's actual entry prices.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Kotak holdings missing `average_price` in `/api/v1/holdings` responses. Previously the field was always 0; now it reads Kotak's `averagePrice` from the holdings API. No other behavior changes.

**Bug Fixes**
- Populates `average_price` for Kotak holdings using the value already returned by Kotak's `/holdings` endpoint.
- Resolves issue #2000.

<sup>Written for commit fa458fb9c7f48a171b8679786adfca090092125b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2001?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

