### PR TITLE
fix(websocket): offload market-data dispatch off the shared event loop

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             test/test_broker_credential_logging.py \
             test/test_option_symbol_service_validation.py \
             test/test_graceful_shutdown.py \
+            test/test_zmq_listener_offloads_market_data.py \
             -v --timeout=60
 
   # Frontend linting

--- a/test/test_zmq_listener_offloads_market_data.py
+++ b/test/test_zmq_listener_offloads_market_data.py
@@ -1,0 +1,109 @@
+"""Regression for #2019: zmq_listener must not run MarketDataService work inline
+on the event loop shared with websockets.serve()'s handshake accept path.
+
+Self-contained, like test_websocket_unsubscribe_contract.py: no real ZMQ
+context, socket or broker adapter.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import json
+import time
+from collections import defaultdict
+
+from websocket_proxy import server as proxy_server
+from websocket_proxy.server import WebSocketProxy
+
+
+class _OneTickThenIdleSocket:
+    """Stands in for the real zmq.asyncio socket: yields one market-data
+    message, then blocks (like a real socket with nothing more to deliver)
+    until the test tears the loop down.
+    """
+
+    def __init__(self, topic: bytes, payload: bytes) -> None:
+        self._delivered = False
+        self._topic = topic
+        self._payload = payload
+
+    async def recv_multipart(self):
+        if not self._delivered:
+            self._delivered = True
+            return [self._topic, self._payload]
+        await asyncio.sleep(3600)
+
+
+def _bare_proxy(socket) -> WebSocketProxy:
+    proxy = WebSocketProxy.__new__(WebSocketProxy)
+    proxy.running = True
+    proxy.socket = socket
+    proxy.last_message_time = {}
+    proxy._last_cleanup_time = 0.0
+    proxy._cleanup_interval = 0.0
+    proxy._throttle_entry_max_age = 999999
+    proxy._last_stale_check = 0.0
+    proxy._stale_check_interval = 0.0
+    proxy._stale_tick_warn_seconds = 0
+    proxy.subscription_index = defaultdict(set)
+    proxy.clients = {}
+    proxy._messages_processed = 0
+    return proxy
+
+
+def test_market_data_dispatch_does_not_stall_the_shared_event_loop(monkeypatch):
+    socket = _OneTickThenIdleSocket(b"NSE_RELIANCE_LTP", json.dumps({"ltp": 100.0}).encode())
+    proxy = _bare_proxy(socket)
+
+    class _BlockingService:
+        def process_market_data(self, data):
+            time.sleep(0.3)
+            proxy.running = False  # stop zmq_listener after this one tick
+            return True
+
+    monkeypatch.setattr(proxy_server, "get_market_data_service", lambda: _BlockingService())
+
+    heartbeats = 0
+
+    async def heartbeat():
+        nonlocal heartbeats
+        while proxy.running:
+            await asyncio.sleep(0.01)
+            heartbeats += 1
+
+    async def scenario():
+        await asyncio.gather(proxy.zmq_listener(), heartbeat())
+
+    asyncio.run(scenario())
+
+    # Fails on unmodified server.py: a synchronous in-loop call blocks every
+    # other coroutine (the WS accept path included) for the full 0.3s, so the
+    # heartbeat gets essentially no chance to run before running() flips.
+    assert heartbeats >= 15, (
+        f"only {heartbeats} heartbeats ran during the 0.3s dispatch; "
+        "the event loop was stalled by a synchronous MarketDataService call"
+    )
+
+
+def test_market_data_dispatch_receives_the_parsed_topic_fields(monkeypatch):
+    # Control: green on both sides, but genuinely sensitive to the refactor
+    # (await asyncio.to_thread(fn, mds_data)) passing the wrong callable or
+    # the wrong argument through.
+    received = []
+
+    socket = _OneTickThenIdleSocket(b"NSE_RELIANCE_LTP", json.dumps({"ltp": 100.0}).encode())
+    proxy = _bare_proxy(socket)
+
+    class _RecordingService:
+        def process_market_data(self, data):
+            received.append(data)
+            proxy.running = False
+            return True
+
+    monkeypatch.setattr(proxy_server, "get_market_data_service", lambda: _RecordingService())
+
+    asyncio.run(proxy.zmq_listener())
+
+    assert received == [
+        {"symbol": "RELIANCE", "exchange": "NSE", "mode": 1, "data": {"ltp": 100.0}}
+    ]

--- a/websocket_proxy/server.py
+++ b/websocket_proxy/server.py
@@ -2101,7 +2101,11 @@ class WebSocketProxy:
                         "data": market_data,
                     }
                     market_data_service = get_market_data_service()
-                    market_data_service.process_market_data(mds_data)
+                    # Runs off the event loop: process_market_data fans out to
+                    # synchronous DB work (sandbox order execution, margin
+                    # reconciliation) that would otherwise stall this loop and
+                    # the websockets.serve() accept path it shares (#2019).
+                    await aio.to_thread(market_data_service.process_market_data, mds_data)
                 except Exception as mds_error:
                     # Don't block WebSocket delivery if MarketDataService has issues
                     logger.debug(f"MarketDataService processing error: {mds_error}")


### PR DESCRIPTION
`zmq_listener` (`websocket_proxy/server.py`) shares one asyncio loop with `websockets.serve()`, and it calls `market_data_service.process_market_data()` directly, no `await`. That call fans out to `WebSocketExecutionEngine._on_market_data`/`_check_and_execute_order`, which does synchronous SQLAlchemy commits and margin reconciliation. A tick that triggers an order blocks the loop for that DB work, and a concurrent client's handshake to the same proxy times out, matching the `TimeoutError: timed out during opening handshake` in the issue.

Wrapped the dispatch in `await asyncio.to_thread(...)`. zmq_listener still awaits it, so ticks are still processed one at a time in order, but the loop is free to accept connections while the thread runs.

Went with your first suggestion but at the outer call site (`process_market_data`) rather than the inner `_check_and_execute_order`: it's the one place all of `_broadcast_update_priority`'s CRITICAL-priority synchronous work already funnels through (today just the sandbox engine, but not only ever that), and it's already wrapped in its own try/except. Didn't touch the subscription-filtering or separate-loop ideas, those are bigger changes.

Added `test/test_zmq_listener_offloads_market_data.py`: builds a bare `WebSocketProxy` (no real ZMQ/sockets), feeds it one tick whose `process_market_data` blocks for 0.3s, and counts how many times a concurrent heartbeat coroutine gets to run during that window. Without the fix the heartbeat never runs, the loop is stalled for the full 0.3s. A second test checks the offloaded call still receives the right parsed fields. Also added the file to `ci.yml`'s test list, it wasn't picking up `test/` by default.

Ran the repo's CI-safe test list plus this new file on Python 3.12 and 3.14 (the matrix extremes), all green except `test_precompress_assets.py`'s stale-variant test, which I confirmed flakes on its own, unrelated to this change. `ruff check` clean on both changed files; `ruff format --check` flags pre-existing formatting elsewhere in server.py, not on the lines I touched.

One thing I noticed but didn't check: #1992 is open on this same file and pulls this exact block into a new `_handle_market_data` method. It still calls `process_market_data` synchronously there, so this bug would survive it landing first, just at a different line, might need a rebase depending on merge order.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes WebSocket handshake timeouts by offloading market-data dispatch from the shared event loop. `zmq_listener` previously called `process_market_data` synchronously, and that call could block the loop with SQLAlchemy commits and margin reconciliation, stalling concurrent client handshakes. Now the dispatch runs in a thread via `asyncio.to_thread`, still awaited so ticks remain ordered, but the loop stays free to accept connections.

**Notes**
- Adds regression tests for the offload and for parsed field delivery.
- `ci.yml` updated to include the new test file.
- This touches the same code block as #1992; a rebase may be needed depending on merge order.

<sup>Written for commit 22e71a02c365feb4b5f887e9b7c630e1e2ae1521. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2046?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

