### PR TITLE
fix(iifl): preserve realized P&L on closed positions

### DIFF
--- a/broker/iifl/mapping/order_data.py
+++ b/broker/iifl/mapping/order_data.py
@@ -314,6 +314,10 @@ def transform_positions_data(positions_data):
         average_price = net_amount
         # Ensure average_price is treated as a float, then format to a string with 2 decimal places
         average_price_formatted = f"{average_price:.2f}"
+        pnl = position.get("pnl", 0.0)
+        if netqty == 0:
+            # XTS exposes closed-position P&L as RealizedMTM rather than pnl.
+            pnl = position.get("RealizedMTM", pnl)
 
         transformed_position = {
             "symbol": position.get("TradingSymbol", ""),
@@ -322,7 +326,7 @@ def transform_positions_data(positions_data):
             "quantity": position.get("Quantity", 0),
             "average_price": average_price_formatted,
             "ltp": position.get("ltp", 0.0),
-            "pnl": position.get("pnl", 0.0),
+            "pnl": pnl,
         }
         # logger.info(f"Transformed Position: {transformed_position}")
         transformed_data.append(transformed_position)

--- a/test/test_iifl_positions_pnl.py
+++ b/test/test_iifl_positions_pnl.py
@@ -1,0 +1,30 @@
+from broker.iifl.mapping.order_data import map_position_data, transform_positions_data
+
+
+def test_closed_position_uses_realized_mtm_for_pnl(monkeypatch):
+    """IIFL keeps realized P&L on a zero-quantity position as RealizedMTM."""
+    monkeypatch.setattr(
+        "broker.iifl.mapping.order_data.get_symbol",
+        lambda _token, _exchange: "BANKNIFTY25AUG2657600CE",
+    )
+
+    response = {
+        "result": {
+            "positionList": [
+                {
+                    "ExchangeInstrumentId": 2657600,
+                    "ExchangeSegment": "NSEFO",
+                    "ProductType": "NRML",
+                    "Quantity": 0,
+                    "BuyAveragePrice": 100.0,
+                    "SellAveragePrice": 110.0,
+                    "RealizedMTM": 33154.5,
+                }
+            ]
+        }
+    }
+
+    positions = transform_positions_data(map_position_data(response))
+
+    assert positions[0]["quantity"] == 0
+    assert positions[0]["pnl"] == 33154.5


### PR DESCRIPTION
Closes #1905.

Closed IIFL positions are returned with `Quantity` set to zero and their realized profit or loss in `RealizedMTM`. The mapper currently reads `pnl`, which is absent or zero for that response, so a fully closed position is reported with zero P&L even when the broker has a realized value.

For zero-quantity positions, the mapper now uses `RealizedMTM` and falls back to the existing `pnl` field when it is not present. Open-position behavior is unchanged. A regression fixture covers a closed position with a realized P&L of 33154.5.

`RealizedMTM` is already the field this repository reads for realized P&L elsewhere on the same broker, in `broker/iifl/api/funds.py`, so this is the existing XTS field name rather than a new assumption.

The same `"pnl": position.get("pnl", 0.0)` line exists in the other XTS-derived mappers — `compositedge`, `fivepaisaxts`, `ibulls`, `jainamxts`, `rmoney` and `wisdom` — so they most likely report closed positions the same way. I have kept this pull request to the broker the issue reports, per the one-fix-per-PR guideline, and am happy to send the others separately if you would like them.

### How this was tested

- The maintained test selection passes 243 tests on `9117eb9cd0bf`, and 244 with this change and its new test added to the selection, in both cases with 6 existing test warnings and one pytest cache-path warning.
- The pre-change fixture produced `quantity: 0` and `pnl: 0.0`; with the source change it produces `pnl: 33154.5`. The regression fails against the base mapper because it does not read `RealizedMTM`.
- `git diff --check` passed.

The tests used Windows and the run's Python 3.12.14 environment. The recorded Mailman environment metadata reports Python 3.14.3 because the venv was created from that interpreter. No live IIFL account or broker credentials were available, so the broker response was tested with a captured-shaped fixture rather than a live request.

The alternative was to patch the API response after mapping or replace every `pnl` lookup. I kept the change at the IIFL mapping boundary, where `Quantity == 0` identifies the closed-position payload and the existing field remains the fallback for other responses.

This change was drafted with AI assistance. codex (`gpt-5.6-luna`) wrote the patch and codex (`gpt-5.6-luna`) reviewed it under Mailman. The test results above come from the harness executing the commands, not from either agent's account of its own work.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes IIFL closed positions being reported with zero P&L by reading `RealizedMTM` when the position quantity is zero, falling back to the existing `pnl` field otherwise. Open-position behavior is unchanged. Adds a regression test covering a closed position with realized P&L of 33154.5.

<sup>Written for commit 4574fe16e736878370d636509fde82bdfdb54a6d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2022?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

