### PR TITLE
feat(trading): add Objects panel with charts 2.1.7

### DIFF
--- a/.claude/skills/chart-indicator/SKILL.md
+++ b/.claude/skills/chart-indicator/SKILL.md
@@ -59,6 +59,12 @@ The descriptor contract has not changed since this skill was written, so an
 existing indicator keeps working on the pinned build. What changed around it,
 newest first:
 
+- **2.1.7: hidden indicators remain hidden through layout restoration and style
+  edits.** Reference levels now follow the instance's visibility along with its
+  plots and other visuals. The new `ChartObjects` inventory also exposes an
+  indicator's visibility and Tier-2 data status to host and widget object
+  panels, but it does not change the descriptor contract or add work to a
+  custom indicator.
 - **2.1.6: Tier-2 studies follow the chart's data context and loaded source
   range.** `createTier2Indicator` receives `dataContext` with the host's symbol,
   exchange and interval, cancels obsolete fetches, extends history when older

--- a/.claude/skills/chart-indicator/reference/api.md
+++ b/.claude/skills/chart-indicator/reference/api.md
@@ -163,13 +163,14 @@ while the sections above stayed true.
 | **2.1.2** | A Tier-2 study's history requests and live callbacks are isolated by data key, so a response for a setting you have left cannot land on the current one. |
 | **2.1.5** | Drawing previews survive past the newest candle. No indicator surface changed. |
 | **2.1.6** | Tier-2 studies receive the host's symbol, exchange and interval through `dataContext`, follow source-range changes, cancel obsolete fetches and expose loading, ready, empty, unsupported and error states with retry. `supports(ctx)` lets a provider decline a context explicitly. `DataLoadingController`, `HistoryRequestPool`, `sharedHistoryRequests` and `BAR_CACHE_VERSION` also joined the core export, but they belong to chart hosts rather than indicator descriptors. |
+| **2.1.7** | Hidden indicator state survives layout restoration and plot-style edits, and reference levels follow instance visibility. The new `ChartObjects` export lets hosts inventory indicators and display their Tier-2 status, but it is host infrastructure and does not change the descriptor contract. The built-in registry remains at 102 ids. |
 
 ## Complete export index
 
 <!-- BEGIN GENERATED EXPORT INDEX -->
 
-All 367 names on the API object, so nothing is a surprise. Generated from
-the installed openalgo-charts@2.1.6 build by `generate-api-index.mjs`; do not
+All 368 names on the API object, so nothing is a surprise. Generated from
+the installed openalgo-charts@2.1.7 build by `generate-api-index.mjs`; do not
 edit this section by hand.
 
 **Registration and introspection** (13)
@@ -219,12 +220,12 @@ Arrays of the descriptors above, as the picker rail groups them.
 
 `ADAPTIVE_INDICATORS`, `AVERAGE_INDICATORS`, `BUILTIN_INDICATORS`, `FLOW_INDICATORS`, `INDEX_INDICATORS`, `OSCILLATOR_INDICATORS`, `OVERLAY_INDICATORS`, `RANGE_INDICATORS`, `SEASONALITY_INDICATORS`, `SIGNAL_INDICATORS`, `STRENGTH_INDICATORS`, `STUDY_INDICATORS`, `VOLATILITY_INDICATORS`, `WAVETREND_INDICATORS`
 
-**Chart infrastructure, not for indicators** (94)
+**Chart infrastructure, not for indicators** (95)
 
 Panes, scales, feeds, drawing primitives, trading controllers, link groups, replay
 and the render backends. An indicator describes what to compute and what to plot;
 the chart owns these.
 
-`addComparison`, `alignToPrimary`, `applyChartSettings`, `backendDegradation`, `backoffDelayMs`, `BAR_CACHE_VERSION`, `BarCache`, `barCacheKey`, `barsSince`, `beginPick`, `BUILTIN_COMMANDS`, `BuySellButtons`, `CandleBuilder`, `candleGeometry`, `candleTier`, `Canvas2dBackend`, `Chart`, `chartSettingsSchema`, `ChartTable`, `classifyAuthAck`, `comparisonController`, `ComparisonController`, `computePriceLevels`, `conflationGroupSize`, `createChart`, `createLinkGroup`, `createRenderBackend`, `DataLoadingController`, `decodeOrder`, `DEFAULT_CANDLE_BUILDER_OPTIONS`, `DEFAULT_CHART_TABLE_OPTIONS`, `DEFAULT_KEYMAP`, `DEFAULT_PRICE_SCALE_OPTIONS`, `DEFAULT_TIME_NAVIGATOR_OPTIONS`, `DEFAULT_TIME_SCALE_OPTIONS`, `DEFAULT_ZOOM_GLIDE_OPTIONS`, `EventMarkers`, `eventToCombo`, `followerIndex`, `followerRange`, `formatCombo`, `formatSubscribe`, `formatUnsubscribe`, `HistoryRequestPool`, `IndicatorDrawings`, `InvalidationLevel`, `isRebasing`, `isReservedCombo`, `isValidCombo`, `LINK_CROSSHAIR_ALPHA`, `LinkCrosshair`, `LinkGroup`, `LogoWatermark`, `mapHistoryResponse`, `mapOrder`, `mapOrderStatus`, `mapPosition`, `normalizeCombo`, `OpenAlgoDataFeed`, `OpenAlgoLiveDataFeed`, `OpenAlgoTradeFeed`, `OpenAlgoWsFeed`, `Pane`, `PaneLegend`, `parseCombo`, `parseMessage`, `parseTopic`, `PriceLevels`, `PriceLine`, `PriceScale`, `readChartSettings`, `readSequence`, `registeredRenderBackends`, `registerRenderBackend`, `ReplayController`, `ReplayShade`, `resolveRenderBackend`, `SCALE_FONT_MAX`, `SCALE_FONT_MIN`, `SeriesMarkers`, `sharedHistoryRequests`, `ShortcutManager`, `SvgContext`, `SvgLinearGradient`, `TextWatermark`, `TickBarAggregator`, `TimeNavigator`, `TimeScale`, `TradeMarkersPrimitive`, `TradingController`, `unregisterRenderBackend`, `valueWhen`, `withBarCache`, `ZoomGlide`
+`addComparison`, `alignToPrimary`, `applyChartSettings`, `backendDegradation`, `backoffDelayMs`, `BAR_CACHE_VERSION`, `BarCache`, `barCacheKey`, `barsSince`, `beginPick`, `BUILTIN_COMMANDS`, `BuySellButtons`, `CandleBuilder`, `candleGeometry`, `candleTier`, `Canvas2dBackend`, `Chart`, `ChartObjects`, `chartSettingsSchema`, `ChartTable`, `classifyAuthAck`, `comparisonController`, `ComparisonController`, `computePriceLevels`, `conflationGroupSize`, `createChart`, `createLinkGroup`, `createRenderBackend`, `DataLoadingController`, `decodeOrder`, `DEFAULT_CANDLE_BUILDER_OPTIONS`, `DEFAULT_CHART_TABLE_OPTIONS`, `DEFAULT_KEYMAP`, `DEFAULT_PRICE_SCALE_OPTIONS`, `DEFAULT_TIME_NAVIGATOR_OPTIONS`, `DEFAULT_TIME_SCALE_OPTIONS`, `DEFAULT_ZOOM_GLIDE_OPTIONS`, `EventMarkers`, `eventToCombo`, `followerIndex`, `followerRange`, `formatCombo`, `formatSubscribe`, `formatUnsubscribe`, `HistoryRequestPool`, `IndicatorDrawings`, `InvalidationLevel`, `isRebasing`, `isReservedCombo`, `isValidCombo`, `LINK_CROSSHAIR_ALPHA`, `LinkCrosshair`, `LinkGroup`, `LogoWatermark`, `mapHistoryResponse`, `mapOrder`, `mapOrderStatus`, `mapPosition`, `normalizeCombo`, `OpenAlgoDataFeed`, `OpenAlgoLiveDataFeed`, `OpenAlgoTradeFeed`, `OpenAlgoWsFeed`, `Pane`, `PaneLegend`, `parseCombo`, `parseMessage`, `parseTopic`, `PriceLevels`, `PriceLine`, `PriceScale`, `readChartSettings`, `readSequence`, `registeredRenderBackends`, `registerRenderBackend`, `ReplayController`, `ReplayShade`, `resolveRenderBackend`, `SCALE_FONT_MAX`, `SCALE_FONT_MIN`, `SeriesMarkers`, `sharedHistoryRequests`, `ShortcutManager`, `SvgContext`, `SvgLinearGradient`, `TextWatermark`, `TickBarAggregator`, `TimeNavigator`, `TimeScale`, `TradeMarkersPrimitive`, `TradingController`, `unregisterRenderBackend`, `valueWhen`, `withBarCache`, `ZoomGlide`
 
 <!-- END GENERATED EXPORT INDEX -->

--- a/docs/userguide/32-charting-terminal/README.md
+++ b/docs/userguide/32-charting-terminal/README.md
@@ -26,8 +26,8 @@ says so and links to `/apikey`.
 | Top bar | Symbol, interval, chart type, product, quantity, indicators, layout, sync, One-Click, replay, undo and redo, feed light, full screen, camera |
 | Left rail | Drawing tools in eight groups, magnet, keep-armed lock, undo, redo, delete |
 | Centre | One to eight chart panes in a grid |
-| Right panel | Watchlist, option chain, or the chart assistant |
-| Right rail | The three buttons that open those panels |
+| Right panel | Watchlist, option chain, Objects, or the chart assistant |
+| Right rail | The four controls that open those panels |
 | Bottom dock | Orders, positions, trades and GTT across every symbol |
 
 The chart grid takes whatever the rails and panels leave. Only the right panel
@@ -155,6 +155,27 @@ Select a drawing to get a floating bar with colour, width, dash, lock, delete
 and, on text tools, an editor. Double-click a text drawing to reopen its editor.
 
 Drawings are saved per pane and survive a reload.
+
+## Objects Panel
+
+The text-labelled **Objects** control on the right rail opens an inventory for
+the active chart pane. Click anywhere in a pane, including its toolbar, to make
+that pane the panel's target. The panel lists the protected price source,
+indicator instances, drawings and an active session profile. Search filters the
+list by object name, kind or source id.
+
+Each row offers only actions that object supports. Indicators can be selected,
+shown or hidden, configured and removed. Drawings can also be locked and focused;
+focusing moves future or off-screen anchors into view. Drawing changes use the
+same undo history and per-pane save as edits on the canvas. Profile rows open the
+existing chart settings form. The primary price source can be configured but
+cannot be hidden, locked or removed.
+
+The panel follows selection and direct changes made on the canvas. Indicator
+visibility is remembered with its settings; older saved panes open their
+indicators as visible. Removing an external-data indicator also releases its
+data requests and empty indicator pane. Object actions do not place, modify or
+cancel orders, and replay keeps every existing order restriction in force.
 
 ## Keyboard Shortcuts
 

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -44,7 +44,7 @@
         "lucide-react": "^0.563.0",
         "next-themes": "^0.4.6",
         "openalgo": "file:..",
-        "openalgo-charts": "2.1.6",
+        "openalgo-charts": "2.1.7",
         "plotly.js-dist-min": "^3.3.1",
         "react": "^19.2.8",
         "react-dom": "^19.2.8",
@@ -11879,9 +11879,9 @@
       "link": true
     },
     "node_modules/openalgo-charts": {
-      "version": "2.1.6",
-      "resolved": "https://registry.npmjs.org/openalgo-charts/-/openalgo-charts-2.1.6.tgz",
-      "integrity": "sha512-vWgn9OCNkxAOLVP8PwzpPqmPIqfgGBIuEMOmmYsmMkbFDhEFwo6jL1d8bYj7vhVv3AFC7zKxGy8LzMFXTz7TDA==",
+      "version": "2.1.7",
+      "resolved": "https://registry.npmjs.org/openalgo-charts/-/openalgo-charts-2.1.7.tgz",
+      "integrity": "sha512-c9/NQU/hJTwspuVKm9D43Bcc+NJygRl3CjDkVVeEyrpV5hO42jCROkP2XyQTlKAIUgGMDOwFCXID1iwD+ZQ38w==",
       "license": "Apache-2.0",
       "engines": {
         "node": ">=20"

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -60,7 +60,7 @@
     "lucide-react": "^0.563.0",
     "next-themes": "^0.4.6",
     "openalgo": "file:..",
-    "openalgo-charts": "2.1.6",
+    "openalgo-charts": "2.1.7",
     "plotly.js-dist-min": "^3.3.1",
     "react": "^19.2.8",
     "react-dom": "^19.2.8",

--- a/frontend/src/components/trading/ChartPane.tsx
+++ b/frontend/src/components/trading/ChartPane.tsx
@@ -3,7 +3,7 @@
 // weight when the whole row opens menus, and it reads as a dated form
 // control. Reserve the glyph for where it distinguishes something.
 import { ChevronDown, RefreshCw, Search, Settings } from 'lucide-react'
-import type { LinkGroup } from 'openalgo-charts'
+import type { ChartObjects, LinkGroup } from 'openalgo-charts'
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { Button } from '@/components/ui/button'
 import {
@@ -241,6 +241,8 @@ interface Props {
    * and whose rows charted nothing, on a page that looks perfectly ready.
    */
   onTerminalChange?(paneId: string, terminal: TradingTerminal | null): void
+  /** Reports the current chart generation's object inventory. */
+  onObjectsChange?(paneId: string, objects: ChartObjects | null): void
   /** Drawing state of this pane, for the shared rail's buttons. */
   onDrawStats?(stats: DrawStats): void
   /** Workspace link group this pane joins, if the page made one. */
@@ -280,6 +282,7 @@ export function ChartPane({
   onFocusPane,
   onSymbolChange,
   onTerminalChange,
+  onObjectsChange,
   onDrawStats,
   linkGroup,
   armed = false,
@@ -306,6 +309,8 @@ export function ChartPane({
   symbolCbRef.current = onSymbolChange
   const terminalCbRef = useRef(onTerminalChange)
   terminalCbRef.current = onTerminalChange
+  const objectsCbRef = useRef(onObjectsChange)
+  objectsCbRef.current = onObjectsChange
   // The flag as it stands when the terminal boots; the effect below tracks it
   // from then on. Read through a ref so the boot effect does not re-run and
   // rebuild the terminal on every toggle.
@@ -432,6 +437,8 @@ export function ChartPane({
       },
       onIndicatorsChange: (list) => aliveRef.current && setIndicators(list),
       onIndicatorSettings: (req) => aliveRef.current && setIndSettings(req),
+      onChartSettings: (req) => aliveRef.current && setChartSettings(req),
+      onObjectsChange: (objects) => objectsCbRef.current?.(paneId, objects),
       onDrawSelect: (sel) => aliveRef.current && setDrawSel(sel),
       // The legend readout is a second switch for the same thing as the context
       // menu row, so the menu label has to follow it.
@@ -627,12 +634,25 @@ export function ChartPane({
     : ''
 
   const chartTypeDef = CHART_TYPES[chartType] ?? CHART_TYPES.candlestick
+  // The three chart-owned settings editors are deliberately lightweight host
+  // overlays rather than Radix dialogs. Publish their presence on the pane so
+  // the page-level Escape handler can dismiss only the top surface.
+  const paneDialogOpen =
+    searchOpen ||
+    pickerOpen ||
+    chartSettings !== null ||
+    indSettings !== null ||
+    textReq !== null ||
+    ticket !== null ||
+    confirmLeave
 
   return (
     <section
       ref={paneRef}
+      data-trading-dialog-open={paneDialogOpen ? 'true' : undefined}
       style={style}
       className="relative flex h-full min-h-0 min-w-0 flex-col overflow-hidden rounded-lg border bg-card"
+      onPointerDownCapture={() => onFocusPane?.(terminalRef.current, paneId)}
     >
       {/* Per-pane control row. One line: the row scrolls rather than wrapping,
           so the view actions stay beside the instrument controls instead of
@@ -959,12 +979,7 @@ export function ChartPane({
             <span className="text-[10px] text-muted-foreground">{lotInfoText(sym, qty)}</span>
           )}
         </div>
-        <div
-          ref={chartRef}
-          className="absolute inset-0"
-          onContextMenuCapture={onContextMenu}
-          onPointerDownCapture={() => onFocusPane?.(terminalRef.current, paneId)}
-        />
+        <div ref={chartRef} className="absolute inset-0" onContextMenuCapture={onContextMenu} />
 
         {!ready && (
           <div className="absolute inset-0 flex items-center justify-center text-sm text-muted-foreground">

--- a/frontend/src/components/trading/ObjectsPanel.test.tsx
+++ b/frontend/src/components/trading/ObjectsPanel.test.tsx
@@ -1,6 +1,6 @@
 import type { ChartObjectSnapshot, ChartObjects } from 'openalgo-charts'
 import { describe, expect, it, vi } from 'vitest'
-import { render, screen, userEvent } from '@/test/test-utils'
+import { act, render, screen, userEvent } from '@/test/test-utils'
 import { ObjectsPanel } from './ObjectsPanel'
 
 const capabilities = (
@@ -94,7 +94,7 @@ describe('ObjectsPanel', () => {
     expect(screen.getByText('Pane 2')).toBeInTheDocument()
     expect(screen.getByText(/Loading/)).toBeInTheDocument()
     expect(screen.getByRole('button', { name: 'Select Open interest' })).toHaveAccessibleDescription(
-      'Indicator, Chart pane 2, Loading, Visible'
+      'Indicator · Chart pane 2 · Loading · Visible'
     )
 
     await userEvent.type(screen.getByRole('searchbox', { name: 'Search objects' }), 'interest')
@@ -123,7 +123,7 @@ describe('ObjectsPanel', () => {
       'true'
     )
     expect(screen.getByRole('button', { name: 'Select Trend line' })).toHaveAccessibleDescription(
-      'Drawing, Chart pane 1, Visible, Unlocked'
+      'Drawing · Chart pane 1 · Visible · Unlocked'
     )
     await userEvent.click(screen.getByRole('button', { name: 'Hide Trend line' }))
     await userEvent.click(screen.getByRole('button', { name: 'Lock Trend line' }))
@@ -152,7 +152,9 @@ describe('ObjectsPanel', () => {
     const second = model([drawing])
     const view = render(<ObjectsPanel model={first.value} paneLabel="Pane 1" />)
 
-    first.publish([primary, drawing])
+    await act(async () => {
+      first.publish([primary, drawing])
+    })
     expect(screen.getByText('Trend line')).toBeInTheDocument()
 
     view.rerender(<ObjectsPanel model={second.value} paneLabel="Pane 2" />)

--- a/frontend/src/components/trading/ObjectsPanel.test.tsx
+++ b/frontend/src/components/trading/ObjectsPanel.test.tsx
@@ -1,0 +1,173 @@
+import type { ChartObjectSnapshot, ChartObjects } from 'openalgo-charts'
+import { describe, expect, it, vi } from 'vitest'
+import { render, screen, userEvent } from '@/test/test-utils'
+import { ObjectsPanel } from './ObjectsPanel'
+
+const capabilities = (
+  patch: Partial<ChartObjectSnapshot['capabilities']> = {}
+): ChartObjectSnapshot['capabilities'] => ({
+  select: false,
+  visibility: false,
+  lock: false,
+  remove: false,
+  settings: false,
+  focus: false,
+  ...patch,
+})
+
+const primary: ChartObjectSnapshot = {
+  id: 'source:primary',
+  sourceId: 'primary',
+  kind: 'source',
+  name: 'NSE:BHEL',
+  paneIndex: 0,
+  visible: true,
+  selected: false,
+  capabilities: capabilities({ settings: true }),
+}
+
+const drawing: ChartObjectSnapshot = {
+  id: 'drawing:trend-1',
+  sourceId: 'trend-1',
+  kind: 'drawing',
+  name: 'Trend line',
+  paneIndex: 0,
+  visible: true,
+  locked: false,
+  selected: true,
+  capabilities: capabilities({
+    select: true,
+    visibility: true,
+    lock: true,
+    remove: true,
+    focus: true,
+  }),
+}
+
+function model(initial: readonly ChartObjectSnapshot[]) {
+  let objects = initial
+  const listeners = new Set<(next: readonly ChartObjectSnapshot[]) => void>()
+  const off = vi.fn()
+  return {
+    value: {
+      list: () => objects,
+      subscribe: (listener: (next: readonly ChartObjectSnapshot[]) => void) => {
+        listeners.add(listener)
+        listener(objects)
+        return () => {
+          listeners.delete(listener)
+          off()
+        }
+      },
+      select: vi.fn(() => true),
+      setVisible: vi.fn(() => true),
+      setLocked: vi.fn(() => true),
+      remove: vi.fn(() => true),
+      openSettings: vi.fn(() => true),
+      focus: vi.fn(() => true),
+    } as unknown as ChartObjects,
+    publish(next: readonly ChartObjectSnapshot[]) {
+      objects = next
+      for (const listener of listeners) listener(objects)
+    },
+    off,
+  }
+}
+
+describe('ObjectsPanel', () => {
+  it('searches the active pane inventory and reports external data state', async () => {
+    const external: ChartObjectSnapshot = {
+      id: 'indicator:oi-1',
+      sourceId: 'oi',
+      kind: 'indicator',
+      name: 'Open interest',
+      paneIndex: 1,
+      visible: true,
+      selected: false,
+      dataStatus: { state: 'loading' },
+      capabilities: capabilities({ select: true, visibility: true, remove: true }),
+    }
+    const objects = model([primary, drawing, external])
+    render(<ObjectsPanel model={objects.value} paneLabel="Pane 2" />)
+
+    expect(screen.getByRole('complementary', { name: 'Objects' })).toBeInTheDocument()
+    expect(screen.getByText('Pane 2')).toBeInTheDocument()
+    expect(screen.getByText(/Loading/)).toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Select Open interest' })).toHaveAccessibleDescription(
+      'Indicator, Chart pane 2, Loading, Visible'
+    )
+
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search objects' }), 'interest')
+    expect(screen.getByText('Open interest')).toBeInTheDocument()
+    expect(screen.queryByText('Trend line')).not.toBeInTheDocument()
+    expect(screen.queryByText('NSE:BHEL')).not.toBeInTheDocument()
+
+    await userEvent.clear(screen.getByRole('searchbox', { name: 'Search objects' }))
+    await userEvent.type(screen.getByRole('searchbox', { name: 'Search objects' }), 'pane 2')
+    expect(screen.getByText('Open interest')).toBeInTheDocument()
+    expect(screen.queryByText('Trend line')).not.toBeInTheDocument()
+  })
+
+  it('offers only supported actions and sends them to the shared model', async () => {
+    const objects = model([primary, drawing])
+    render(<ObjectsPanel model={objects.value} paneLabel="Pane 1" />)
+
+    expect(screen.queryByRole('button', { name: 'Remove NSE:BHEL' })).not.toBeInTheDocument()
+    expect(screen.queryByRole('button', { name: 'Hide NSE:BHEL' })).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Settings for NSE:BHEL' }))
+    expect(objects.value.openSettings).toHaveBeenCalledWith('source:primary')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Select Trend line' }))
+    expect(screen.getByRole('button', { name: 'Select Trend line' })).toHaveAttribute(
+      'aria-pressed',
+      'true'
+    )
+    expect(screen.getByRole('button', { name: 'Select Trend line' })).toHaveAccessibleDescription(
+      'Drawing, Chart pane 1, Visible, Unlocked'
+    )
+    await userEvent.click(screen.getByRole('button', { name: 'Hide Trend line' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Lock Trend line' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Focus Trend line' }))
+    await userEvent.click(screen.getByRole('button', { name: 'Remove Trend line' }))
+
+    expect(objects.value.select).toHaveBeenCalledWith('drawing:trend-1', false)
+    expect(objects.value.setVisible).toHaveBeenCalledWith('drawing:trend-1', false)
+    expect(objects.value.setLocked).toHaveBeenCalledWith('drawing:trend-1', true)
+    expect(objects.value.focus).toHaveBeenCalledWith('drawing:trend-1')
+    expect(objects.value.remove).toHaveBeenCalledWith('drawing:trend-1')
+  })
+
+  it('reports an action rejected by the current model', async () => {
+    const objects = model([drawing])
+    objects.value.setVisible = vi.fn(() => false)
+    render(<ObjectsPanel model={objects.value} paneLabel="Pane 1" />)
+
+    await userEvent.click(screen.getByRole('button', { name: 'Hide Trend line' }))
+
+    expect(screen.getByRole('alert')).toHaveTextContent('Could not hide Trend line')
+  })
+
+  it('follows model publications and releases the old subscription', async () => {
+    const first = model([primary])
+    const second = model([drawing])
+    const view = render(<ObjectsPanel model={first.value} paneLabel="Pane 1" />)
+
+    first.publish([primary, drawing])
+    expect(screen.getByText('Trend line')).toBeInTheDocument()
+
+    view.rerender(<ObjectsPanel model={second.value} paneLabel="Pane 2" />)
+    expect(first.off).toHaveBeenCalledOnce()
+    expect(screen.queryByText('NSE:BHEL')).not.toBeInTheDocument()
+    await userEvent.click(screen.getByRole('button', { name: 'Hide Trend line' }))
+    expect(first.value.setVisible).not.toHaveBeenCalled()
+    expect(second.value.setVisible).toHaveBeenCalledWith('drawing:trend-1', false)
+
+    view.unmount()
+    expect(second.off).toHaveBeenCalledOnce()
+  })
+
+  it('shows an empty state while the active pane has no model', () => {
+    render(<ObjectsPanel model={null} paneLabel="Pane 1" />)
+    expect(screen.getByText('No chart objects available')).toBeInTheDocument()
+  })
+})

--- a/frontend/src/components/trading/ObjectsPanel.tsx
+++ b/frontend/src/components/trading/ObjectsPanel.tsx
@@ -1,0 +1,247 @@
+import type { ChartObjectSnapshot, ChartObjects } from 'openalgo-charts'
+import { useCallback, useMemo, useState, useSyncExternalStore } from 'react'
+import { cn } from '@/lib/utils'
+import { PANEL_HEADER, PanelShell } from './panelShell'
+
+interface Props {
+  model: ChartObjects | null
+  paneLabel: string
+}
+
+const KIND_LABEL: Record<ChartObjectSnapshot['kind'], string> = {
+  source: 'Source',
+  indicator: 'Indicator',
+  drawing: 'Drawing',
+  profile: 'Profile',
+}
+const NO_OBJECTS: readonly ChartObjectSnapshot[] = Object.freeze([])
+
+function statusLabel(object: ChartObjectSnapshot): string | null {
+  const state = object.dataStatus?.state
+  if (!state) return null
+  return state[0].toUpperCase() + state.slice(1)
+}
+
+function Action({
+  label,
+  name,
+  ariaLabel,
+  onClick,
+  danger = false,
+}: {
+  label: string
+  name: string
+  ariaLabel?: string
+  onClick(): void
+  danger?: boolean
+}) {
+  return (
+    <button
+      type="button"
+      className={cn(
+        'rounded border border-border px-1.5 py-1 text-[11px] leading-none text-muted-foreground hover:bg-accent hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring',
+        danger && 'hover:border-destructive/50 hover:text-destructive'
+      )}
+      aria-label={ariaLabel ?? `${label} ${name}`}
+      onClick={onClick}
+    >
+      {label}
+    </button>
+  )
+}
+
+export function ObjectsPanel({ model, paneLabel }: Props) {
+  const [query, setQuery] = useState('')
+  const [actionError, setActionError] = useState<{ model: ChartObjects; message: string } | null>(
+    null
+  )
+  const subscribe = useCallback(
+    (notify: () => void) => model?.subscribe(() => notify()) ?? (() => {}),
+    [model]
+  )
+  const getSnapshot = useCallback(() => model?.list() ?? NO_OBJECTS, [model])
+  const objects = useSyncExternalStore(subscribe, getSnapshot, getSnapshot)
+
+  const shown = useMemo(() => {
+    const needle = query.trim().toLocaleLowerCase()
+    if (!needle) return objects
+    return objects.filter((object) =>
+      `${object.name} ${KIND_LABEL[object.kind]} ${object.sourceId} pane ${object.paneIndex + 1}`
+        .toLocaleLowerCase()
+        .includes(needle)
+    )
+  }, [objects, query])
+
+  const act = (verb: string, name: string, action: () => boolean) => {
+    let accepted = false
+    try {
+      accepted = action()
+    } catch {
+      // Optional providers are host code. Keep their failure inside this panel.
+    }
+    setActionError(
+      accepted || !model ? null : { model, message: `Could not ${verb.toLocaleLowerCase()} ${name}` }
+    )
+  }
+
+  return (
+    <PanelShell
+      id="oa-panel-objects"
+      label="Objects"
+      storageKey="oa-trading-objects-width"
+      defaultWidth={360}
+    >
+      <div className={PANEL_HEADER}>
+        <div className="min-w-0 flex-1">
+          <div className="truncate text-[13px] font-medium">Objects</div>
+          <div className="truncate text-[10px] text-muted-foreground">{paneLabel}</div>
+        </div>
+      </div>
+
+      <div className="border-b px-2 py-2">
+        <input
+          type="search"
+          value={query}
+          onChange={(event) => setQuery(event.target.value)}
+          placeholder="Search objects"
+          aria-label="Search objects"
+          className="h-8 w-full rounded-md border border-input bg-background px-2.5 text-xs outline-none placeholder:text-muted-foreground focus-visible:ring-1 focus-visible:ring-ring"
+        />
+        {actionError?.model === model && (
+          <p role="alert" className="mt-2 text-[11px] text-destructive">
+            {actionError.message}
+          </p>
+        )}
+      </div>
+
+      <div className="min-h-0 flex-1 overflow-y-auto px-2 py-2">
+        {!model ? (
+          <p className="px-2 py-8 text-center text-xs text-muted-foreground">
+            No chart objects available
+          </p>
+        ) : shown.length === 0 ? (
+          <p className="px-2 py-8 text-center text-xs text-muted-foreground">No matching objects</p>
+        ) : (
+          <div className="space-y-1.5">
+            {shown.map((object) => {
+              const status = statusLabel(object)
+              const detailId = `oa-object-details-${encodeURIComponent(object.id)}`
+              const details = [
+                KIND_LABEL[object.kind],
+                `Chart pane ${object.paneIndex + 1}`,
+                status,
+                object.visible ? 'Visible' : 'Hidden',
+                object.capabilities.lock ? (object.locked ? 'Locked' : 'Unlocked') : null,
+              ].filter(Boolean)
+              const content = (
+                <>
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-medium">{object.name}</span>
+                    <span
+                      id={detailId}
+                      className="block truncate text-[10px] text-muted-foreground"
+                    >
+                      {details.join(' · ')}
+                    </span>
+                  </span>
+                  {!object.visible && (
+                    <span className="shrink-0 text-[10px] text-muted-foreground">Hidden</span>
+                  )}
+                  {object.locked && (
+                    <span className="shrink-0 text-[10px] text-muted-foreground">Locked</span>
+                  )}
+                </>
+              )
+              return (
+                <div
+                  key={object.id}
+                  className={cn(
+                    'rounded-md border border-border bg-card px-2 py-2',
+                    object.selected && 'border-primary/60 bg-primary/5'
+                  )}
+                >
+                  {object.capabilities.select ? (
+                    <button
+                      type="button"
+                      className="flex w-full items-center gap-2 rounded-sm text-left focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+                      aria-label={`Select ${object.name}`}
+                      aria-describedby={detailId}
+                      aria-pressed={object.selected}
+                      onClick={(event) =>
+                        act('select', object.name, () =>
+                          model.select(object.id, event.shiftKey || event.ctrlKey || event.metaKey)
+                        )
+                      }
+                    >
+                      {content}
+                    </button>
+                  ) : (
+                    <div className="flex items-center gap-2">{content}</div>
+                  )}
+
+                  {Object.values(object.capabilities).some(Boolean) && (
+                    <div className="mt-2 flex flex-wrap gap-1">
+                      {object.capabilities.visibility && (
+                        <Action
+                          label={object.visible ? 'Hide' : 'Show'}
+                          name={object.name}
+                          onClick={() =>
+                            act(object.visible ? 'hide' : 'show', object.name, () =>
+                              model.setVisible(object.id, !object.visible)
+                            )
+                          }
+                        />
+                      )}
+                      {object.capabilities.lock && (
+                        <Action
+                          label={object.locked ? 'Unlock' : 'Lock'}
+                          name={object.name}
+                          onClick={() =>
+                            act(object.locked ? 'unlock' : 'lock', object.name, () =>
+                              model.setLocked(object.id, !object.locked)
+                            )
+                          }
+                        />
+                      )}
+                      {object.capabilities.settings && (
+                        <Action
+                          label="Settings"
+                          name={object.name}
+                          ariaLabel={`Settings for ${object.name}`}
+                          onClick={() =>
+                            act('open settings for', object.name, () =>
+                              model.openSettings(object.id)
+                            )
+                          }
+                        />
+                      )}
+                      {object.capabilities.focus && (
+                        <Action
+                          label="Focus"
+                          name={object.name}
+                          onClick={() =>
+                            act('focus', object.name, () => model.focus(object.id))
+                          }
+                        />
+                      )}
+                      {object.capabilities.remove && (
+                        <Action
+                          label="Remove"
+                          name={object.name}
+                          onClick={() =>
+                            act('remove', object.name, () => model.remove(object.id))
+                          }
+                          danger
+                        />
+                      )}
+                    </div>
+                  )}
+                </div>
+              )
+            })}
+          </div>
+        )}
+      </div>
+    </PanelShell>
+  )
+}

--- a/frontend/src/components/trading/RightRail.test.tsx
+++ b/frontend/src/components/trading/RightRail.test.tsx
@@ -33,11 +33,21 @@ describe('RightRail', () => {
     expect(screen.getByRole('button', { name: 'Option chain' })).toBeInTheDocument()
   })
 
+  it('opens Objects from a visible text label', async () => {
+    const onSelect = rail()
+    const button = screen.getByRole('button', { name: 'Objects' })
+    expect(button).toHaveTextContent('Objects')
+
+    await userEvent.click(button)
+    expect(onSelect).toHaveBeenCalledWith('objects')
+  })
+
   it('recognises only the panels the rail actually renders', () => {
     // Storage outlives a release. A remembered name that no longer resolves
     // has to read as "no panel", not as one.
     expect(isPanelId('agent')).toBe(true)
     expect(isPanelId('watchlist')).toBe(true)
+    expect(isPanelId('objects')).toBe(true)
     expect(isPanelId('depth')).toBe(false)
     expect(isPanelId(null)).toBe(false)
   })

--- a/frontend/src/components/trading/RightRail.tsx
+++ b/frontend/src/components/trading/RightRail.tsx
@@ -20,6 +20,7 @@ const PANELS = [
   // so it is last rather than wedged between two that are.
   { id: 'watchlist', label: 'Watchlist', icon: List },
   { id: 'options', label: 'Option chain', icon: Table2 },
+  { id: 'objects', label: 'Objects', text: true },
   { id: 'agent', label: 'Assistant', icon: Bot },
 ] as const
 
@@ -69,7 +70,9 @@ export function RightRail({ active, onSelect }: Props) {
 
   return (
     <div className="flex w-10 shrink-0 flex-col items-center gap-0.5 no-scrollbar overflow-y-auto border-l bg-background/40 py-1">
-      {PANELS.map(({ id, label, icon: Icon }) => {
+      {PANELS.map((panel) => {
+        const { id, label } = panel
+        const Icon = 'icon' in panel ? panel.icon : null
         const isOpen = active === id
         return (
           <div key={id} className="group relative">
@@ -82,14 +85,28 @@ export function RightRail({ active, onSelect }: Props) {
               // only way back to a full-width chart, so the button that opened
               // a panel has to be the button that puts it away.
               onClick={() => onSelect(isOpen ? null : id)}
-              className={cn(RAIL_BTN, isOpen && RAIL_BTN_ON)}
+              className={cn(
+                RAIL_BTN,
+                'text-[11px]',
+                Icon === null && 'h-[68px]',
+                isOpen && RAIL_BTN_ON
+              )}
               aria-label={label}
               aria-expanded={isOpen}
               // Only while the panel exists. Pointing aria-controls at an id
               // that is not in the document is worse than omitting it.
               aria-controls={isOpen ? `oa-panel-${id}` : undefined}
             >
-              <Icon className="h-[18px] w-[18px]" strokeWidth={RAIL_ICON_STROKE} />
+              {Icon ? (
+                <Icon className="h-[18px] w-[18px]" strokeWidth={RAIL_ICON_STROKE} />
+              ) : (
+                <span
+                  className="leading-none tracking-wide"
+                  style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}
+                >
+                  {label}
+                </span>
+              )}
             </button>
             {/* Opens left: this rail is against the viewport edge, so a tip
                 opening right would be clipped. */}

--- a/frontend/src/lib/trading/chartObjectsAdapter.test.ts
+++ b/frontend/src/lib/trading/chartObjectsAdapter.test.ts
@@ -1,0 +1,102 @@
+import type { ChartObjectDrawing, ChartObjectDrawingSource } from 'openalgo-charts'
+import { describe, expect, it, vi } from 'vitest'
+import { CurrentDrawingSource, profileObjectProvider } from './chartObjectsAdapter'
+
+function drawing(id: string): ChartObjectDrawing {
+  return {
+    id,
+    tool: 'trend-line',
+    paneIndex: 0,
+    points: [
+      { time: 1, price: 100 },
+      { time: 2, price: 110 },
+    ],
+  }
+}
+
+function source(item: ChartObjectDrawing): ChartObjectDrawingSource {
+  return {
+    drawings: vi.fn(() => [item]),
+    get: vi.fn((id) => (id === item.id ? item : undefined)),
+    selection: vi.fn(() => [item.id]),
+    select: vi.fn(),
+    update: vi.fn(),
+    remove: vi.fn(() => true),
+  }
+}
+
+describe('CurrentDrawingSource', () => {
+  it('is an inert structural source before the lazy drawing tier attaches', () => {
+    const current = new CurrentDrawingSource()
+
+    expect(current.drawings()).toEqual([])
+    expect(current.get('old')).toBeUndefined()
+    expect(current.selection()).toEqual([])
+    expect(current.remove('old')).toBe(false)
+    expect(() => current.select('old')).not.toThrow()
+    expect(() => current.update('old', { locked: true })).not.toThrow()
+  })
+
+  it('forwards operations only to the current chart generation', () => {
+    const first = source(drawing('first'))
+    const second = source(drawing('second'))
+    const current = new CurrentDrawingSource()
+
+    current.attach(first)
+    expect(current.drawings()).toEqual([expect.objectContaining({ id: 'first' })])
+
+    current.attach(second)
+    current.select('second', true)
+    current.update('second', { visible: false })
+    expect(current.remove('second')).toBe(true)
+
+    expect(first.select).not.toHaveBeenCalled()
+    expect(first.update).not.toHaveBeenCalled()
+    expect(first.remove).not.toHaveBeenCalled()
+    expect(second.select).toHaveBeenCalledWith('second', true)
+    expect(second.update).toHaveBeenCalledWith('second', { visible: false })
+    expect(second.remove).toHaveBeenCalledWith('second')
+  })
+
+  it('does not clear a newer generation through a stale detach', () => {
+    const first = source(drawing('first'))
+    const second = source(drawing('second'))
+    const current = new CurrentDrawingSource()
+
+    current.attach(first)
+    current.attach(second)
+    current.detach(first)
+
+    expect(current.get('second')).toEqual(expect.objectContaining({ id: 'second' }))
+    current.detach(second)
+    expect(current.drawings()).toEqual([])
+  })
+})
+
+describe('profileObjectProvider', () => {
+  it('registers TPO with settings as its only operation', () => {
+    const openSettings = vi.fn()
+    const provider = profileObjectProvider('tpo', openSettings)
+
+    expect(provider.id).toBe('profile:tpo')
+    expect(provider.get()).toEqual({
+      kind: 'profile',
+      name: 'Time Price Opportunity',
+      paneIndex: 0,
+      visible: true,
+    })
+    provider.openSettings?.()
+    expect(openSettings).toHaveBeenCalledOnce()
+    expect(provider).not.toHaveProperty('remove')
+    expect(provider).not.toHaveProperty('setVisible')
+    expect(provider).not.toHaveProperty('setLocked')
+    expect(provider).not.toHaveProperty('select')
+    expect(provider).not.toHaveProperty('focus')
+  })
+
+  it('names the session volume profile explicitly', () => {
+    expect(profileObjectProvider('session-volume-profile', vi.fn()).get()?.name).toBe(
+      'Session Volume Profile'
+    )
+  })
+})

--- a/frontend/src/lib/trading/chartObjectsAdapter.ts
+++ b/frontend/src/lib/trading/chartObjectsAdapter.ts
@@ -1,0 +1,72 @@
+import type {
+  ChartObjectDrawing,
+  ChartObjectDrawingSource,
+  ChartObjectProvider,
+} from 'openalgo-charts'
+import type { ProfileKind } from './profileSettings'
+
+/**
+ * Stable structural drawing source for a terminal whose drawing controller is
+ * loaded lazily and replaced with every chart generation.
+ *
+ * ChartObjects keeps this proxy for its own lifetime. Attaching a newer
+ * controller immediately redirects every operation; a late cleanup may only
+ * detach the controller it originally installed.
+ */
+export class CurrentDrawingSource implements ChartObjectDrawingSource {
+  private current: ChartObjectDrawingSource | null = null
+
+  attach(source: ChartObjectDrawingSource): void {
+    this.current = source
+  }
+
+  detach(source: ChartObjectDrawingSource): void {
+    if (this.current === source) this.current = null
+  }
+
+  drawings(): readonly ChartObjectDrawing[] {
+    return this.current?.drawings() ?? []
+  }
+
+  get(id: string): ChartObjectDrawing | undefined {
+    return this.current?.get(id)
+  }
+
+  selection(): readonly string[] {
+    return this.current?.selection() ?? []
+  }
+
+  select(id: string | readonly string[] | null, additive = false): void {
+    this.current?.select(id, additive)
+  }
+
+  update(id: string, patch: { visible?: boolean; locked?: boolean }): void {
+    this.current?.update(id, patch)
+  }
+
+  remove(id: string): boolean {
+    return this.current?.remove(id) ?? false
+  }
+}
+
+const PROFILE_NAMES: Record<ProfileKind, string> = {
+  tpo: 'Time Price Opportunity',
+  'session-volume-profile': 'Session Volume Profile',
+}
+
+/** Profiles are host primitives, so only explicitly supported actions exist. */
+export function profileObjectProvider(
+  kind: ProfileKind,
+  openSettings: () => void
+): ChartObjectProvider {
+  return {
+    id: `profile:${kind}`,
+    get: () => ({
+      kind: 'profile',
+      name: PROFILE_NAMES[kind],
+      paneIndex: 0,
+      visible: true,
+    }),
+    openSettings,
+  }
+}

--- a/frontend/src/lib/trading/terminal.test.ts
+++ b/frontend/src/lib/trading/terminal.test.ts
@@ -16,7 +16,7 @@ import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
 
 import { CandleBuilder } from 'openalgo-charts'
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 
 import { priceDp } from './format'
 import {
@@ -26,7 +26,10 @@ import {
   orderUnits,
   productOptionsFor,
   resolveTick,
+  sameIndicatorRecords,
+  sameIndicatorInstances,
   type SymbolView,
+  TradingTerminal,
   usesLots,
 } from './terminal'
 
@@ -230,6 +233,148 @@ describe('dedupeIndicators', () => {
 
   it('leaves an empty list alone', () => {
     expect(dedupeIndicators([])).toEqual([])
+  })
+
+  it('preserves the optional visibility carried by a saved instance', () => {
+    const hidden = { ...ema(20), visible: false }
+    expect(dedupeIndicators([hidden])).toEqual([hidden])
+  })
+})
+
+describe('sameIndicatorRecords', () => {
+  it('ignores object notifications that did not change indicator persistence', () => {
+    const saved = [{ indicatorId: 'ema', settings: { period: 20 }, visible: true }]
+    expect(sameIndicatorRecords(saved, [{ ...saved[0], settings: { period: 20 } }])).toBe(true)
+  })
+
+  it('detects visibility and settings changes', () => {
+    const saved = [{ indicatorId: 'ema', settings: { period: 20 }, visible: true }]
+    expect(sameIndicatorRecords(saved, [{ ...saved[0], visible: false }])).toBe(false)
+    expect(sameIndicatorRecords(saved, [{ ...saved[0], settings: { period: 50 } }])).toBe(false)
+  })
+})
+
+describe('sameIndicatorInstances', () => {
+  it('detects a rebuilt instance even when its descriptor and settings are unchanged', () => {
+    expect(
+      sameIndicatorInstances(
+        [{ id: 'ema-1', name: 'EMA' }],
+        [{ id: 'ema-2', name: 'EMA' }]
+      )
+    ).toBe(false)
+  })
+
+  it('ignores unrelated object notifications for the same live instances', () => {
+    const current = [{ id: 'ema-2', name: 'EMA' }]
+    expect(sameIndicatorInstances(current, current.map((item) => ({ ...item })))).toBe(true)
+  })
+})
+
+describe('chart object lifecycle', () => {
+  const methods = TradingTerminal.prototype as unknown as {
+    applyIndicators(this: unknown): Promise<void>
+    syncIndicators(this: unknown): void
+    destroy(this: unknown): void
+  }
+
+  it('restores saved visibility and treats a legacy record as visible', async () => {
+    const visibilities: boolean[] = []
+    const addIndicator = vi.fn((_id: string, _settings: Record<string, unknown>) => ({
+      setVisible: (visible: boolean) => visibilities.push(visible),
+    }))
+    const syncIndicators = vi.fn()
+    const terminal = Object.assign(Object.create(TradingTerminal.prototype), {
+      chart: { addIndicator },
+      destroyed: false,
+      activeIndicators: [
+        { indicatorId: 'ema', settings: { period: 9 }, visible: false },
+        { indicatorId: 'sma', settings: { period: 20 } },
+      ],
+      restoringIndicatorsOn: null,
+      applyingIndicators: false,
+      loadIndicators: vi.fn().mockResolvedValue(undefined),
+      syncIndicators,
+    })
+
+    await methods.applyIndicators.call(terminal)
+
+    expect(addIndicator.mock.calls.map(([id]) => id)).toEqual(['ema', 'sma'])
+    expect(visibilities).toEqual([false, true])
+    expect(syncIndicators).toHaveBeenCalledOnce()
+    expect(terminal.restoringIndicatorsOn).toBeNull()
+  })
+
+  it('disposes inventory observation before drawing and chart teardown', () => {
+    const order: string[] = []
+    const terminal = Object.assign(Object.create(TradingTerminal.prototype), {
+      destroyed: false,
+      onVisibilityChange: () => {},
+      offData: null,
+      data: null,
+      objects: { destroy: () => order.push('objects') },
+      cb: { onObjectsChange: () => {} },
+      offProfileObject: null,
+      detachDrawing: () => order.push('drawing'),
+      bookTimer: null,
+      stopLtpFallback: () => {},
+      offLtp: null,
+      offDepth: null,
+      offWsState: null,
+      offWsControl: null,
+      offOrderUpdate: null,
+      offReplayPointer: null,
+      offLegendActions: null,
+      ws: null,
+      stopReplay: () => {},
+      profileLayer: null,
+      chart: { destroy: () => order.push('chart') },
+      screenshotExcluded: [],
+    })
+
+    methods.destroy.call(terminal)
+
+    expect(order).toEqual(['objects', 'drawing', 'chart'])
+    expect(terminal.objects).toBeNull()
+    expect(terminal.chart).toBeNull()
+  })
+
+  it('clears a rejected lazy-load guard so a later sync persists live state', async () => {
+    const persisted = vi.fn()
+    const indicator = {
+      id: 'ema-next',
+      indicatorId: 'ema',
+      name: 'EMA',
+      settings: () => ({ period: 9 }),
+      visible: () => false,
+    }
+    const chart = { indicators: () => [indicator] }
+    const terminal = Object.assign(Object.create(TradingTerminal.prototype), {
+      chart,
+      destroyed: false,
+      activeIndicators: [],
+      announcedIndicators: [{ id: indicator.id, name: indicator.name }],
+      restoringIndicatorsOn: null,
+      applyingIndicators: false,
+      loadIndicators: vi.fn().mockRejectedValue(new Error('chunk failed')),
+      cleanError: () => 'chunk failed',
+      toast: vi.fn(),
+      lsSet: persisted,
+    })
+
+    await methods.applyIndicators.call(terminal)
+
+    expect(terminal.restoringIndicatorsOn).toBeNull()
+    expect(terminal.toast).toHaveBeenCalledWith('Indicators could not be restored: chunk failed', 'err')
+
+    methods.syncIndicators.call(terminal)
+
+    expect(persisted).toHaveBeenCalledWith(
+      'indicators',
+      JSON.stringify([{ indicatorId: 'ema', settings: { period: 9 }, visible: false }])
+    )
+    expect(terminal.activeIndicators).toEqual([
+      { indicatorId: 'ema', settings: { period: 9 }, visible: false },
+    ])
   })
 })
 

--- a/frontend/src/lib/trading/terminal.ts
+++ b/frontend/src/lib/trading/terminal.ts
@@ -13,11 +13,12 @@
  * cancel, real-time order stream, REST fallback) is unchanged.
  */
 
-import type { LinkGroup } from 'openalgo-charts'
+import type { ChartObjectSnapshot, LinkGroup } from 'openalgo-charts'
 import {
   type Bar,
   BuySellButtons,
   CandleBuilder,
+  ChartObjects,
   type ChartTheme,
   compactVolume,
   createChart,
@@ -111,6 +112,7 @@ import {
   describeDrawings,
   isAgentDrawingId,
 } from './chartContract'
+import { CurrentDrawingSource, profileObjectProvider } from './chartObjectsAdapter'
 import {
   buildChartTheme,
   isLightTheme,
@@ -261,6 +263,10 @@ export interface TerminalCallbacks {
    * canvas-only and ships no DOM, so the form is ours to render.
    */
   onIndicatorSettings?(req: IndicatorSettingsRequest): void
+  /** The current chart generation's shared object inventory. */
+  onObjectsChange?(objects: ChartObjects | null): void
+  /** Opens this pane's existing chart settings dialog. */
+  onChartSettings?(req: ChartSettingsRequest): void
   /** A drawing was selected (or deselected), for the style popover. */
   onDrawSelect?(sel: DrawSelection | null): void
   /**
@@ -478,6 +484,28 @@ export function dedupeIndicators<T extends { indicatorId: string; settings: unkn
     return true
   })
 }
+
+export interface SavedIndicatorRecord {
+  indicatorId: string
+  settings: Record<string, unknown>
+  /** Missing in saves written before visibility persistence. */
+  visible?: boolean
+}
+
+/** Avoid storage and React work for generic object events that changed no indicator. */
+export function sameIndicatorRecords(
+  left: readonly SavedIndicatorRecord[],
+  right: readonly SavedIndicatorRecord[]
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
+
+export function sameIndicatorInstances(
+  left: readonly { id: string; name: string }[],
+  right: readonly { id: string; name: string }[]
+): boolean {
+  return JSON.stringify(left) === JSON.stringify(right)
+}
 const STRATEGY = 'chart-trading'
 /**
  * Minimum gap between two armed fires, the scalping terminal's figure. A
@@ -589,6 +617,9 @@ export class TradingTerminal {
      interval / chart-type / theme change, so both round-trip through plain
      data here and are re-applied to the new chart. */
   private draw: DrawingControllerInstance | null = null
+  private readonly objectDrawings = new CurrentDrawingSource()
+  private objects: ChartObjects | null = null
+  private offProfileObject: (() => void) | null = null
   private drawJson: DrawingsDocument = emptyDrawings()
   /**
    * A 1.9.x save (a bare array) waiting for the draw tier to migrate it. The
@@ -603,10 +634,14 @@ export class TradingTerminal {
   private drawStay = false
   /** True once a drawing control has been touched — gates the lazy tier fetch. */
   private drawEnabled = false
-  private activeIndicators: { indicatorId: string; settings: Record<string, unknown> }[] = []
+  private activeIndicators: SavedIndicatorRecord[] = []
   private indicatorsLoaded = false
   /** Guards syncIndicators while applyIndicators is mid-flight. */
   private applyingIndicators = false
+  /** The generation whose saved instances are still crossing an async tier load. */
+  private restoringIndicatorsOn: ChartInstance | null = null
+  /** Last live instance identities sent to the pane toolbar. */
+  private announcedIndicators: { id: string; name: string }[] = []
   /** History paging: in-flight guard, and whether the broker ran out. */
   private loadingOlder: { chart: ReturnType<typeof createChart>; ticket: number } | null = null
   private noMoreHistory = false
@@ -1386,6 +1421,8 @@ export class TradingTerminal {
   }
 
   private installProfile(): void {
+    this.offProfileObject?.()
+    this.offProfileObject = null
     this.profileLayer?.dispose()
     this.profileLayer = null
     const chart = this.chart
@@ -1416,10 +1453,58 @@ export class TradingTerminal {
         this.toast(`Profile could not be rendered: ${this.cleanError(error)}`, 'err'),
       onWarning: (message) => this.toast(message, ''),
     })
+    this.offProfileObject =
+      this.objects?.register(profileObjectProvider(kind, () => this.requestChartSettings())) ?? null
+  }
+
+  /** Open the pane-owned chart dialog from the canvas or object inventory. */
+  private requestChartSettings(): void {
+    void this.chartSettings().then((request) => {
+      if (request) this.cb.onChartSettings?.(request)
+    })
+  }
+
+  /** Reuse the existing pane editors for every built-in object settings action. */
+  private openObjectSettings(object: ChartObjectSnapshot): void {
+    if (object.kind === 'source') {
+      this.requestChartSettings()
+      return
+    }
+    if (object.kind === 'indicator') {
+      this.openIndicatorSettings(object.sourceId)
+      return
+    }
+    if (object.kind === 'drawing') {
+      this.objects?.select(object.id)
+      if (this.isTextDrawing(object.sourceId)) this.requestDrawTextEdit(object.sourceId)
+    }
+  }
+
+  /** Install one inventory for exactly one chart generation. */
+  private installObjects(): void {
+    const chart = this.chart
+    if (!chart || this.destroyed) return
+    const objects = new ChartObjects(chart, {
+      drawings: this.objectDrawings,
+      onSettings: (object) => this.openObjectSettings(object),
+    })
+    this.objects = objects
+    this.cb.onObjectsChange?.(objects)
+  }
+
+  /** Release inventory observations before any object or chart it reads. */
+  private detachObjects(): void {
+    const objects = this.objects
+    this.objects = null
+    this.cb.onObjectsChange?.(null)
+    this.offProfileObject?.()
+    this.offProfileObject = null
+    objects?.destroy()
   }
 
   private buildChart() {
     this.stopReplay()
+    this.detachObjects()
     this.profileLayer?.dispose()
     this.profileLayer = null
     // Snapshot drawings before the chart they live on goes away.
@@ -1480,6 +1565,11 @@ export class TradingTerminal {
       // to start under both or they land on top of the buttons.
       legendOffset: { top: 80 },
     })
+    this.chart.setDataContext(
+      this.sym
+        ? { symbol: this.sym.symbol, exchange: this.sym.exchange, interval: this.interval }
+        : { interval: this.interval }
+    )
     const cfg = CHART_TYPES[this.ctype] || CHART_TYPES.candlestick
     const dp = this.dp()
     const light = isLightTheme(mode, appMode)
@@ -1512,6 +1602,7 @@ export class TradingTerminal {
     // A rebuild makes a fresh series, so the preference has to be re-applied
     // rather than assumed -- switching chart type or theme would show it again.
     if (!this.volumeOn || isProfileKind(this.ctype)) this.volume.applyOptions({ visible: false })
+    this.installObjects()
     // Same reasoning for the settings patch: a chart-type or theme switch
     // rebuilds the chart, and without this the user's colours, timezone and
     // scale options would silently revert to the engine defaults.
@@ -1699,6 +1790,9 @@ export class TradingTerminal {
     // list still held it — so the next rebuild (timeframe, chart type, theme)
     // brought the deleted indicator back.
     this.chart.on('indicatorRemoved', () => this.syncIndicators())
+    // Visibility changes made from the Objects panel stay with the pane on a
+    // chart rebuild, just like settings and removal from the canvas legend.
+    this.chart.on('objects:change', () => this.syncIndicators())
     this.chart.on('paneRemoved', () => this.placeWatermark())
     // Scrolling back past the loaded range pages in older bars.
     this.chart.setHistoryLoader(() => void this.loadOlderHistory())
@@ -1867,12 +1961,14 @@ export class TradingTerminal {
    */
   private detachDrawing(): void {
     if (!this.draw) return
+    const draw = this.draw
     try {
-      this.drawJson = this.draw.toJSON()
-      this.draw.destroy()
+      this.drawJson = draw.toJSON()
+      draw.destroy()
     } catch {
       /* chart already gone; keep the last snapshot we have */
     }
+    this.objectDrawings.detach(draw)
     this.draw = null
   }
 
@@ -1898,6 +1994,7 @@ export class TradingTerminal {
       stayInDrawingMode: this.drawStay,
     })
     this.draw = draw
+    this.objectDrawings.attach(draw)
     this.drawShortcuts = drawingShortcuts()
     this.matchShortcut = matchDrawingShortcut
     this.keyAction = keyToDrawingAction
@@ -1940,6 +2037,7 @@ export class TradingTerminal {
       if (this.editSelectedText()) (p as { handled?: boolean }).handled = true
     })
     this.chart.on('draw:update', () => this.afterDrawChange())
+    this.objects?.refresh()
   }
 
   private afterDrawChange(): void {
@@ -2403,23 +2501,35 @@ export class TradingTerminal {
     // would add this run's indicators to a chart another run has already
     // populated, duplicating every one of them.
     const chart = this.chart
-    await this.loadIndicators()
-    if (this.destroyed || !this.chart || this.chart !== chart) return
-    // Re-adding walks the tracked list, so a sync mid-loop would read a
-    // half-applied chart and truncate it.
-    this.applyingIndicators = true
+    if (!chart) return
+    this.restoringIndicatorsOn = chart
     try {
-      // syncIndicators writes the result back, so a layout that already
-      // carries duplicates heals on the next load.
-      for (const rec of dedupeIndicators(this.activeIndicators)) {
-        try {
-          this.chart.addIndicator(rec.indicatorId, rec.settings)
-        } catch {
-          /* an id that is no longer registered — skip rather than break the chart */
+      await this.loadIndicators()
+      if (this.destroyed || !this.chart || this.chart !== chart) return
+      // Re-adding walks the tracked list, so a sync mid-loop would read a
+      // half-applied chart and truncate it.
+      this.applyingIndicators = true
+      try {
+        // syncIndicators writes the result back, so a layout that already
+        // carries duplicates heals on the next load.
+        for (const rec of dedupeIndicators(this.activeIndicators)) {
+          try {
+            const inst = this.chart.addIndicator(rec.indicatorId, rec.settings)
+            inst.setVisible(rec.visible !== false)
+          } catch {
+            /* an id that is no longer registered — skip rather than break the chart */
+          }
         }
+      } finally {
+        this.applyingIndicators = false
       }
+    } catch (error) {
+      if (!this.destroyed && this.chart === chart) {
+        this.toast(`Indicators could not be restored: ${this.cleanError(error)}`, 'err')
+      }
+      return
     } finally {
-      this.applyingIndicators = false
+      if (this.restoringIndicatorsOn === chart) this.restoringIndicatorsOn = null
     }
     this.syncIndicators()
   }
@@ -2670,14 +2780,22 @@ export class TradingTerminal {
   }
 
   private syncIndicators(): void {
-    if (!this.chart || this.applyingIndicators) return
-    this.placeWatermark()
-    this.activeIndicators = this.chart.indicators().map((i) => ({
+    if (!this.chart || this.applyingIndicators || this.restoringIndicatorsOn === this.chart) return
+    const next = this.chart.indicators().map((i) => ({
       indicatorId: i.indicatorId,
       settings: { ...i.settings() },
+      visible: i.visible(),
     }))
-    this.lsSet('indicators', JSON.stringify(this.activeIndicators))
-    this.cb.onIndicatorsChange?.(this.listIndicators())
+    if (!sameIndicatorRecords(this.activeIndicators, next)) {
+      this.activeIndicators = next
+      this.lsSet('indicators', JSON.stringify(this.activeIndicators))
+    }
+    const announced = this.listIndicators().map(({ id, name }) => ({ id, name }))
+    if (!sameIndicatorInstances(this.announcedIndicators, announced)) {
+      this.announcedIndicators = announced
+      this.placeWatermark()
+      this.cb.onIndicatorsChange?.(announced)
+    }
   }
 
   async addIndicatorById(indicatorId: string): Promise<void> {
@@ -4052,6 +4170,7 @@ export class TradingTerminal {
     this.offData = null
     this.data?.destroy()
     this.data = null
+    this.detachObjects()
     this.detachDrawing()
     if (this.bookTimer) clearInterval(this.bookTimer)
     this.bookTimer = null

--- a/frontend/src/pages/Trading.tsx
+++ b/frontend/src/pages/Trading.tsx
@@ -1,5 +1,5 @@
 import { LayoutGrid, Link2 as LinkIcon } from 'lucide-react'
-import { createLinkGroup, type LinkGroup } from 'openalgo-charts'
+import { type ChartObjects, createLinkGroup, type LinkGroup } from 'openalgo-charts'
 import { lazy, Suspense, useCallback, useEffect, useRef, useState } from 'react'
 import { Navbar } from '@/components/layout/Navbar'
 
@@ -21,6 +21,7 @@ import {
   writeDockTab,
 } from '@/components/trading/dock/dockState'
 import { TradingDock } from '@/components/trading/dock/TradingDock'
+import { ObjectsPanel } from '@/components/trading/ObjectsPanel'
 import { OptionChainPanel } from '@/components/trading/OptionChainPanel'
 import { isPanelId, type PanelId, RightRail } from '@/components/trading/RightRail'
 import { TickBox } from '@/components/trading/TickBox'
@@ -241,6 +242,7 @@ export default function Trading() {
    */
   const [focusedPane, setFocusedPane] = useState('p0')
   const [paneSymbols, setPaneSymbols] = useState<Record<string, string | null>>({})
+  const [paneObjects, setPaneObjects] = useState<Record<string, ChartObjects>>({})
   /**
    * Every live pane's terminal, keyed by pane id.
    *
@@ -254,6 +256,19 @@ export default function Trading() {
   const noteTerminal = useCallback((paneId: string, terminal: TradingTerminal | null) => {
     if (terminal) terminalsRef.current[paneId] = terminal
     else delete terminalsRef.current[paneId]
+  }, [])
+
+  const noteObjects = useCallback((paneId: string, objects: ChartObjects | null) => {
+    setPaneObjects((previous) => {
+      if (objects) {
+        if (previous[paneId] === objects) return previous
+        return { ...previous, [paneId]: objects }
+      }
+      if (!(paneId in previous)) return previous
+      const next = { ...previous }
+      delete next[paneId]
+      return next
+    })
   }, [])
 
   /** The pane a panel acts on: the focused one, else any pane that is up. */
@@ -342,6 +357,12 @@ export default function Trading() {
     () => panelTarget()?.snapshotPng() ?? Promise.resolve(null),
     [panelTarget]
   )
+  const objectsPaneId = paneObjects[focusedPane]
+    ? focusedPane
+    : (Object.keys(paneObjects)[0] ?? focusedPane)
+  const objectsPaneLabel = `Pane ${Number(objectsPaneId.slice(1)) + 1}${
+    paneSymbols[objectsPaneId] ? ` · ${paneSymbols[objectsPaneId]}` : ''
+  }`
   const railStats: DrawStats = { ...stats, tool, magnet, stay }
   /**
    * Hand a key event to the focused pane; it reports whether the drawing tier
@@ -419,7 +440,8 @@ export default function Trading() {
       if (document.body.hasAttribute('data-scroll-locked')) return
       if (
         document.querySelector(
-          '[data-state="open"][role="dialog"],' +
+          '[data-trading-dialog-open="true"],' +
+            '[data-state="open"][role="dialog"],' +
             '[data-state="open"][data-slot="popover-content"],' +
             '[data-state="open"][role="menu"],' +
             '[data-state="open"][role="listbox"]'
@@ -436,8 +458,11 @@ export default function Trading() {
       if (closes === 'dock') setDock(null)
       else if (closes === 'panel') setPanel(null)
     }
-    window.addEventListener('keydown', onKey)
-    return () => window.removeEventListener('keydown', onKey)
+    // Capture sees an open pane dialog before that dialog's own window-level
+    // Escape listener unmounts it. In bubble order the dialog could disappear
+    // first, making this handler also close the panel underneath it.
+    window.addEventListener('keydown', onKey, { capture: true })
+    return () => window.removeEventListener('keydown', onKey, { capture: true })
   }, [panel, dock, tool])
 
   useEffect(() => {
@@ -670,6 +695,7 @@ export default function Trading() {
                     onFocusPane={focusPane}
                     onSymbolChange={noteSymbol}
                     onTerminalChange={noteTerminal}
+                    onObjectsChange={noteObjects}
                     onDrawStats={setStats}
                     onToggleRail={() => setShowRail((v) => !v)}
                     railVisible={showRail}
@@ -720,6 +746,9 @@ export default function Trading() {
                 onCaptureChart={captureChart}
               />
             </Suspense>
+          )}
+          {apiKey && wsUrl && panel === 'objects' && (
+            <ObjectsPanel model={paneObjects[objectsPaneId] ?? null} paneLabel={objectsPaneLabel} />
           )}
 
           {apiKey && wsUrl && <RightRail active={panel} onSelect={setPanel} />}


### PR DESCRIPTION
Add an Objects panel to `/trading` for the active chart pane. Users can find indicators and drawings, reuse their existing editors, change visibility, lock or focus drawings, remove objects and use drawing undo. Saved legacy profile charts expose their existing settings action.

Pin `openalgo-charts` to 2.1.7 and update the chart-indicator skill and canonical terminal guide in the same change. Object inventories follow chart replacement, indicator visibility survives reloads, and indicator controls receive fresh instance IDs after rebuilds. Failed lazy loading clears its restoration guard. Escape closes the active settings editor while preserving the Objects panel underneath.

Validation: production build, lint and skill coverage; 17 synthetic `/trading` browser workflows covering active panes, persistence, drawing actions, profile settings, replay isolation and order guards. All 1,916 frontend tests and coverage runs pass in CI on Node 20, 22 and 24, alongside the build matrix, browser tests, lint and skill checks. CI generated and committed the production frontend assets in `87c905ea1`; no generated dist was committed manually.
