### PR TITLE
feat(api): add decision-telemetry intake endpoint (/api/v1/analyze)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,6 +65,7 @@ jobs:
             test/test_broker_credential_logging.py \
             test/test_option_symbol_service_validation.py \
             test/test_graceful_shutdown.py \
+            test/test_analyze_intake.py \
             -v --timeout=60
 
   # Frontend linting

--- a/restx_api/__init__.py
+++ b/restx_api/__init__.py
@@ -11,6 +11,7 @@ api = Api(
 )
 
 # Import namespaces
+from .analyze import api as analyze_ns
 from .analyzer import api as analyzer_ns
 from .basket_order import api as basket_order_ns
 from .cancel_all_order import api as cancel_all_order_ns
@@ -47,10 +48,10 @@ from .place_order import api as place_order_ns
 from .place_smart_order import api as place_smart_order_ns
 from .pnl_symbols import api as pnl_symbols_ns
 from .portfolio import api as portfolio_ns
-from .sip import api as sip_ns
 from .positionbook import api as positionbook_ns
 from .quotes import api as quotes_ns
 from .search import api as search_ns
+from .sip import api as sip_ns
 from .split_order import api as split_order_ns
 from .strategy import api as strategy_ns
 from .symbol import api as symbol_ns
@@ -95,6 +96,7 @@ api.add_namespace(option_greeks_ns, path="/optiongreeks")
 api.add_namespace(multi_option_greeks_ns, path="/multioptiongreeks")
 api.add_namespace(synthetic_future_ns, path="/syntheticfuture")
 api.add_namespace(analyzer_ns, path="/analyzer")
+api.add_namespace(analyze_ns, path="/analyze")
 api.add_namespace(ping_ns, path="/ping")
 api.add_namespace(telegram_ns, path="/telegram")
 api.add_namespace(whatsapp_ns, path="/whatsapp")

--- a/restx_api/account_schema.py
+++ b/restx_api/account_schema.py
@@ -44,6 +44,28 @@ class AnalyzerToggleSchema(Schema):
     mode = fields.Bool(required=True)
 
 
+class AnalyzerIntakeSchema(Schema):
+    """Decision-telemetry intake payload (ADR-006 Amendment 5 producer contract).
+
+    The producer is an external strategy process (LOATS) whose routed
+    TradeDecision payload carries exactly these decision fields plus the
+    standard ``apikey``. Unknown fields are retained rather than rejected so
+    the producer can extend its telemetry without a gateway release; the
+    required fields are the minimum a decision row must carry to be
+    attributable.
+    """
+
+    class Meta:
+        # Decision telemetry is producer-owned and evolving; keep extra keys.
+        unknown = INCLUDE
+
+    apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    decision_id = fields.Str(required=True, validate=validate.Length(min=1, max=256))
+    symbol = fields.Str(required=True, validate=validate.Length(min=1, max=64))
+    decision_type = fields.Str(required=True, validate=validate.Length(min=1, max=64))
+    timestamp = fields.Str(required=True, validate=validate.Length(min=1, max=64))
+
+
 class PingSchema(Schema):
     apikey = fields.Str(required=True, validate=validate.Length(min=1, max=256))
 

--- a/restx_api/analyze.py
+++ b/restx_api/analyze.py
@@ -1,0 +1,76 @@
+"""Decision-telemetry intake endpoint (``POST /api/v1/analyze``).
+
+ADR-006 Amendment 5 counterpart: the strategy process (LOATS) routes every
+TradeDecision through this endpoint once its ``ANALYZER_INTAKE_PATH`` setting
+points here. Until now the routed decision received an HTTP 404 from the
+gateway's absent ``/analyze`` intake — an honestly-counted error outcome under
+the read-only semantic. This endpoint accepts the decision telemetry, records
+it in the analyzer log, and acknowledges with a structured success response so
+the producer's routing counters reflect real deliveries.
+
+The endpoint is intentionally receive-and-record only: it never places orders,
+never touches broker credentials beyond the standard apikey authentication,
+and is therefore safe to expose alongside the read-only ANALYZE-mode surface.
+"""
+
+import os
+
+from flask import jsonify, make_response, request
+from flask_restx import Namespace, Resource
+from marshmallow import ValidationError
+
+from database.analyzer_db import async_log_analyzer
+from database.auth_db import get_auth_token_broker
+from limiter import limiter
+from restx_api.account_schema import AnalyzerIntakeSchema
+from services.analyze_intake_service import record_decision_intake
+from utils.logging import get_logger
+
+API_RATE_LIMIT = os.getenv("API_RATE_LIMIT", "10 per second")
+api = Namespace("analyze", description="Decision Telemetry Intake API")
+
+# Initialize logger
+logger = get_logger(__name__)
+
+# Initialize schema
+analyzer_intake_schema = AnalyzerIntakeSchema()
+
+
+@api.route("/", strict_slashes=False)
+class AnalyzeIntake(Resource):
+    @limiter.limit(API_RATE_LIMIT)
+    def post(self):
+        """Record a routed strategy decision and acknowledge receipt."""
+        try:
+            data = request.json
+
+            try:
+                intake_data = analyzer_intake_schema.load(data)
+            except ValidationError as err:
+                error_response = {"status": "error", "message": err.messages}
+                # Bad schema: skip DB audit to avoid flooding (house rule).
+                return make_response(jsonify(error_response), 400)
+
+            api_key = intake_data.pop("apikey", None)
+
+            # API-key authentication only (no direct auth_token path: the
+            # producer is by definition an external API client).
+            AUTH_TOKEN, broker_name = get_auth_token_broker(api_key)
+            if AUTH_TOKEN is None:
+                error_response = {"status": "error", "message": "Invalid openalgo apikey"}
+                # Skip logging for invalid API keys to prevent database flooding.
+                return make_response(jsonify(error_response), 403)
+
+            # apikey is already popped; log WITHOUT the credential.
+            log_request = {k: v for k, v in (data or {}).items() if k != "apikey"}
+
+            success, response_data, status_code = record_decision_intake(
+                intake_data=intake_data,
+                original_data=log_request,
+            )
+            return make_response(jsonify(response_data), status_code)
+
+        except Exception:
+            logger.exception("An unexpected error occurred in the analyze intake endpoint.")
+            error_response = {"status": "error", "message": "An unexpected error occurred"}
+            return make_response(jsonify(error_response), 500)

--- a/services/analyze_intake_service.py
+++ b/services/analyze_intake_service.py
@@ -1,0 +1,64 @@
+"""Decision-telemetry intake service (ADR-006 Amendment 5 counterpart).
+
+Records a routed strategy decision (producer: LOATS ``route_to_analyzer``)
+into the analyzer log and acknowledges receipt. Pure receive-and-record:
+no broker calls, no order state, no mode toggles — the ANALYZE-mode read-only
+semantic is untouched. The apikey never reaches storage: the resource strips
+it before calling this service, and this service re-strips defensively.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from typing import Any
+
+from database.analyzer_db import async_log_analyzer
+from utils.logging import get_logger
+
+# Initialize logger
+logger = get_logger(__name__)
+
+# Single-thread executor for the audit write: acknowledgement must not wait
+# on database I/O, matching the fire-and-forget audit pattern used by the
+# order/data endpoints (log_executor.submit).
+_log_executor = ThreadPoolExecutor(max_workers=1)
+
+# api_type under which decision-telemetry rows are stored in analyzer_logs.
+DECISION_INTAKE_API_TYPE = "analyze_intake"
+
+
+def record_decision_intake(
+    intake_data: dict[str, Any],
+    original_data: dict[str, Any],
+) -> tuple[bool, dict[str, Any], int]:
+    """Record one routed decision and return the acknowledgement.
+
+    Args:
+        intake_data: Validated decision payload (apikey already removed).
+        original_data: Raw request body (apikey removed) kept for the audit log.
+
+    Returns:
+        Tuple of (success, response_data, http_status_code). The acknowledgement
+        precedes the audit write: the log task is submitted fire-and-forget and
+        its failures are contained inside ``async_log_analyzer``.
+    """
+    try:
+        decision_id = str(intake_data.get("decision_id", "unknown"))
+        # Defensive re-strip: audit rows must never carry the credential.
+        safe_request = {k: v for k, v in original_data.items() if k != "apikey"}
+
+        _log_executor.submit(
+            async_log_analyzer, safe_request, {"status": "success"}, DECISION_INTAKE_API_TYPE
+        )
+
+        response_data = {
+            "status": "success",
+            "data": {
+                "decision_id": decision_id,
+                "recorded": True,
+            },
+        }
+        return True, response_data, 200
+
+    except Exception as e:
+        logger.exception(f"Error recording decision intake: {e}")
+        error_response = {"status": "error", "message": "Failed to record decision"}
+        return False, error_response, 500

--- a/test/test_analyze_intake.py
+++ b/test/test_analyze_intake.py
@@ -1,0 +1,211 @@
+"""Contract tests for the decision-telemetry intake (``POST /api/v1/analyze``).
+
+Producer: LOATS ``route_to_analyzer`` posts ``TradeDecision.to_analyzer_payload()``
+(exactly these decision fields plus ``apikey``) to ``/api/v1/analyze``. The
+ADR-006 Amendment 5 follow-up that deferred this intake had a hidden defect:
+LOATS shipped the producer side pointing at ``analyze`` while the gateway never
+shipped the endpoint, so every routed decision silently resolved as an HTTP 404
+error outcome. These tests pin the three layers that must stay aligned:
+
+* the schema accepts the real producer payload (wire compatibility),
+* the namespace is actually registered under ``/analyze`` (the historical
+  defect: an implemented-but-unregistered endpoint is indistinguishable from
+  a missing one for the producer),
+* the service records telemetry without ever persisting the credential.
+
+The checks stay deliberately coarse (no app boot, no database) so they are
+CI-safe in the same way ``test_telegram_api_contract.py`` is.
+"""
+
+import ast
+from pathlib import Path
+
+import pytest
+from marshmallow import ValidationError
+
+from restx_api.account_schema import AnalyzerIntakeSchema
+from services import analyze_intake_service
+
+MODULE_PATH = Path(__file__).resolve().parents[1] / "restx_api" / "analyze.py"
+INIT_PATH = Path(__file__).resolve().parents[1] / "restx_api" / "__init__.py"
+
+# The real producer shape: TradeDecision.to_analyzer_payload() + apikey.
+LOATS_PAYLOAD = {
+    "apikey": "x" * 64,
+    "decision_id": "d-20260914-091501-000123",
+    "symbol": "RELIANCE",
+    "decision_type": "DecisionType.BUY",
+    "timestamp": "2026-09-14T09:15:01.123456+00:00",
+    "as_of_date": "2026-09-14",
+    "entry_price": 1257.5,
+    "quantity": 10,
+    "stop_loss": 1232.35,
+    "take_profit": 1307.8,
+    "trailing_stop_config": {"enabled": True, "trail_pct": 1.5},
+    "position_size_method": "risk_based",
+    "risk_percentage": 1.0,
+    "var_analysis": {"var_95": 2500.0},
+    "gating_rules_result": {"passed": True},
+    "source_breakdown": {"ta": 0.6, "sentiment": 0.4},
+    "metadata": {"cycle": 40912},
+    "status": "PENDING",
+    "risk_reward_ratio": 2.0,
+}
+
+
+@pytest.fixture(scope="module")
+def module_tree() -> ast.Module:
+    return ast.parse(MODULE_PATH.read_text(encoding="utf-8"), filename=str(MODULE_PATH))
+
+
+# ---------------------------------------------------------------------------
+# Schema: wire compatibility with the producer
+# ---------------------------------------------------------------------------
+
+
+def test_schema_accepts_full_producer_payload():
+    loaded = AnalyzerIntakeSchema().load(LOATS_PAYLOAD)
+    assert loaded["decision_id"] == LOATS_PAYLOAD["decision_id"]
+    assert loaded["symbol"] == "RELIANCE"
+
+
+def test_schema_retains_producer_extension_fields():
+    # unknown = INCLUDE: the producer may extend telemetry without a
+    # coordinated gateway release.
+    payload = dict(LOATS_PAYLOAD)
+    payload["future_field"] = {"nested": [1, 2, 3]}
+    loaded = AnalyzerIntakeSchema().load(payload)
+    assert loaded["future_field"] == {"nested": [1, 2, 3]}
+
+
+@pytest.mark.parametrize(
+    "required_field",
+    ["apikey", "decision_id", "symbol", "decision_type", "timestamp"],
+)
+def test_schema_rejects_missing_required_fields(required_field):
+    payload = {k: v for k, v in LOATS_PAYLOAD.items() if k != required_field}
+    with pytest.raises(ValidationError):
+        AnalyzerIntakeSchema().load(payload)
+
+
+def test_schema_rejects_oversized_decision_id():
+    payload = dict(LOATS_PAYLOAD)
+    payload["decision_id"] = "d" * 257
+    with pytest.raises(ValidationError):
+        AnalyzerIntakeSchema().load(payload)
+
+
+# ---------------------------------------------------------------------------
+# Resource: static contract (route, auth, credential handling)
+# ---------------------------------------------------------------------------
+
+
+def test_resource_uses_apikey_auth_and_403_on_invalid(module_tree):
+    source = MODULE_PATH.read_text(encoding="utf-8")
+    assert "get_auth_token_broker" in source, "intake must authenticate via apikey"
+    assert "Invalid openalgo apikey" in source, "must follow the house 403 message"
+    assert "403" in source, "invalid apikey must be rejected with 403"
+
+
+def test_resource_never_logs_the_credential(module_tree):
+    # The audit request passed onward must be built with apikey removed, and
+    # no raw request body may reach the audit call.
+    class _Visitor(ast.NodeVisitor):
+        def __init__(self) -> None:
+            self.log_calls: list[ast.Call] = []
+
+        def visit_Call(self, node: ast.Call) -> None:  # noqa: N802
+            func = node.func
+            if isinstance(func, ast.Name) and func.id == "record_decision_intake":
+                self.log_calls.append(node)
+            self.generic_visit(node)
+
+    visitor = _Visitor()
+    visitor.visit(module_tree)
+    assert visitor.log_calls, "resource must delegate recording to the service"
+    call = visitor.log_calls[0]
+    keywords = {kw.arg: kw for kw in call.keywords if kw.arg}
+    assert "intake_data" in keywords and "original_data" in keywords
+    assert "data" not in keywords, "raw body (contains apikey) must not be passed onward"
+
+
+def test_namespace_registered_under_analyze_path():
+    # The ADR-006 Am5 defect class: producer points at /analyze while the
+    # gateway never registers the route -> every decision 404s forever.
+    init_source = INIT_PATH.read_text(encoding="utf-8")
+    assert "from .analyze import api as analyze_ns" in init_source
+    assert 'api.add_namespace(analyze_ns, path="/analyze")' in init_source
+
+
+# ---------------------------------------------------------------------------
+# Service: recording semantics
+# ---------------------------------------------------------------------------
+
+
+def test_service_records_without_credential(monkeypatch):
+    captured: dict = {}
+
+    def _fake_log(request_data, response_data, api_type):
+        captured["request"] = request_data
+        captured["response"] = response_data
+        captured["api_type"] = api_type
+
+    monkeypatch.setattr(analyze_intake_service, "async_log_analyzer", _fake_log)
+
+    intake = {k: v for k, v in LOATS_PAYLOAD.items() if k != "apikey"}
+    original = dict(LOATS_PAYLOAD)  # contains apikey, as the resource strips it
+
+    success, response_data, status_code = analyze_intake_service.record_decision_intake(
+        intake_data=intake, original_data=original
+    )
+
+    assert success is True
+    assert status_code == 200
+    assert response_data["status"] == "success"
+    assert response_data["data"]["decision_id"] == LOATS_PAYLOAD["decision_id"]
+    assert response_data["data"]["recorded"] is True
+
+    assert captured["api_type"] == analyze_intake_service.DECISION_INTAKE_API_TYPE
+    assert "apikey" not in captured["request"], "audit row must never carry the credential"
+    assert captured["request"]["decision_id"] == LOATS_PAYLOAD["decision_id"]
+
+
+def test_service_does_not_mutate_caller_data(monkeypatch):
+    monkeypatch.setattr(analyze_intake_service, "async_log_analyzer", lambda *a, **k: None)
+    original = dict(LOATS_PAYLOAD)
+    original["decision_id"] = "d-1"
+    original["symbol"] = "TCS"
+    analyze_intake_service.record_decision_intake(
+        intake_data={"decision_id": "d-1", "symbol": "TCS"}, original_data=original
+    )
+    assert "apikey" in original, "caller's dict must not be mutated"
+    assert original["apikey"] == LOATS_PAYLOAD["apikey"]
+
+
+def test_service_contains_log_submission_failure(monkeypatch):
+    def _boom(*a, **k):
+        raise RuntimeError("executor unavailable")
+
+    monkeypatch.setattr(analyze_intake_service._log_executor, "submit", _boom)
+
+    success, response_data, status_code = analyze_intake_service.record_decision_intake(
+        intake_data={"decision_id": "d-2"}, original_data={}
+    )
+    assert success is False
+    assert status_code == 500
+    assert response_data["status"] == "error"
+
+
+def test_service_defaults_missing_decision_id(monkeypatch):
+    captured: dict = {}
+
+    def _fake_log(request_data, response_data, api_type):
+        captured["response"] = response_data
+
+    monkeypatch.setattr(analyze_intake_service, "async_log_analyzer", _fake_log)
+
+    _, response_data, status_code = analyze_intake_service.record_decision_intake(
+        intake_data={}, original_data={}
+    )
+    assert status_code == 200
+    assert response_data["data"]["decision_id"] == "unknown"


### PR DESCRIPTION
## Summary

External strategy producers (LOATS, per its ADR-006 Amendment 5) route every TradeDecision to `/api/v1/analyze` (`ANALYZER_INTAKE_PATH=analyze`). The producer side shipped on 11 Sep, but the gateway never had the endpoint — every routed decision resolved as HTTP 404 and was honestly counted as a routing error. This PR adds the endpoint so that error class becomes real decisional telemetry, without touching the producer.

## Changes

- `restx_api/analyze.py` — new `/api/v1/analyze` endpoint: receive-and-record only; apikey-authenticated, rate-limited, schema-validated (`decision_id`/`symbol`/`decision_type`/`timestamp` required; unknown fields retained so producers can evolve); acknowledges `200 {"status": "success"}`. No orders, no broker calls, no analyzer-mode changes — the read-only ANALYZE-mode semantic is intact.
- `services/analyze_intake_service.py` — records into `analyzer_logs` under `api_type=analyze_intake` with the credential stripped.
- `restx_api/__init__.py`, `restx_api/account_schema.py` — namespace registration + request schema.
- `test/test_analyze_intake.py` — 15 contract cases, including the historical defect class: the namespace registered under `/analyze` is asserted, because an implemented-but-unregistered route is indistinguishable from a missing one for the producer.
- `.github/workflows/ci.yml` — `test_analyze_intake.py` added to the CI-safe backend test job.

## Companion note: upstream test env defect (separate from this change)

`tests/test_python_editor.py` binds a server to port 5000 (the platform's default dev port). On machines where a foreign OpenAlgo instance is already listening on 5000, the suite's assertions evaluate against the **wrong server** — independent of this PR (locally A/B-proven against a live :5000 instance; the failures follow the foreign server, not the diff). Candidate upstream fix: bind to an explicit ephemeral test port, or skip when a foreign server answers. Flagging here because it produces false local/CI failures that look like regressions.

## Test plan

- [x] `pytest test/test_analyze_intake.py` → **15 passed** (Windows 11, Python 3.11, repo venv; against this exact tree, post-rebase onto current main)
- [x] Live probe: `POST /api/v1/analyze` → 400 on empty payload; unknown route → 404 (registration proven on a running instance)
- [x] Working tree clean on `main` = `a51822b4`, rebased onto upstream tip `c1bc96c9`

Base-branch note: rebased onto current upstream `main`; the only conflict vs main was `.github/workflows/ci.yml` (both sides appended one test line — union-resolved).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the `/api/v1/analyze` decision-telemetry intake endpoint. LOATS producers have routed every TradeDecision to this path since 11 Sep, but the gateway returned a 404 for each one, counted as a routing error. The new endpoint turns that error class into real decisional telemetry without touching the producer.

**Changes**
- Receive-and-record only: apikey-authenticated, rate-limited, schema-validated. `decision_id`, `symbol`, `decision_type`, and `timestamp` are required; unknown fields are retained so the producer can evolve. Acknowledges `200 {"status": "success"}`.
- No orders, no broker calls, no analyzer-mode changes; the read-only ANALYZE-mode semantic is intact.
- Records into `analyzer_logs` under `api_type=analyze_intake` with the apikey stripped before storage.
- Registers the namespace under `/analyze` and adds the request schema.
- Adds 15 contract tests covering the producer wire shape, namespace registration, and credential handling; wired into the CI backend job.
- Separate upstream issue, not from this PR: `tests/test_python_editor.py` binds port 5000 and can false-fail against a foreign instance.

<sup>Written for commit a51822b4c47aa80b7680f44706aeb92c4db26fe1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/marketcalls/openalgo/pull/2047?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

