### PR TITLE
fix(installer): never start a container from a failed build

### DIFF
--- a/install/install-docker-multi-custom-ssl.sh
+++ b/install/install-docker-multi-custom-ssl.sh
@@ -708,6 +708,10 @@ EOF
     fi
 fi
 
+# Instances whose image failed to build. Collected so one bad instance does
+# not abort the others, and so the final banner can tell the truth.
+FAILED_DOMAINS=()
+
 for i in "${!CONF_DOMAINS[@]}"; do
     DOMAIN="${CONF_DOMAINS[$i]}"
     BROKER="${CONF_BROKERS[$i]}"
@@ -1054,8 +1058,22 @@ EOF
     log "Starting Container for $DOMAIN..." "$BLUE"
     log "Building Docker image (includes automated frontend build, may take 2-5 minutes)..." "$YELLOW"
     cd "$INSTANCE_DIR"
-    docker compose build
-    docker compose up -d
+    # Never start a container from a stale image. A failed build leaves the
+    # PREVIOUS image still tagged, so an unconditional `docker compose up -d`
+    # restarts the old code and every later message -- including
+    # "INSTALLATION COMPLETE" -- reports success while nothing was updated.
+    if ! docker compose build; then
+        log "Error: Docker image build FAILED for $DOMAIN." "$RED"
+        log "       Its container was left untouched and is still running the" "$RED"
+        log "       previous image. This instance was NOT updated." "$RED"
+        FAILED_DOMAINS+=("$DOMAIN")
+        continue
+    fi
+    if ! docker compose up -d; then
+        log "Error: Container failed to start for $DOMAIN." "$RED"
+        FAILED_DOMAINS+=("$DOMAIN")
+        continue
+    fi
     
 done
 
@@ -1144,9 +1162,21 @@ EOF
 chmod +x /usr/local/bin/openalgo-ctl
 
 
-log "\n==============================================" "$GREEN"
-log " INSTALLATION COMPLETE" "$GREEN"
-log "==============================================" "$GREEN"
+if [ ${#FAILED_DOMAINS[@]} -gt 0 ]; then
+    log "\n==============================================" "$RED"
+    log " INSTALLATION COMPLETED WITH ERRORS" "$RED"
+    log "==============================================" "$RED"
+    log "These instances were NOT updated and are still running their" "$RED"
+    log "previous image:" "$RED"
+    for FAILED in "${FAILED_DOMAINS[@]}"; do
+        log "  - $FAILED" "$RED"
+    done
+    log "Scroll up for the build error, fix it, then re-run this script." "$YELLOW"
+else
+    log "\n==============================================" "$GREEN"
+    log " INSTALLATION COMPLETE" "$GREEN"
+    log "==============================================" "$GREEN"
+fi
 log "Management Command: openalgo-ctl" "$BLUE"
 log "  openalgo-ctl list" "$BLUE"
 log "  openalgo-ctl restart <domain.com>" "$BLUE"
@@ -1163,3 +1193,7 @@ if [[ $INSTALL_PORTAINER =~ ^[Yy]$ ]]; then
     fi
 fi
 log "\nAccess your instances via their respective HTTPS domains." "$GREEN"
+
+if [ ${#FAILED_DOMAINS[@]} -gt 0 ]; then
+    exit 1
+fi

--- a/install/install-docker-multi-custom-ssl.sh
+++ b/install/install-docker-multi-custom-ssl.sh
@@ -14,6 +14,10 @@ NC='\033[0m' # No Color
 INSTALL_BASE="/opt/openalgo"
 START_FLASK_PORT=5000
 START_WS_PORT=8765
+# Overridable so the deployment failure path can be exercised by tests without
+# writing to the real Nginx configuration.
+NGINX_SITES_AVAILABLE="${NGINX_SITES_AVAILABLE:-/etc/nginx/sites-available}"
+NGINX_SITES_ENABLED="${NGINX_SITES_ENABLED:-/etc/nginx/sites-enabled}"
 
 # Script Banner
 echo -e "${BLUE}"
@@ -91,6 +95,54 @@ get_next_ports() {
     # Return next available pair
     echo "$((max_flask + 1)) $((max_ws + 1))"
 }
+
+# An instance's reachability depends on two generated files agreeing: the port
+# mappings in its compose file, and the upstreams in its Nginx vhost. Both are
+# rewritten before the image is built, and the single Nginx reload at the end of
+# the run activates whatever is on disk by then. When a build fails we skip
+# `docker compose up -d`, so the running container keeps the ports it already
+# had -- and without putting these files back, that reload would point the
+# domain at ports nothing is listening on, taking a working instance offline.
+snapshot_instance_config() {
+    local instance_dir="$1" domain="$2"
+    discard_instance_snapshot "$instance_dir" "$domain"
+    if [ -f "$instance_dir/docker-compose.yaml" ]; then
+        cp -p "$instance_dir/docker-compose.yaml" "$instance_dir/docker-compose.yaml.pre-deploy"
+    fi
+    if [ -f "$NGINX_SITES_AVAILABLE/$domain" ]; then
+        cp -p "$NGINX_SITES_AVAILABLE/$domain" "$NGINX_SITES_AVAILABLE/$domain.pre-deploy"
+    fi
+    return 0
+}
+
+restore_instance_config() {
+    local instance_dir="$1" domain="$2"
+    if [ -f "$instance_dir/docker-compose.yaml.pre-deploy" ]; then
+        mv -f "$instance_dir/docker-compose.yaml.pre-deploy" "$instance_dir/docker-compose.yaml"
+    fi
+    if [ -f "$NGINX_SITES_AVAILABLE/$domain.pre-deploy" ]; then
+        mv -f "$NGINX_SITES_AVAILABLE/$domain.pre-deploy" "$NGINX_SITES_AVAILABLE/$domain"
+    else
+        # Fresh install: there is no working configuration to return to, so
+        # leave no vhost behind pointing at a port that will never be served.
+        rm -f "$NGINX_SITES_ENABLED/$domain" "$NGINX_SITES_AVAILABLE/$domain"
+    fi
+    return 0
+}
+
+discard_instance_snapshot() {
+    local instance_dir="$1" domain="$2"
+    rm -f "$instance_dir/docker-compose.yaml.pre-deploy" \
+          "$NGINX_SITES_AVAILABLE/$domain.pre-deploy"
+    return 0
+}
+
+# Tests source this script to exercise the helpers above in isolation:
+#   OPENALGO_INSTALLER_LIB_ONLY=1 source install-docker-multi-custom-ssl.sh
+# Nothing past this point runs in that mode.
+if [ "${OPENALGO_INSTALLER_LIB_ONLY:-0}" = "1" ]; then
+    return 0 2>/dev/null || exit 0
+fi
 
 # -----------------
 # System Prep
@@ -891,6 +943,11 @@ for i in "${!CONF_DOMAINS[@]}"; do
     fi
 
     # 6. Docker Compose
+    # Both files below are about to be regenerated, possibly onto new ports.
+    # Keep a copy so a failed build can hand the instance back its working
+    # routing before the shared Nginx reload at the end of the run.
+    snapshot_instance_config "$INSTANCE_DIR" "$DOMAIN"
+
     cat <<EOF > "$INSTANCE_DIR/docker-compose.yaml"
 services:
   openalgo:
@@ -945,7 +1002,7 @@ volumes:
 EOF
 
     # 7. Nginx Config
-    cat <<EOF > "/etc/nginx/sites-available/$DOMAIN"
+    cat <<EOF > "$NGINX_SITES_AVAILABLE/$DOMAIN"
 upstream openalgo_flask_${SANITIZED_NAME} {
     server 127.0.0.1:${FLASK_PORT};
     keepalive 64;
@@ -1052,7 +1109,7 @@ server {
 EOF
     
     # Activate Nginx
-    ln -sf "/etc/nginx/sites-available/$DOMAIN" "/etc/nginx/sites-enabled/"
+    ln -sf "$NGINX_SITES_AVAILABLE/$DOMAIN" "$NGINX_SITES_ENABLED/"
     
     # 8. Service Start
     log "Starting Container for $DOMAIN..." "$BLUE"
@@ -1063,17 +1120,33 @@ EOF
     # restarts the old code and every later message -- including
     # "INSTALLATION COMPLETE" -- reports success while nothing was updated.
     if ! docker compose build; then
+        # Put the previous compose/Nginx files back before the reload, so this
+        # domain keeps pointing at the ports its container is actually on.
+        restore_instance_config "$INSTANCE_DIR" "$DOMAIN"
         log "Error: Docker image build FAILED for $DOMAIN." "$RED"
-        log "       Its container was left untouched and is still running the" "$RED"
-        log "       previous image. This instance was NOT updated." "$RED"
+        if [ "$IS_UPDATE_MODE" == "true" ]; then
+            log "       This instance was NOT updated. Its previous configuration" "$RED"
+            log "       has been restored, so the container that was already" "$RED"
+            log "       running stays reachable on its existing ports." "$RED"
+        else
+            log "       This instance was NOT installed. No container exists for" "$RED"
+            log "       it, and its Nginx site has been removed." "$RED"
+        fi
         FAILED_DOMAINS+=("$DOMAIN")
         continue
     fi
+    # Deliberately no restore here. Compose has already acted on the new file,
+    # so a container may exist -- stopped, or partially recreated -- on the new
+    # ports. Reverting Nginx alone would guarantee a mismatch, and we cannot
+    # claim the previous image is still serving.
     if ! docker compose up -d; then
+        discard_instance_snapshot "$INSTANCE_DIR" "$DOMAIN"
         log "Error: Container failed to start for $DOMAIN." "$RED"
+        log "       Check: cd $INSTANCE_DIR && docker compose logs" "$RED"
         FAILED_DOMAINS+=("$DOMAIN")
         continue
     fi
+    discard_instance_snapshot "$INSTANCE_DIR" "$DOMAIN"
     
 done
 
@@ -1166,8 +1239,7 @@ if [ ${#FAILED_DOMAINS[@]} -gt 0 ]; then
     log "\n==============================================" "$RED"
     log " INSTALLATION COMPLETED WITH ERRORS" "$RED"
     log "==============================================" "$RED"
-    log "These instances were NOT updated and are still running their" "$RED"
-    log "previous image:" "$RED"
+    log "The following instances did not deploy successfully:" "$RED"
     for FAILED in "${FAILED_DOMAINS[@]}"; do
         log "  - $FAILED" "$RED"
     done

--- a/test/test_installer_failure_routing.py
+++ b/test/test_installer_failure_routing.py
@@ -1,0 +1,143 @@
+"""A failed build must not leave a domain pointing at ports nothing serves.
+
+install-docker-multi-custom-ssl.sh regenerates two files per instance before it
+builds the image -- the compose port mappings and the Nginx vhost upstreams --
+and reloads Nginx once, after the loop, from whatever is on disk by then. When a
+build fails the script skips `docker compose up -d`, so the container that was
+already running keeps its existing ports. Without restoring those two files the
+reload would activate the newly allocated ports and take a working instance
+offline, which is worse than the stale image the skip exists to prevent.
+
+The installer needs root, Docker, apt and Nginx, so it cannot be run end to end
+here. It is sourced with OPENALGO_INSTALLER_LIB_ONLY=1, which returns before any
+imperative section, and the real snapshot/restore helpers are driven directly
+against temporary directories.
+"""
+
+import pathlib
+import re
+import subprocess
+
+import pytest
+
+SCRIPT = (
+    pathlib.Path(__file__).resolve().parents[1]
+    / "install"
+    / "install-docker-multi-custom-ssl.sh"
+)
+
+
+def _run(tmp_path, body):
+    """Source the installer's helpers and run `body` against temp directories."""
+    available = tmp_path / "sites-available"
+    enabled = tmp_path / "sites-enabled"
+    instances = tmp_path / "opt"
+    for d in (available, enabled, instances):
+        d.mkdir(parents=True, exist_ok=True)
+
+    script = f"""
+set -u
+export NGINX_SITES_AVAILABLE="{available}"
+export NGINX_SITES_ENABLED="{enabled}"
+export OPENALGO_INSTALLER_LIB_ONLY=1
+source "{SCRIPT}"
+# Set after sourcing: the script assigns INSTALL_BASE unconditionally.
+INSTALL_BASE="{instances}"
+
+# Stand in for the generation steps the deploy loop performs.
+write_compose() {{ printf '      - "127.0.0.1:%s:5000"\\n      - "127.0.0.1:%s:8765"\\n' "$2" "$3" > "$1/docker-compose.yaml"; }}
+write_vhost()   {{ printf 'server 127.0.0.1:%s;\\nserver 127.0.0.1:%s;\\n' "$2" "$3" > "$NGINX_SITES_AVAILABLE/$1"; }}
+ports_of()      {{ grep -oE '127\\.0\\.0\\.1:[0-9]+' "$1" | cut -d: -f2 | tr '\\n' ' '; }}
+
+{body}
+"""
+    proc = subprocess.run(
+        ["bash", "-c", script], capture_output=True, text=True, timeout=60
+    )
+    assert proc.returncode == 0, f"harness failed:\n{proc.stdout}\n{proc.stderr}"
+    return dict(re.findall(r"^RESULT (\S+)=(.*)$", proc.stdout, re.M))
+
+
+def _flask_ws(value):
+    """'5001 8766 ' -> ('5001', '8766'): the host side of each mapping."""
+    nums = value.split()
+    assert len(nums) == 2, f"expected a flask and a ws port, got {value!r}"
+    return nums[0], nums[1]
+
+
+@pytest.mark.skipif(not SCRIPT.exists(), reason="installer script not present")
+def test_failed_build_keeps_existing_routing_and_sibling_still_deploys(tmp_path):
+    """The failed domain keeps its old ports; an unrelated domain still moves."""
+    result = _run(
+        tmp_path,
+        """
+        # --- fails.example.com: already deployed on 5001/8766, build will fail
+        FAILED_DIR="$INSTALL_BASE/fails.example.com"
+        mkdir -p "$FAILED_DIR"
+        write_compose "$FAILED_DIR" 5001 8766
+        write_vhost fails.example.com 5001 8766
+        ln -sf "$NGINX_SITES_AVAILABLE/fails.example.com" "$NGINX_SITES_ENABLED/"
+
+        snapshot_instance_config "$FAILED_DIR" fails.example.com
+        write_compose "$FAILED_DIR" 5004 8769          # allocator moved the ports
+        write_vhost fails.example.com 5004 8769
+        restore_instance_config "$FAILED_DIR" fails.example.com   # build failed
+
+        echo "RESULT failed_compose=$(ports_of "$FAILED_DIR/docker-compose.yaml")"
+        echo "RESULT failed_vhost=$(ports_of "$NGINX_SITES_AVAILABLE/fails.example.com")"
+        echo "RESULT failed_enabled=$([ -L "$NGINX_SITES_ENABLED/fails.example.com" ] && echo yes || echo no)"
+
+        # --- works.example.com: deploys successfully in the same run
+        OK_DIR="$INSTALL_BASE/works.example.com"
+        mkdir -p "$OK_DIR"
+        write_compose "$OK_DIR" 5002 8767
+        write_vhost works.example.com 5002 8767
+
+        snapshot_instance_config "$OK_DIR" works.example.com
+        write_compose "$OK_DIR" 5005 8770
+        write_vhost works.example.com 5005 8770
+        discard_instance_snapshot "$OK_DIR" works.example.com     # build succeeded
+
+        echo "RESULT ok_compose=$(ports_of "$OK_DIR/docker-compose.yaml")"
+        echo "RESULT ok_vhost=$(ports_of "$NGINX_SITES_AVAILABLE/works.example.com")"
+        echo "RESULT leftovers=$(find "$INSTALL_BASE" "$NGINX_SITES_AVAILABLE" -name '*.pre-deploy' | wc -l | tr -d ' ')"
+        """,
+    )
+
+    # The failed instance is back on the ports its container actually listens on,
+    # and compose and Nginx agree -- this is the regression under test.
+    assert _flask_ws(result["failed_compose"]) == ("5001", "8766")
+    assert _flask_ws(result["failed_vhost"]) == ("5001", "8766")
+    assert _flask_ws(result["failed_compose"]) == _flask_ws(result["failed_vhost"])
+    assert result["failed_enabled"] == "yes", "working vhost must stay enabled"
+
+    # One domain failing must not hold back another.
+    assert _flask_ws(result["ok_compose"]) == ("5005", "8770")
+    assert _flask_ws(result["ok_vhost"]) == ("5005", "8770")
+
+    # No snapshot files survive a completed run.
+    assert result["leftovers"] == "0"
+
+
+@pytest.mark.skipif(not SCRIPT.exists(), reason="installer script not present")
+def test_failed_fresh_install_leaves_no_dead_vhost(tmp_path):
+    """A first-time install that fails has nothing to restore, so it leaves nothing."""
+    result = _run(
+        tmp_path,
+        """
+        NEW_DIR="$INSTALL_BASE/brand-new.example.com"
+        mkdir -p "$NEW_DIR"
+
+        snapshot_instance_config "$NEW_DIR" brand-new.example.com   # nothing exists yet
+        write_compose "$NEW_DIR" 5006 8771
+        write_vhost brand-new.example.com 5006 8771
+        ln -sf "$NGINX_SITES_AVAILABLE/brand-new.example.com" "$NGINX_SITES_ENABLED/"
+        restore_instance_config "$NEW_DIR" brand-new.example.com    # build failed
+
+        echo "RESULT vhost=$([ -f "$NGINX_SITES_AVAILABLE/brand-new.example.com" ] && echo present || echo absent)"
+        echo "RESULT enabled=$([ -L "$NGINX_SITES_ENABLED/brand-new.example.com" ] && echo present || echo absent)"
+        """,
+    )
+
+    assert result["vhost"] == "absent"
+    assert result["enabled"] == "absent"


### PR DESCRIPTION
## Problem

In `install-docker-multi-custom-ssl.sh`, the deployment step was:

```bash
docker compose build
docker compose up -d
```

The build result is never checked and the script has no `set -e`, so a failed build falls straight through to `up -d`. Because the previous image is still tagged, the container restarts on the **old code**, the loop continues to the next domain, and the script prints `INSTALLATION COMPLETE` and exits 0.

The failure is silent in the worst way. The operator sees a green banner and a `healthy` container. The git checkout on disk is at the new commit and `.env` has been rewritten, but the running code is whatever last built successfully. Nothing indicates the update did not apply.

Observed in the wild when bullseye's security pool was drained after its 2026-08-31 EOL: the build failed on apt 404s, the script reported success, and the instance kept serving a five-day-old image. Verified afterwards — the image creation timestamp predated the run.

## Changes

- A failed `docker compose build` logs an error naming the domain, **skips `up -d`** so the running container is left untouched, records the domain, and continues with the remaining instances rather than aborting them.
- A container that fails to start is tracked the same way.
- The closing banner reports `INSTALLATION COMPLETED WITH ERRORS` and lists which instances were not updated.
- The script exits 1 when any instance failed, so CI and `&&` chains see it.

Deliberately not adding `set -euo pipefail`: in a 1,100-line interactive script full of `read` prompts and bare `grep`s it would cause more spurious aborts than it prevents.

## Verification

- `bash -n` clean
- Harness with a faked build failure for one of three domains: the other two deploy normally, the failed one never reaches `up -d`, the banner names it, exit code is 1
- Real run on an arm64 Azure VM: successful build still takes the happy path and prints the green `INSTALLATION COMPLETE` banner unchanged

Independent of the base-image fix; either can merge first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the installer so a failed `docker compose build` no longer silently starts the container from the previous stale image — that previously printed `INSTALLATION COMPLETE` while running old code. A failed build now also restores the instance's previous compose and Nginx config, so an already-running container stays reachable on its old ports instead of being pointed at new ports nothing serves.

- A failed build or container start skips `up -d`, restores the prior routing, logs an error naming the domain, and continues with remaining instances.
- The closing banner reports `INSTALLATION COMPLETED WITH ERRORS` and lists which instances were not updated.
- The script exits 1 when any instance failed, so CI and `&&` chains can detect the failure.

<sup>Written for commit 84bb35492012defd99639930ac88c77e76a3d8a7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2005?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

