### PR TITLE
fix(fyers): treat HSM multiplier=0 sentinel as no-scaling, not skip-conversion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -64,6 +64,7 @@ jobs:
             test/test_precompress_assets.py \
             test/test_broker_credential_logging.py \
             test/test_option_symbol_service_validation.py \
+            test/test_fyers_hsm_multiplier_sentinel.py \
             -v --timeout=60
 
   # Frontend linting

--- a/broker/fyers/streaming/fyers_mapping.py
+++ b/broker/fyers/streaming/fyers_mapping.py
@@ -57,6 +57,16 @@ class FyersDataMapper:
             multiplier = fyers_data.get("multiplier", 100)  # Default 100
             precision = fyers_data.get("precision", 2)  # Default 2
 
+            # The HSM wire sends multiplier=0 for instruments with no
+            # lot-multiplier scaling (currency futures among them). 0 is a
+            # sentinel for "no scaling", never a divisor: skipping the
+            # conversion leaked raw paisa prices (caught live 2026-08:
+            # USDINR tick 9574.25 vs REST ~96.1; the REST-quote path masks
+            # it because REST returns rupees). Normalize to 1 so the
+            # segment divisor below still applies.
+            if multiplier <= 0:
+                multiplier = 1
+
             # Apply segment-specific conversion
             segment_divisor = 1
             if exchange in ["BSE", "MCX", "NSE", "NFO", "CDS", "BCD"]:
@@ -68,8 +78,7 @@ class FyersDataMapper:
                 segment_divisor = 100
 
             # Convert to actual price
-            if multiplier > 0:
-                ltp = ltp / multiplier / segment_divisor
+            ltp = ltp / multiplier / segment_divisor
 
             # Round to precision
             ltp = round(ltp, precision)
@@ -121,6 +130,12 @@ class FyersDataMapper:
             multiplier = fyers_data.get("multiplier", 100)
             precision = fyers_data.get("precision", 2)
 
+            # Sentinel normalization as in map_to_openalgo_ltp: 0 (or any
+            # non-positive value) means "no scaling" — without this the
+            # quote path zeroed every price field for currency instruments.
+            if multiplier <= 0:
+                multiplier = 1
+
             # Check if this is an index based on symbol or type
             is_index = (
                 "-INDEX" in symbol
@@ -137,7 +152,7 @@ class FyersDataMapper:
                 segment_divisor = 100
 
             def convert_price(value):
-                if not value or multiplier <= 0:
+                if not value:
                     return 0.0
                 # Apply multiplier and segment conversion
                 return round(value / multiplier / segment_divisor, precision)
@@ -209,6 +224,12 @@ class FyersDataMapper:
             multiplier = fyers_data.get("multiplier", 100)
             precision = fyers_data.get("precision", 2)
 
+            # Sentinel normalization as in map_to_openalgo_ltp: 0 (or any
+            # non-positive value) means "no scaling" — without this the
+            # depth path zeroed every level for currency instruments.
+            if multiplier <= 0:
+                multiplier = 1
+
             # Apply segment-specific conversion based on exchange
             segment_divisor = 1
             if exchange in ("BSE", "MCX", "NSE", "NFO", "CDS", "BCD"):
@@ -218,7 +239,7 @@ class FyersDataMapper:
                 segment_divisor = 100
 
             def convert_price(value):
-                if value and multiplier > 0:
+                if value:
                     # First apply the multiplier conversion, then segment-specific conversion
                     price = value / multiplier / segment_divisor
                     return round(price, precision)

--- a/test/test_fyers_hsm_multiplier_sentinel.py
+++ b/test/test_fyers_hsm_multiplier_sentinel.py
@@ -1,0 +1,111 @@
+"""Fyers HSM wire multiplier=0 sentinel must not skip the segment divisor.
+
+The Fyers HSM WebSocket sends ``multiplier=0`` for instruments with no
+lot-multiplier scaling — currency futures (CDS) among them. The mapping
+guard treated 0 as "skip the whole conversion": LTP and depth passed
+through raw paisa (100x too large) and the quote path zeroed every price
+field. Caught live on 2026-08 (OA_Yuv receipt: USDINR tick 9574.25 vs
+REST truth ~96.1); the REST-quote path masked the LTP case because REST
+returns rupees.
+
+Observed HSM wire shapes (OA_Yuv live receipts, 2026-08): equity ticks
+carry multiplier=1 and paisa prices; CDS ticks carry multiplier=0.
+Fix semantics: a non-positive multiplier is a sentinel for "no multiplier
+scaling" (normalize to 1) — the paisa segment divisor is always applied.
+"""
+
+import pytest
+
+from broker.fyers.streaming.fyers_mapping import FyersDataMapper
+
+
+@pytest.fixture()
+def mapper():
+    return FyersDataMapper()
+
+
+# --- controls: documented arithmetic on real wire shapes -------------------
+
+
+def test_ltp_equity_paisa_multiplier_one(mapper):
+    # Observed equity shape: paisa price, multiplier=1.
+    data = {"symbol": "NSE:RELIANCE-EQ", "ltp": 250000, "multiplier": 1, "precision": 2}
+    assert mapper.map_to_openalgo_ltp(data)["ltp"] == 2500.0
+
+
+def test_quote_equity_paisa_multiplier_one(mapper):
+    data = {
+        "symbol": "NSE:RELIANCE-EQ",
+        "ltp": 250000,
+        "open_price": 249500,
+        "high_price": 250500,
+        "low_price": 249000,
+        "prev_close_price": 249800,
+        "multiplier": 1,
+        "precision": 2,
+    }
+    quote = mapper.map_to_openalgo_quote(data)
+    assert quote["ltp"] == 2500.0
+    assert quote["open"] == 2495.0
+
+
+# --- the bug: currency sentinel (multiplier=0) ------------------------------
+
+
+def test_ltp_currency_sentinel_still_gets_segment_divisor(mapper):
+    # 9574.25 paisa with multiplier=0: pre-fix this returned 9574.25 raw.
+    data = {"symbol": "CDS:USDINR26OCTFUT", "ltp": 9574.25, "multiplier": 0, "precision": 4}
+    assert mapper.map_to_openalgo_ltp(data)["ltp"] == 95.7425
+
+
+def test_bcd_currency_sentinel_still_gets_segment_divisor(mapper):
+    data = {"symbol": "BCD:EURINR26OCTFUT", "ltp": 1102500, "multiplier": 0, "precision": 4}
+    assert mapper.map_to_openalgo_ltp(data)["ltp"] == 11025.0
+
+
+def test_quote_currency_sentinel_never_zeroes_prices(mapper):
+    # Pre-fix every price field came back 0.0 under the sentinel.
+    data = {
+        "symbol": "CDS:USDINR26OCTFUT",
+        "ltp": 9574.25,
+        "open_price": 9570,
+        "high_price": 9580,
+        "low_price": 9560,
+        "prev_close_price": 9575,
+        "multiplier": 0,
+        "precision": 4,
+    }
+    quote = mapper.map_to_openalgo_quote(data)
+    assert quote["ltp"] == 95.7425
+    assert quote["open"] == 95.70
+    assert quote["high"] == 95.80
+    assert quote["low"] == 95.60
+    assert quote["close"] == 95.75
+
+
+def test_depth_currency_sentinel_never_zeroes_prices(mapper):
+    data = {
+        "type": "dp",
+        "symbol": "CDS:USDINR26OCTFUT",
+        "bid_price1": 9570,
+        "ask_price1": 9575,
+        "multiplier": 0,
+        "precision": 4,
+    }
+    depth = mapper.map_to_openalgo_depth(data)
+    assert depth["depth"]["buy"][0]["price"] == 95.70
+    assert depth["depth"]["sell"][0]["price"] == 95.75
+
+
+def test_negative_multiplier_treated_as_sentinel(mapper):
+    data = {"symbol": "CDS:USDINR26OCTFUT", "ltp": 9574.25, "multiplier": -1, "precision": 4}
+    assert mapper.map_to_openalgo_ltp(data)["ltp"] == 95.7425
+
+
+# --- the wire omitting multiplier keeps the documented default --------------
+
+
+def test_ltp_missing_multiplier_keeps_default_100(mapper):
+    # Unchanged branch: absent field -> default 100 applies with the divisor.
+    data = {"symbol": "MCX:CRUDEOIL26DECFUT", "ltp": 650000, "precision": 2}
+    assert mapper.map_to_openalgo_ltp(data)["ltp"] == 65.0


### PR DESCRIPTION
## Problem

Fyers HSM WebSocket ticks arrive with `multiplier=0` for instruments that carry no lot-multiplier scaling — **currency futures (CDS/BCD) among them**. The three price-conversion sites in `broker/fyers/streaming/fyers_mapping.py` guard the division behind `if multiplier > 0` / `if multiplier <= 0`, so a sentinel value silently skips the **entire** conversion, including the paisa segment divisor added for CDS/BCD in #1755's follow-up (`1815de268`):

| Path | Pre-fix behaviour with `multiplier=0` | Observed live |
|---|---|---|
| `map_to_openalgo_ltp` | raw paisa passes through (**100× too large**) | USDINR tick `9574.25` vs REST truth `~96.1` |
| `map_to_openalgo_quote` | every price field **zeroed** (`convert_price` returns `0.0`) | all OHLC `0.0` |
| `map_to_openalgo_depth` | every level **zeroed** | all levels `0.0` |

The REST-quote path masks the LTP case (REST returns rupees, so charts/quotes look right until a WS tick is consumed); the sandbox WS fill path is not so lucky — it booked USDINR fills 100× large before `1815de268`, and the quote/depth zeroing remains reachable today.

## Root cause

`0` is a **sentinel for "no multiplier scaling"**, not a divisor. The July fix (`1815de268`) correctly added `CDS`/`BCD` to the paisa segment list at all three sites but left the sentinel guard in front of the division, so currency still never receives it.

## Fix

Normalize a non-positive multiplier to `1` at all three conversion sites, making the division unconditional:

```python
# The HSM wire sends multiplier=0 for instruments with no
# lot-multiplier scaling (currency futures among them). 0 is a
# sentinel for "no scaling", never a divisor ...
if multiplier <= 0:
    multiplier = 1
```

- LTP: `9574.25 paisa → /1 → /100 → 95.7425` ✅ (was `9574.25` raw)
- Quote/depth: fields convert instead of zeroing
- Equity/other wires that carry `multiplier=1` and paisa prices: unchanged
- Non-paisa segments (divisor `1`): sentinel normalization is a no-op
- Absent `multiplier` field: the existing `get("multiplier", 100)` default is untouched

## Tests

`test/test_fyers_hsm_multiplier_sentinel.py` (9 cases, no credentials — added to the CI-safe backend-test list):

- controls pin the documented arithmetic on observed wire shapes (equity `multiplier=1` + paisa → `2500.0`)
- the bug cases: CDS/BCD `multiplier=0` on LTP (raw paisa pre-fix), quote (all-zeros pre-fix), depth (all-zeros pre-fix)
- negative multiplier treated as sentinel; sentinel no-op on divisor-1 segments; absent-field default-100 branch unchanged

All 9 pass on 3.14 locally; `ruff format --check` clean on both touched files.

## Evidence

Live receipt from an OA deployment on the fyers broker (2026-08): WS LTP stream for `CDS:USDINR` futures read `9574.25` while the REST quote endpoint returned `96.135` for the same instrument moments apart — exactly the ×100 signature this patch removes. Happy to provide further probe details if useful.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fyers HSM WebSocket price conversion so the `multiplier=0` sentinel (meaning no lot-multiplier scaling, sent for currency futures) no longer skips the whole conversion. Previously LTP passed through raw paisa — 100x too large — and quote and depth prices zeroed out; now all three conversion sites in `fyers_mapping.py` normalize non-positive multipliers to 1 before applying the segment divisor.

Equity ticks, non-paisa segments, and the absent-field default (`100`) are unchanged.

**Tests**
- Adds `test/test_fyers_hsm_multiplier_sentinel.py` covering bug and control cases, and includes it in the CI-safe backend test list.

<sup>Written for commit 9b94ba89d3e551995f46514e66f75e0ce6a04c51. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2012?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

