### PR TITLE
feat(optionsymbol): return the option quote in one batched Dhan request

### DIFF
--- a/docs/api/options-services/optionsymbol.md
+++ b/docs/api/options-services/optionsymbol.md
@@ -116,6 +116,7 @@ curl -X POST http://127.0.0.1:5000/api/v1/optionsymbol \
 | expiry_date | Expiry date in DDMMMYY format | Mandatory | - |
 | offset | Strike offset: ATM, ITM1-ITM50, OTM1-OTM50 | Mandatory | - |
 | option_type | Option type: CE or PE | Mandatory | - |
+| include_quotes | Include the selected option's current quote in the response | Optional | false |
 
 ## Response Fields
 
@@ -128,6 +129,7 @@ curl -X POST http://127.0.0.1:5000/api/v1/optionsymbol \
 | tick_size | number | Minimum price movement |
 | freeze_qty | number | Maximum quantity per order |
 | underlying_ltp | number | Current underlying price |
+| quote | object | Selected option quote; returned only when `include_quotes` is true |
 
 ## Understanding Offset
 
@@ -149,6 +151,7 @@ curl -X POST http://127.0.0.1:5000/api/v1/optionsymbol \
 
 - The offset is calculated based on actual **strike intervals** in the database
 - **underlying_ltp** shows the current price used for ATM calculation
+- Set **include_quotes** to `true` when the selected option's quote is needed with the resolved symbol. The underlying and candidate option quotes are fetched in one batch when supported.
 - Use this endpoint to **discover the symbol** before placing orders
 - For placing orders directly with offset, use [OptionsOrder](../order-management/optionsorder.md)
 

--- a/frontend/src/components/flow/panels/ConfigPanel.tsx
+++ b/frontend/src/components/flow/panels/ConfigPanel.tsx
@@ -2299,6 +2299,21 @@ export function ConfigPanel() {
                     ))}
                   </div>
                 </div>
+                <div className="flex items-center justify-between rounded-lg border p-3">
+                  <div className="space-y-1">
+                    <Label htmlFor="option-symbol-include-quotes" className="text-xs">
+                      Include Quotes
+                    </Label>
+                    <p className="text-[10px] text-muted-foreground">
+                      Return the selected option quote with the resolved symbol.
+                    </p>
+                  </div>
+                  <Switch
+                    id="option-symbol-include-quotes"
+                    checked={Boolean(nodeData.includeQuotes)}
+                    onCheckedChange={(v) => handleDataChange('includeQuotes', v)}
+                  />
+                </div>
                 <div className="space-y-2">
                   <Label className="text-xs">Output Variable</Label>
                   <Input

--- a/frontend/src/lib/flow/constants.ts
+++ b/frontend/src/lib/flow/constants.ts
@@ -1538,6 +1538,7 @@ export const DEFAULT_NODE_DATA = {
     expiryDate: '',
     offset: 'ATM',
     optionType: 'CE' as const,
+    includeQuotes: false,
     outputVariable: '',
   },
   expiry: {

--- a/frontend/src/types/flow.ts
+++ b/frontend/src/types/flow.ts
@@ -425,6 +425,7 @@ export interface OptionSymbolNodeData {
   expiryDate: string // Format: 30DEC25 - can use {{variable}}
   offset: string // ATM, ITM1-10, OTM1-10 - can use {{variable}}
   optionType: 'CE' | 'PE'
+  includeQuotes?: boolean
   outputVariable?: string
 }
 

--- a/mcp/mcpserver.py
+++ b/mcp/mcpserver.py
@@ -1353,6 +1353,7 @@ def get_option_symbol(
     offset: str,
     option_type: str,
     expiry_date: str | None = None,
+    include_quotes: bool = False,
 ) -> str:
     """
     Get option symbol for specific strike and expiry.
@@ -1364,9 +1365,11 @@ def get_option_symbol(
         option_type: 'CE' for Call or 'PE' for Put
         expiry_date: Expiry date in 'DDMMMYY' format (e.g., '28OCT25'). Optional when
                      the underlying already includes an expiry.
+        include_quotes: Include the selected option quote in the response.
 
     Returns:
-        JSON with symbol, exchange, lotsize, tick_size, underlying_ltp
+        JSON with symbol, exchange, lotsize, tick_size, underlying_ltp, and the
+        selected option quote when include_quotes is true.
     """
     try:
         params: dict[str, Any] = {
@@ -1377,6 +1380,8 @@ def get_option_symbol(
         }
         if expiry_date is not None:
             params["expiry_date"] = expiry_date
+        if include_quotes:
+            params["include_quotes"] = True
         response = client.optionsymbol(**params)
         return json.dumps(response, indent=2)
     except Exception as e:

--- a/restx_api/data_schemas.py
+++ b/restx_api/data_schemas.py
@@ -149,6 +149,9 @@ class OptionSymbolSchema(Schema):
     option_type = fields.Str(
         required=True, validate=validate.OneOf(["CE", "PE", "ce", "pe"])
     )  # Call or Put option
+    include_quotes = fields.Bool(
+        required=False, load_default=False
+    )  # Include the selected option quote in the response
 
 
 class OptionGreeksSchema(Schema):

--- a/restx_api/option_symbol.py
+++ b/restx_api/option_symbol.py
@@ -15,7 +15,8 @@ Request Body:
     "expiry_date": "28OCT25",  // Optional if underlying includes expiry
     "strike_int": 50,  // Optional: Strike interval. If omitted, actual strikes from database are used (RECOMMENDED)
     "offset": "ITM2",  // ATM, ITM1-ITM50, OTM1-OTM50
-    "option_type": "CE"  // CE or PE
+    "option_type": "CE",  // CE or PE
+    "include_quotes": true  // Optional: include the selected option quote
 }
 
 Response:
@@ -25,7 +26,12 @@ Response:
     "exchange": "NFO",
     "lotsize": 25,
     "tick_size": 0.05,
-    "underlying_ltp": 23587.50
+    "underlying_ltp": 23587.50,
+    "quote": {
+        "ltp": 125.5,
+        "bid": 125.25,
+        "ask": 125.75
+    }
 }
 """
 
@@ -71,6 +77,7 @@ class OptionSymbol(Resource):
             )  # Optional - if not provided, actual strikes from database will be used
             offset = data["offset"]
             option_type = data["option_type"]
+            include_quotes = data.get("include_quotes", False)
 
             logger.info(
                 f"Option symbol request: underlying={underlying}, exchange={exchange}, "
@@ -86,6 +93,7 @@ class OptionSymbol(Resource):
                 offset=offset,
                 option_type=option_type,
                 api_key=api_key,
+                include_quotes=include_quotes,
             )
 
             return response, status_code

--- a/services/agent/tools/options.py
+++ b/services/agent/tools/options.py
@@ -487,6 +487,7 @@ class OptionsToolkit(OpenAlgoToolkit):
         expiry_date: str,
         offset: str,
         option_type: str,
+        include_quotes: bool = False,
     ) -> str:
         """Resolve one tradable option symbol from an offset relative to ATM.
 
@@ -525,6 +526,7 @@ class OptionsToolkit(OpenAlgoToolkit):
                 does not matter. An offset past the end of the listed ladder is
                 an error, not a clamp to the last strike.
             option_type: ``CE`` for a call or ``PE`` for a put.
+            include_quotes: Include the selected option quote in the response.
 
         Returns:
             JSON with ``symbol`` (the OpenAlgo option symbol to trade),
@@ -532,13 +534,15 @@ class OptionsToolkit(OpenAlgoToolkit):
             NFO, which is not the exchange you passed in), ``lotsize``,
             ``tick_size``, ``freeze_qty`` (the largest quantity the exchange
             accepts in one order) and ``underlying_ltp`` (the price ATM was
-            resolved against).
+            resolved against). When ``include_quotes`` is true, it also includes
+            the selected option's quote.
         """
         underlying = self._symbol_argument(underlying, "underlying")
         exchange = self._exchange_argument(exchange, UNDERLYING_EXCHANGES)
         expiry = self._expiry_argument(expiry_date, underlying, allow_embedded=True)
         offset = self._offset_argument(offset)
         option_type = self._option_type_argument(option_type)
+        include_quotes = self._bool_argument(include_quotes, "include_quotes")
 
         payload = self.service_call(
             resolve_option_symbol,
@@ -551,6 +555,7 @@ class OptionsToolkit(OpenAlgoToolkit):
             strike_int=None,
             offset=offset,
             option_type=option_type,
+            include_quotes=include_quotes,
         )
 
         return wrap_tool_result(

--- a/services/flow_executor_service.py
+++ b/services/flow_executor_service.py
@@ -2384,6 +2384,9 @@ class NodeExecutor:
         expiry_date = self.get_str(node_data, "expiryDate", "")
         offset = self.get_str(node_data, "offset", "ATM")
         option_type = self.get_str(node_data, "optionType", "CE")
+        include_quotes = node_data.get(
+            "includeQuotes", node_data.get("include_quotes", False)
+        ) is True
         self.log(f"Resolving option symbol: {underlying} {option_type} {offset}")
         result = self.client.optionsymbol(
             underlying=underlying,
@@ -2391,6 +2394,7 @@ class NodeExecutor:
             expiry_date=expiry_date,
             offset=offset,
             option_type=option_type,
+            include_quotes=include_quotes,
         )
         self.log(f"Option symbol result: {result}")
         self.store_output(node_data, result)

--- a/services/flow_openalgo_client.py
+++ b/services/flow_openalgo_client.py
@@ -392,6 +392,7 @@ class FlowOpenAlgoClient:
         expiry_date: str,
         offset: str = "ATM",
         option_type: str = "CE",
+        include_quotes: bool = False,
     ) -> dict[str, Any]:
         """Get option symbol resolved from underlying/expiry/offset"""
         from services.option_symbol_service import get_option_symbol
@@ -404,6 +405,7 @@ class FlowOpenAlgoClient:
             offset=offset,
             option_type=option_type,
             api_key=self.api_key,
+            include_quotes=include_quotes,
         )
         return self._handle_response(success, response, status_code)
 

--- a/services/option_symbol_service.py
+++ b/services/option_symbol_service.py
@@ -42,7 +42,7 @@ from typing import Any, Optional
 from database.auth_db import get_auth_token_broker
 from database.symbol import SymToken, db_session
 from services.flow_node_contracts import parse_underlying_symbol
-from services.quotes_service import get_quotes
+from services.quotes_service import get_multiquotes, get_quotes
 from utils.constants import CRYPTO_EXCHANGES
 from utils.logging import get_logger
 
@@ -82,6 +82,33 @@ def clear_strikes_cache():
 #: CRUDEOIL19AUG26FUT but no plain CRUDEOIL, so asking for a spot quote there
 #: returns nothing and the whole chain comes back empty.
 NO_SPOT_EXCHANGES = frozenset({"MCX", "CDS", "BCD", "NCDEX", "NCO"})
+# Only adapters whose multiquote method makes one upstream request for a batch
+# may use the combined underlying-and-option request. Keep this allowlist
+# explicit because some adapters fan out internally despite exposing the same
+# method, which would erase the latency win.
+OPTION_SYMBOL_QUOTE_BATCH_LIMITS = {"dhan": 1000}
+DEFAULT_OPTION_SYMBOL_QUOTE_BATCH_LIMIT = 1
+
+
+def _extract_multiquote_data(
+    response: dict[str, Any], symbol: str, exchange: str
+) -> dict[str, Any] | None:
+    """Return one symbol's normalized quote from a multiquote response."""
+    results = response.get("results", [])
+    if not isinstance(results, list):
+        return None
+
+    for result in results:
+        if not isinstance(result, dict):
+            continue
+        if result.get("symbol") != symbol:
+            continue
+        if result.get("exchange") and result["exchange"] != exchange:
+            continue
+        data = result.get("data")
+        if isinstance(data, dict):
+            return data
+    return None
 
 
 def find_near_month_futures(base_symbol: str, exchange: str) -> dict[str, Any] | None:
@@ -202,6 +229,26 @@ def _is_finite_number(value: Any) -> bool:
         return math.isfinite(value)
     except (TypeError, OverflowError, ValueError):
         return False
+
+
+def _has_usable_ltp(quote: Any) -> bool:
+    """Return whether a quote payload contains a finite numeric LTP."""
+    return isinstance(quote, dict) and _is_finite_number(quote.get("ltp"))
+
+
+def _get_option_symbol_quote_batch_limit(credential: str | None) -> int:
+    """Return the authenticated broker's safe single-request quote limit."""
+    if not isinstance(credential, str) or not credential:
+        return DEFAULT_OPTION_SYMBOL_QUOTE_BATCH_LIMIT
+
+    try:
+        _, broker_name = get_auth_token_broker(credential)
+    except Exception:
+        logger.exception("Unable to determine broker for option-symbol quote batching")
+        return DEFAULT_OPTION_SYMBOL_QUOTE_BATCH_LIMIT
+
+    broker_key = broker_name.strip().lower() if isinstance(broker_name, str) else ""
+    return OPTION_SYMBOL_QUOTE_BATCH_LIMITS.get(broker_key, DEFAULT_OPTION_SYMBOL_QUOTE_BATCH_LIMIT)
 
 
 def validate_option_type(option_type: Any) -> str:
@@ -704,6 +751,7 @@ def get_option_symbol(
     option_type: str,
     api_key: str,
     underlying_ltp: float | None = None,
+    include_quotes: bool = False,
 ) -> tuple[bool, dict[str, Any], int]:
     """
     Main function to get option symbol based on underlying and parameters.
@@ -717,6 +765,9 @@ def get_option_symbol(
         option_type: Option type ("CE" or "PE")
         api_key: OpenAlgo API key
         underlying_ltp: Optional pre-fetched LTP to avoid redundant quote requests
+        include_quotes: Include the selected option's quote in the response. When no
+            LTP is supplied, the underlying and candidate option symbols are fetched
+            in one multiquote request when the broker's batch limit allows it.
 
     Returns:
         Tuple of (success, response_data, status_code)
@@ -818,10 +869,82 @@ def get_option_symbol(
         else:
             quote_symbol = underlying
 
-        # Step 3: Get LTP of underlying (use provided LTP if available to avoid rate limits)
+        # Step 3: Get the underlying LTP. An include_quotes request can resolve the
+        # target strike from the same snapshot as the option quote by asking for the
+        # underlying and every candidate strike together.
+        options_exchange = get_option_exchange(quote_exchange)
+        quote_batch: dict[tuple[str, str], dict[str, Any]] = {}
+        quote_batch_used = False
+        batched_underlying_ltp = None
+        quote_candidate_strikes = None
+
+        if include_quotes and underlying_ltp is None:
+            quote_candidate_strikes = get_available_strikes(
+                base_symbol, final_expiry, option_type, options_exchange
+            )
+            quote_batch_limit = _get_option_symbol_quote_batch_limit(api_key)
+            batch_size = len(quote_candidate_strikes) + 1 if quote_candidate_strikes else 0
+            if quote_candidate_strikes and batch_size <= quote_batch_limit:
+                quote_symbols = [{"symbol": quote_symbol, "exchange": quote_exchange}]
+                quote_symbols.extend(
+                    {
+                        "symbol": construct_option_symbol(
+                            base_symbol, final_expiry, strike, option_type
+                        ),
+                        "exchange": options_exchange,
+                    }
+                    for strike in quote_candidate_strikes
+                )
+                batch_success, batch_response, _ = get_multiquotes(quote_symbols, api_key)
+                if batch_success and isinstance(batch_response, dict):
+                    batch_results = batch_response.get("results", [])
+                    if not isinstance(batch_results, list):
+                        batch_results = []
+                    for result in batch_results:
+                        if not isinstance(result, dict):
+                            continue
+                        result_symbol = result.get("symbol")
+                        result_exchange = result.get("exchange") or (
+                            quote_exchange if result_symbol == quote_symbol else options_exchange
+                        )
+                        result_data = result.get("data")
+                        if result_symbol and isinstance(result_data, dict):
+                            quote_batch[(result_symbol, result_exchange)] = result_data
+
+                    underlying_quote = _extract_multiquote_data(
+                        batch_response, quote_symbol, quote_exchange
+                    )
+                    if underlying_quote is not None:
+                        batched_underlying_ltp = underlying_quote.get("ltp")
+                        quote_batch_used = _has_usable_ltp(underlying_quote)
+                else:
+                    batch_message = (
+                        batch_response.get("message", "Unknown error")
+                        if isinstance(batch_response, dict)
+                        else "Invalid multiquote response"
+                    )
+                    logger.warning(
+                        f"Unable to batch quotes for {underlying}; falling back to the standard quote path: "
+                        f"{batch_message}"
+                    )
+            elif quote_candidate_strikes:
+                # Expected on every adapter outside the allowlist, so keep it off
+                # the warning channel for what is a normal opt-in request.
+                logger.debug(
+                    f"Skipping batched option-symbol quotes for {underlying}: "
+                    f"{batch_size} instruments exceed the broker limit of {quote_batch_limit}"
+                )
+            else:
+                logger.debug(
+                    f"Skipping batched option-symbol quotes for {underlying}: no candidate strikes"
+                )
+
         if underlying_ltp is not None:
             ltp = underlying_ltp
             logger.info(f"Using provided LTP: {ltp} for {quote_symbol}")
+        elif quote_batch_used:
+            ltp = batched_underlying_ltp
+            logger.info(f"Using batched LTP: {ltp} for {quote_symbol}")
         else:
             logger.info(f"Fetching LTP for: {quote_symbol} on {quote_exchange}")
 
@@ -867,18 +990,17 @@ def get_option_symbol(
                 500,
             )
 
-        # Step 4: Map to options exchange
-        options_exchange = get_option_exchange(quote_exchange)
-
-        # Step 5: Determine calculation method based on strike_int parameter
+        # Step 4: Determine calculation method based on strike_int parameter
         if strike_int is None:
             # NEW METHOD: Use actual strikes from database
             logger.info("Using actual strikes method (strike_int not provided)")
 
             # Fetch all available strikes for this underlying and expiry
-            available_strikes = get_available_strikes(
-                base_symbol, final_expiry, option_type, options_exchange
-            )
+            available_strikes = quote_candidate_strikes
+            if available_strikes is None:
+                available_strikes = get_available_strikes(
+                    base_symbol, final_expiry, option_type, options_exchange
+                )
 
             if not available_strikes:
                 logger.error(
@@ -933,12 +1055,12 @@ def get_option_symbol(
             # Calculate target strike based on offset
             target_strike = calculate_offset_strike(atm_strike, offset, strike_int, option_type)
 
-        # Step 6: Construct option symbol
+        # Step 5: Construct option symbol
         option_symbol = construct_option_symbol(
             base_symbol, final_expiry, target_strike, option_type
         )
 
-        # Step 7: Find option in database
+        # Step 6: Find option in database
         option_details = find_option_in_database(option_symbol, options_exchange)
 
         if not option_details:
@@ -954,23 +1076,59 @@ def get_option_symbol(
                 404,
             )
 
-        # Step 8: Get freeze quantity
+        # Step 7: Get freeze quantity
         from database.qty_freeze_db import get_freeze_qty_for_option
 
         freeze_qty = get_freeze_qty_for_option(option_details["symbol"], option_details["exchange"])
 
-        # Step 9: Return success response with simplified format
+        # An initial batch already contains the selected leg. If the caller supplied
+        # the underlying LTP, fetch only that leg now. The fallback path also fetches
+        # only the leg after its normal underlying request.
+        option_quote = None
+        if include_quotes:
+            option_quote = quote_batch.get((option_details["symbol"], option_details["exchange"]))
+            if not _has_usable_ltp(option_quote):
+                quote_success, quote_response, quote_status = get_multiquotes(
+                    [
+                        {
+                            "symbol": option_details["symbol"],
+                            "exchange": option_details["exchange"],
+                        }
+                    ],
+                    api_key,
+                )
+                if not quote_success:
+                    return False, quote_response, quote_status
+                option_quote = _extract_multiquote_data(
+                    quote_response, option_details["symbol"], option_details["exchange"]
+                )
+
+            if not _has_usable_ltp(option_quote):
+                return (
+                    False,
+                    {
+                        "status": "error",
+                        "message": f"Could not determine a usable LTP for {option_details['symbol']}.",
+                    },
+                    500,
+                )
+
+        # Step 8: Return success response with simplified format
+        response_data = {
+            "status": "success",
+            "symbol": option_details["symbol"],
+            "exchange": option_details["exchange"],
+            "lotsize": option_details["lotsize"],
+            "tick_size": option_details["tick_size"],
+            "freeze_qty": freeze_qty,
+            "underlying_ltp": ltp,
+        }
+        if include_quotes:
+            response_data["quote"] = option_quote
+
         return (
             True,
-            {
-                "status": "success",
-                "symbol": option_details["symbol"],
-                "exchange": option_details["exchange"],
-                "lotsize": option_details["lotsize"],
-                "tick_size": option_details["tick_size"],
-                "freeze_qty": freeze_qty,
-                "underlying_ltp": ltp,
-            },
+            response_data,
             200,
         )
 

--- a/test/test_flow_qa_regressions.py
+++ b/test/test_flow_qa_regressions.py
@@ -1124,6 +1124,19 @@ def test_option_expiry_templates_call_the_client_after_resolving_validly(
     assert option_expiry_env.client.calls[0][0] == node_type
 
 
+def test_option_symbol_passes_include_quotes_to_the_client(option_expiry_env, monkeypatch):
+    """The Flow node must preserve the opt-in quote request at execution time."""
+    result, _ = _run_graph(
+        monkeypatch,
+        "optionSymbol",
+        {**_OPTION_EXPIRY_TEMPLATE, "includeQuotes": True},
+        {"underlying": "NIFTY", "expiry": "27AUG26"},
+    )
+
+    assert result["status"] == "success"
+    assert option_expiry_env.client.calls[0][1]["include_quotes"] is True
+
+
 @pytest.mark.parametrize("node_type", ["optionSymbol", "optionChain"])
 def test_explicit_dynamic_expiry_overrides_an_embedded_expiry_and_must_be_valid(
     option_expiry_env, monkeypatch, node_type

--- a/test/test_option_quote_batching.py
+++ b/test/test_option_quote_batching.py
@@ -1,0 +1,158 @@
+"""Regression tests for option-symbol quote batching at broker boundaries."""
+
+import json
+import sys
+import urllib.parse
+from pathlib import Path
+
+sys.path.insert(0, str(Path(__file__).resolve().parents[1]))
+
+from broker.dhan.api import data as dhan_data  # noqa: E402
+from broker.fyers.api import data as fyers_data  # noqa: E402
+from broker.zebu.api import data as zebu_data  # noqa: E402
+from services import option_symbol_service as oss  # noqa: E402
+
+
+def test_only_dhan_uses_the_single_upstream_request_batch(monkeypatch):
+    def broker_for_key(_api_key):
+        return "auth-token", "dhan"
+
+    monkeypatch.setattr(oss, "get_auth_token_broker", broker_for_key)
+    assert oss._get_option_symbol_quote_batch_limit("test-api-key") == 1000
+
+    for broker in ("fyers", "zebu"):
+        monkeypatch.setattr(
+            oss,
+            "get_auth_token_broker",
+            lambda _api_key, broker=broker: ("auth-token", broker),
+        )
+        assert oss._get_option_symbol_quote_batch_limit("test-api-key") == 1
+
+
+def test_dhan_multiquote_batch_makes_one_upstream_request(monkeypatch):
+    symbols = [
+        {"symbol": "NIFTY", "exchange": "NSE_INDEX"},
+        {"symbol": "NIFTY28OCT2523500CE", "exchange": "NFO"},
+    ]
+    security_ids = {symbols[0]["symbol"]: "101", symbols[1]["symbol"]: "202"}
+    upstream_calls = []
+
+    monkeypatch.setattr(
+        dhan_data,
+        "get_token",
+        lambda symbol, exchange: security_ids[symbol],
+    )
+
+    def fake_get_api_response(endpoint, auth, method="POST", payload="", retry_count=0):
+        upstream_calls.append((endpoint, auth, method, payload))
+        request = json.loads(payload)
+        response_data = {
+            segment: {
+                str(security_id): {
+                    "last_price": 100.0,
+                    "ohlc": {"open": 99.0, "high": 101.0, "low": 98.0, "close": 99.5},
+                    "depth": {},
+                }
+                for security_id in security_ids_for_segment
+            }
+            for segment, security_ids_for_segment in request.items()
+        }
+        return {"status": "success", "data": response_data}
+
+    monkeypatch.setattr(dhan_data, "get_api_response", fake_get_api_response)
+
+    results = dhan_data.BrokerData("auth-token").get_multiquotes(symbols)
+
+    assert len(upstream_calls) == 1
+    assert upstream_calls[0][0] == "/v2/marketfeed/quote"
+    assert len(results) == len(symbols)
+
+
+def test_fyers_derivative_multiquote_adds_one_depth_request_per_symbol(monkeypatch):
+    symbols = [
+        {"symbol": "NIFTY28OCT2523500CE", "exchange": "NFO"},
+        {"symbol": "NIFTY28OCT2523500PE", "exchange": "NFO"},
+    ]
+    upstream_calls = []
+
+    def fake_get_br_symbol(symbol, exchange):
+        return f"{exchange}:{symbol}"
+
+    monkeypatch.setattr(fyers_data, "get_br_symbol", fake_get_br_symbol)
+
+    def fake_get_api_response(endpoint, auth, method="GET", payload="", _retry_count=0):
+        upstream_calls.append(endpoint)
+        if endpoint.startswith("/data/quotes?symbols="):
+            encoded_symbols = endpoint.split("=", 1)[1]
+            broker_symbols = urllib.parse.unquote(encoded_symbols).split(",")
+            return {
+                "s": "ok",
+                "d": [
+                    {"s": "ok", "n": broker_symbol, "v": {"lp": 100.0}}
+                    for broker_symbol in broker_symbols
+                ],
+            }
+
+        if endpoint.startswith("/data/depth?symbol="):
+            encoded_symbol = endpoint.split("?symbol=", 1)[1].split("&", 1)[0]
+            broker_symbol = urllib.parse.unquote(encoded_symbol)
+            return {"s": "ok", "d": {broker_symbol: {"oi": 7}}}
+
+        raise AssertionError(f"Unexpected Fyers endpoint: {endpoint}")
+
+    monkeypatch.setattr(fyers_data, "get_api_response", fake_get_api_response)
+
+    results = fyers_data.BrokerData("auth-token").get_multiquotes(symbols)
+
+    assert len(upstream_calls) == 1 + len(symbols)
+    assert sum(endpoint.startswith("/data/quotes?") for endpoint in upstream_calls) == 1
+    assert sum(endpoint.startswith("/data/depth?") for endpoint in upstream_calls) == len(symbols)
+    assert len(results) == len(symbols)
+
+
+def test_zebu_multiquote_makes_one_upstream_request_per_symbol(monkeypatch):
+    symbols = [
+        {"symbol": "SBIN", "exchange": "NSE"},
+        {"symbol": "INFY", "exchange": "NSE"},
+    ]
+    upstream_payloads = []
+
+    monkeypatch.setattr(zebu_data, "USE_ASYNC", False)
+    monkeypatch.setattr(
+        zebu_data,
+        "get_br_symbol",
+        lambda symbol, exchange: f"{exchange}:{symbol}",
+    )
+    monkeypatch.setattr(
+        zebu_data,
+        "get_token",
+        lambda symbol, exchange: {"SBIN": "101", "INFY": "202"}[symbol],
+    )
+    monkeypatch.setenv("BROKER_API_KEY", "test-user:::test-client")
+
+    class FakeResponse:
+        def json(self):
+            return {
+                "stat": "Ok",
+                "bp1": "99",
+                "sp1": "101",
+                "o": "100",
+                "h": "102",
+                "l": "98",
+                "lp": "100",
+                "c": "99",
+                "v": "10",
+                "oi": "5",
+            }
+
+    def fake_post(url, **kwargs):
+        upstream_payloads.append(json.loads(kwargs["content"].removeprefix("jData=")))
+        return FakeResponse()
+
+    monkeypatch.setattr(zebu_data.httpx, "post", fake_post)
+
+    results = zebu_data.BrokerData("auth-token").get_multiquotes(symbols)
+
+    assert len(upstream_payloads) == len(symbols)
+    assert {payload["token"] for payload in upstream_payloads} == {"101", "202"}
+    assert len(results) == len(symbols)

--- a/test/test_option_symbol_service_validation.py
+++ b/test/test_option_symbol_service_validation.py
@@ -27,6 +27,7 @@ import pytest
 
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
+from restx_api.data_schemas import OptionSymbolSchema  # noqa: E402
 from services import option_symbol_service as oss  # noqa: E402
 from services.option_symbol_service import (  # noqa: E402
     VALID_OPTION_TYPES,
@@ -233,6 +234,7 @@ def stub_resolver(monkeypatch):
         return True, {"status": "success", "data": {"ltp": 23587.50}}, 200
 
     monkeypatch.setattr(oss, "get_quotes", fake_get_quotes)
+    monkeypatch.setattr(oss, "get_auth_token_broker", lambda credential: ("auth-token", "dhan"))
     monkeypatch.setattr(oss, "get_available_strikes", lambda *args, **kwargs: list(STRIKES))
     monkeypatch.setattr(
         oss,
@@ -264,12 +266,21 @@ class TestGetOptionSymbolBoundary:
         request.update(overrides)
         return request
 
+    def test_include_quotes_is_optional_and_boolean(self):
+        request = self._request()
+        request["apikey"] = request.pop("api_key")
+
+        assert OptionSymbolSchema().load(request)["include_quotes"] is False
+        request["include_quotes"] = True
+        assert OptionSymbolSchema().load(request)["include_quotes"] is True
+
     def test_actual_strikes_path_resolves_as_before(self, stub_resolver):
         success, response, status_code = get_option_symbol(**self._request())
 
         assert (success, status_code) == (True, 200)
         assert response["symbol"] == "NIFTY28OCT2523500CE"
         assert response["underlying_ltp"] == 23587.50
+        assert "quote" not in response
 
     def test_strike_int_path_resolves_as_before(self, stub_resolver):
         success, response, status_code = get_option_symbol(**self._request(strike_int=50))
@@ -318,6 +329,229 @@ class TestGetOptionSymbolBoundary:
         assert success is True
         assert response["symbol"] == "NIFTY28OCT2523450CE"
         assert stub_resolver == []
+
+    def test_include_quotes_uses_one_batch_for_underlying_and_selected_option(
+        self, stub_resolver, monkeypatch
+    ):
+        multiquote_calls = []
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": item["symbol"],
+                            "exchange": item["exchange"],
+                            "data": {"ltp": 23587.50 if item["symbol"] == "NIFTY" else 123.45},
+                        }
+                        for item in symbols
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(**self._request(include_quotes=True))
+
+        assert (success, status_code) == (True, 200)
+        assert response["symbol"] == "NIFTY28OCT2523500CE"
+        assert response["quote"] == {"ltp": 123.45}
+        assert stub_resolver == []
+        assert len(multiquote_calls) == 1
+        assert {item["symbol"] for item in multiquote_calls[0]} == {
+            "NIFTY",
+            "NIFTY28OCT2523400CE",
+            "NIFTY28OCT2523450CE",
+            "NIFTY28OCT2523500CE",
+            "NIFTY28OCT2523550CE",
+            "NIFTY28OCT2523600CE",
+            "NIFTY28OCT2523650CE",
+            "NIFTY28OCT2523700CE",
+            "NIFTY28OCT2523750CE",
+        }
+
+    @pytest.mark.parametrize("broker", ["fyers", "zebu"])
+    def test_include_quotes_skips_batching_for_multi_request_adapters(
+        self, stub_resolver, monkeypatch, broker
+    ):
+        candidate_strikes = list(STRIKES)
+        multiquote_calls = []
+
+        monkeypatch.setattr(oss, "get_available_strikes", lambda *args: candidate_strikes)
+        monkeypatch.setattr(oss, "get_auth_token_broker", lambda credential: ("token", broker))
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            assert len(symbols) == 1
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": symbols[0]["symbol"],
+                            "exchange": symbols[0]["exchange"],
+                            "data": {"ltp": 123.45},
+                        }
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(**self._request(include_quotes=True))
+
+        assert (success, status_code) == (True, 200)
+        assert response["quote"] == {"ltp": 123.45}
+        assert stub_resolver == [("NIFTY", "NSE_INDEX")]
+        assert len(multiquote_calls) == 1
+        assert multiquote_calls[0][0]["symbol"] == response["symbol"]
+
+    @pytest.mark.parametrize("invalid_option_quote", [{}, {"ltp": None}])
+    def test_include_quotes_retries_when_the_batch_quote_has_no_ltp(
+        self, stub_resolver, monkeypatch, invalid_option_quote
+    ):
+        multiquote_calls = []
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            is_retry = len(multiquote_calls) == 2
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": item["symbol"],
+                            "exchange": item["exchange"],
+                            "data": (
+                                {"ltp": 23587.50}
+                                if item["symbol"] == "NIFTY"
+                                else {"ltp": 123.45}
+                                if is_retry
+                                else invalid_option_quote
+                            ),
+                        }
+                        for item in symbols
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(**self._request(include_quotes=True))
+
+        assert (success, status_code) == (True, 200)
+        assert response["quote"] == {"ltp": 123.45}
+        assert len(multiquote_calls) == 2
+        assert len(multiquote_calls[1]) == 1
+
+    @pytest.mark.parametrize("invalid_option_quote", [{}, {"ltp": None}])
+    def test_include_quotes_rejects_missing_ltp_after_fallback(
+        self, stub_resolver, monkeypatch, invalid_option_quote
+    ):
+        multiquote_calls = []
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": item["symbol"],
+                            "exchange": item["exchange"],
+                            "data": (
+                                {"ltp": 23587.50}
+                                if item["symbol"] == "NIFTY"
+                                else invalid_option_quote
+                            ),
+                        }
+                        for item in symbols
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(**self._request(include_quotes=True))
+
+        assert (success, status_code) == (False, 500)
+        assert "usable LTP" in response["message"]
+        assert len(multiquote_calls) == 2
+
+    def test_include_quotes_with_prefetched_ltp_fetches_only_the_option(
+        self, stub_resolver, monkeypatch
+    ):
+        multiquote_calls = []
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": symbols[0]["symbol"],
+                            "exchange": symbols[0]["exchange"],
+                            "data": {"ltp": 88.25},
+                        }
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(
+            **self._request(underlying_ltp=23574.00, include_quotes=True)
+        )
+
+        assert (success, status_code) == (True, 200)
+        assert response["symbol"] == "NIFTY28OCT2523450CE"
+        assert response["quote"] == {"ltp": 88.25}
+        assert stub_resolver == []
+        assert multiquote_calls == [[{"symbol": "NIFTY28OCT2523450CE", "exchange": "NFO"}]]
+
+    def test_include_quotes_reuses_option_data_when_batch_lacks_underlying(
+        self, stub_resolver, monkeypatch
+    ):
+        multiquote_calls = []
+
+        def fake_get_multiquotes(symbols, api_key):
+            multiquote_calls.append(symbols)
+            return (
+                True,
+                {
+                    "status": "success",
+                    "results": [
+                        {
+                            "symbol": "NIFTY28OCT2523500CE",
+                            "exchange": "NFO",
+                            "data": {"ltp": 123.45},
+                        }
+                    ],
+                },
+                200,
+            )
+
+        monkeypatch.setattr(oss, "get_multiquotes", fake_get_multiquotes)
+
+        success, response, status_code = get_option_symbol(**self._request(include_quotes=True))
+
+        assert (success, status_code) == (True, 200)
+        assert response["quote"] == {"ltp": 123.45}
+        assert stub_resolver == [("NIFTY", "NSE_INDEX")]
+        assert len(multiquote_calls) == 1
 
 
 class TestNoSilentPutFallback:


### PR DESCRIPTION
Closes #1816.

When option-symbol lookup is used with Dhan, resolving a strike can issue one quote request for the underlying and another for the option chain. Each request pays the broker's rate-limit wait, so a quote-enabled lookup can be much slower than the work requires.

The new `include_quotes` option is opt-in. For Dhan, the service requests the underlying and candidate option symbols together, reuses that response to resolve the strike, and returns the selected option quote. The path is exposed through REST, MCP, the agent tool, the Flow executor, and the Flow editor. Fyers and Zebu retain their adapter-specific request behavior, while unknown or oversized cases keep the existing fallback path. Default callers keep the existing response and quote behavior.

This follows the batched-multiquote pattern already merged in #1973. Only `frontend/src/` sources are touched; `frontend/dist/` is untouched and left to CI.

### How this was tested

- The maintained test selection passes 243 tests on `9117eb9cd0bf` and 253 with this change, in both cases with 6 existing test warnings and one pytest cache-path warning. Both counts were re-run against the final commit.
- The focused option and adapter-boundary tests passed 159 tests, and the Flow regression selection passed 182 tests.
- The pre-change reproducer made two quote calls for the quote-enabled lookup; the Dhan path now makes one combined multiquote call when the batch fits.
- `npm run build` passes in `frontend` on Node 25.9.0, so the Flow-editor change compiles. The rebuilt `frontend/dist/` was restored and is not part of this branch.
- `git diff --check` passed.

The tests used Windows and the run's Python 3.12.14 environment. The recorded Mailman environment metadata reports Python 3.14.3 because the venv was created from that interpreter. No live Dhan account or broker credentials were available, so the reported live latency was not re-measured locally.

The alternative was to send every broker through one generic batch size and split requests automatically. I did not use that design because Fyers and Zebu perform different upstream work inside their quote adapters. The combined optimization is limited to Dhan, while the other adapters retain their existing request behavior.

This change was drafted with AI assistance. codex (`gpt-5.6-luna`) wrote the patch and codex (`gpt-5.6-luna`) reviewed it under Mailman. The test results above come from the harness executing the commands, not from either agent's account of its own work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds an opt-in `include_quotes` option to option-symbol lookup that, on Dhan, resolves the strike and returns the selected option's quote from one batched multiquote call instead of two separate calls that each paid rate-limit latency.

- `include_quotes` is accepted by the REST endpoint, MCP server, agent tool, Flow executor, and the Flow editor.
- The response includes `quote` only when `include_quotes` is true; existing callers see the same response as before.
- Fyers and Zebu keep their current request pattern; unknown brokers or oversized batches fall back to the pre-existing path.

<sup>Written for commit 328394ceb28abc2c79c2524001d80d8d8b157a39. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2021?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

