### PR TITLE
fix: require upstream WebSocket adapter readiness

### DIFF
--- a/broker/fyers/streaming/fyers_websocket_adapter.py
+++ b/broker/fyers/streaming/fyers_websocket_adapter.py
@@ -1047,6 +1047,12 @@ class FyersWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.error(f"Error sending data via ZeroMQ: {e}")
             self.logger.error(f"Data causing error: {data}")
 
+    def is_connected(self) -> bool:
+        """Check the outer adapter and the underlying Fyers socket."""
+        return self.connected and bool(
+            self.fyers_adapter and self.fyers_adapter.is_connected()
+        )
+
     def get_connection_status(self) -> dict[str, Any]:
         """Get connection status"""
         status = {

--- a/websocket_proxy/broker_factory.py
+++ b/websocket_proxy/broker_factory.py
@@ -222,7 +222,7 @@ class _PooledAdapterWrapper:
         # marks itself connected when it starts that work (ref ConnectionPool.connect()),
         # so also inspect the underlying adapters before reusing a cached pool
         # or reporting health.
-        return bool(self._pool.adapters) and all(
+        return bool(self._pool.adapters) and any(
             adapter_is_connected(adapter)
             for adapter in self._pool.adapters
         )

--- a/websocket_proxy/broker_factory.py
+++ b/websocket_proxy/broker_factory.py
@@ -8,7 +8,7 @@ from .base_adapter import (
     MAX_WEBSOCKET_CONNECTIONS,
     BaseBrokerWebSocketAdapter,
 )
-from .connection_manager import ConnectionPool
+from .connection_manager import ConnectionPool, adapter_is_connected
 
 logger = get_logger(__name__)
 
@@ -223,7 +223,7 @@ class _PooledAdapterWrapper:
         # so also inspect the underlying adapters before reusing a cached pool
         # or reporting health.
         return bool(self._pool.adapters) and all(
-            bool(getattr(adapter, "connected", False))
+            adapter_is_connected(adapter)
             for adapter in self._pool.adapters
         )
 

--- a/websocket_proxy/broker_factory.py
+++ b/websocket_proxy/broker_factory.py
@@ -215,9 +215,17 @@ class _PooledAdapterWrapper:
     @property
     def connected(self) -> bool:
         """Check if pool is connected"""
-        if self._pool:
-            return self._pool.connected
-        return False
+        if not self._pool or not self._pool.connected:
+            return False
+
+        # Some broker adapters establish their socket asynchronously. The pool
+        # marks itself connected when it starts that work (ref ConnectionPool.connect()),
+        # so also inspect the underlying adapters before reusing a cached pool
+        # or reporting health.
+        return bool(self._pool.adapters) and all(
+            bool(getattr(adapter, "connected", False))
+            for adapter in self._pool.adapters
+        )
 
     def publish_market_data(self, topic: str, data: dict):
         """Publish market data through the pool"""

--- a/websocket_proxy/connection_manager.py
+++ b/websocket_proxy/connection_manager.py
@@ -39,6 +39,16 @@ def get_shared_publisher_for_pooled_creation():
     return getattr(_pooled_creation_context, "shared_publisher", None)
 
 
+def adapter_is_connected(adapter: Any) -> bool:
+    """Return an adapter's actual connection state when it exposes one."""
+    readiness = getattr(adapter, "is_connected", None)
+    if callable(readiness):
+        return bool(readiness())
+    if readiness is not None:
+        return bool(readiness)
+    return bool(getattr(adapter, "connected", False))
+
+
 # Default configuration - can be overridden via environment variables
 DEFAULT_MAX_SYMBOLS_PER_WEBSOCKET = 1000
 DEFAULT_MAX_WEBSOCKET_CONNECTIONS = 3
@@ -1066,7 +1076,7 @@ class ConnectionPool:
                         "index": idx + 1,
                         "symbols": count,
                         "capacity_percent": (count / self.max_symbols * 100),
-                        "connected": bool(getattr(self.adapters[idx], "connected", False)),
+                        "connected": adapter_is_connected(self.adapters[idx]),
                     }
                     for idx, count in enumerate(self.adapter_symbol_counts)
                 ],

--- a/websocket_proxy/connection_manager.py
+++ b/websocket_proxy/connection_manager.py
@@ -571,6 +571,12 @@ class ConnectionPool:
                                 self._recovering = False
                         self.logger.error(f"Adapter connection failed: {error_msg}")
                         return {"success": False, "error": error_msg}
+                    # Note: adapter.connect() above may have started an async thread
+                    #       to do the connection, but we mark connected as True to
+                    #       indicate pool is connected, but that doesn't necessarily mean the
+                    #       underlying adapter is fully connected yet. The adapter's
+                    #       is_connected() method must be used to check the actual
+                    #       connection state if needed.
                     self.connected = True
                     return {"success": True, "message": "Connected"}
                 else:
@@ -1060,6 +1066,7 @@ class ConnectionPool:
                         "index": idx + 1,
                         "symbols": count,
                         "capacity_percent": (count / self.max_symbols * 100),
+                        "connected": bool(getattr(self.adapters[idx], "connected", False)),
                     }
                     for idx, count in enumerate(self.adapter_symbol_counts)
                 ],

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -30,6 +30,8 @@ from .port_check import find_available_port, is_port_in_use
 
 # Initialize logger
 logger = get_logger("websocket_proxy")
+WS_CONNECT_READY_TIMEOUT = 30
+WS_CONNECT_READY_POLL_INTERVAL = 1
 
 
 class WebSocketProxy:
@@ -382,6 +384,7 @@ class WebSocketProxy:
                     "total_symbols": health["subscriptions"]["unique_symbols"],
                     "clients_connected": health["clients"]["connected_count"],
                     "brokers": health["broker_adapters"]["brokers"],
+                    "adapter_health": self.get_adapter_health(),
                 }
                 with open(tmp_path, "w") as f:
                     json.dump(snapshot, f)
@@ -1105,6 +1108,42 @@ class WebSocketProxy:
                     logger.exception(f"Broker error for {broker_name}: {error_str}")
                     await self.send_error(client_id, "BROKER_ERROR", error_str)
                     return
+
+        # Some adapters return from connect() before their broker handshake has
+        # completed. Do not report a successful auth handshake until the
+        # adapter's underlying connection is actually ready; otherwise a broker
+        # HTTP 401/403 is hidden behind a locally successful WebSocket login.
+        adapter = self.broker_adapters.get(user_id)
+        if adapter is not None:
+            for _ in range(WS_CONNECT_READY_TIMEOUT):
+                if bool(getattr(adapter, "connected", False)):
+                    break
+                await aio.sleep(WS_CONNECT_READY_POLL_INTERVAL)
+        if adapter is None or not bool(getattr(adapter, "connected", False)):
+            self.broker_adapters.pop(user_id, None)
+            if adapter is not None:
+                try:
+                    adapter.disconnect()
+                except Exception as disconnect_error:
+                    logger.warning(
+                        f"Error disconnecting unready adapter for user {user_id}: "
+                        f"{disconnect_error}"
+                    )
+            try:
+                from .broker_factory import cleanup_pools_for_user
+
+                cleanup_pools_for_user(user_id, broker_name=broker_name)
+            except Exception as cleanup_error:
+                logger.warning(
+                    f"Error cleaning unready adapter pool for user {user_id}: "
+                    f"{cleanup_error}"
+                )
+            await self.send_error(
+                client_id,
+                "BROKER_CONNECTION_ERROR",
+                "Upstream broker WebSocket did not become ready after authentication",
+            )
+            return
 
         # Send success response with broker information
         await self.send_message(

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -1159,6 +1159,7 @@ class WebSocketProxy:
                     f"Skipping cleanup for unready adapter for user {user_id}; "
                     "another authentication attempt owns the current adapter"
                 )
+            self.user_mapping.pop(client_id, None)
             await self.send_error(
                 client_id,
                 "BROKER_CONNECTION_ERROR",

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -1134,8 +1134,10 @@ class WebSocketProxy:
                 f"Broker adapter readiness wait failed for user {user_id} "
                 f"after {WS_CONNECT_READY_TIMEOUT * WS_CONNECT_READY_POLL_INTERVAL}s"
             )
-            self.broker_adapters.pop(user_id, None)
-            if adapter is not None:
+            current_adapter = self.broker_adapters.get(user_id)
+            owns_adapter = adapter is not None and current_adapter is adapter
+            if owns_adapter:
+                self.broker_adapters.pop(user_id, None)
                 try:
                     adapter.disconnect()
                 except Exception as disconnect_error:
@@ -1143,14 +1145,19 @@ class WebSocketProxy:
                         f"Error disconnecting unready adapter for user {user_id}: "
                         f"{disconnect_error}"
                     )
-            try:
-                from .broker_factory import cleanup_pools_for_user
+                try:
+                    from .broker_factory import cleanup_pools_for_user
 
-                cleanup_pools_for_user(user_id, broker_name=broker_name)
-            except Exception as cleanup_error:
-                logger.warning(
-                    f"Error cleaning unready adapter pool for user {user_id}: "
-                    f"{cleanup_error}"
+                    cleanup_pools_for_user(user_id, broker_name=broker_name)
+                except Exception as cleanup_error:
+                    logger.warning(
+                        f"Error cleaning unready adapter pool for user {user_id}: "
+                        f"{cleanup_error}"
+                    )
+            else:
+                logger.info(
+                    f"Skipping cleanup for unready adapter for user {user_id}; "
+                    "another authentication attempt owns the current adapter"
                 )
             await self.send_error(
                 client_id,

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -1114,12 +1114,26 @@ class WebSocketProxy:
         # adapter's underlying connection is actually ready; otherwise a broker
         # HTTP 401/403 is hidden behind a locally successful WebSocket login.
         adapter = self.broker_adapters.get(user_id)
+        adapter_ready = False
         if adapter is not None:
-            for _ in range(WS_CONNECT_READY_TIMEOUT):
+            for attempt in range(WS_CONNECT_READY_TIMEOUT):
                 if bool(getattr(adapter, "connected", False)):
+                    adapter_ready = True
+                    logger.info(
+                        f"Broker adapter ready for user {user_id} after "
+                        f"{attempt * WS_CONNECT_READY_POLL_INTERVAL}s"
+                    )
                     break
+                logger.info(
+                    f"Waiting for broker adapter for user {user_id} to become "
+                    f"ready ({attempt + 1}/{WS_CONNECT_READY_TIMEOUT})"
+                )
                 await aio.sleep(WS_CONNECT_READY_POLL_INTERVAL)
-        if adapter is None or not bool(getattr(adapter, "connected", False)):
+        if not adapter_ready:
+            logger.warning(
+                f"Broker adapter readiness wait failed for user {user_id} "
+                f"after {WS_CONNECT_READY_TIMEOUT * WS_CONNECT_READY_POLL_INTERVAL}s"
+            )
             self.broker_adapters.pop(user_id, None)
             if adapter is not None:
                 try:


### PR DESCRIPTION
## Summary

- Treat the pool-level `connected` flag as necessary but insufficient when adapters connect asynchronously.
- Require every underlying adapter to report readiness before exposing pooled health.
- Delay local WebSocket authentication success until the upstream broker handshake is ready, with a bounded 30-second poll.
- Clean up unready adapters and pools on timeout.
- Include per-adapter connection state in proxy health statistics.
- Add explanatory comments documenting the distinction between pool state and adapter state.

This prevents a locally successful WebSocket authentication from masking an upstream broker rejection such as HTTP 401/403.

## Validation

- `python3 -m py_compile websocket_proxy/broker_factory.py websocket_proxy/connection_manager.py websocket_proxy/server.py`
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WebSocket health and authentication so a locally successful login can no longer mask upstream broker rejections like HTTP 401/403.

- Pool health now requires the pool's connection flag and at least one underlying adapter to report actual readiness, using each adapter's `is_connected()` method when available; `FyersWebSocketAdapter` now exposes the underlying Fyers socket state.
- Per-adapter connection state is included in proxy health stats, so partially connected pools remain usable while their individual adapters stay observable.
- Authentication polls up to 30 seconds for adapter readiness, then fails cleanly, removes the client mapping, and cleans up only the adapter owned by the failed attempt on timeout, leaving concurrent attempts untouched.

<sup>Written for commit 82f86240ec601d5d150cfc0a5be5014c7264d5fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2013?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

