### PR TITLE
fix(upstox): normalize tick_size from paise to rupees

### DIFF
--- a/broker/upstox/database/master_contract_db.py
+++ b/broker/upstox/database/master_contract_db.py
@@ -308,6 +308,17 @@ def process_upstox_json(path):
         "CLUSD": "WTIOIL",
     })
 
+    # Upstox ships tick_size in paise on every tradeable segment, so rupees is
+    # that value over 100: NSE_EQ arrives as 1/5/10, NSE_FO and BSE_FO as 5,
+    # MCX_FO as 50, BCD_FO and NCD_FO as 0.25. Left raw, BSE_FO SENSEX options
+    # report a tick of Rs 5.00 instead of Rs 0.05, and anything rounding a price
+    # to that tick lands 100x too coarse.
+    #
+    # Unlike Dhan, no index exception is needed here: Upstox sends null rather
+    # than a rupee value for NSE_INDEX and BSE_INDEX, which coerces to NaN and
+    # divides harmlessly.
+    df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100
+
     return df
 
 

--- a/test/test_upstox_tick_size.py
+++ b/test/test_upstox_tick_size.py
@@ -1,0 +1,85 @@
+"""Upstox master contract tick size units.
+
+Upstox ships ``tick_size`` in paise on every tradeable segment, so rupees is
+that value over 100. Sampled from the live instrument master: NSE_EQ arrives as
+1/5/10, NSE_FO and BSE_FO as 5, MCX_FO as 50, and the currency segments
+BCD_FO/NCD_FO as 0.25.
+
+Left raw, ``/api/v1/symbol`` reported a BSE_FO SENSEX option tick as Rs 5.00
+instead of Rs 0.05. Any code rounding a price to that tick then works at 100x
+the intended granularity, which is how an SL-L limit price came out equal to
+its trigger instead of a percentage above it.
+
+Index rows need no exception here. Upstox sends null for NSE_INDEX and
+BSE_INDEX rather than a rupee value, so they coerce to NaN and divide
+harmlessly -- the opposite of Dhan, which ships indices already in rupees and
+therefore needs one (see ``test_dhan_tick_size.py``).
+
+These pin the rule because the failure is silent: nothing raises, the number is
+simply wrong by two orders of magnitude in a column nobody reads directly.
+"""
+
+import pandas as pd
+import pytest
+
+
+def convert(frame: pd.DataFrame) -> pd.Series:
+    """The conversion as ``process_upstox_json`` performs it."""
+    return pd.to_numeric(frame["tick_size"], errors="coerce") / 100
+
+
+@pytest.mark.parametrize(
+    ("segment", "raw", "expected"),
+    [
+        # The reported bug: SENSEX weekly options on BSE F&O.
+        ("BSE_FO", 5.0, 0.05),
+        ("BSE_FO", 100.0, 1.0),
+        # Equity, both ticks NSE and BSE actually quote.
+        ("NSE_EQ", 1.0, 0.01),
+        ("NSE_EQ", 5.0, 0.05),
+        ("NSE_EQ", 10.0, 0.10),
+        ("BSE_EQ", 1.0, 0.01),
+        # Derivatives.
+        ("NSE_FO", 5.0, 0.05),
+        ("NSE_FO", 1.0, 0.01),
+        # Commodities quote coarser.
+        ("MCX_FO", 50.0, 0.50),
+        ("MCX_FO", 10.0, 0.10),
+        # Currency genuinely quotes in four decimals, and must keep them.
+        ("BCD_FO", 0.25, 0.0025),
+        ("NCD_FO", 0.25, 0.0025),
+    ],
+)
+def test_tick_size_units(segment, raw, expected):
+    frame = pd.DataFrame({"exchange": [segment], "tick_size": [raw]})
+    assert convert(frame).iloc[0] == pytest.approx(expected)
+
+
+def test_a_sensex_option_tick_is_five_paise_not_five_rupees():
+    """The regression itself, in the units a trader would recognise."""
+    frame = pd.DataFrame({"exchange": ["BSE_FO"], "tick_size": [5.0]})
+    assert convert(frame).iloc[0] == pytest.approx(0.05)
+    assert convert(frame).iloc[0] != pytest.approx(5.0)
+
+
+def test_an_index_without_a_tick_stays_missing():
+    """Upstox sends null for index rows; that must not become a silent zero."""
+    frame = pd.DataFrame({"exchange": ["NSE_INDEX", "BSE_INDEX"], "tick_size": [None, None]})
+    assert convert(frame).isna().all()
+
+
+def test_a_missing_tick_becomes_nan_not_a_silent_zero():
+    frame = pd.DataFrame({"exchange": ["NSE_EQ", "BSE_FO"], "tick_size": ["", None]})
+    assert convert(frame).isna().all()
+
+
+def test_the_conversion_the_module_ships_matches_this_rule():
+    """Guards against the source drifting away from what is asserted above.
+
+    Read rather than imported: ``process_upstox_json`` wants a JSON file on disk
+    and the whole broker package behind it, and the unit rule is one expression.
+    """
+    from pathlib import Path
+
+    source = Path("broker/upstox/database/master_contract_db.py").read_text(encoding="utf-8")
+    assert 'df["tick_size"] = pd.to_numeric(df["tick_size"], errors="coerce") / 100' in source


### PR DESCRIPTION
Fixes #1982

## Problem

`/api/v1/symbol` returned `tick_size: 5` for a BFO SENSEX option where `0.05` is correct.

The divergence reported in the issue is not between the two endpoints. Neither `symbol_service` nor `search_service` transforms `tick_size`, so the raw value reaches both. The root cause is one layer down: the Upstox master contract loader never converted the field, while the other broker loaders do (`angel`, `arrow`, `dhan`, `kotak`, `nubra`, `shoonya` and `tradesmart` all divide by 100).

Any code reading `tick_size` and rounding a price to it then worked at 100x the intended granularity. In the reporter's case a 5 percent buffer was rounded away at a tick of Rs 5.00 instead of Rs 0.05, so an SL-L limit price came out equal to its trigger.

## Evidence

Sampled from the live instrument master (`complete.json.gz`, 118,705 rows). Upstox ships paise on every tradeable segment:

| segment | raw tick_size | rupees |
| --- | --- | --- |
| BSE_FO | 5.0 | 0.05 |
| NSE_FO | 5.0, 1.0 | 0.05, 0.01 |
| NSE_EQ | 1.0, 5.0, 10.0 | 0.01, 0.05, 0.10 |
| BSE_EQ | 1.0, 5.0 | 0.01, 0.05 |
| MCX_FO | 50.0, 10.0 | 0.50, 0.10 |
| BCD_FO, NCD_FO | 0.25 | 0.0025 |
| NSE_INDEX, BSE_INDEX | null | n/a |

## Change

One expression in `process_upstox_json`, matching the pattern the other loaders already use.

Two deliberate scope decisions, both verified against the same data:

- **No index exception is needed here, unlike Dhan.** Dhan ships index rows already in rupees and therefore needs one. Upstox sends null for `NSE_INDEX` and `BSE_INDEX`, which coerces to NaN and divides harmlessly. All 139 index rows stay NaN, with no silent zeros.
- **`strike_price` is left alone.** Upstox already ships it in rupees, for example a SENSEX 71700 strike arrives as `71700.0`. Scaling it would have introduced a second bug.

## Migration

None required. `master_contract_download` calls `delete_symtoken_table` and repopulates, so existing installations pick up corrected values on their next daily master contract download.

## Tests

`test/test_upstox_tick_size.py`, following the structure of the existing `test/test_dhan_tick_size.py`: a local mirror of the shipped expression, parameterized cases per segment, the currency four-decimal case, null and empty handling, and a source-drift guard so the module cannot quietly diverge from what is asserted.

```
uv run pytest test/test_upstox_tick_size.py test/test_dhan_tick_size.py -v
29 passed

uv run ruff check broker/upstox/database/master_contract_db.py test/test_upstox_tick_size.py
All checks passed!
```

The full-suite collection errors in my local environment are missing third-party packages and are identical on `main` with and without this branch, which adds 16 tests and no new errors.

`ruff format` was deliberately not run against `broker/upstox/database/master_contract_db.py`. That file is already unformatted on `main` and reformatting it would add 244 lines of unrelated diff around an 11-line change. Happy to send that separately if wanted.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Upstox master contract loader so `tick_size` is converted from paise to rupees, changing a BSE_FO SENSEX option tick from Rs 5.00 to the correct Rs 0.05. Fixes #1982.

- Divides by 100 in `process_upstox_json`, matching the other broker loaders.
- No index exception needed: Upstox sends null for index rows, which becomes NaN rather than a silent zero.
- `strike_price` is untouched; Upstox already ships it in rupees.
- No migration required; the daily master contract download repopulates corrected values.
- Tests cover each segment's observed raw values, null handling, and a source-drift guard.

<sup>Written for commit 24e431d9e3fdf9ba8991649a218a44b95e02378b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2026?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

