### PR TITLE
fix(upstox): stamp the synthetic daily candle in IST, not host local time

### DIFF
--- a/broker/upstox/api/data.py
+++ b/broker/upstox/api/data.py
@@ -2,7 +2,7 @@ import json
 import os
 import time
 import urllib.parse
-from datetime import datetime, timedelta
+from datetime import datetime, timedelta, timezone
 
 import httpx
 import numpy as np
@@ -19,6 +19,12 @@ from utils.httpx_client import get_httpx_client
 from utils.logging import get_logger
 
 logger = get_logger(__name__)
+
+# Upstox stamps every candle in IST. Building a timestamp by adding 5h30m to a
+# naive datetime is not a timezone conversion -- .timestamp() then reads the
+# result in whatever zone the host runs in, so the value moves with the
+# deployment. Attach the offset instead.
+IST = timezone(timedelta(hours=5, minutes=30))
 
 # /v3/market-quote/quotes accepts at most 500 instrument keys per call (UDAPI100042)
 FULL_QUOTE_BATCH_SIZE = 500
@@ -825,15 +831,19 @@ class BrokerData:
                                         )
 
                                 if not is_stale:
-                                    # Create today's daily candle with midnight timestamp
-                                    today_ts = int(
-                                        (
-                                            datetime.combine(today, datetime.min.time())
-                                            + timedelta(hours=5, minutes=30)
-                                        ).timestamp()
-                                    )
+                                    # Stamp the synthetic bar exactly as Upstox stamps a real
+                                    # daily candle -- IST midnight, ISO 8601 with the offset --
+                                    # so both paths carry one convention into
+                                    # safe_to_datetime(). The previous form added 5h30m to a
+                                    # naive datetime and let .timestamp() interpret it locally,
+                                    # which was 19800s out on an IST host and 39600s out in a
+                                    # UTC container; it only ever looked correct because the
+                                    # interval == "D" branch normalises through .date() and
+                                    # discards the error.
                                     today_candle = [
-                                        today_ts * 1000,  # Upstox uses milliseconds
+                                        datetime.combine(
+                                            today, datetime.min.time(), tzinfo=IST
+                                        ).isoformat(),
                                         quotes.get("open", quotes.get("ltp", 0)),
                                         quotes.get("high", quotes.get("ltp", 0)),
                                         quotes.get("low", quotes.get("ltp", 0)),


### PR DESCRIPTION
When a daily history request covers today and the historical endpoint has not published today's bar yet, the adapter synthesises one from the quotes API. It built the timestamp by adding 5h30m to a NAIVE datetime and then calling .timestamp(), which reads the result in whatever zone the host runs in. That is not a timezone conversion: the value came out 19800s off on an IST machine and 39600s off in a UTC container, so the same code produced a different epoch per deployment.

It never surfaced because the interval == "D" branch normalises through .date() before converting, discarding the error -- so the bar was only ever accidentally correct, and only for daily.

The synthetic bar also travelled in a different format from every real one: milliseconds versus Upstox's ISO 8601 string, so safe_to_datetime() produced a naive value for it and a tz-aware value for the rest, two conventions reconciled solely by that .date() call.

Now emits IST midnight as ISO 8601 with the offset, byte-identical to a real Upstox daily candle, so one convention flows through. Verified the synthetic and real bars yield the same epoch, and that the today_found check at the top of the branch still parses it (it already accepted either form).

This does not close #1765. It removes a confirmed timezone defect found while investigating it; the reported 86400s shift did not reproduce against a live session, and the historical-vs-synthetic path selection that likely drives the other symptoms is untouched.


Claude-Session: https://claude.ai/code/session_014aVCTxCsgBactQEvtxmoCV

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Upstox adapter's synthetic daily candle timestamp so it's stamped in IST, not host local time, and matches the format of real Upstox candles.

- The old code added 5h30m to a naive datetime and called `.timestamp()`, which reads the host's timezone, so the epoch varied by deployment.
- The synthetic bar now uses IST midnight as ISO 8601 with offset, byte-identical to a real candle, so both paths carry one convention.
- This does not close #1765; it only removes the confirmed timezone defect found during investigation.

<sup>Written for commit 934f09fa9a4e28eba13aeb62d998c099df9751f2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2030?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

