### PR TITLE
fix(tradebook): use fill_timestamp not order_timestamp, preserve per-fill trade_id

### DIFF
--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -226,6 +226,13 @@ def transform_tradebook_data(tradebook_data):
             "average_price": trade.get("avgPrc", 0.0),
             "trade_value": float(trade.get("fldQty", 0.0)) * float(trade.get("avgPrc", 0.0)),
             "orderid": trade.get("nOrdNo", ""),
+            # "flId" is Kotak's own per-fill trade ID (Kotak-Neo/kotak-neo-api-v2
+            # docs/Trade_report.md - two fills under the same order carry two
+            # distinct flId values). Previously dropped entirely, leaving no
+            # stable per-fill identity for a consumer to dedup repeated
+            # tradebook pulls against - only "orderid", shared by every fill
+            # under one order.
+            "trade_id": trade.get("flId", ""),
             "timestamp": trade.get("exTm", ""),
         }
         transformed_data.append(transformed_trade)

--- a/broker/kotak/mapping/order_data.py
+++ b/broker/kotak/mapping/order_data.py
@@ -231,8 +231,12 @@ def transform_tradebook_data(tradebook_data):
             # distinct flId values). Previously dropped entirely, leaving no
             # stable per-fill identity for a consumer to dedup repeated
             # tradebook pulls against - only "orderid", shared by every fill
-            # under one order.
-            "trade_id": trade.get("flId", ""),
+            # under one order. Emitted under OpenAlgo's own established key
+            # "tradeid" (no underscore) - the documented tradebook contract
+            # (docs/prompt/flow-import-format.md) and existing consumers
+            # (services/telegram_bot_service*.py, broker/groww's own
+            # adapter) already expect that exact key.
+            "tradeid": trade.get("flId", ""),
             "timestamp": trade.get("exTm", ""),
         }
         transformed_data.append(transformed_trade)

--- a/broker/zerodha/mapping/order_data.py
+++ b/broker/zerodha/mapping/order_data.py
@@ -180,8 +180,12 @@ def transform_tradebook_data(tradebook_data):
             # previously dropped entirely - only "orderid" survived, shared
             # by every fill under one order, giving no stable per-fill
             # identity for a consumer to dedup repeated tradebook pulls
-            # against.
-            "trade_id": trade.get("trade_id", ""),
+            # against. Emitted under OpenAlgo's own established key
+            # "tradeid" (no underscore) - the documented tradebook contract
+            # (docs/prompt/flow-import-format.md) and existing consumers
+            # (services/telegram_bot_service*.py, broker/groww's own
+            # adapter) already expect that exact key.
+            "tradeid": trade.get("trade_id", ""),
             "timestamp": trade.get("fill_timestamp") or trade.get("order_timestamp", ""),
         }
         transformed_data.append(transformed_trade)

--- a/broker/zerodha/mapping/order_data.py
+++ b/broker/zerodha/mapping/order_data.py
@@ -163,7 +163,26 @@ def transform_tradebook_data(tradebook_data):
             "average_price": trade.get("average_price", 0.0),
             "trade_value": trade.get("quantity", 0) * trade.get("average_price", 0.0),
             "orderid": trade.get("order_id", ""),
-            "timestamp": trade.get("order_timestamp", ""),
+            # Kite's own docs (kite.trade/docs/connect/v3/orders/) document
+            # three separate timestamps on a trade: order_timestamp ("when
+            # the order was registered by the API" - order-placement time,
+            # shared by every fill under one order), exchange_timestamp
+            # ("when the order was registered by the exchange"), and
+            # fill_timestamp ("when the trade was filled at the exchange") -
+            # the one actually correct for a TRADE record. order_timestamp
+            # was used here instead, which is very likely the root cause of
+            # a known bug (AlgoMirror KNOWN_ISSUES.md #2): one account's
+            # Trade Book rows showed time-only values with no date, while an
+            # identical code path on another account showed full datetimes -
+            # order_timestamp is the field genuinely liable to do that for a
+            # multi-fill order, since it's an order-level field being reused
+            # per fill.  "trade_id" is Kite's own per-fill identifier,
+            # previously dropped entirely - only "orderid" survived, shared
+            # by every fill under one order, giving no stable per-fill
+            # identity for a consumer to dedup repeated tradebook pulls
+            # against.
+            "trade_id": trade.get("trade_id", ""),
+            "timestamp": trade.get("fill_timestamp") or trade.get("order_timestamp", ""),
         }
         transformed_data.append(transformed_trade)
     return transformed_data


### PR DESCRIPTION
Fixes #2006

## Problem

Two data-quality gaps in `transform_tradebook_data()`:

1. **Zerodha uses the wrong timestamp field.** Kite's own docs ([kite.trade/docs/connect/v3/orders/](https://kite.trade/docs/connect/v3/orders/)) document `order_timestamp` as 'when the order was registered by the API' (an order-level field, identical across every fill under one multi-fill order) vs `fill_timestamp` as 'when the trade was filled at the exchange' — the field actually correct for a per-trade record. The current code uses `order_timestamp`.
2. **`trade_id` (Zerodha) / `flId` (Kotak) — the broker's own per-fill identifier — is dropped entirely** for both brokers. Only `orderid`/`nOrdNo` survives, which is shared by every fill under one order, leaving no stable per-fill key for a consumer to dedup a repeated tradebook pull against.

## Evidence this isn't just theoretical

- We hit the timestamp issue in production: one account's Trade Book showed bare `HH:MM:SS` with no date on some rows, an identical code path on another account showed full datetimes for the same day.
- `blueprints/pnltracker.py` (lines 318-319) already independently falls back to `fill_timestamp` when `timestamp` looks wrong — informal corroboration this exact gap was already suspected, just never fixed at the source:
  ```python
  trade_timestamp = (
      trade.get("timestamp") or trade.get("fill_timestamp") or trade.get("fill_time")
  )
  ```
- Kotak's own SDK docs ([Kotak-Neo/kotak-neo-api-v2 docs/Trade_report.md](https://github.com/Kotak-Neo/Kotak-neo-api-v2/blob/main/docs/Trade_report.md)) show two fills under one `nOrdNo` carrying two distinct `flId` values in the documented sample response — confirming it's a real per-fill ID, not redundant with the order ID.

## Fix

**Zerodha:**
```python
"trade_id": trade.get("trade_id", ""),
"timestamp": trade.get("fill_timestamp") or trade.get("order_timestamp", ""),
```
(fallback kept for defensiveness in case `fill_timestamp` is ever absent)

**Kotak:**
```python
"trade_id": trade.get("flId", ""),
```
(Kotak's existing `timestamp: trade.get("exTm", "")` is already correct — full-datetime exchange execution time — no change needed there)

## Verification

- `python -m py_compile` — clean on both files.
- Confirmed `services/tradebook_service.py`'s `format_trade_data()` passes every dict key through generically with no allowlist, so `trade_id` reaches consumers with no other code changes needed.
- Live confirmation against a real account is pending market hours (filing alongside the fix since it rests on documented broker field semantics, not a computed value that needs numeric verification) — happy to report back real before/after timestamps once markets reopen.

## Regression coverage

Happy to add tests covering: a trade with both `order_timestamp` and `fill_timestamp` set differently uses `fill_timestamp`; a trade with only `order_timestamp` still gets a timestamp via fallback; `trade_id`/`flId` survive into the transformed dict unchanged for both brokers.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two data-quality gaps in `transform_tradebook_data()`: uses `fill_timestamp` instead of `order_timestamp` for Zerodha fills, and exposes each fill's broker-level identifier (`trade_id` for Zerodha, `flId` for Kotak) under the canonical `tradeid` key so consumers can deduplicate repeated tradebook pulls. This addresses issue #2006.

- Zerodha now uses `fill_timestamp` (actual exchange fill time) with `order_timestamp` as fallback, fixing a known date-format bug where some rows showed bare times.
- Kotak's timestamp (`exTm`) was already correct; only the `tradeid` mapping was added.
- `tradeid` reaches consumers unchanged since `format_trade_data()` passes all dict keys through generically.

<sup>Written for commit 3044dc8d4cb0871a7311f6b88ec5b58e9dadc7e9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2007?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

