### PR TITLE
fix(docker): move base images from EOL bullseye to trixie

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,11 @@
 # ------------------------------ Python Builder Stage ----------------------- #
-FROM python:3.12-bullseye AS python-builder
+# Base images track Debian 13 "trixie". Debian 11 "bullseye" reached end of LTS
+# on 2026-08-31 and its security pool was drained days later, so every build
+# began failing with 404s on systemd, tzdata, libtiff5 and libgbm1 while the
+# package index still advertised them. Debian 12 "bookworm" is not the fix --
+# its regular security support ended 2026-07-11 and it is already LTS-only.
+# Trixie has security support to 2028-08-09 (LTS to 2030-06-30).
+FROM python:3.12-trixie AS python-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl build-essential && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -14,7 +20,7 @@ RUN pip install --no-cache-dir uv && \
     rm -rf /root/.cache
 
 # ------------------------------ Frontend Builder Stage --------------------- #
-FROM node:22-bullseye-slim AS frontend-builder
+FROM node:22-trixie-slim AS frontend-builder
 WORKDIR /app
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm ci
@@ -23,7 +29,7 @@ RUN cd frontend && npm run build
 
 # --------------------------------------------------------------------------- #
 # ------------------------------ Production Stage --------------------------- #
-FROM python:3.12-slim-bullseye AS production
+FROM python:3.12-slim-trixie AS production
 # 0 – set timezone to IST (Asia/Kolkata) & install runtime dependencies
 #     chromium + fonts-liberation are required by Kaleido 1.x (plotly static
 #     image export) which drives a real headless Chromium via choreographer.

--- a/docs/design/11-docker/README.md
+++ b/docs/design/11-docker/README.md
@@ -13,7 +13,7 @@ OpenAlgo provides Docker support for containerized deployment with **3-stage bui
 
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        Stage 1: Python Builder                               │
-│                        (python:3.12-bullseye)                                │
+│                        (python:3.12-trixie)                                  │
 │                                                                              │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
 │  │  1. Install build dependencies (curl, build-essential)                │  │
@@ -26,7 +26,7 @@ OpenAlgo provides Docker support for containerized deployment with **3-stage bui
                                      │
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        Stage 2: Frontend Builder                             │
-│                        (node:22-bullseye-slim)                               │
+│                        (node:22-trixie-slim)                                 │
 │                                                                              │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
 │  │  1. Copy frontend/package*.json                                       │  │
@@ -39,7 +39,7 @@ OpenAlgo provides Docker support for containerized deployment with **3-stage bui
                                      ▼
 ┌─────────────────────────────────────────────────────────────────────────────┐
 │                        Stage 3: Production                                   │
-│                        (python:3.12-slim-bullseye)                           │
+│                        (python:3.12-slim-trixie)                             │
 │                                                                              │
 │  ┌───────────────────────────────────────────────────────────────────────┐  │
 │  │  1. Set timezone to IST (Asia/Kolkata)                                │  │
@@ -85,7 +85,7 @@ OpenAlgo provides Docker support for containerized deployment with **3-stage bui
 
 ```dockerfile
 # ------------------------------ Python Builder Stage ----------------------- #
-FROM python:3.12-bullseye AS python-builder
+FROM python:3.12-trixie AS python-builder
 RUN apt-get update && apt-get install -y --no-install-recommends \
     curl build-essential && \
     apt-get clean && rm -rf /var/lib/apt/lists/*
@@ -100,7 +100,7 @@ RUN pip install --no-cache-dir uv && \
     rm -rf /root/.cache
 
 # ------------------------------ Frontend Builder Stage --------------------- #
-FROM node:22-bullseye-slim AS frontend-builder
+FROM node:22-trixie-slim AS frontend-builder
 WORKDIR /app
 COPY frontend/package*.json ./frontend/
 RUN cd frontend && npm ci
@@ -108,7 +108,7 @@ COPY frontend/ ./frontend/
 RUN cd frontend && npm run build
 
 # ------------------------------ Production Stage --------------------------- #
-FROM python:3.12-slim-bullseye AS production
+FROM python:3.12-slim-trixie AS production
 
 # Set timezone to IST and install runtime dependencies for scipy/numba
 RUN apt-get update && apt-get install -y --no-install-recommends \

--- a/docs/docker/DOCKER_BUILD_GUIDE.md
+++ b/docs/docker/DOCKER_BUILD_GUIDE.md
@@ -67,18 +67,18 @@ docker run -d \
 
 The Dockerfile uses **multi-stage builds** for optimization:
 
-1. **Python Builder Stage** (`python:3.12-bullseye`)
+1. **Python Builder Stage** (`python:3.12-trixie`)
    - Installs `uv` package manager
    - Creates virtual environment
    - Installs all Python dependencies from `pyproject.toml`
    - Installs Gunicorn with eventlet support
 
-2. **Frontend Builder Stage** (`node:22-bullseye-slim`)
+2. **Frontend Builder Stage** (`node:22-trixie-slim`)
    - Installs npm dependencies
    - Builds React frontend (`npm run build`)
    - Outputs to `frontend/dist/`
 
-3. **Production Stage** (`python:3.12-slim-bullseye`)
+3. **Production Stage** (`python:3.12-slim-trixie`)
    - Minimal base image
    - **Installs runtime libraries for numba/scipy:**
      - `libopenblas0` - BLAS/LAPACK for linear algebra
@@ -103,11 +103,17 @@ None required - all configuration is in `.env` file.
 
 ### Image Size
 
-- **Base image** (`python:3.12-slim-bullseye`): ~145 MB
-- **Python dependencies**: ~650 MB
-- **Runtime libraries**: ~15 MB
-- **Frontend dist**: ~5 MB
-- **Total final image**: ~815 MB
+Measured on arm64 with `docker history`, uncompressed:
+
+- **Runtime layer** (chromium, fonts, BLAS, tzdata): ~750 MB
+- **Python virtualenv**: ~1.1 GB
+- **Application source**: ~50 MB
+- **Frontend dist**: ~10 MB
+- **Total final image**: ~2.7 GB
+
+Chromium dominates the runtime layer; it is present for Kaleido's static
+image export (the Telegram bot's /chart). The figures above supersede an
+earlier ~815 MB estimate that predated that dependency.
 
 ## Configuration Requirements
 


### PR DESCRIPTION
## Problem

Debian 11 "bullseye" reached end of LTS on 2026-08-31. Its security pool has since been drained while `bullseye-security` still serves an index advertising the removed files, so `apt-get update` succeeds and the install step then fails:

```
E: Failed to fetch .../systemd_247.3-7+deb11u8_arm64.deb    404  Not Found
E: Failed to fetch .../tzdata_2026b-0+deb11u1_all.deb       404  Not Found
E: Failed to fetch .../libtiff5_4.2.0-1+deb11u8_arm64.deb   404  Not Found
E: Failed to fetch .../libgbm1_20.3.5-1+deb11u1_arm64.deb   404  Not Found
```

This breaks **every** image build, not only fresh installs — any existing deployment that rebuilds hits it. The index carries `Valid-Until: Mon, 07 Sep 2026`, after which apt refuses the repository outright and even `apt-get update` fails.

## Why trixie and not bookworm

Bookworm's regular security support ended **2026-07-11**; it is already LTS-only and would need this same change again in 2028. Trixie has security support to 2028-08-09 and LTS to 2030-06-30.

## Changes

Three `FROM` lines, plus a comment recording why:

| stage | before | after |
|---|---|---|
| python-builder | `python:3.12-bullseye` | `python:3.12-trixie` |
| frontend-builder | `node:22-bullseye-slim` | `node:22-trixie-slim` |
| production | `python:3.12-slim-bullseye` | `python:3.12-slim-trixie` |

No package names changed — every explicitly installed package exists in trixie. The 404s were all transitive dependencies. Docs updated to match; the ASCII stage diagram is re-padded so column alignment is unchanged.

## Verification

Built and deployed on a live arm64 Azure VM (Ubuntu 24.04 host, Docker):

- Build completes 30/30 in 151s
- `groupadd --gid 1000 appuser` succeeds — the UID pin added for #1394 holds on trixie, which was the main risk in changing base images
- Kaleido static export verified in-container against Chromium 150: `fig.to_image(format="png", engine="kaleido")` → `KALEIDO OK`
- Instance came up healthy and is serving

## Image size impact

The production image grows from 2.14 GB to 2.71 GB on arm64. Cleanly attributable to the distro is the apt layer, **570 MB → 751 MB (+181 MB)**, consistent with `chromium` (214→276 MB) and `chromium-common` (17→85 MB). The remaining delta sits in the venv and source layers and is not cleanly attributable — the bullseye image I compared against was built from an older commit, so those layers mix code changes with any wheel-selection differences from the newer glibc.

Chromium is `150.0.7871.100` in both bookworm and trixie, so this cost is not avoidable by choosing bookworm.

## Not caused by this change

`/chart` in the Telegram bot fails with `If using all scalar values, you must pass an index` at `services/telegram_bot_service.py:227` when the history API returns a status dict instead of a DataFrame — e.g. on a non-trading day. Confirmed to fail identically on an unmodified bullseye instance, so it is pre-existing and unrelated. Filed separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Moves all Docker base images from Debian 11 bullseye (EOL) to Debian 13 trixie to fix failing builds caused by bullseye's drained security pool.

- All three build stages now use trixie-based images (`python:3.12-trixie`, `node:22-trixie-slim`, `python:3.12-slim-trixie`).
- Bookworm was not chosen because its regular security support ended 2026-07-11; trixie offers support until 2028-08-09 and LTS to 2030.
- No explicit package names changed; only transitive dependencies were causing the 404s.
- Production image grows from 2.14 GB to 2.71 GB on arm64, driven mainly by Chromium version differences.
- Verified on a live arm64 VM: build completes, UID pin holds, and Kaleido static export works.
- Docs updated to match new base images and corrected the earlier image size estimate.

<sup>Written for commit 211bd7dd01c862d028f5ba9496c9996b30c90bc8. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2004?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

