### PR TITLE
fix(samco): stop reconnecting after a rejected session token

### DIFF
--- a/broker/samco/streaming/samcoWebSocket.py
+++ b/broker/samco/streaming/samcoWebSocket.py
@@ -61,6 +61,7 @@ class SamcoWebSocket:
         on_close: Callable | None = None,
         on_open: Callable | None = None,
         on_data: Callable | None = None,
+        auth_error_check: Callable | None = None,
     ):
         """
         Initialize Samco WebSocket client
@@ -73,6 +74,10 @@ class SamcoWebSocket:
             on_close: Callback for connection close
             on_open: Callback for connection open
             on_data: Callback for market data
+            auth_error_check: Predicate that returns True when an error string
+                means the broker refused a dead credential (401/403). The
+                adapter passes BaseBrokerWebSocketAdapter.is_auth_error so
+                samco shares the fleet's auth-error vocabulary.
         """
         # Authentication credentials
         # URL-decode the session token if it contains encoded characters
@@ -91,6 +96,13 @@ class SamcoWebSocket:
         self._on_close_callback = on_close
         self._on_open_callback = on_open
         self._on_data_callback = on_data
+        self.auth_error_check = auth_error_check
+
+        # Auth-failure state. Set from the error/close handlers when the broker
+        # rejects the session token; the adapter reads it to stop reconnecting
+        # instead of hammering the broker with a credential that cannot work.
+        self.auth_failed = False
+        self.auth_failure_reason = None
 
         # Subscription tracking
         self.subscribed_symbols = {}  # {symbol_key: {symbol, exchange, mode}}
@@ -191,6 +203,11 @@ class SamcoWebSocket:
         """Initialize WebSocket connection with authentication headers"""
         self.running = True
         self.DISCONNECT_FLAG = False
+        # A new attempt carries a freshly re-read token, so the previous
+        # attempt's verdict must not block it. The adapter has already
+        # consumed the old flag by the time it calls connect() again.
+        self.auth_failed = False
+        self.auth_failure_reason = None
 
         # Build headers with session token
         # Log token info for debugging (first/last 4 chars only for security)
@@ -227,6 +244,12 @@ class SamcoWebSocket:
             if self.connected:
                 self.logger.info("Samco WebSocket connected successfully")
                 return True
+            if self.auth_failed:
+                # The handshake was rejected outright; waiting out the full
+                # timeout only delays the adapter's decision to stop.
+                self.logger.error(f"Samco WebSocket auth failure: {self.auth_failure_reason}")
+                self.close_connection()
+                return False
             time.sleep(0.1)
 
         self.logger.error("Connection timeout")
@@ -665,9 +688,34 @@ class SamcoWebSocket:
         except (ValueError, TypeError):
             return 0
 
+    def _is_auth_error(self, detail) -> bool:
+        """True when `detail` reads as the broker refusing a dead credential."""
+        if self.auth_error_check is None or detail in (None, ""):
+            return False
+        try:
+            return bool(self.auth_error_check(str(detail)))
+        except Exception:
+            self.logger.exception("samco auth_error_check raised; treating as non-auth error")
+            return False
+
+    def _record_auth_failure(self, reason: str) -> None:
+        """Latch the auth-failure verdict for the adapter to act on."""
+        if self.auth_failed:
+            return
+        self.auth_failed = True
+        self.auth_failure_reason = reason
+        self.logger.error(f"Samco WebSocket auth failure: {reason}")
+
     def _on_error(self, ws, error) -> None:
         """Handle WebSocket connection errors — reconnection is handled by the adapter"""
         self.logger.error(f"Samco WebSocket error: {error}")
+
+        # websocket-client raises WebSocketBadStatusException with the HTTP
+        # status attached when the handshake itself is rejected; the status
+        # attribute is more reliable than the stringified message.
+        status = getattr(error, "status_code", None)
+        if status in (401, 403) or self._is_auth_error(error):
+            self._record_auth_failure(str(error))
 
         if self._on_error_callback:
             try:
@@ -681,6 +729,11 @@ class SamcoWebSocket:
         """Handle WebSocket connection close event"""
         self.connected = False
         self.logger.info(f"Samco WebSocket closed: {close_status_code} - {close_msg}")
+
+        # The adapter's on_close callback only receives `ws`, so the close
+        # reason has to be judged here and latched on the client.
+        if self._is_auth_error(close_msg) or self._is_auth_error(close_status_code):
+            self._record_auth_failure(f"close code={close_status_code} msg={close_msg}")
 
         self._stop_heartbeat()
         self._stop_subscription_flusher()

--- a/broker/samco/streaming/samco_adapter.py
+++ b/broker/samco/streaming/samco_adapter.py
@@ -38,6 +38,7 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self._reconnecting = False  # Guard against concurrent reconnect threads
         self._broker_data = None  # Cached BrokerData for index listing lookups
         self._index_listing_cache = {}  # {symbol_exchange: listing_id}
+        self.auth_failed = False  # Set when the broker rejects the session token
 
     def initialize(
         self, broker_name: str, user_id: str, auth_data: dict[str, str] | None = None
@@ -73,7 +74,13 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 raise ValueError("Missing required authentication data (session_token)")
 
         # Create SamcoWebSocket instance
-        self.ws_client = SamcoWebSocket(session_token=session_token, user_id=user_id)
+        self.ws_client = SamcoWebSocket(
+            session_token=session_token,
+            user_id=user_id,
+            # is_auth_error() is inherited from BaseBrokerWebSocketAdapter, so
+            # samco shares the fleet's 401/403 vocabulary instead of its own.
+            auth_error_check=self.is_auth_error,
+        )
 
         # Set callbacks
         self.ws_client.on_open = self._on_open
@@ -139,10 +146,24 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         )
 
                     self.ws_client.connect()
+
+                    # A rejected session token cannot be fixed by retrying: the
+                    # user has to re-login. Retrying anyway hammers the broker
+                    # for the rest of the session and risks an IP rate-limit.
+                    if getattr(self.ws_client, "auth_failed", False):
+                        self._stop_for_auth_failure(
+                            getattr(self.ws_client, "auth_failure_reason", None)
+                        )
+                        return
+
                     self.reconnect_attempts = 0  # Reset attempts on successful connection
                     break
 
                 except Exception as e:
+                    if self.is_auth_error(str(e)):
+                        self._stop_for_auth_failure(str(e))
+                        return
+
                     self.reconnect_attempts += 1
                     delay = min(
                         self.reconnect_delay * (2**self.reconnect_attempts),
@@ -156,6 +177,24 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         finally:
             with self.lock:
                 self._reconnecting = False
+
+    def _stop_for_auth_failure(self, reason: str | None) -> None:
+        """
+        Stop reconnecting because the broker refused our credentials.
+
+        Clearing `running` is what breaks the loop: `_connect_with_retry` tests
+        it on every pass and `_on_close` only respawns the retry thread while it
+        is set. Without this, a dead token produces a reconnect storm that runs
+        until the process is restarted.
+        """
+        with self.lock:
+            self.auth_failed = True
+            self.connected = False
+            self.running = False
+        self.logger.error(
+            f"Auth failure on Samco WebSocket ({reason}); stopping reconnect loop. "
+            "User must re-login to refresh the session token."
+        )
 
     def disconnect(self) -> None:
         """Disconnect from Samco WebSocket"""
@@ -401,10 +440,21 @@ class SamcoWebSocketAdapter(BaseBrokerWebSocketAdapter):
         """Callback for WebSocket errors"""
         self.logger.error(f"Samco WebSocket error: {error}")
 
+        # The close callback owns reconnect scheduling; we only have to clear
+        # `running` here so it short-circuits.
+        if self.is_auth_error(str(error)):
+            self._stop_for_auth_failure(str(error))
+
     def _on_close(self, wsapp) -> None:
         """Callback when connection is closed"""
         self.logger.info("Samco WebSocket connection closed")
         self.connected = False
+
+        # The client keeps the close code/message to itself (this callback only
+        # gets `wsapp`), so read the verdict it latched for us.
+        if getattr(self.ws_client, "auth_failed", False):
+            self._stop_for_auth_failure(getattr(self.ws_client, "auth_failure_reason", None))
+            return
 
         # Attempt to reconnect if we're still running
         if self.running:


### PR DESCRIPTION
fix(samco): stop reconnecting after a rejected session token

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stops the Samco WebSocket from reconnecting after the broker rejects the session token, so a dead credential no longer causes an unbounded reconnect storm.

- Treats 401/403 responses as auth failures on both handshake errors and close events.
- The adapter clears `running` on auth failure, breaking the retry loop and reconnect scheduling.
- After an auth failure, users must re-login to get a fresh session token.

<sup>Written for commit cc856ac6b14d68d6b2fae4bc42c068639581701c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2035?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

