### PR TITLE
feat(fivepaisaxts): batch websocket subscriptions into one request per mode,fix(fivepaisaxts): stop unsubscribe from tearing down the whole feed  and  fix(kotak): always emit ltp in quote and depth payloads #2038

### DIFF
--- a/broker/fivepaisaxts/streaming/fivepaisaxts_adapter.py
+++ b/broker/fivepaisaxts/streaming/fivepaisaxts_adapter.py
@@ -4,6 +4,7 @@ import os
 import sys
 import threading
 import time
+from collections import deque
 from typing import Any, Dict, List, Optional
 
 from broker.fivepaisaxts.streaming.fivepaisaxts_websocket import FivepaisaXTSWebSocketClient
@@ -24,6 +25,30 @@ from .fivepaisaxts_mapping import FivepaisaXTSCapabilityRegistry, FivepaisaXTSEx
 class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
     """Fivepaisa XTS specific implementation of the WebSocket adapter"""
 
+    # Subscription batching: the XTS market-data API takes an `instruments`
+    # ARRAY per request, so coalesce instruments sharing an xtsMessageCode into
+    # one request instead of one request per symbol.
+    #
+    # This matters more here than on a pure socket broker: the client's
+    # subscribe() is a BLOCKING HTTP POST with a 10s timeout, issued inline from
+    # subscribe(). One request per symbol makes a 1000-symbol startup 1000
+    # sequential round-trips.
+    MAX_INSTRUMENTS_PER_SUBSCRIBE = 50
+    # Gap between successive batch requests, applied only when more batches
+    # remain, so a single-symbol subscribe is not penalised with a wait.
+    SUBSCRIPTION_DELAY = 0.5
+    # Collect window opened by the first queued instrument, before the first
+    # request goes out.
+    #
+    # Callers subscribe one symbol at a time (an option chain fires ~50 separate
+    # subscribe() calls), so without this the drain thread would send the very
+    # first instrument immediately, find the queue momentarily empty, exit, and
+    # be restarted by the next enqueue - one 1-instrument request per symbol,
+    # which is the flood this batching exists to prevent. Waiting once here lets
+    # the burst accumulate so it leaves as one request per mode. Matches the
+    # window the sibling 5Paisa adapter opens.
+    SUBSCRIPTION_COLLECT_WINDOW = 0.5
+
     def __init__(self):
         super().__init__()
         self.logger = get_logger("fivepaisa_xts_websocket")
@@ -37,6 +62,13 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.running = False
         self.lock = threading.Lock()
         self._reconnect_thread_active = False  # Guard against duplicate reconnect threads
+
+        # Subscription batch queue: items are (mode, instrument_dict). A single
+        # processor thread drains it into coalesced multi-instrument requests.
+        self.pending_subscriptions = deque()
+        self._sub_thread = None
+        self._stop_event = threading.Event()
+        self._batch_seq = 0  # Names each batch's correlation id
 
         # Log the ZMQ port being used
         self.logger.info(f"Fivepaisa XTS adapter initialized with ZMQ port: {self.zmq_port}")
@@ -192,6 +224,11 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
             self.logger.error("WebSocket client not initialized. Call initialize() first.")
             return
 
+        # A previous disconnect() left the stop event set; clear it or the batch
+        # processor started by the first subscribe after this connect exits on
+        # its collect window and nothing is ever sent.
+        self._stop_event.clear()
+
         threading.Thread(target=self._connect_with_retry, daemon=True).start()
 
     def _connect_with_retry(self) -> None:
@@ -236,9 +273,7 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
                     with self.lock:
                         self.reconnect_attempts += 1
                         attempts = self.reconnect_attempts
-                    delay = min(
-                        self.reconnect_delay * (2**attempts), self.max_reconnect_delay
-                    )
+                    delay = min(self.reconnect_delay * (2**attempts), self.max_reconnect_delay)
                     self.logger.error(f"Connection failed: {e}. Retrying in {delay} seconds...")
                     time.sleep(delay)
 
@@ -258,6 +293,13 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self.logger.info(
             "Set running=False and max reconnect attempts to prevent auto-reconnection"
         )
+
+        # Wake the batch processor out of any inter-batch wait and drop queued
+        # work, so it cannot fire a subscribe request at a client we are about
+        # to release.
+        self._stop_event.set()
+        with self.lock:
+            self.pending_subscriptions.clear()
 
         # Disconnect and release Socket.IO client
         if hasattr(self, "ws_client") and self.ws_client:
@@ -285,6 +327,144 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
     # cleanup_zmq() is inherited from BaseBrokerWebSocketAdapter which handles:
     # - idempotency (_zmq_cleaned_up flag), shared-ZMQ skip, _instance_count
     #   decrement, socket nulling, and shared context lifecycle.
+
+    @staticmethod
+    def _instrument_key(instrument: dict) -> tuple:
+        """Identity of an instrument, normalised to strings.
+
+        XTS carries the segment as an int and the instrument id as a string in
+        some paths and the reverse in others, so comparing the raw dicts misses
+        matches that are the same instrument.
+        """
+        return (
+            str(instrument.get("exchangeSegment")),
+            str(instrument.get("exchangeInstrumentID")),
+        )
+
+    def _enqueue_subscriptions(self, items: list) -> None:
+        """Queue (mode, instrument) items for batched sending and ensure the
+        batch processor thread is running."""
+        if not items:
+            return
+        with self.lock:
+            self.pending_subscriptions.extend(items)
+            if self._sub_thread is None or not self._sub_thread.is_alive():
+                self._sub_thread = threading.Thread(
+                    target=self._process_pending_subscriptions, daemon=True
+                )
+                self._sub_thread.start()
+
+    def _process_pending_subscriptions(self) -> None:
+        """Drain the pending queue into coalesced XTS subscribe requests.
+
+        Instruments are grouped by mode - mode maps 1:1 onto xtsMessageCode and
+        a request carries exactly one code - and sent up to
+        MAX_INSTRUMENTS_PER_SUBSCRIBE per request, with a throttle between
+        requests. Failed batches are re-queued. This replaces the previous
+        one-request-per-symbol flood on bulk subscribe and on resubscribe.
+        """
+        consecutive_failures = 0
+
+        # Collect window: let the rest of the burst land before the first
+        # request goes out (see SUBSCRIPTION_COLLECT_WINDOW). Interruptible, so
+        # a disconnect during the window does not stall shutdown.
+        if self._stop_event.wait(self.SUBSCRIPTION_COLLECT_WINDOW):
+            with self.lock:
+                self._sub_thread = None
+            return
+
+        while self.running and not self._stop_event.is_set():
+            # Decide whether to exit on an EMPTY queue under the same lock that
+            # _enqueue_subscriptions holds when it appends work and checks our
+            # liveness. Testing emptiness outside the lock is a lost-wakeup
+            # race: an enqueue could add an item and observe this thread still
+            # alive (so skip starting a new one) in the instant between our
+            # unlocked test and our return, stranding that item until the next
+            # enqueue or reconnect. Clearing _sub_thread here closes that window.
+            with self.lock:
+                if not self.pending_subscriptions:
+                    self._sub_thread = None
+                    return
+
+            if not (self.connected and self.ws_client):
+                # Not connected yet; _on_open re-queues everything on connect,
+                # so back off briefly and re-check (interruptible).
+                consecutive_failures += 1
+                if consecutive_failures > 5:
+                    self.logger.warning(
+                        "Batch processor: not connected after retries; pausing queue."
+                    )
+                    break
+                if self._stop_event.wait(min(2 * consecutive_failures, 10)):
+                    break
+                continue
+            consecutive_failures = 0
+
+            # Pull a batch of same-mode instruments. The mode is taken from the
+            # head of the queue, but matching instruments are then gathered from
+            # ANYWHERE in it: callers interleave modes freely, and a
+            # front-run-only scan would alternate modes item by item and emit
+            # one-instrument requests, which is the flood this exists to
+            # prevent. Order within a mode is preserved.
+            batch_mode = None
+            batch_instruments = []
+            with self.lock:
+                if self.pending_subscriptions:
+                    batch_mode = self.pending_subscriptions[0][0]
+                    remaining = deque()
+                    for mode, instrument in self.pending_subscriptions:
+                        if (
+                            mode == batch_mode
+                            and len(batch_instruments) < self.MAX_INSTRUMENTS_PER_SUBSCRIBE
+                        ):
+                            batch_instruments.append(instrument)
+                        else:
+                            remaining.append((mode, instrument))
+                    self.pending_subscriptions = remaining
+                    self._batch_seq += 1
+                    correlation_id = f"batch_mode_{batch_mode}_{self._batch_seq}"
+
+            if not batch_instruments:
+                continue
+
+            # Snapshot the client ref: disconnect() nulls self.ws_client, and
+            # this send is a blocking HTTP POST, so reading the attribute again
+            # mid-call is a race the check above cannot cover.
+            client = self.ws_client
+            if client is None:
+                break
+
+            try:
+                client.subscribe(correlation_id, batch_mode, batch_instruments)
+                self.logger.info(
+                    f"Sent batched subscription: {len(batch_instruments)} instruments "
+                    f"in mode {batch_mode}"
+                )
+            except Exception as e:
+                self.logger.error(f"Batch subscription failed (mode {batch_mode}): {e}")
+                # Re-queue the failed batch (front, preserving order) for retry,
+                # but not while stopping: disconnect() has just emptied the
+                # queue, and _on_open re-queues the whole book on reconnect, so
+                # putting these back would only plant duplicates.
+                if self._stop_event.is_set() or not self.running:
+                    break
+                with self.lock:
+                    for instrument in reversed(batch_instruments):
+                        self.pending_subscriptions.appendleft((batch_mode, instrument))
+                if self._stop_event.wait(self.SUBSCRIPTION_DELAY * 2):
+                    break
+                continue
+
+            # Throttle only when more work remains, so a single-symbol
+            # subscribe (the common UI case) is not made to wait for nothing.
+            if self.pending_subscriptions:
+                if self._stop_event.wait(self.SUBSCRIPTION_DELAY):
+                    break
+
+        # Loop exited via stop/pause (not the empty-queue return above): clear
+        # the handle so a later _enqueue_subscriptions starts a fresh processor.
+        with self.lock:
+            self._sub_thread = None
 
     def subscribe(
         self, symbol: str, exchange: str, mode: int = 2, depth_level: int = 5
@@ -397,13 +577,11 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 f"Stored subscription [{correlation_id}]: symbol={symbol}, exchange={exchange}, brexchange={brexchange}, token_info={token_info}, mode={mode}"
             )
 
-        # Subscribe if connected
+        # Queue for batched sending. When not connected we skip: _on_open
+        # re-queues every stored subscription on (re)connect, so enqueuing here
+        # too would send each instrument twice.
         if self.connected and self.ws_client:
-            try:
-                self.ws_client.subscribe(correlation_id, mode, instruments)
-            except Exception as e:
-                self.logger.error(f"Error subscribing to {symbol}.{exchange}: {e}")
-                return self._create_error_response("SUBSCRIPTION_ERROR", str(e))
+            self._enqueue_subscriptions([(mode, instruments[0])])
 
         # Return success with capability info
         return self._create_success_response(
@@ -469,22 +647,36 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
         token = token_info["token"]
         brexchange = token_info["brexchange"]
 
-        # Create instrument list for Fivepaisa XTS API
+        # Create instrument list for Fivepaisa XTS API. str() on the token to
+        # match what subscribe() stores, so the queued-subscribe cancellation
+        # below and the client's instrument bookkeeping both find it.
         instruments = [
             {
                 "exchangeSegment": FivepaisaXTSExchangeMapper.get_exchange_type(brexchange),
-                "exchangeInstrumentID": token,
+                "exchangeInstrumentID": str(token) if token is not None else "",
             }
         ]
 
         # Generate correlation ID
         correlation_id = f"{symbol}_{exchange}_{mode}"
 
-        # Remove from subscriptions
+        # Remove from subscriptions, and cancel any still-queued subscribe for
+        # the same (mode, instrument). Without this, a quick
+        # subscribe -> unsubscribe sends Unsubscribe now but leaves the batched
+        # Subscribe in the queue, which the processor then sends afterwards -
+        # resurrecting a stale server-side subscription and its feed traffic.
         with self.lock:
             if correlation_id in self.subscriptions:
                 del self.subscriptions[correlation_id]
                 self.logger.info(f"Removed {symbol}.{exchange} from subscription registry")
+
+            if self.pending_subscriptions:
+                target = (mode, self._instrument_key(instruments[0]))
+                self.pending_subscriptions = deque(
+                    item
+                    for item in self.pending_subscriptions
+                    if (item[0], self._instrument_key(item[1])) != target
+                )
 
         # Unsubscribe if connected
         if self.connected and self.ws_client:
@@ -524,16 +716,31 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
         self._resubscribe_all()
 
     def _resubscribe_all(self):
-        """Resubscribe to all stored subscriptions"""
+        """Resubscribe to all stored subscriptions via the batch queue.
+
+        Coalesced into multi-instrument requests rather than one blocking HTTP
+        POST per symbol: a reconnect with a full book was the worst case for the
+        old path, since it replayed every subscription serially.
+
+        Deduped on (mode, instrument): distinct correlation ids can name the
+        same instrument in the same mode - mode 3 stores the depth level in its
+        id, so two depth levels on one token are two entries - and the server
+        only needs telling once.
+        """
+        items = []
+        seen = set()
         with self.lock:
-            for correlation_id, sub in self.subscriptions.items():
-                try:
-                    self.ws_client.subscribe(correlation_id, sub["mode"], sub["instruments"])
-                    self.logger.info(f"Resubscribed to {sub['symbol']}.{sub['exchange']}")
-                except Exception as e:
-                    self.logger.error(
-                        f"Error resubscribing to {sub['symbol']}.{sub['exchange']}: {e}"
-                    )
+            for sub in self.subscriptions.values():
+                for instrument in sub["instruments"]:
+                    key = (sub["mode"], self._instrument_key(instrument))
+                    if key in seen:
+                        continue
+                    seen.add(key)
+                    items.append((sub["mode"], instrument))
+
+        if items:
+            self.logger.info(f"Resubscribing {len(items)} instrument(s) in batches")
+            self._enqueue_subscriptions(items)
 
     def _on_error(self, wsapp, error) -> None:
         """Callback for WebSocket errors"""

--- a/broker/fivepaisaxts/streaming/fivepaisaxts_adapter.py
+++ b/broker/fivepaisaxts/streaming/fivepaisaxts_adapter.py
@@ -275,7 +275,11 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         attempts = self.reconnect_attempts
                     delay = min(self.reconnect_delay * (2**attempts), self.max_reconnect_delay)
                     self.logger.error(f"Connection failed: {e}. Retrying in {delay} seconds...")
-                    time.sleep(delay)
+                    # Interruptible: disconnect() sets _stop_event, so teardown
+                    # wakes us immediately instead of leaving this thread parked
+                    # for up to max_reconnect_delay in a bare sleep.
+                    if self._stop_event.wait(delay):
+                        break
 
             if self.reconnect_attempts >= self.max_reconnect_attempts:
                 self.logger.error("Max reconnection attempts reached. Giving up.")
@@ -666,9 +670,18 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
         # Subscribe in the queue, which the processor then sends afterwards -
         # resurrecting a stale server-side subscription and its feed traffic.
         with self.lock:
-            if correlation_id in self.subscriptions:
-                del self.subscriptions[correlation_id]
-                self.logger.info(f"Removed {symbol}.{exchange} from subscription registry")
+            # subscribe() appends the depth level to a mode-3 id, so an exact
+            # match never found a depth subscription and left it in the registry
+            # for _resubscribe_all() to restore on the next reconnect - a symbol
+            # the user had unsubscribed coming back on its own. Match on the
+            # prefix instead, so the caller need not know the depth level.
+            for key in [
+                k
+                for k in self.subscriptions
+                if k == correlation_id or k.startswith(f"{correlation_id}_")
+            ]:
+                del self.subscriptions[key]
+                self.logger.info(f"Removed {symbol}.{exchange} [{key}] from subscription registry")
 
             if self.pending_subscriptions:
                 target = (mode, self._instrument_key(instruments[0]))
@@ -687,16 +700,14 @@ class FivepaisaXTSWebSocketAdapter(BaseBrokerWebSocketAdapter):
                 self.ws_client.unsubscribe(correlation_id, mode, instruments)
                 self.logger.info(f"Successfully sent unsubscribe request for {symbol}.{exchange}")
 
-                # Always disconnect and perform cleanup after unsubscription
-                self.logger.info("Initiating disconnect and cleanup after unsubscription")
-                self.disconnect()
-
-                return self._create_success_response(
-                    f"Unsubscribed from {symbol}.{exchange} and disconnected from XTS server",
-                    symbol=symbol,
-                    exchange=exchange,
-                    mode=mode,
-                )
+                # Deliberately NOT disconnecting here. This used to call
+                # self.disconnect() on every unsubscribe, which closed the
+                # Socket.IO client, cleared `running`, pinned reconnect_attempts
+                # at the maximum and released ZMQ - so dropping ONE symbol
+                # killed the feed for every other subscribed symbol, with no way
+                # back: _on_close gates reconnection on `running`. The proxy
+                # owns adapter teardown and disconnects us itself once the last
+                # client goes away.
             except Exception as e:
                 self.logger.error(f"Error unsubscribing from {symbol}.{exchange}: {e}")
                 return self._create_error_response("UNSUBSCRIPTION_ERROR", str(e))

--- a/broker/fivepaisaxts/streaming/fivepaisaxts_websocket.py
+++ b/broker/fivepaisaxts/streaming/fivepaisaxts_websocket.py
@@ -37,6 +37,21 @@ class FivepaisaXTSWebSocketClient:
     QUOTE_MODE = 2
     DEPTH_MODE = 3
 
+    # Mode to XTS message code, per the XTS documentation:
+    # 1501 = Touchline / full market data, 1502 = market depth,
+    # 1505 = full market data, 1510 = open interest, 1512 = LTP.
+    #
+    # Shared by subscribe() and unsubscribe() so the two cannot disagree:
+    # unsubscribe used to read the code back from its correlation id's stored
+    # entry and silently fall back to 1501, which unsubscribed the wrong feed
+    # for LTP and depth as soon as subscriptions were batched under ids of
+    # their own.
+    MODE_TO_XTS_CODE = {
+        1: 1512,  # LTP
+        2: 1501,  # Quote
+        3: 1502,  # Market depth
+    }
+
     # Exchange Types (matching XTS API)
     NSE_EQ = 1
     NSE_FO = 2
@@ -234,20 +249,7 @@ class FivepaisaXTSWebSocketClient:
         if not self.connected:
             raise RuntimeError("Socket.IO not connected")
 
-        # Map mode to XTS message code
-        # Based on XTS documentation:
-        # 1501 = LTP/Touchline
-        # 1502 = Market Depth
-        # 1505 = Full Market Data
-        # 1510 = Open Interest
-        # 1512 = LTP
-        mode_to_xts_code = {
-            1: 1512,  # LTP mode -> 1512 (LTP)
-            2: 1501,  # Quote mode -> 1501 (Full Market Data)
-            3: 1502,  # Depth mode -> 1502 (Market Depth)
-        }
-
-        xts_message_code = mode_to_xts_code.get(mode, 1501)
+        xts_message_code = self.MODE_TO_XTS_CODE.get(mode, 1501)
 
         # Prepare subscription request
         subscription_request = {"instruments": instruments, "xtsMessageCode": xts_message_code}
@@ -298,6 +300,34 @@ class FivepaisaXTSWebSocketClient:
             f"Subscribed to {len(instruments)} instruments with XTS code {xts_message_code} (mode {mode})"
         )
 
+    @staticmethod
+    def _instrument_key(instrument: dict) -> tuple:
+        """Identity of an instrument, normalised to strings.
+
+        XTS carries the segment as an int and the instrument id as a string in
+        some paths and the reverse in others, so comparing raw values misses
+        matches that are the same instrument.
+        """
+        return (
+            str(instrument.get("exchangeSegment")),
+            str(instrument.get("exchangeInstrumentID")),
+        )
+
+    def _forget_instruments(self, xts_message_code: int, instruments: list[dict]) -> None:
+        """Remove `instruments` from every stored entry using the same code."""
+        targets = {self._instrument_key(i) for i in instruments}
+        for correlation_id in list(self.subscriptions):
+            entry = self.subscriptions[correlation_id]
+            if entry.get("xts_message_code") != xts_message_code:
+                continue
+            kept = [
+                i for i in entry.get("instruments", []) if self._instrument_key(i) not in targets
+            ]
+            if not kept:
+                del self.subscriptions[correlation_id]
+            else:
+                entry["instruments"] = kept
+
     def unsubscribe(self, correlation_id: str, mode: int, instruments: list[dict]):
         """
         Unsubscribe from market data using XTS HTTP API
@@ -310,14 +340,20 @@ class FivepaisaXTSWebSocketClient:
         if not self.connected:
             return
 
-        # Get the XTS message code from stored subscription
-        subscription = self.subscriptions.get(correlation_id, {})
-        xts_message_code = subscription.get("xts_message_code", 1501)
+        # Derive the code from the mode, the same way subscribe() does. Reading
+        # it back from `correlation_id` only worked while every subscribe used
+        # a per-symbol id; batched subscribes are stored under a batch id, so
+        # the lookup missed and every unsubscribe fell back to 1501.
+        xts_message_code = self.MODE_TO_XTS_CODE.get(mode, 1501)
 
         # Prepare unsubscription request
         unsubscription_request = {"instruments": instruments, "xtsMessageCode": xts_message_code}
 
-        # Remove from subscriptions
+        # Drop these instruments from whichever stored entries hold them,
+        # deleting an entry once it is empty. `self.subscriptions` is also the
+        # tick filter (see _process_1105_data), so an instrument left behind
+        # here keeps being accepted after it was unsubscribed.
+        self._forget_instruments(xts_message_code, instruments)
         if correlation_id in self.subscriptions:
             del self.subscriptions[correlation_id]
 
@@ -478,19 +514,16 @@ class FivepaisaXTSWebSocketClient:
             exchange_segment_int = int(exchange_segment)
             instrument_id_int = int(instrument_id)
 
-            # Check if we have any subscription for this instrument
-            is_subscribed = False
-            for sub in self.subscriptions.values():
-                # Get instruments from the subscription
-                for instrument in sub.get("instruments", []):
-                    if (
-                        instrument.get("exchangeSegment") == exchange_segment_int
-                        and instrument.get("exchangeInstrumentID") == instrument_id_int
-                    ):
-                        is_subscribed = True
-                        break
-                if is_subscribed:
-                    break
+            # Check if we have any subscription for this instrument. Compare on
+            # the normalised key: the adapter stores exchangeInstrumentID as a
+            # string, so the previous `== instrument_id_int` could never match
+            # and every 1105 tick was dropped here.
+            wanted = (str(exchange_segment_int), str(instrument_id_int))
+            is_subscribed = any(
+                self._instrument_key(instrument) == wanted
+                for sub in self.subscriptions.values()
+                for instrument in sub.get("instruments", [])
+            )
 
             if not is_subscribed:
                 # Skip processing for unsubscribed instruments

--- a/broker/kotak/streaming/kotak_adapter.py
+++ b/broker/kotak/streaming/kotak_adapter.py
@@ -466,7 +466,12 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                             "ltp": float(ltp),
                             "ltt": parsed_data.get("timestamp", int(time.time() * 1000)),
                         }
-                    elif mode == 2 and effective_ltp > 0:
+                    elif mode == 2:
+                        # Same contract point as mode 3 below: a quote payload
+                        # always carries ltp, defaulted to 0. Gating the whole
+                        # publish on a non-zero price meant a mode-2 subscriber
+                        # received nothing at all - not even the book's OHLC and
+                        # volume - until the instrument's first trade of the day.
                         publish_data = {
                             "ltp": effective_ltp,
                             "ltt": parsed_data.get("timestamp", int(time.time() * 1000)),
@@ -492,8 +497,23 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                         else:
                             continue  # No depth data available at all
 
+                        # ltp is a first-class field of the mode-3 payload
+                        # (docs/prompt/websockets-format.md), emitted
+                        # unconditionally by every other broker adapter -
+                        # angel, shoonya, dhan, zerodha, upstox all default it
+                        # to 0 rather than dropping the key.
+                        #
+                        # Kotak used to omit it whenever effective_ltp was 0,
+                        # on the reasoning that this "lets the frontend fall
+                        # back to polled REST data". It does - permanently. The
+                        # chart subscribes Depth alone for tradeable symbols and
+                        # stops its REST quote poll only on a depth frame
+                        # carrying ltp, so a payload without the key is read as
+                        # "keep polling" and nothing can ever clear it
+                        # (issue #2038).
                         publish_data = {
                             "timestamp": int(time.time() * 1000),
+                            "ltp": effective_ltp,
                             "depth": {
                                 "buy": depth_buy,
                                 "sell": depth_sell,
@@ -501,10 +521,6 @@ class KotakWebSocketAdapter(BaseBrokerWebSocketAdapter):
                             "totalbuyqty": depth_total_buy,
                             "totalsellqty": depth_total_sell,
                         }
-                        # Only include LTP if valid; omitting it lets
-                        # the frontend fall back to polled REST data
-                        if effective_ltp > 0:
-                            publish_data["ltp"] = effective_ltp
                     else:
                         continue
                     publish_data.update(


### PR DESCRIPTION
feat(fivepaisaxts): batch websocket subscriptions into one request per mode,fix(fivepaisaxts): stop unsubscribe from tearing down the whole feed  and  fix(kotak): always emit ltp in quote and depth payloads #2038

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Fivepaisa XTS and Kotak streaming: Fivepaisa XTS now batches WebSocket subscriptions into one request per mode instead of one per symbol, and unsubscribing no longer disconnects the whole feed. Kotak now always emits `ltp` in quote and depth payloads, so the trading chart stops polling REST data.

**Fivepaisa XTS**

- Subscribe and resubscribe drain through a queue into requests of up to 50 instruments per mode instead of one blocking HTTP POST per symbol.
- `unsubscribe()` no longer calls `disconnect()`, which used to kill every other subscription; the proxy owns teardown.
- Unsubscribe now derives the XTS message code from the mode via a shared map and removes individual instruments from batched entries, so the tick filter stops accepting unsubscribed symbols.
- Reconnect backoff waits on the stop event so teardown wakes the reconnect thread immediately.
- The 1105 tick filter compared instrument IDs as ints against stored strings and matched nothing; both now compare on a normalized key.

**Kotak**

- Mode-2 and mode-3 payloads always include `ltp`, defaulted to 0; the old omission left the chart polling REST data permanently (issue #2038).

<sup>Written for commit f5bc823db0158e5ec8936db3482f672a3ebdf43f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2042?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

